### PR TITLE
Change Feed Processor: Adds Linked CancellationTokenSource to prevent stalling

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedProcessing/FeedProcessorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedProcessing/FeedProcessorCore.cs
@@ -47,6 +47,8 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedProcessing
                 {
                     do
                     {
+                        CancellationTokenSource cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+                        cancellationTokenSource.CancelAfter(3000);
                         ResponseMessage response = await this.resultSetIterator.ReadNextAsync(cancellationToken).ConfigureAwait(false);
                         if (response.StatusCode != HttpStatusCode.NotModified && !response.IsSuccessStatusCode)
                         {

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedProcessing/FeedProcessorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedProcessing/FeedProcessorCore.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedProcessing
                     do
                     {
                         CancellationTokenSource cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-                        cancellationTokenSource.CancelAfter(3000);
+                        cancellationTokenSource.CancelAfter(30000);
                         ResponseMessage response = await this.resultSetIterator.ReadNextAsync(cancellationToken).ConfigureAwait(false);
                         if (response.StatusCode != HttpStatusCode.NotModified && !response.IsSuccessStatusCode)
                         {

--- a/Microsoft.Azure.Cosmos/src/Resource/FeedIterators/FeedIteratorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/FeedIterators/FeedIteratorCore.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Azure.Cosmos
         /// <returns>A query response from cosmos service</returns>
         public override Task<ResponseMessage> ReadNextAsync(CancellationToken cancellationToken = default)
         {
-            return this.ReadNextAsync(NoOpTrace.Singleton);
+            return this.ReadNextAsync(NoOpTrace.Singleton, cancellationToken);
         }
 
         public override async Task<ResponseMessage> ReadNextAsync(


### PR DESCRIPTION
# Pull Request Template

## Description
In some situations, the lease processor gets stuck, but the lease renewer keeps working. To prevent this situation from stalling indefinitely, this PR adds a linked cancellation token source to the cancellation token in order to cancel it after some time.

## Type of change
- [] New feature (non-breaking change which adds functionality)

## Closing issues

closes #2466 