### PR TITLE
Documentation: Fix Container.PatchItemAsync<T> Example

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
@@ -734,14 +734,14 @@ namespace Microsoft.Azure.Cosmos
         /// }*/
         /// 
         /// List<PatchOperation> patchOperations = new List<PatchOperation>()
-        ///                                             {
-        ///                                                 PatchOperation.CreateAddOperation("/daysOfWeek", new string[]{"Monday", "Thursday"}),
-        ///                                                 PatchOperation.CreateReplaceOperation("/frequency", 2),
-        ///                                                 PatchOperation.CreateRemoveOperation("/description")
-        ///                                             };
+        /// {
+        ///     PatchOperation.Add("/daysOfWeek", new string[]{"Monday", "Thursday"}),
+        ///     PatchOperation.Replace("/frequency", 2),
+        ///     PatchOperation.Remove("/description")
+        /// };
         /// 
-        /// ItemResponse item = await this.container.PatchItemAsync<dynamic>(toDoActivity.id, new PartitionKey(toDoActivity.status), patchOperations);
-        /// /* item = {
+        /// ItemResponse<dynamic> item = await this.container.PatchItemAsync<dynamic>(toDoActivity.id, new PartitionKey(toDoActivity.status), patchOperations);
+        /// /* item.Resource = {
         ///     "id" : "someId",
         ///     "status" : "someStatusPK",
         ///     "description" : null,


### PR DESCRIPTION
## Description

The example for the [`Container.PatchItemAsync<T>` Method](https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.cosmos.container.patchitemasync?view=azure-dotnet) had a few errors and this PR addresses them.

Resolves Azure/azure-sdk-for-net#29253

## Type of change

- [x] This change requires a documentation update

## Closing issues

Resolves Azure/azure-sdk-for-net#29253