### PR TITLE
OperationCanceledException: Adds Exception Trace as Child 

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/CosmosOperationCanceledException.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/CosmosOperationCanceledException.cs
@@ -50,7 +50,8 @@ namespace Microsoft.Azure.Cosmos
                 throw new ArgumentNullException(nameof(trace));
             }
 
-            trace.AddDatum("Operation Cancelled Exception", originalException);
+            ITrace child = trace.StartChild("CosmosOperationCanceledException");
+            child.AddDatum("Operation Cancelled Exception", originalException);
             this.Diagnostics = new CosmosTraceDiagnostics(trace);
             this.tokenCancellationRequested = originalException.CancellationToken.IsCancellationRequested;
             this.toStringMessage = this.CreateToStringMessage();

--- a/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/CosmosOperationCanceledException.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/CosmosOperationCanceledException.cs
@@ -50,8 +50,10 @@ namespace Microsoft.Azure.Cosmos
                 throw new ArgumentNullException(nameof(trace));
             }
 
-            ITrace child = trace.StartChild("CosmosOperationCanceledException");
-            child.AddDatum("Operation Cancelled Exception", originalException);
+            using (ITrace child = trace.StartChild("CosmosOperationCanceledException"))
+            {
+                child.AddDatum("Operation Cancelled Exception", originalException);
+            }
             this.Diagnostics = new CosmosTraceDiagnostics(trace);
             this.tokenCancellationRequested = originalException.CancellationToken.IsCancellationRequested;
             this.toStringMessage = this.CreateToStringMessage();


### PR DESCRIPTION
# Pull Request Template

## Description
In cases where the Diagnostics get truncated, the CosmosOperationCanceledException trace's stack trace can take up most of the space. This can prevent necessary information, such as the network requests, from showing in the diagnostics. This fixes that by adding this exception trace as a child rather than inside the primary data.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Closing issues
closes #3314 

