### PR TITLE
ObjectDisposedException: Fixes Exception logic by catching the error upon client disposal before it gets traced

### DIFF
--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -1208,8 +1208,9 @@ namespace Microsoft.Azure.Cosmos
             if (!this.cancellationTokenSource.IsCancellationRequested)
             {
                 this.cancellationTokenSource.Cancel();
-                this.cancellationTokenSource.Dispose();
             }
+
+            this.cancellationTokenSource.Dispose();
 
             if (this.StoreModel != null)
             {

--- a/Microsoft.Azure.Cosmos/src/GatewayAccountReader.cs
+++ b/Microsoft.Azure.Cosmos/src/GatewayAccountReader.cs
@@ -64,6 +64,10 @@ namespace Microsoft.Azure.Cosmos
                     }
                 }
             }
+            catch (ObjectDisposedException) when (this.cancellationToken.IsCancellationRequested)
+            {
+                throw new OperationCanceledException("Client is being disposed, cancelling further operations.");
+            }
             catch (OperationCanceledException ex)
             // this is the DocumentClient token, which only gets cancelled upon disposal
             when (!this.cancellationToken.IsCancellationRequested) 

--- a/Microsoft.Azure.Cosmos/src/GatewayAccountReader.cs
+++ b/Microsoft.Azure.Cosmos/src/GatewayAccountReader.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.Cosmos
             }
             catch (ObjectDisposedException) when (this.cancellationToken.IsCancellationRequested)
             {
-                throw new OperationCanceledException("Client is being disposed, cancelling further operations.");
+                throw new OperationCanceledException($"Client is being disposed for {serviceEndpoint} at {DateTime.UtcNow}, cancelling further operations.");
             }
             catch (OperationCanceledException ex)
             // this is the DocumentClient token, which only gets cancelled upon disposal


### PR DESCRIPTION
# Pull Request Template

## Description
The CosmosClientEarlyDisposeTest is experiencing transient failures, due to potential cases where Http client is being used after disposal. In order to mitigate, we catch the error before it gets logged in the GW AccountReader, which is a part of all stack traces when this test failure occurs.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
