### PR TITLE
CosmosOperationCanceledException: Fixes Closure on Cancellation Token status

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/CosmosOperationCanceledException.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/CosmosOperationCanceledException.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Azure.Cosmos
     {
         private readonly OperationCanceledException originalException;
         private readonly Lazy<string> lazyMessage;
+        private readonly Lazy<string> toStringMessage;
         private readonly bool tokenCancellationRequested;
 
         /// <summary>
@@ -34,6 +35,7 @@ namespace Microsoft.Azure.Cosmos
             this.originalException = originalException ?? throw new ArgumentNullException(nameof(originalException));
             this.Diagnostics = diagnostics ?? throw new ArgumentNullException(nameof(diagnostics));
             this.tokenCancellationRequested = originalException.CancellationToken.IsCancellationRequested;
+            this.toStringMessage = this.CreateToStringMessage();
             this.lazyMessage = this.CreateLazyMessage();
         }
 
@@ -51,6 +53,7 @@ namespace Microsoft.Azure.Cosmos
             trace.AddDatum("Operation Cancelled Exception", originalException);
             this.Diagnostics = new CosmosTraceDiagnostics(trace);
             this.tokenCancellationRequested = originalException.CancellationToken.IsCancellationRequested;
+            this.toStringMessage = this.CreateToStringMessage();
             this.lazyMessage = this.CreateLazyMessage();
         }
 
@@ -91,12 +94,16 @@ namespace Microsoft.Azure.Cosmos
         /// <inheritdoc/>
         public override string ToString()
         {
-            return $"{this.originalException}{Environment.NewLine}Cancellation Token has expired: {this.tokenCancellationRequested}. Learn more at: https://aka.ms/cosmosdb-tsg-request-timeout{Environment.NewLine}CosmosDiagnostics: {this.Diagnostics}";
+            return this.toStringMessage.Value;
         }
 
         private Lazy<string> CreateLazyMessage()
         {
             return new Lazy<string>(() => $"{this.originalException.Message}{Environment.NewLine}Cancellation Token has expired: {this.tokenCancellationRequested}. Learn more at: https://aka.ms/cosmosdb-tsg-request-timeout{Environment.NewLine}CosmosDiagnostics: {this.Diagnostics}");
+        }
+        private Lazy<string> CreateToStringMessage()
+        {
+            return new Lazy<string>(() => $"{this.originalException}{Environment.NewLine}Cancellation Token has expired: {this.tokenCancellationRequested}. Learn more at: https://aka.ms/cosmosdb-tsg-request-timeout{Environment.NewLine}CosmosDiagnostics: {this.Diagnostics}");
         }
     }
 }


### PR DESCRIPTION
# Pull Request Template

## Description

Cancellation token status is currently evaluated when lazyMessage.value is used. This PR updates this to get the cancellation token during creation of the exception

## Type of change

- [] Bug fix (non-breaking change which fixes an issue)

## Closing issues
closes #3248 