Sample Diagnostics Json after changes:
```{
    "Summary": {},
    "name": "CreateItemAsync",
    "id": "6a73ea1e-78d4-4dc8-827c-b0219b8e86d7",
    "start time": "03:21:02:853",
    "duration in milliseconds": 18.6144,
    "data": {
        "Client Configuration": {
            "Client Created Time Utc": "2022-06-30T03:21:02.5549268Z",
            "MachineId": "hashedMachineName:36958ae9-96cf-5367-78eb-c36b4d8d0517",
            "NumberOfClientsCreated": 2,
            "NumberOfActiveClients": 1,
            "ConnectionMode": "Gateway",
            "User Agent": "cosmos-netstandard-sdk/3.28.0|2|X64|Microsoft Windows 10.0.22000|.NET 6.0.6|N|",
            "ConnectionConfig": {
                "gw": "(cps:50, urto:10, p:False, httpf: False)",
                "rntbd": "(cto: 5, icto: -1, mrpc: 30, mcpe: 65535, erd: True, pr: ReuseUnicastPort)",
                "other": "(ed:False, be:False)"
            },
            "ConsistencyConfig": "(consistency: NotSet, prgns:[], apprgn: )",
            "ProcessorCount": 0
        }
    },
    "children": [
        {
            "name": "ItemSerialize",
            "id": "45eb2bd8-14b3-465a-a7e3-c0d17efecae6",
            "start time": "03:21:02:853",
            "duration in milliseconds": 0.2823
        },
        {
            "name": "Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler",
            "id": "42aca8d9-97db-47df-a1ca-b825425f50a8",
            "start time": "03:21:02:869",
            "duration in milliseconds": 0.5707,
            "children": [
                {
                    "name": "Get Collection Cache",
                    "id": "69058d18-216d-4c96-bcab-bd8c1ef936bb",
                    "start time": "03:21:02:869",
                    "duration in milliseconds": 0.0017
                }
            ]
        },
        {
            "name": "CosmosOperationCanceledException",
            "id": "c69f5c43-0d2b-4a14-8227-7bb4771fea57",
            "start time": "03:21:02:872",
            "duration in milliseconds": 6.257,
            "data": {
                "Operation Cancelled Exception": "System.OperationCanceledException: The operation was canceled.\r\n   at System.Threading.CancellationToken.ThrowOperationCanceledException()\r\n   at System.Threading.CancellationToken.ThrowIfCancellationRequested()\r\n   at Microsoft.Azure.Cosmos.Common.CollectionCache.ResolveByNameAsync(String apiVersion, String resourceAddress, Boolean forceRefesh, ITrace trace, IClientSideRequestStatistics clientSideRequestStatistics, CancellationToken cancellationToken) in E:\\azure-cosmos-dotnet-v3\\Microsoft.Azure.Cosmos\\src\\Routing\\CollectionCache.cs:line 274\r\n   at Microsoft.Azure.Cosmos.Common.CollectionCache.ResolveCollectionAsync(DocumentServiceRequest request, CancellationToken cancellationToken, ITrace trace) in E:\\azure-cosmos-dotnet-v3\\Microsoft.Azure.Cosmos\\src\\Routing\\CollectionCache.cs:line 147\r\n   at Microsoft.Azure.Cosmos.Routing.ClientCollectionCache.ResolveCollectionWithSessionContainerCleanupAsync(DocumentServiceRequest request, Func`1 resolveContainerProvider) in E:\\azure-cosmos-dotnet-v3\\Microsoft.Azure.Cosmos\\src\\Routing\\ClientCollectionCache.cs:line 150\r\n   at Microsoft.Azure.Cosmos.RequestMessage.AssertPartitioningDetailsAsync(CosmosClient client, CancellationToken cancellationToken, ITrace trace) in E:\\azure-cosmos-dotnet-v3\\Microsoft.Azure.Cosmos\\src\\Handler\\RequestMessage.cs:line 226\r\n   at Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler.SendAsync(RequestMessage request, CancellationToken cancellationToken) in E:\\azure-cosmos-dotnet-v3\\Microsoft.Azure.Cosmos\\src\\Handler\\RequestInvokerHandler.cs:line 75\r\n   at Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler.SendAsync(String resourceUriString, ResourceType resourceType, OperationType operationType, RequestOptions requestOptions, ContainerInternal cosmosContainerCore, FeedRange feedRange, Stream streamPayload, Action`1 requestEnricher, ITrace trace, CancellationToken cancellationToken) in E:\\azure-cosmos-dotnet-v3\\Microsoft.Azure.Cosmos\\src\\Handler\\RequestInvokerHandler.cs:line 290\r\n   at Microsoft.Azure.Cosmos.ContainerCore.ProcessItemStreamAsync(Nullable`1 partitionKey, String itemId, Stream streamPayload, OperationType operationType, ItemRequestOptions requestOptions, ITrace trace, CancellationToken cancellationToken) in E:\\azure-cosmos-dotnet-v3\\Microsoft.Azure.Cosmos\\src\\Resource\\Container\\ContainerCore.Items.cs:line 1026\r\n   at Microsoft.Azure.Cosmos.ContainerCore.ExtractPartitionKeyAndProcessItemStreamAsync[T](Nullable`1 partitionKey, String itemId, T item, OperationType operationType, ItemRequestOptions requestOptions, ITrace trace, CancellationToken cancellationToken) in E:\\azure-cosmos-dotnet-v3\\Microsoft.Azure.Cosmos\\src\\Resource\\Container\\ContainerCore.Items.cs:line 960\r\n   at Microsoft.Azure.Cosmos.ContainerCore.CreateItemAsync[T](T item, ITrace trace, Nullable`1 partitionKey, ItemRequestOptions requestOptions, CancellationToken cancellationToken) in E:\\azure-cosmos-dotnet-v3\\Microsoft.Azure.Cosmos\\src\\Resource\\Container\\ContainerCore.Items.cs:line 82\r\n   at Microsoft.Azure.Cosmos.ClientContextCore.RunWithDiagnosticsHelperAsync[TResult](ITrace trace, Func`2 task, Func`2 openTelemetry, String operationName) in E:\\azure-cosmos-dotnet-v3\\Microsoft.Azure.Cosmos\\src\\Resource\\ClientContextCore.cs:line 481"
            }
        }
    ]
}


