### PR TITLE
Change Feed Processor: Adds Task.Delay check to prevent stalling

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedProcessing/FeedProcessorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedProcessing/FeedProcessorCore.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedProcessing
                             throw CosmosExceptionFactory.CreateRequestTimeoutException("Change Feed request timed out", new Headers());
                         }
 
-                        ResponseMessage response = task.Result;
+                        ResponseMessage response = await task;
 
                         if (response.StatusCode != HttpStatusCode.NotModified && !response.IsSuccessStatusCode)
                         {

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedProcessing/FeedProcessorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedProcessing/FeedProcessorCore.cs
@@ -15,7 +15,6 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedProcessing
     using Microsoft.Azure.Cosmos.ChangeFeed.FeedManagement;
     using Microsoft.Azure.Cosmos.Core.Trace;
     using Microsoft.Azure.Cosmos.Resource.CosmosExceptions;
-    using Microsoft.Azure.Documents;
 
     internal sealed class FeedProcessorCore : FeedProcessor
     {

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedProcessing/FeedProcessorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedProcessing/FeedProcessorCore.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedProcessing
                     {
                         Task<ResponseMessage> task = this.resultSetIterator.ReadNextAsync(cancellationToken);
 
-                        if (await Task.WhenAny(task, Task.Delay(30000)) != task)
+                        if (!ReferenceEquals(await Task.WhenAny(task, Task.Delay(this.options.RequestTimeout)), task))
                         {
                             throw CosmosExceptionFactory.CreateRequestTimeoutException("ChangeFeed timed out after 30s.", new Headers());
                         }

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedProcessing/FeedProcessorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedProcessing/FeedProcessorCore.cs
@@ -48,12 +48,12 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedProcessing
                     do
                     {
                         Task<ResponseMessage> task = this.resultSetIterator.ReadNextAsync(cancellationToken);
-                        Task catchExceptionFromTask = task.ContinueWith(task => DefaultTrace.TraceInformation(
+                        
+                        if (!ReferenceEquals(await Task.WhenAny(task, Task.Delay(this.options.RequestTimeout)), task))
+                        {
+                            Task catchExceptionFromTask = task.ContinueWith(task => DefaultTrace.TraceInformation(
                             "Timed out Change Feed request failed with exception: {2}", task.Exception.InnerException),
                             TaskContinuationOptions.OnlyOnFaulted);
-
-                        if (!ReferenceEquals(await Task.WhenAny(catchExceptionFromTask, Task.Delay(this.options.RequestTimeout)), task))
-                        {
                             throw CosmosExceptionFactory.CreateRequestTimeoutException("Change Feed request timed out", new Headers());
                         }
 

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedProcessing/ProcessorOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedProcessing/ProcessorOptions.cs
@@ -5,6 +5,7 @@
 namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedProcessing
 {
     using System;
+    using Microsoft.Azure.Documents;
 
     internal class ProcessorOptions
     {
@@ -19,5 +20,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedProcessing
         public bool StartFromBeginning { get; set; }
 
         public DateTime? StartTime { get; set; }
+
+        public TimeSpan RequestTimeout { get; set; } = CosmosHttpClient.GatewayRequestTimeout;
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/FeedProcessorCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/FeedProcessorCoreTests.cs
@@ -71,8 +71,11 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
             Mock<PartitionCheckpointer> mockCheckpointer = new Mock<PartitionCheckpointer>();
             Mock<FeedIterator> mockIterator = new Mock<FeedIterator>();
             mockIterator.Setup(i => i.ReadNextAsync(It.IsAny<CancellationToken>()))
-                .Callback(async (CancellationToken token) => await Task.Delay(2000))
-                .ReturnsAsync(GetResponse(HttpStatusCode.OK, true));
+                .Returns(async () =>
+                {
+                    await Task.Delay(2000);
+                    return GetResponse(HttpStatusCode.OK, true);
+                });
             mockIterator.SetupSequence(i => i.HasMoreResults).Returns(true).Returns(false);
 
             CustomSerializer serializer = new CustomSerializer();

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/FeedProcessorCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/FeedProcessorCoreTests.cs
@@ -78,8 +78,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
             ChangeFeedObserverFactoryCore<MyDocument> factory = new ChangeFeedObserverFactoryCore<MyDocument>(handler, new CosmosSerializerCore(serializer));
             ProcessorOptions options = new ProcessorOptions()
             {
-                FeedPollDelay = TimeSpan.FromMilliseconds(100),
-                RequestTimeout = TimeSpan.FromSeconds(0)
+                RequestTimeout = TimeSpan.FromSeconds(1)
             };
             FeedProcessorCore processor = new FeedProcessorCore(factory.CreateObserver(), mockIterator.Object, options, mockCheckpointer.Object);
             

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/FeedProcessorCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/FeedProcessorCoreTests.cs
@@ -61,7 +61,6 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         [TestMethod]
         public async Task ReadAsyncExpectedTimeoutTest()
         {
-
             ChangesHandler<MyDocument> handler = (changes, cancelationToken) =>
             {
                 IReadOnlyList<MyDocument> list = changes as IReadOnlyList<MyDocument>;
@@ -71,14 +70,16 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
             };
             Mock<PartitionCheckpointer> mockCheckpointer = new Mock<PartitionCheckpointer>();
             Mock<FeedIterator> mockIterator = new Mock<FeedIterator>();
-            mockIterator.Setup(i => i.ReadNextAsync(It.IsAny<CancellationToken>())).ReturnsAsync(GetResponse(HttpStatusCode.OK, true));
+            mockIterator.Setup(i => i.ReadNextAsync(It.IsAny<CancellationToken>()))
+                .Callback(async (CancellationToken token) => await Task.Delay(2000))
+                .ReturnsAsync(GetResponse(HttpStatusCode.OK, true));
             mockIterator.SetupSequence(i => i.HasMoreResults).Returns(true).Returns(false);
 
             CustomSerializer serializer = new CustomSerializer();
             ChangeFeedObserverFactoryCore<MyDocument> factory = new ChangeFeedObserverFactoryCore<MyDocument>(handler, new CosmosSerializerCore(serializer));
             ProcessorOptions options = new ProcessorOptions()
             {
-                RequestTimeout = TimeSpan.FromSeconds(1)
+                RequestTimeout = TimeSpan.FromMilliseconds(100)
             };
             FeedProcessorCore processor = new FeedProcessorCore(factory.CreateObserver(), mockIterator.Object, options, mockCheckpointer.Object);
             

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/FeedProcessorCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/FeedProcessorCoreTests.cs
@@ -59,6 +59,35 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         }
 
         [TestMethod]
+        public async Task ReadAsyncExpectedTimeoutTest()
+        {
+
+            ChangesHandler<MyDocument> handler = (changes, cancelationToken) =>
+            {
+                IReadOnlyList<MyDocument> list = changes as IReadOnlyList<MyDocument>;
+                Assert.IsNotNull(list);
+                Assert.AreEqual("test", list[0].id);
+                return Task.CompletedTask;
+            };
+            Mock<PartitionCheckpointer> mockCheckpointer = new Mock<PartitionCheckpointer>();
+            Mock<FeedIterator> mockIterator = new Mock<FeedIterator>();
+            mockIterator.Setup(i => i.ReadNextAsync(It.IsAny<CancellationToken>())).ReturnsAsync(GetResponse(HttpStatusCode.OK, true));
+            mockIterator.SetupSequence(i => i.HasMoreResults).Returns(true).Returns(false);
+
+            CustomSerializer serializer = new CustomSerializer();
+            ChangeFeedObserverFactoryCore<MyDocument> factory = new ChangeFeedObserverFactoryCore<MyDocument>(handler, new CosmosSerializerCore(serializer));
+            ProcessorOptions options = new ProcessorOptions()
+            {
+                FeedPollDelay = TimeSpan.FromMilliseconds(100),
+                RequestTimeout = TimeSpan.FromSeconds(0)
+            };
+            FeedProcessorCore processor = new FeedProcessorCore(factory.CreateObserver(), mockIterator.Object, options, mockCheckpointer.Object);
+            
+            CosmosException timeoutException = await Assert.ThrowsExceptionAsync<CosmosException>(() => processor.RunAsync(default));
+            Assert.AreEqual(timeoutException.StatusCode, HttpStatusCode.RequestTimeout);
+        }
+
+        [TestMethod]
         public async Task ThrowsOnFailedCustomSerializer()
         {
             CancellationTokenSource cancellationTokenSource = new CancellationTokenSource(1000);


### PR DESCRIPTION
# Pull Request Template

## Description

In some situations, the lease processor gets stuck, but the lease renewer keeps working. To prevent this situation from stalling indefinitely, this PR adds a linked cancellation token source to the cancellation token in order to cancel it after some time.

## Type of change
- [] New feature (non-breaking change which adds functionality)

## Closing issues
closes #2466