### PR TITLE
Diagnostics: Adds VM Region into Client Configuration

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Telemetry/VmMetadataApiHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/VmMetadataApiHandler.cs
@@ -121,6 +121,15 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         }
 
         /// <summary>
+        /// Get Machine Region (If Azure System) else null
+        /// </summary>
+        /// <returns>VM region</returns>
+        internal static string GetMachineRegion()
+        {
+            return VmMetadataApiHandler.azMetadata?.Compute?.Location;
+        }
+
+        /// <summary>
         /// Hash a passed Value
         /// </summary>
         /// <param name="rawData"></param>

--- a/Microsoft.Azure.Cosmos/src/Tracing/TraceData/ClientConfigurationTraceDatum.cs
+++ b/Microsoft.Azure.Cosmos/src/Tracing/TraceData/ClientConfigurationTraceDatum.cs
@@ -31,6 +31,7 @@ namespace Microsoft.Azure.Cosmos.Tracing.TraceData
             this.cachedNumberOfClientCreated = CosmosClient.numberOfClientsCreated;
             this.cachedNumberOfActiveClient = CosmosClient.NumberOfActiveClients;
             this.cachedUserAgentString = this.UserAgentContainer.UserAgent;
+            this.cachedMachineId = VmMetadataApiHandler.GetMachineId();
             this.cachedSerializedJson = this.GetSerializedDatum();
             this.ProcessorCount = Environment.ProcessorCount;
             this.ConnectionMode = cosmosClientContext.ClientOptions.ConnectionMode;
@@ -56,11 +57,13 @@ namespace Microsoft.Azure.Cosmos.Tracing.TraceData
             {
                 if (this.cachedUserAgentString != this.UserAgentContainer.UserAgent ||
                     this.cachedNumberOfClientCreated != CosmosClient.numberOfClientsCreated ||
-                    this.cachedNumberOfActiveClient != CosmosClient.NumberOfActiveClients)
+                    this.cachedNumberOfActiveClient != CosmosClient.NumberOfActiveClients ||
+                    !ReferenceEquals(this.cachedMachineId, VmMetadataApiHandler.GetMachineId()))
                 {
                     this.cachedNumberOfActiveClient = CosmosClient.NumberOfActiveClients;
                     this.cachedNumberOfClientCreated = CosmosClient.numberOfClientsCreated;
                     this.cachedUserAgentString = this.UserAgentContainer.UserAgent;
+                    this.cachedMachineId = VmMetadataApiHandler.GetMachineId();
                     this.cachedSerializedJson = this.GetSerializedDatum();
                 }
 
@@ -76,6 +79,8 @@ namespace Microsoft.Azure.Cosmos.Tracing.TraceData
 
         private string cachedUserAgentString;
 
+        private string cachedMachineId;
+
         internal override void Accept(ITraceDatumVisitor traceDatumVisitor)
         {
             traceDatumVisitor.Visit(this);
@@ -89,7 +94,7 @@ namespace Microsoft.Azure.Cosmos.Tracing.TraceData
             jsonTextWriter.WriteFieldName("Client Created Time Utc");
             jsonTextWriter.WriteStringValue(this.ClientCreatedDateTimeUtc.ToString("o", CultureInfo.InvariantCulture));
             jsonTextWriter.WriteFieldName("MachineId");
-            jsonTextWriter.WriteStringValue(VmMetadataApiHandler.GetMachineId());
+            jsonTextWriter.WriteStringValue(this.cachedMachineId);
             jsonTextWriter.WriteFieldName("NumberOfClientsCreated");
             jsonTextWriter.WriteNumber64Value(this.cachedNumberOfClientCreated);
             jsonTextWriter.WriteFieldName("NumberOfActiveClients");

--- a/Microsoft.Azure.Cosmos/src/Tracing/TraceData/ClientConfigurationTraceDatum.cs
+++ b/Microsoft.Azure.Cosmos/src/Tracing/TraceData/ClientConfigurationTraceDatum.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Azure.Cosmos.Tracing.TraceData
             this.cachedSerializedJson = this.GetSerializedDatum();
             this.ProcessorCount = Environment.ProcessorCount;
             this.ConnectionMode = cosmosClientContext.ClientOptions.ConnectionMode;
+            this.cachedVMRegion = VmMetadataApiHandler.GetMachineRegion();
         }
 
         public DateTime ClientCreatedDateTimeUtc { get; }
