### PR TITLE
Telemetry: Fixes Inconsistent behavior of VM Metadata Async Initialization

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Tracing/TraceData/ClientConfigurationTraceDatum.cs
+++ b/Microsoft.Azure.Cosmos/src/Tracing/TraceData/ClientConfigurationTraceDatum.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Azure.Cosmos.Tracing.TraceData
             this.cachedNumberOfClientCreated = CosmosClient.numberOfClientsCreated;
             this.cachedNumberOfActiveClient = CosmosClient.NumberOfActiveClients;
             this.cachedUserAgentString = this.UserAgentContainer.UserAgent;
+            this.cachedMachineId = VmMetadataApiHandler.GetMachineId();
             this.cachedSerializedJson = this.GetSerializedDatum();
             this.ProcessorCount = Environment.ProcessorCount;
             this.ConnectionMode = cosmosClientContext.ClientOptions.ConnectionMode;
@@ -56,11 +57,13 @@ namespace Microsoft.Azure.Cosmos.Tracing.TraceData
             {
                 if (this.cachedUserAgentString != this.UserAgentContainer.UserAgent ||
                     this.cachedNumberOfClientCreated != CosmosClient.numberOfClientsCreated ||
-                    this.cachedNumberOfActiveClient != CosmosClient.NumberOfActiveClients)
+                    this.cachedNumberOfActiveClient != CosmosClient.NumberOfActiveClients ||
+                    this.cachedMachineId != VmMetadataApiHandler.GetMachineId())
                 {
                     this.cachedNumberOfActiveClient = CosmosClient.NumberOfActiveClients;
                     this.cachedNumberOfClientCreated = CosmosClient.numberOfClientsCreated;
                     this.cachedUserAgentString = this.UserAgentContainer.UserAgent;
+                    this.cachedMachineId = VmMetadataApiHandler.GetMachineId();
                     this.cachedSerializedJson = this.GetSerializedDatum();
                 }
 
@@ -76,6 +79,8 @@ namespace Microsoft.Azure.Cosmos.Tracing.TraceData
 
         private string cachedUserAgentString;
 
+        private string cachedMachineId;
+
         internal override void Accept(ITraceDatumVisitor traceDatumVisitor)
         {
             traceDatumVisitor.Visit(this);
@@ -89,7 +94,7 @@ namespace Microsoft.Azure.Cosmos.Tracing.TraceData
             jsonTextWriter.WriteFieldName("Client Created Time Utc");
             jsonTextWriter.WriteStringValue(this.ClientCreatedDateTimeUtc.ToString("o", CultureInfo.InvariantCulture));
             jsonTextWriter.WriteFieldName("MachineId");
-            jsonTextWriter.WriteStringValue(VmMetadataApiHandler.GetMachineId());
+            jsonTextWriter.WriteStringValue(this.cachedMachineId);
             jsonTextWriter.WriteFieldName("NumberOfClientsCreated");
             jsonTextWriter.WriteNumber64Value(this.cachedNumberOfClientCreated);
             jsonTextWriter.WriteFieldName("NumberOfActiveClients");

--- a/Microsoft.Azure.Cosmos/src/Tracing/TraceData/ClientConfigurationTraceDatum.cs
+++ b/Microsoft.Azure.Cosmos/src/Tracing/TraceData/ClientConfigurationTraceDatum.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.Cosmos.Tracing.TraceData
                 if (this.cachedUserAgentString != this.UserAgentContainer.UserAgent ||
                     this.cachedNumberOfClientCreated != CosmosClient.numberOfClientsCreated ||
                     this.cachedNumberOfActiveClient != CosmosClient.NumberOfActiveClients ||
-                    this.cachedMachineId != VmMetadataApiHandler.GetMachineId())
+                    !ReferenceEquals(this.cachedMachineId, VmMetadataApiHandler.GetMachineId()))
                 {
                     this.cachedNumberOfActiveClient = CosmosClient.NumberOfActiveClients;
                     this.cachedNumberOfClientCreated = CosmosClient.numberOfClientsCreated;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
@@ -944,8 +944,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 }
             }
 
-            Assert.AreEqual(1, machineId.Count, $"Multiple Machine Id has been generated i.e {JsonConvert.SerializeObject(machineId)}");
-
             if(isAzureInstance.HasValue)
             {
                 if (isAzureInstance.Value)
@@ -955,6 +953,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 else
                 {
                     Assert.AreNotEqual("vmId:d0cb93eb-214b-4c2b-bd3d-cc93e90d9efd", machineId.First(), $"Generated Machine id is : {machineId.First()}");
+                    Assert.AreEqual(1, machineId.Count, $"Multiple Machine Id has been generated i.e {JsonConvert.SerializeObject(machineId)}");
                 }
             }
 


### PR DESCRIPTION
# Pull Request Template

## Description

VM Metadata is initializes its azMetadata asynchronously, which is used in the Client Configuration Diagnostics to retrieve the machine Id. This fixes that by adding a cached machine Id and updating the serialized json accordingly.

## Type of change
- [] Bug fix (non-breaking change which fixes an issue)

## Closing issues
closes #3238