### PR TITLE
DocumentClient: Fixes ObjectDisposedException during Background Refresh by adding Cancellation Token

### DIFF
--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -163,7 +163,7 @@ namespace Microsoft.Azure.Cosmos
         //SessionContainer.
         internal ISessionContainer sessionContainer;
 
-        private CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+        private readonly CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
 
         private AsyncLazy<QueryPartitionProvider> queryPartitionProvider;
 
@@ -1205,7 +1205,7 @@ namespace Microsoft.Azure.Cosmos
                 return;
             }
 
-            if (this.cancellationTokenSource != null && !this.cancellationTokenSource.IsCancellationRequested)
+            if (!this.cancellationTokenSource.IsCancellationRequested)
             {
                 this.cancellationTokenSource.Cancel();
             }

--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -1208,6 +1208,7 @@ namespace Microsoft.Azure.Cosmos
             if (!this.cancellationTokenSource.IsCancellationRequested)
             {
                 this.cancellationTokenSource.Cancel();
+                this.cancellationTokenSource.Dispose();
             }
 
             if (this.StoreModel != null)

--- a/Microsoft.Azure.Cosmos/src/GatewayAccountReader.cs
+++ b/Microsoft.Azure.Cosmos/src/GatewayAccountReader.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.Cosmos
         private readonly AuthorizationTokenProvider cosmosAuthorization;
         private readonly CosmosHttpClient httpClient;
         private readonly Uri serviceEndpoint;
-        private CancellationToken cancellationToken;
+        private readonly CancellationToken cancellationToken;
 
         // Backlog: Auth abstractions are spilling through. 4 arguments for this CTOR are result of it.
         public GatewayAccountReader(Uri serviceEndpoint,

--- a/Microsoft.Azure.Cosmos/src/GatewayAccountReader.cs
+++ b/Microsoft.Azure.Cosmos/src/GatewayAccountReader.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.Cosmos
                 {
                     trace.AddDatum("Client Side Request Stats", stats);
                     throw CosmosExceptionFactory.CreateRequestTimeoutException(
-                                                message: ex.Message,
+                                                message: ex.Data?["Message"]?.ToString() ?? ex.Message,
                                                 headers: new Headers()
                                                 {
                                                     ActivityId = System.Diagnostics.Trace.CorrelationManager.ActivityId.ToString()

--- a/Microsoft.Azure.Cosmos/src/GatewayAccountReader.cs
+++ b/Microsoft.Azure.Cosmos/src/GatewayAccountReader.cs
@@ -65,6 +65,8 @@ namespace Microsoft.Azure.Cosmos
                 }
             }
             catch (OperationCanceledException ex)
+            // this is the DocumentClient token, which only gets cancelled upon disposal
+            when (!this.cancellationToken.IsCancellationRequested) 
             {
                 // Catch Operation Cancelled Exception and convert to Timeout 408 if the user did not cancel it.
                 using (ITrace trace = Trace.GetRootTrace("Account Read Exception", TraceComponent.Transport, TraceLevel.Info))

--- a/Microsoft.Azure.Cosmos/src/GatewayAccountReader.cs
+++ b/Microsoft.Azure.Cosmos/src/GatewayAccountReader.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.Cosmos
                 {
                     trace.AddDatum("Client Side Request Stats", stats);
                     throw CosmosExceptionFactory.CreateRequestTimeoutException(
-                                                message: ex.Data?["Message"].ToString(),
+                                                message: ex.Message,
                                                 headers: new Headers()
                                                 {
                                                     ActivityId = System.Diagnostics.Trace.CorrelationManager.ActivityId.ToString()

--- a/Microsoft.Azure.Cosmos/src/Routing/AsyncCacheNonBlocking.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/AsyncCacheNonBlocking.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.Cosmos
     /// </summary>
     internal sealed class AsyncCacheNonBlocking<TKey, TValue> : IDisposable
     {
-        private readonly CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+        private readonly CancellationTokenSource cancellationTokenSource;
         private readonly ConcurrentDictionary<TKey, AsyncLazyWithRefreshTask<TValue>> values;
         private readonly Func<Exception, bool> removeFromCacheOnBackgroundRefreshException;
 
@@ -30,11 +30,15 @@ namespace Microsoft.Azure.Cosmos
 
         public AsyncCacheNonBlocking(
             Func<Exception, bool> removeFromCacheOnBackgroundRefreshException = null,
-            IEqualityComparer<TKey> keyEqualityComparer = null)
+            IEqualityComparer<TKey> keyEqualityComparer = null,
+            CancellationToken cancellationToken = default)
         {
             this.keyEqualityComparer = keyEqualityComparer ?? EqualityComparer<TKey>.Default;
             this.values = new ConcurrentDictionary<TKey, AsyncLazyWithRefreshTask<TValue>>(this.keyEqualityComparer);
             this.removeFromCacheOnBackgroundRefreshException = removeFromCacheOnBackgroundRefreshException ?? AsyncCacheNonBlocking<TKey, TValue>.RemoveNotFoundFromCacheOnException;
+            this.cancellationTokenSource = cancellationToken == default
+                ? new CancellationTokenSource()
+                : CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
         }
 
         public AsyncCacheNonBlocking()

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientTests.cs
@@ -255,14 +255,14 @@ namespace Microsoft.Azure.Cosmos.Tests
                 using CosmosClient cosmos = new(ConnectionString);
             }
 
-            string assertMsg = "";
+            string assertMsg = string.Empty;
 
             foreach (string s in errors)
             {
-                assertMsg += s + "\n";
+                assertMsg += s + Environment.NewLine;
             }
 
-            Assert.AreEqual(0, errors.Count, $"\nErrors found in trace:\n{assertMsg}");
+            Assert.AreEqual(0, errors.Count, $"{Environment.NewLine}Errors found in trace:{Environment.NewLine}{assertMsg}");
         }
 
         private class TestTraceListener : TraceListener

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientTests.cs
@@ -245,7 +245,6 @@ namespace Microsoft.Azure.Cosmos.Tests
                 {
                     errors.Add(message);
                 }
-               
             }
 
             DefaultTrace.TraceSource.Listeners.Add(new TestTraceListener { Callback = TraceHandler });
@@ -258,7 +257,7 @@ namespace Microsoft.Azure.Cosmos.Tests
 
             string assertMsg = "";
 
-            foreach(string s in errors)
+            foreach (string s in errors)
             {
                 assertMsg += s + "\n";
             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientTests.cs
@@ -252,10 +252,13 @@ namespace Microsoft.Azure.Cosmos.Tests
 
             for (int z = 0; z < 100; ++z)
             {
-                using CosmosClient cosmos = new(ConnectionString);
+                using CosmosClient cosmos = new(ConnectionString, new CosmosClientOptions
+                {
+                    EnableClientTelemetry = true
+                });
             }
 
-            string assertMsg = string.Empty;
+            string assertMsg = String.Empty;
 
             foreach (string s in errors)
             {


### PR DESCRIPTION
# Pull Request Template

## Description

Adds a cancellation token into DocumentClient that cancels upon disposal. This removes the ObjectDisposedException that gets traced if a CosmosClient is quickly disposed after initialization.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)

## Closing issues
closes #3259 and closes #2619