### PR TITLE
order by query result to support __sys_rid

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/OrderByQueryResult.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/OrderByQueryResult.cs
@@ -50,14 +50,18 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
         {
             get
             {
+                // cassandra row uses __sys_rid as opposed to _rid
                 if (!this.cosmosObject.TryGetValue("_rid", out CosmosElement cosmosElement))
                 {
-                    throw new InvalidOperationException($"Underlying object does not have an '_rid' field.");
+                    if (!this.cosmosObject.TryGetValue("__sys_rid", out cosmosElement))
+                    {
+                        throw new InvalidOperationException($"Underlying object does not have an '_rid' or '__sys_id' field.");
+                    }
                 }
 
                 if (!(cosmosElement is CosmosString cosmosString))
                 {
-                    throw new InvalidOperationException($"'_rid' field was not a string.");
+                    throw new InvalidOperationException($"'_rid' or '__sys_id' field was not a string.");
                 }
 
                 return cosmosString.Value;


### PR DESCRIPTION
# Pull Request Template

## Description

cassandra rows may use __sys prefix for system properties in backend, so the order by query result needs to honor __sys_rid in addition to _rid.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber