### PR TITLE
Query: Adds new dependency files from ServiceInterop.dll

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
+++ b/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
@@ -130,6 +130,9 @@
 	<ItemGroup Condition=" '$(ProjectRef)' != 'True' ">
 		<None Include="$(OutputPath)\Cosmos.CRTCompat.dll" Pack="true" IsAssembly="true" PackagePath="runtimes\win-x64\native" />
 		<None Include="$(OutputPath)\Microsoft.Azure.Cosmos.ServiceInterop.dll" Pack="true" IsAssembly="true" PackagePath="runtimes\win-x64\native" />
+        <None Include="$(OutputPath)\vcruntime140_1.dll" Pack="true" IsAssembly="true" PackagePath="runtimes\win-x64\native" />
+        <None Include="$(OutputPath)\vcruntime140.dll" Pack="true" IsAssembly="true" PackagePath="runtimes\win-x64\native" />
+        <None Include="$(OutputPath)\msvcp140.dll" Pack="true" IsAssembly="true" PackagePath="runtimes\win-x64\native" />
 		<None Include="$(NugetPackageRoot)\Microsoft.HybridRow\$(HybridRowVersion)\lib\netstandard2.0\Microsoft.Azure.Cosmos.Core.dll" Pack="true" IsAssembly="true" PackagePath="lib\netstandard2.0" />
 		<None Include="$(NugetPackageRoot)\Microsoft.HybridRow\$(HybridRowVersion)\lib\netstandard2.0\Microsoft.Azure.Cosmos.Serialization.HybridRow.dll" Pack="true" IsAssembly="true" PackagePath="lib\netstandard2.0" />
 		<None Include="$(NugetPackageRoot)\Microsoft.Azure.Cosmos.Direct\$(DirectVersion)\lib\netstandard2.0\Microsoft.Azure.Cosmos.Direct.dll" Pack="true" IsAssembly="true" PackagePath="lib\netstandard2.0" />

--- a/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.targets
+++ b/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.targets
@@ -30,4 +30,28 @@ Copyright (C) Microsoft Corporation. All rights reserved.
     </ContentWithTargetPath>
   </ItemGroup>
 
+  <ItemGroup>
+      <ContentWithTargetPath Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-x64\native\msvcp140.dll">
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          <TargetPath>msvcp140.dll</TargetPath>
+          <Visible>False</Visible>
+      </ContentWithTargetPath>
+  </ItemGroup>
+
+  <ItemGroup>
+      <ContentWithTargetPath Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-x64\native\vcruntime140.dll">
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          <TargetPath>vcruntime140.dll</TargetPath>
+          <Visible>False</Visible>
+      </ContentWithTargetPath>
+  </ItemGroup>
+
+  <ItemGroup>
+      <ContentWithTargetPath Include="$(MSBuildThisFileDirectory)..\..\runtimes\win-x64\native\vcruntime140_1.dll">
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+          <TargetPath>vcruntime140_1.dll</TargetPath>
+          <Visible>False</Visible>
+      </ContentWithTargetPath>
+  </ItemGroup>
+    
 </Project>


### PR DESCRIPTION
https://github.com/Azure/azure-cosmos-dotnet-v3/pull/3308 includes an updated ServiceInterop.dll that includes new dependencies.

This PR makes sure those dependencies are bundled and included as part of the SDK package in the paths as the ServiceInterop.dll