### PR TITLE
Support IsType Linq expressions

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ClientResources.Designer.cs
+++ b/Microsoft.Azure.Cosmos/src/ClientResources.Designer.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.Cosmos {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class ClientResources {
@@ -543,6 +543,15 @@ namespace Microsoft.Azure.Cosmos {
         internal static string PKAndEpkSetTogether {
             get {
                 return ResourceManager.GetString("PKAndEpkSetTogether", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Property {0} does not support type comparison..
+        /// </summary>
+        internal static string PropertyDoesNotSupportTypeComparison {
+            get {
+                return ResourceManager.GetString("PropertyDoesNotSupportTypeComparison", resourceCulture);
             }
         }
         

--- a/Microsoft.Azure.Cosmos/src/ClientResources.resx
+++ b/Microsoft.Azure.Cosmos/src/ClientResources.resx
@@ -318,4 +318,7 @@
   <data name="FeedToken_InvalidFeedTokenForContainer" xml:space="preserve">
     <value>The continuation was generated for container {0} but current container is {1}.</value>
   </data>
+  <data name="PropertyDoesNotSupportTypeComparison" xml:space="preserve">
+    <value>Property {0} does not support type comparison.</value>
+  </data>
 </root>

--- a/Microsoft.Azure.Cosmos/src/Linq/ExpressionToSQL.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/ExpressionToSQL.cs
@@ -13,7 +13,6 @@ namespace Microsoft.Azure.Cosmos.Linq
     using System.Linq;
     using System.Linq.Expressions;
     using System.Reflection;
-    using System.Text;
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.CosmosElements.Numbers;
     using Microsoft.Azure.Cosmos.Serializer;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqAttributeContractBaselineTests.TestTypeNameHandlingAttributeContract.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqAttributeContractBaselineTests.TestTypeNameHandlingAttributeContract.xml
@@ -1,0 +1,14 @@
+﻿<Results>
+  <Result>
+    <Input>
+      <Description><![CDATA[TypeIs]]></Description>
+      <Expression><![CDATA[query.Where(doc => (doc.Child Is DatumChild))]]></Expression>
+    </Input>
+    <Output>
+      <SqlQuery><![CDATA[
+SELECT VALUE root 
+FROM root 
+WHERE (root["Child"]["$type"] = "Microsoft.Azure.Cosmos.Services.Management.Tests.LinqProviderTests.LinqAttributeContractBaselineTests+DatumChild, Microsoft.Azure.Cosmos.EmulatorTests")]]></SqlQuery>
+    </Output>
+  </Result>
+</Results>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/LinqAttributeContractBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/LinqAttributeContractBaselineTests.cs
@@ -86,6 +86,7 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests.LinqProviderTests
                 obj.JsonPropertyAndDataMember = random.NextDouble() < 0.3 ? "Hello" : LinqTestsCommon.RandomString(random, random.Next(MaxStringLength));
                 obj.DataMember = random.NextDouble() < 0.3 ? "Hello" : LinqTestsCommon.RandomString(random, random.Next(MaxStringLength));
                 obj.Default = random.NextDouble() < 0.3 ? "Hello" : LinqTestsCommon.RandomString(random, random.Next(MaxStringLength));
+                obj.Child = new DatumChild();
                 return obj;
             };
             getQuery = LinqTestsCommon.GenerateTestCosmosData(createDataFunc, Records, testCollection);
@@ -133,6 +134,9 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests.LinqProviderTests
             [JsonProperty(PropertyName = "jsonPropertyHasHigherPriority")]
             [DataMember(Name = "thanDataMember")]
             public string JsonPropertyAndDataMember;
+
+            [JsonProperty(TypeNameHandling = TypeNameHandling.Objects)]
+            public IDatumChild Child;
         }
 
         /// <summary>
@@ -161,6 +165,10 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests.LinqProviderTests
                 this.JsonPropertyAndDataMember = jsonPropertyAndDataMember;
             }
         }
+
+        public interface IDatumChild {}
+
+        public class DatumChild : IDatumChild {}
 
         /// <summary>
         /// In general the attribute priority is as follows:
@@ -249,6 +257,17 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests.LinqProviderTests
         {
             var inputs = new List<LinqTestInput>();
             inputs.Add(new LinqTestInput("New", b => getQuery(b).Select(doc => new Datum2(doc.JsonProperty, doc.DataMember, doc.Default, doc.JsonPropertyAndDataMember))));
+            this.ExecuteTestSuite(inputs);
+        }
+
+        /// <summary>
+        /// Tests to see if we can filter by type metadata
+        /// </summary>
+        [TestMethod]
+        public void TestTypeNameHandlingAttributeContract()
+        {
+            var inputs = new List<LinqTestInput>();
+            inputs.Add(new LinqTestInput("TypeIs", b => getQuery(b).Where(doc => doc.Child is DatumChild)));
             this.ExecuteTestSuite(inputs);
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Microsoft.Azure.Cosmos.EmulatorTests.csproj
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Microsoft.Azure.Cosmos.EmulatorTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <IsTestProject>true</IsTestProject>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -34,6 +34,7 @@
     <None Remove="BaselineTest\TestBaseline\EndToEndTraceWriterBaselineTests.ReadManyAsync.xml" />
     <None Remove="BaselineTest\TestBaseline\EndToEndTraceWriterBaselineTests.StreamPointOperationsAsync.xml" />
     <None Remove="BaselineTest\TestBaseline\EndToEndTraceWriterBaselineTests.TypedPointOperationsAsync.xml" />
+    <None Remove="BaselineTest\TestBaseline\LinqAttributeContractBaselineTests.TestTypeNameHandlingAttributeContract.xml" />
     <None Remove="BaselineTest\TestBaseline\LinqTranslationBaselineTests.TestDateTimeJsonConverterTimezones.xml" />
     <None Remove="BaselineTest\TestBaseline\LinqTranslationBaselineTests.TestMemberAccessWithNullableTypes.xml" />
   </ItemGroup>
@@ -120,6 +121,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="BaselineTest\TestBaseline\LinqAttributeContractBaselineTests.TestSelectAttributeContract.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="BaselineTest\TestBaseline\LinqAttributeContractBaselineTests.TestTypeNameHandlingAttributeContract.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="BaselineTest\TestBaseline\LinqConstantFoldingBaselineTests.TestBinaryOperators.xml">

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Linq/CosmosLinqTypeIsTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Linq/CosmosLinqTypeIsTests.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.Cosmos.Linq
             // Should work for document properties with TypeNameHandling configured
             Expression<Func<TestDocument, bool>> expr = a => a.Child is TestDocumentChild;
             string sql = SqlTranslator.TranslateExpression(expr.Body);
-            Assert.AreEqual("(a[\"Child\"].$type = \"Microsoft.Azure.Cosmos.Linq.CosmosLinqTypeIsTests+TestDocumentChild, Microsoft.Azure.Cosmos.Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=69c3241e6f0468ca\")", sql);
+            Assert.AreEqual("(a[\"Child\"][\"$type\"] = \"Microsoft.Azure.Cosmos.Linq.CosmosLinqTypeIsTests+TestDocumentChild, Microsoft.Azure.Cosmos.Tests\")", sql);
         }
 
         [TestMethod]
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.Cosmos.Linq
             // Should work for nested document properties with TypeNameHandling configured
             Expression<Func<TestDocument, bool>> expr = a => a.Child.InnerChild is TestDocumentChild;
             string sql = SqlTranslator.TranslateExpression(expr.Body);
-            Assert.AreEqual("(a[\"Child\"][\"InnerChild\"].$type = \"Microsoft.Azure.Cosmos.Linq.CosmosLinqTypeIsTests+TestDocumentChild, Microsoft.Azure.Cosmos.Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=69c3241e6f0468ca\")", sql);
+            Assert.AreEqual("(a[\"Child\"][\"InnerChild\"][\"$type\"] = \"Microsoft.Azure.Cosmos.Linq.CosmosLinqTypeIsTests+TestDocumentChild, Microsoft.Azure.Cosmos.Tests\")", sql);
         }
 
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Linq/CosmosLinqTypeIsTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Linq/CosmosLinqTypeIsTests.cs
@@ -1,0 +1,48 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Linq
+{
+    using System;
+    using System.Linq.Expressions;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Newtonsoft.Json;
+
+    [TestClass]
+    public class CosmosLinqTypeIsTests
+    {
+        [TestMethod]
+        public void TypeIsStatementWithTypeNameHandlingIsTranslated()
+        {
+            // Should work documents with property attributes
+            Expression<Func<TestDocumentWithPropertyTypeNameHandling, bool>> expr = a => a.Child is TestDocumentChild;
+            string sql = SqlTranslator.TranslateExpression(expr.Body);
+            Assert.AreEqual("(a[\"Child\"].$type = \"Microsoft.Azure.Cosmos.Linq.CosmosLinqTypeIsTests+TestDocumentChild, Microsoft.Azure.Cosmos.Tests, Version=0.0.0.0, Culture=neutral, PublicKeyToken=69c3241e6f0468ca\")", sql);
+        }
+
+        [TestMethod]
+        public void TypeIsStatementWithoutTypeNameHandlingThrowsException()
+        {
+            // Should throw for documents with no TypeNameHandling configured
+            Expression<Func<TestDocumentWithoutPropertyTypeNameHandling, bool>> expr = a => a.Child is TestDocumentChild;
+            Assert.ThrowsException<DocumentQueryException>(() => SqlTranslator.TranslateExpression(expr.Body));
+        }
+
+        class TestDocumentWithPropertyTypeNameHandling
+        {
+            [JsonProperty(TypeNameHandling = TypeNameHandling.Objects)]
+            public ITestDocumentChild Child { get; set; }
+        }
+
+        class TestDocumentWithoutPropertyTypeNameHandling
+        {
+            [JsonProperty(TypeNameHandling = TypeNameHandling.None)]
+            public ITestDocumentChild Child { get; set; }
+        }
+
+        interface ITestDocumentChild {}
+
+        class TestDocumentChild : ITestDocumentChild {}
+    }
+}


### PR DESCRIPTION
## Description

A common use case for documents stored in Cosmos is having polymorphic child objects, consider this case:

```csharp
interface IUser {
    UserType UserType { get; }
}

class Administrator : IUser {
    public UserType UserType => UserType.Administrator;
}

class Customer : IUser {
    public UserType UserType => UserType.Customer;
}

class AuditLog {
    [JsonProperty("id")]
    public string Id { get; init; }

    [JsonProperty("initiator", TypeNameHandling = TypeNameHandling.Objects)]
    public IUser Initiator { get; init; }
}
```

In the above example, we have a document `AuditLog` stored in Cosmos, where we are ensuring that the client JSON serializer can properly deserialize into the correct concrete implementation of the general `IUser` interface by using the `TypeNameHandling` features of the serializer.

A scenario we then often run into is how do we query for documents with certain types of child objects? Well, our current solution is to add another property on the containing document to have it be a separate queryable column:

```csharp
class AuditLog {
    [JsonProperty("id")]
    public string Id { get; init; }

    [JsonProperty("initiator", TypeNameHandling = TypeNameHandling.Objects)]
    public IUser Initiator { get; init; }

    [JsonProperty("initiatorType")]
    public Type InitiatorType => Initiator.GetType();
}
```

At which point we can have a query like: 

```csharp
query.Where(auditLog => auditLog.InitiatorType == typeof(Administrator));
```

But, wouldn't it be better to support native Linq constructs using the `IsType` expression? Well, that's what this PR enables:

```csharp
query.Where(auditLog => auditLog.Initiator is Administrator);
```

By making sure the document property is configured for type name handling, we can easily support translating the Linq into SQL to target the current serializers `$type` metadata field for the given type operand.

This is my first PR to this repo, so please let me know if there's anything missing, I did add unit tests and emulator tests to verify the behavior. I do realize this is very tied into the way this CosmosDB client is currently utilizing Newtonsoft.JSON, and would encourage input about future direction for this. The code I've written up here is defensive in the sense that unless you explicitly add the Newtonsoft.JSON attributes, the functionality stays the same as before and throws an exception.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update