@@ -58,13 +59,15 @@ namespace Microsoft.Azure.Cosmos.Tracing.TraceData
                 if (this.cachedUserAgentString != this.UserAgentContainer.UserAgent ||
                     this.cachedNumberOfClientCreated != CosmosClient.numberOfClientsCreated ||
                     this.cachedNumberOfActiveClient != CosmosClient.NumberOfActiveClients ||
-                    !ReferenceEquals(this.cachedMachineId, VmMetadataApiHandler.GetMachineId()))
+                    !ReferenceEquals(this.cachedMachineId, VmMetadataApiHandler.GetMachineId()) ||
+                    !ReferenceEquals(this.cachedVMRegion, VmMetadataApiHandler.GetMachineRegion()))
                 {
                     this.cachedNumberOfActiveClient = CosmosClient.NumberOfActiveClients;
                     this.cachedNumberOfClientCreated = CosmosClient.numberOfClientsCreated;
                     this.cachedUserAgentString = this.UserAgentContainer.UserAgent;
                     this.cachedMachineId = VmMetadataApiHandler.GetMachineId();
                     this.cachedSerializedJson = this.GetSerializedDatum();
+                    this.cachedVMRegion = VmMetadataApiHandler.GetMachineRegion();
                 }
 
                 return this.cachedSerializedJson;
@@ -80,6 +83,7 @@ namespace Microsoft.Azure.Cosmos.Tracing.TraceData
         private string cachedUserAgentString;
 
         private string cachedMachineId;
+        private string cachedVMRegion;
 
         internal override void Accept(ITraceDatumVisitor traceDatumVisitor)
         {
@@ -95,6 +99,11 @@ namespace Microsoft.Azure.Cosmos.Tracing.TraceData
             jsonTextWriter.WriteStringValue(this.ClientCreatedDateTimeUtc.ToString("o", CultureInfo.InvariantCulture));
             jsonTextWriter.WriteFieldName("MachineId");
             jsonTextWriter.WriteStringValue(this.cachedMachineId);
+            if (this.cachedVMRegion != null)
+            {
+                jsonTextWriter.WriteFieldName("VM Region");
+                jsonTextWriter.WriteStringValue(this.cachedVMRegion);
+            }
             jsonTextWriter.WriteFieldName("NumberOfClientsCreated");
             jsonTextWriter.WriteNumber64Value(this.cachedNumberOfClientCreated);
             jsonTextWriter.WriteFieldName("NumberOfActiveClients");

--- a/Microsoft.Azure.Cosmos/src/Tracing/TraceData/ClientConfigurationTraceDatum.cs
+++ b/Microsoft.Azure.Cosmos/src/Tracing/TraceData/ClientConfigurationTraceDatum.cs
@@ -66,8 +66,8 @@ namespace Microsoft.Azure.Cosmos.Tracing.TraceData
                     this.cachedNumberOfClientCreated = CosmosClient.numberOfClientsCreated;
                     this.cachedUserAgentString = this.UserAgentContainer.UserAgent;
                     this.cachedMachineId = VmMetadataApiHandler.GetMachineId();
-                    this.cachedSerializedJson = this.GetSerializedDatum();
                     this.cachedVMRegion = VmMetadataApiHandler.GetMachineRegion();
+                    this.cachedSerializedJson = this.GetSerializedDatum();
                 }
 
                 return this.cachedSerializedJson;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
@@ -944,8 +944,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 }
             }
 
-            Assert.AreEqual(1, machineId.Count, $"Multiple Machine Id has been generated i.e {JsonConvert.SerializeObject(machineId)}");
-
             if(isAzureInstance.HasValue)
             {
                 if (isAzureInstance.Value)
@@ -955,6 +953,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 else
                 {
                     Assert.AreNotEqual("vmId:d0cb93eb-214b-4c2b-bd3d-cc93e90d9efd", machineId.First(), $"Generated Machine id is : {machineId.First()}");
+                    Assert.AreEqual(1, machineId.Count, $"Multiple Machine Id has been generated i.e {JsonConvert.SerializeObject(machineId)}");
                 }
             }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/VmMetadataApiHandlerTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/VmMetadataApiHandlerTest.cs
@@ -57,6 +57,7 @@ namespace Microsoft.Azure.Cosmos
 
             await Task.Delay(2000);
             Assert.AreEqual("vmId:d0cb93eb-214b-4c2b-bd3d-cc93e90d9efd", VmMetadataApiHandler.GetMachineId());
+            Assert.AreEqual(VmMetadataApiHandler.GetMachineRegion(), "eastus");
         }
 
         [TestMethod]
@@ -81,6 +82,7 @@ namespace Microsoft.Azure.Cosmos
             await Task.Delay(2000);
             Assert.IsNull(VmMetadataApiHandler.GetMachineInfo());
             Assert.IsNotNull(VmMetadataApiHandler.GetMachineId());
+            Assert.IsNull(VmMetadataApiHandler.GetMachineRegion());
         }
 
         [TestMethod]


### PR DESCRIPTION
# Pull Request Template

## Description
If the Client is using an Azure VM, we are able to retrieve the VM's region and add it into the client configuration diagnostics. This is useful to determine if cross region operations are being performed.

## Type of change
- [] New feature (non-breaking change which adds functionality)

## Closing issues
closes #3247 