### PR TITLE
[Internal] Query: Adds CosmosUndefined to represent undefined values

### DIFF
--- a/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosArray.EagerCosmosArray.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosArray.EagerCosmosArray.cs
@@ -39,10 +39,7 @@ namespace Microsoft.Azure.Cosmos.CosmosElements
 
                 foreach (CosmosElement arrayItem in this)
                 {
-                    if (arrayItem is not CosmosUndefined)
-                    {
-                        arrayItem.WriteTo(jsonWriter);
-                    }
+                    arrayItem.WriteTo(jsonWriter);
                 }
 
                 jsonWriter.WriteArrayEnd();

--- a/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosArray.EagerCosmosArray.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosArray.EagerCosmosArray.cs
@@ -39,7 +39,10 @@ namespace Microsoft.Azure.Cosmos.CosmosElements
 
                 foreach (CosmosElement arrayItem in this)
                 {
-                    arrayItem.WriteTo(jsonWriter);
+                    if (arrayItem is not CosmosUndefined)
+                    {
+                        arrayItem.WriteTo(jsonWriter);
+                    }
                 }
 
                 jsonWriter.WriteArrayEnd();

--- a/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosElement.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosElement.cs
@@ -272,6 +272,7 @@ namespace Microsoft.Azure.Cosmos.CosmosElements
             private CosmosElementToTypeOrder()
             {
             }
+
             public int Visit(CosmosUndefined cosmosUndefined)
             {
                 return 0;
@@ -325,6 +326,7 @@ namespace Microsoft.Azure.Cosmos.CosmosElements
             private CosmosElementWithinTypeComparer()
             {
             }
+
             public int Visit(CosmosUndefined cosmosUndefined, CosmosElement input)
             {
                 return cosmosUndefined.CompareTo((CosmosUndefined)input);

--- a/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosElement.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosElement.cs
@@ -272,45 +272,49 @@ namespace Microsoft.Azure.Cosmos.CosmosElements
             private CosmosElementToTypeOrder()
             {
             }
-
-            public int Visit(CosmosNull cosmosNull)
+            public int Visit(CosmosUndefined cosmosUndefined)
             {
                 return 0;
             }
 
-            public int Visit(CosmosBoolean cosmosBoolean)
+            public int Visit(CosmosNull cosmosNull)
             {
                 return 1;
             }
 
-            public int Visit(CosmosNumber cosmosNumber)
+            public int Visit(CosmosBoolean cosmosBoolean)
             {
                 return 2;
             }
 
-            public int Visit(CosmosString cosmosString)
+            public int Visit(CosmosNumber cosmosNumber)
             {
                 return 3;
             }
 
-            public int Visit(CosmosArray cosmosArray)
+            public int Visit(CosmosString cosmosString)
             {
                 return 4;
             }
 
-            public int Visit(CosmosObject cosmosObject)
+            public int Visit(CosmosArray cosmosArray)
             {
                 return 5;
             }
 
-            public int Visit(CosmosGuid cosmosGuid)
+            public int Visit(CosmosObject cosmosObject)
             {
                 return 6;
             }
 
-            public int Visit(CosmosBinary cosmosBinary)
+            public int Visit(CosmosGuid cosmosGuid)
             {
                 return 7;
+            }
+
+            public int Visit(CosmosBinary cosmosBinary)
+            {
+                return 8;
             }
         }
 
@@ -320,6 +324,10 @@ namespace Microsoft.Azure.Cosmos.CosmosElements
 
             private CosmosElementWithinTypeComparer()
             {
+            }
+            public int Visit(CosmosUndefined cosmosUndefined, CosmosElement input)
+            {
+                return cosmosUndefined.CompareTo((CosmosUndefined)input);
             }
 
             public int Visit(CosmosArray cosmosArray, CosmosElement input)

--- a/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosObject.EagerCosmosObject.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosObject.EagerCosmosObject.cs
@@ -49,8 +49,11 @@ namespace Microsoft.Azure.Cosmos.CosmosElements
 
                 foreach (KeyValuePair<string, CosmosElement> kvp in this.dictionary)
                 {
-                    jsonWriter.WriteFieldName(kvp.Key);
-                    kvp.Value.WriteTo(jsonWriter);
+                    if (kvp.Value is not CosmosUndefined)
+                    {
+                        jsonWriter.WriteFieldName(kvp.Key);
+                        kvp.Value.WriteTo(jsonWriter);
+                    }
                 }
 
                 jsonWriter.WriteObjectEnd();

--- a/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosUndefined.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosUndefined.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.Cosmos.CosmosElements
 #endif
     sealed class CosmosUndefined : CosmosElement, IEquatable<CosmosUndefined>, IComparable<CosmosUndefined>
     {
-        public static readonly CosmosUndefined Instance = new CosmosUndefined();
+        private static readonly CosmosUndefined Instance = new CosmosUndefined();
 
         private CosmosUndefined()
         {
@@ -61,6 +61,11 @@ namespace Microsoft.Azure.Cosmos.CosmosElements
 
         public override void WriteTo(IJsonWriter jsonWriter)
         {
+        }
+
+        public static CosmosUndefined Create()
+        {
+            return Instance;
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosUndefined.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosUndefined.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.Cosmos.CosmosElements
 
         public override int GetHashCode()
         {
-            return Instance.GetHashCode();
+            return 0;
         }
 
         public override void WriteTo(IJsonWriter jsonWriter)

--- a/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosUndefined.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosUndefined.cs
@@ -61,7 +61,8 @@ namespace Microsoft.Azure.Cosmos.CosmosElements
 
         public override void WriteTo(IJsonWriter jsonWriter)
         {
-            // TODO: is this kosher ?
+            // We could be more forgiving here, e.g. just return
+            throw new InvalidOperationException("Cannot serialize CosmosUndefined");
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosUndefined.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosUndefined.cs
@@ -61,8 +61,6 @@ namespace Microsoft.Azure.Cosmos.CosmosElements
 
         public override void WriteTo(IJsonWriter jsonWriter)
         {
-            // We could be more forgiving here, e.g. just return
-            throw new InvalidOperationException("Cannot serialize CosmosUndefined");
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosUndefined.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosUndefined.cs
@@ -1,0 +1,67 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+namespace Microsoft.Azure.Cosmos.CosmosElements
+{
+#nullable enable
+
+    using System;
+    using Microsoft.Azure.Cosmos.Json;
+    using Microsoft.Azure.Cosmos.Query.Core.Monads;
+
+#if INTERNAL
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+#pragma warning disable SA1600 // Elements should be documented
+    public
+#else
+    internal
+#endif
+    sealed class CosmosUndefined : CosmosElement, IEquatable<CosmosUndefined>, IComparable<CosmosUndefined>
+    {
+        public static readonly CosmosUndefined Instance = new CosmosUndefined();
+
+        private CosmosUndefined()
+        {
+        }
+
+        public override void Accept(ICosmosElementVisitor cosmosElementVisitor)
+        {
+            cosmosElementVisitor.Visit(this);
+        }
+
+        public override TResult Accept<TResult>(ICosmosElementVisitor<TResult> cosmosElementVisitor)
+        {
+            return cosmosElementVisitor.Visit(this);
+        }
+
+        public override TResult Accept<TArg, TResult>(ICosmosElementVisitor<TArg, TResult> cosmosElementVisitor, TArg input)
+        {
+            return cosmosElementVisitor.Visit(this, input);
+        }
+
+        public int CompareTo(CosmosUndefined other)
+        {
+            return 0;
+        }
+
+        public override bool Equals(CosmosElement cosmosElement)
+        {
+            return cosmosElement is CosmosUndefined;
+        }
+
+        public bool Equals(CosmosUndefined other)
+        {
+            return true;
+        }
+
+        public override int GetHashCode()
+        {
+            return Instance.GetHashCode();
+        }
+
+        public override void WriteTo(IJsonWriter jsonWriter)
+        {
+            // TODO: is this kosher ?
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/CosmosElements/ICosmosElementVisitor.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosElements/ICosmosElementVisitor.cs
@@ -23,5 +23,6 @@ namespace Microsoft.Azure.Cosmos.CosmosElements
         void Visit(CosmosNumber cosmosNumber);
         void Visit(CosmosObject cosmosObject);
         void Visit(CosmosString cosmosString);
+        void Visit(CosmosUndefined cosmosUndefined);
     }
 }

--- a/Microsoft.Azure.Cosmos/src/CosmosElements/ICosmosElementVisitor{TArg,TResult}.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosElements/ICosmosElementVisitor{TArg,TResult}.cs
@@ -23,5 +23,6 @@ namespace Microsoft.Azure.Cosmos.CosmosElements
         TResult Visit(CosmosNumber cosmosNumber, TArg input);
         TResult Visit(CosmosObject cosmosObject, TArg input);
         TResult Visit(CosmosString cosmosString, TArg input);
+        TResult Visit(CosmosUndefined cosmosUndefined, TArg input);
     }
 }

--- a/Microsoft.Azure.Cosmos/src/CosmosElements/ICosmosElementVisitor{TResult}.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosElements/ICosmosElementVisitor{TResult}.cs
@@ -23,5 +23,6 @@ namespace Microsoft.Azure.Cosmos.CosmosElements
         TResult Visit(CosmosNumber cosmosNumber);
         TResult Visit(CosmosObject cosmosObject);
         TResult Visit(CosmosString cosmosString);
+        TResult Visit(CosmosUndefined cosmosUndefined);
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Json/JsonSerializer.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/JsonSerializer.cs
@@ -140,7 +140,7 @@ namespace Microsoft.Azure.Cosmos.Json
                 }
 
                 CosmosElement cosmosElement = tryCreateFromBuffer.Result;
-                TryCatch<object> tryAcceptVisitor = cosmosElement.Accept(Visitor.Singleton, typeof(T));
+                TryCatch<object> tryAcceptVisitor = cosmosElement.Accept(DeserializationVisitor.Singleton, typeof(T));
                 if (tryAcceptVisitor.Failed)
                 {
                     return TryCatch<T>.FromException(tryAcceptVisitor.Exception);
@@ -154,7 +154,7 @@ namespace Microsoft.Azure.Cosmos.Json
                         return TryCatch<T>.FromResult(default);
                     }
 
-                    // string needs to be handle differntly since JsonReader return UtfAnyString instead of string.
+                    // string needs to be handle differently since JsonReader return UtfAnyString instead of string.
                     if (type == typeof(string))
                     {
                         return TryCatch<T>.FromResult((T)(object)tryAcceptVisitor.Result.ToString());
@@ -173,9 +173,9 @@ namespace Microsoft.Azure.Cosmos.Json
             return TryCatch<T>.ConvertToTryGet<T>(tryDeserialize, out result);
         }
 
-        private sealed class Visitor : ICosmosElementVisitor<Type, TryCatch<object>>
+        private sealed class DeserializationVisitor : ICosmosElementVisitor<Type, TryCatch<object>>
         {
-            public static readonly Visitor Singleton = new Visitor();
+            public static readonly DeserializationVisitor Singleton = new DeserializationVisitor();
 
             private static class Exceptions
             {
@@ -211,7 +211,7 @@ namespace Microsoft.Azure.Cosmos.Json
                 public static readonly object Null = null;
             }
 
-            private Visitor()
+            private DeserializationVisitor()
             {
             }
 
@@ -220,7 +220,7 @@ namespace Microsoft.Azure.Cosmos.Json
                 bool isReadOnlyList = type.IsGenericType && (type.GetGenericTypeDefinition() == typeof(IReadOnlyList<>));
                 if (!isReadOnlyList)
                 {
-                    return TryCatch<object>.FromException(Visitor.Exceptions.ExpectedArray);
+                    return TryCatch<object>.FromException(DeserializationVisitor.Exceptions.ExpectedArray);
                 }
 
                 Type genericArgumentType = type.GenericTypeArguments.First();
@@ -269,7 +269,7 @@ namespace Microsoft.Azure.Cosmos.Json
             {
                 if (type != typeof(ReadOnlyMemory<byte>))
                 {
-                    return TryCatch<object>.FromException(Visitor.Exceptions.ExpectedBinary);
+                    return TryCatch<object>.FromException(DeserializationVisitor.Exceptions.ExpectedBinary);
                 }
 
                 return TryCatch<object>.FromResult(cosmosBinary.Value);
@@ -279,17 +279,17 @@ namespace Microsoft.Azure.Cosmos.Json
             {
                 if (type != typeof(bool))
                 {
-                    return TryCatch<object>.FromException(Visitor.Exceptions.ExpectedBoolean);
+                    return TryCatch<object>.FromException(DeserializationVisitor.Exceptions.ExpectedBoolean);
                 }
 
-                return TryCatch<object>.FromResult(cosmosBoolean.Value ? Visitor.BoxedValues.True : Visitor.BoxedValues.False);
+                return TryCatch<object>.FromResult(cosmosBoolean.Value ? DeserializationVisitor.BoxedValues.True : DeserializationVisitor.BoxedValues.False);
             }
 
             public TryCatch<object> Visit(CosmosGuid cosmosGuid, Type type)
             {
                 if (type != typeof(Guid))
                 {
-                    return TryCatch<object>.FromException(Visitor.Exceptions.ExpectedGuid);
+                    return TryCatch<object>.FromException(DeserializationVisitor.Exceptions.ExpectedGuid);
                 }
 
                 return TryCatch<object>.FromResult(cosmosGuid.Value);
@@ -299,7 +299,7 @@ namespace Microsoft.Azure.Cosmos.Json
             {
                 if (type.IsValueType && !(type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>)))
                 {
-                    return TryCatch<object>.FromException(Visitor.Exceptions.ExpectedReferenceOrNullableType);
+                    return TryCatch<object>.FromException(DeserializationVisitor.Exceptions.ExpectedReferenceOrNullableType);
                 }
 
                 return TryCatch<object>.FromResult(default);
@@ -307,7 +307,7 @@ namespace Microsoft.Azure.Cosmos.Json
 
             public TryCatch<object> Visit(CosmosUndefined cosmosUndefined, Type type)
             {
-                return TryCatch<object>.FromException(Visitor.Exceptions.UnexpectedUndefined);
+                return TryCatch<object>.FromException(DeserializationVisitor.Exceptions.UnexpectedUndefined);
             }
 
             public TryCatch<object> Visit(CosmosNumber cosmosNumber, Type type)
@@ -556,7 +556,7 @@ namespace Microsoft.Azure.Cosmos.Json
             {
                 if (type != typeof(string))
                 {
-                    return TryCatch<object>.FromException(Visitor.Exceptions.ExpectedString);
+                    return TryCatch<object>.FromException(DeserializationVisitor.Exceptions.ExpectedString);
                 }
 
                 return TryCatch<object>.FromResult(cosmosString.Value.ToString());

--- a/Microsoft.Azure.Cosmos/src/Json/JsonSerializer.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/JsonSerializer.cs
@@ -199,6 +199,9 @@ namespace Microsoft.Azure.Cosmos.Json
 
                 public static readonly CosmosElementWrongTypeException ExpectedString = new CosmosElementWrongTypeException(
                     message: $"Expected return type of '{typeof(string)}'.");
+
+                public static readonly CosmosElementWrongTypeException UnexpectedUndefined = new CosmosElementWrongTypeException(
+                    message: $"Did not expect to encounter '{typeof(CosmosUndefined)}'.");
             }
 
             private static class BoxedValues
@@ -240,6 +243,7 @@ namespace Microsoft.Azure.Cosmos.Json
                             CosmosString _ => typeof(string),
                             CosmosGuid _ => typeof(Guid),
                             CosmosBinary _ => typeof(ReadOnlyMemory<byte>),
+                            CosmosUndefined _ => typeof(object),
                             _ => throw new ArgumentOutOfRangeException($"Unknown cosmos element type."),
                         };
 
@@ -303,12 +307,7 @@ namespace Microsoft.Azure.Cosmos.Json
 
             public TryCatch<object> Visit(CosmosUndefined cosmosUndefined, Type type)
             {
-                if (type.IsValueType && !(type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>)))
-                {
-                    return TryCatch<object>.FromException(Visitor.Exceptions.ExpectedReferenceOrNullableType);
-                }
-
-                return TryCatch<object>.FromResult(default);
+                return TryCatch<object>.FromException(Visitor.Exceptions.UnexpectedUndefined);
             }
 
             public TryCatch<object> Visit(CosmosNumber cosmosNumber, Type type)

--- a/Microsoft.Azure.Cosmos/src/Json/JsonSerializer.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/JsonSerializer.cs
@@ -301,6 +301,16 @@ namespace Microsoft.Azure.Cosmos.Json
                 return TryCatch<object>.FromResult(default);
             }
 
+            public TryCatch<object> Visit(CosmosUndefined cosmosUndefined, Type type)
+            {
+                if (type.IsValueType && !(type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>)))
+                {
+                    return TryCatch<object>.FromException(Visitor.Exceptions.ExpectedReferenceOrNullableType);
+                }
+
+                return TryCatch<object>.FromResult(default);
+            }
+
             public TryCatch<object> Visit(CosmosNumber cosmosNumber, Type type)
             {
                 if (type == typeof(Number64))

--- a/Microsoft.Azure.Cosmos/src/Linq/ExpressionToSQL.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/ExpressionToSQL.cs
@@ -2011,6 +2011,11 @@ namespace Microsoft.Azure.Cosmos.Linq
             {
                 return SqlLiteralScalarExpression.Create(SqlStringLiteral.Create(cosmosString.Value));
             }
+
+            public SqlScalarExpression Visit(CosmosUndefined cosmosUndefined)
+            {
+                return SqlLiteralScalarExpression.Create(SqlUndefinedLiteral.Create());
+            }
         }
         private enum SubqueryKind
         {

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Aggregate/Aggregators/AggregateItem.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Aggregate/Aggregators/AggregateItem.cs
@@ -37,8 +37,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Aggregate.Aggregators
                 {
                     if (!this.cosmosObject.TryGetValue(ItemName1, out cosmosElement))
                     {
-                        // Undefined
-                        cosmosElement = null;
+                        cosmosElement = CosmosUndefined.Instance;
                     }
                 }
 

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Aggregate/Aggregators/AggregateItem.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Aggregate/Aggregators/AggregateItem.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Aggregate.Aggregators
                 {
                     if (!this.cosmosObject.TryGetValue(ItemName1, out cosmosElement))
                     {
-                        cosmosElement = CosmosUndefined.Instance;
+                        cosmosElement = CosmosUndefined.Create();
                     }
                 }
 

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Aggregate/Aggregators/AverageAggregator.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Aggregate/Aggregators/AverageAggregator.cs
@@ -198,11 +198,11 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Aggregate.Aggregators
             /// Returns the average or undefined if any of the intermediate averages resulted in an undefined value.
             /// </summary>
             /// <returns>The average or undefined if any of the intermediate averages resulted in an undefined value.</returns>
-            public CosmosNumber GetAverage()
+            public CosmosElement GetAverage()
             {
                 if (!this.Sum.HasValue || this.Count <= 0)
                 {
-                    return null;
+                    return CosmosUndefined.Instance;
                 }
 
                 return CosmosNumber64.Create(this.Sum.Value / this.Count);

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Aggregate/Aggregators/AverageAggregator.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Aggregate/Aggregators/AverageAggregator.cs
@@ -202,7 +202,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Aggregate.Aggregators
             {
                 if (!this.Sum.HasValue || this.Count <= 0)
                 {
-                    return CosmosUndefined.Instance;
+                    return CosmosUndefined.Create();
                 }
 
                 return CosmosNumber64.Create(this.Sum.Value / this.Count);

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Aggregate/Aggregators/MinMaxAggregator.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Aggregate/Aggregators/MinMaxAggregator.cs
@@ -18,7 +18,6 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Aggregate.Aggregators
     /// </summary>
     internal sealed class MinMaxAggregator : IAggregator
     {
-        private static readonly CosmosElement Undefined = CosmosUndefined.Instance;
         /// <summary>
         /// Whether or not the aggregation is a min or a max.
         /// </summary>
@@ -37,16 +36,16 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Aggregate.Aggregators
 
         public void Aggregate(CosmosElement localMinMax)
         {
-            // If the value became undefinded at some point then it should stay that way.
-            if (this.globalMinMax == Undefined)
+            // If the value became undefined at some point then it should stay that way.
+            if (this.globalMinMax is CosmosUndefined)
             {
                 return;
             }
 
-            if (localMinMax == Undefined)
+            if (localMinMax is CosmosUndefined)
             {
                 // If we got an undefined in the pipeline then the whole thing becomes undefined.
-                this.globalMinMax = Undefined;
+                this.globalMinMax = CosmosUndefined.Create();
                 return;
             }
 
@@ -84,7 +83,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Aggregate.Aggregators
                     }
                     else
                     {
-                        localMinMax = Undefined;
+                        localMinMax = CosmosUndefined.Create();
                     }
                 }
             }
@@ -92,11 +91,11 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Aggregate.Aggregators
             if (!ItemComparer.IsMinOrMax(this.globalMinMax) && (!IsPrimitve(localMinMax) || !IsPrimitve(this.globalMinMax)))
             {
                 // This means we are comparing non primitives which is undefined
-                this.globalMinMax = Undefined;
+                this.globalMinMax = CosmosUndefined.Create();
                 return;
             }
 
-            // Finally do the comparision
+            // Finally do the comparison
             if (this.isMinAggregation)
             {
                 if (ItemComparer.Instance.Compare(localMinMax, this.globalMinMax) < 0)
@@ -119,7 +118,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Aggregate.Aggregators
             if ((this.globalMinMax == ItemComparer.MinValue) || (this.globalMinMax == ItemComparer.MaxValue))
             {
                 // The filter did not match any documents.
-                result = Undefined;
+                result = CosmosUndefined.Create();
             }
             else
             {
@@ -161,7 +160,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Aggregate.Aggregators
                         break;
 
                     case MinMaxContinuationToken.MinMaxContinuationTokenType.Undefined:
-                        globalMinMax = MinMaxAggregator.Undefined;
+                        globalMinMax = CosmosUndefined.Create();
                         break;
 
                     case MinMaxContinuationToken.MinMaxContinuationTokenType.Value:
@@ -197,7 +196,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Aggregate.Aggregators
             {
                 minMaxContinuationToken = MinMaxContinuationToken.CreateMaxValueContinuationToken();
             }
-            else if (this.globalMinMax == Undefined)
+            else if (this.globalMinMax is CosmosUndefined)
             {
                 minMaxContinuationToken = MinMaxContinuationToken.CreateUndefinedValueContinuationToken();
             }

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Aggregate/Aggregators/MinMaxAggregator.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Aggregate/Aggregators/MinMaxAggregator.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Aggregate.Aggregators
     /// </summary>
     internal sealed class MinMaxAggregator : IAggregator
     {
-        private static readonly CosmosElement Undefined = null;
+        private static readonly CosmosElement Undefined = CosmosUndefined.Instance;
         /// <summary>
         /// Whether or not the aggregation is a min or a max.
         /// </summary>
@@ -261,6 +261,11 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Aggregate.Aggregators
             public bool Visit(CosmosString cosmosString)
             {
                 return true;
+            }
+
+            public bool Visit(CosmosUndefined cosmosUndefined)
+            {
+                return false;
             }
         }
 

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Aggregate/Aggregators/MinMaxAggregator.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Aggregate/Aggregators/MinMaxAggregator.cs
@@ -183,11 +183,6 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Aggregate.Aggregators
 
         private static bool IsPrimitve(CosmosElement cosmosElement)
         {
-            if (cosmosElement == Undefined)
-            {
-                return false;
-            }
-
             return cosmosElement.Accept(IsPrimitiveCosmosElementVisitor.Singleton);
         }
 

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Aggregate/Aggregators/SingleGroupAggregator.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Aggregate/Aggregators/SingleGroupAggregator.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Aggregate.Aggregators
                 foreach (string alias in this.orderedAliases)
                 {
                     AggregateValue aggregateValue = this.aliasToValue[alias];
-                    if (aggregateValue.Result != null)
+                    if (!(aggregateValue.Result is CosmosUndefined))
                     {
                         dictionary[alias] = aggregateValue.Result;
                         keys.Add(alias);

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Aggregate/Aggregators/SingleGroupAggregator.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Aggregate/Aggregators/SingleGroupAggregator.cs
@@ -239,7 +239,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Aggregate.Aggregators
                     AggregateValue aggregateValue = aliasAndValue.Value;
                     if (!payload.TryGetValue(alias, out CosmosElement payloadValue))
                     {
-                        payloadValue = CosmosUndefined.Instance;
+                        payloadValue = CosmosUndefined.Create();
                     }
 
                     aggregateValue.AddValue(payloadValue);
@@ -451,7 +451,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Aggregate.Aggregators
 
                         if (!rawContinuationToken.TryGetValue(nameof(ScalarAggregateValue.value), out value))
                         {
-                            value = CosmosUndefined.Instance;
+                            value = CosmosUndefined.Create();
                         }
 
                         initialized = rawInitialized.Value;

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Aggregate/Aggregators/SingleGroupAggregator.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Aggregate/Aggregators/SingleGroupAggregator.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Aggregate.Aggregators
                 foreach (string alias in this.orderedAliases)
                 {
                     AggregateValue aggregateValue = this.aliasToValue[alias];
-                    if (!(aggregateValue.Result is CosmosUndefined))
+                    if (aggregateValue.Result is not CosmosUndefined)
                     {
                         dictionary[alias] = aggregateValue.Result;
                         keys.Add(alias);
@@ -239,7 +239,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Aggregate.Aggregators
                     AggregateValue aggregateValue = aliasAndValue.Value;
                     if (!payload.TryGetValue(alias, out CosmosElement payloadValue))
                     {
-                        payloadValue = null;
+                        payloadValue = CosmosUndefined.Instance;
                     }
 
                     aggregateValue.AddValue(payloadValue);
@@ -287,8 +287,12 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Aggregate.Aggregators
 
                     foreach (string key in this.keyOrdering)
                     {
-                        jsonWriter.WriteFieldName(key);
-                        this[key].WriteTo(jsonWriter);
+                        CosmosElement value = this[key];
+                        if (value is not CosmosUndefined)
+                        {
+                            jsonWriter.WriteFieldName(key);
+                            value.WriteTo(jsonWriter);
+                        }
                     }
 
                     jsonWriter.WriteObjectEnd();
@@ -447,7 +451,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Aggregate.Aggregators
 
                         if (!rawContinuationToken.TryGetValue(nameof(ScalarAggregateValue.value), out value))
                         {
-                            value = null;
+                            value = CosmosUndefined.Instance;
                         }
 
                         initialized = rawInitialized.Value;

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Aggregate/Aggregators/SumAggregator.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Aggregate/Aggregators/SumAggregator.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Aggregate.Aggregators
         {
             if (double.IsNaN(this.globalSum))
             {
-                return CosmosUndefined.Instance;
+                return CosmosUndefined.Create();
             }
 
             return CosmosNumber64.Create(this.globalSum);

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Aggregate/Aggregators/SumAggregator.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Aggregate/Aggregators/SumAggregator.cs
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Aggregate.Aggregators
             }
 
             // If someone tried to add an undefined just set the globalSum to NaN and it will stay that way for the duration of the aggregation.
-            if (localSum == null)
+            if (localSum is CosmosUndefined)
             {
                 this.globalSum = double.NaN;
                 return;
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Aggregate.Aggregators
         {
             if (double.IsNaN(this.globalSum))
             {
-                return null;
+                return CosmosUndefined.Instance;
             }
 
             return CosmosNumber64.Create(this.globalSum);

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/CosmosElementToQueryLiteral.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/CosmosElementToQueryLiteral.cs
@@ -58,6 +58,11 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
             this.stringBuilder.AppendFormat("C_Guid(\"{0}\")", cosmosGuid.Value);
         }
 
+        public void Visit(CosmosUndefined cosmosUndefined)
+        {
+            throw new ArgumentException($"{nameof(CosmosUndefined)} is not a legal argument.");
+        }
+
         public void Visit(CosmosNull cosmosNull)
         {
             this.stringBuilder.Append("null");

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/ItemComparer.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/ItemComparer.cs
@@ -32,11 +32,6 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
         public static readonly MaxValueItem MaxValue = MaxValueItem.Singleton;
 
         /// <summary>
-        /// Undefined is represented by null in the CosmosElement library.
-        /// </summary>
-        private static readonly CosmosElement Undefined = null;
-
-        /// <summary>
         /// Compares to objects and returns their partial sort relationship.
         /// </summary>
         /// <param name="element1">The first element to compare.</param>
@@ -71,16 +66,6 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
             if (object.ReferenceEquals(element2, MaxValueItem.Singleton))
             {
                 return -1;
-            }
-
-            if (element1 == Undefined)
-            {
-                return -1;
-            }
-
-            if (element2 == Undefined)
-            {
-                return 1;
             }
 
             return element1.CompareTo(element2);

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/OrderByCrossPartitionQueryPipelineStage.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/OrderByCrossPartitionQueryPipelineStage.cs
@@ -837,7 +837,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
                 AppendToBuilders(builders, "( ");
 
                 // We need to add the filter for within the same type.
-                if (!(orderByItem is CosmosUndefined))
+                if (orderByItem is not CosmosUndefined)
                 {
                     StringBuilder sb = new StringBuilder();
                     CosmosElementToQueryLiteral cosmosElementToQueryLiteral = new CosmosElementToQueryLiteral(sb);

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/OrderByCrossPartitionQueryPipelineStage.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/OrderByCrossPartitionQueryPipelineStage.cs
@@ -864,9 +864,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
                 }
 
                 // Now we need to include all the types that match the sort order.
-                ReadOnlyMemory<string> isDefinedFunctions = orderByItem == default
-                    ? CosmosElementToIsSystemFunctionsVisitor.VisitUndefined(sortOrder == SortOrder.Ascending)
-                    : orderByItem.Accept(CosmosElementToIsSystemFunctionsVisitor.Singleton, sortOrder == SortOrder.Ascending);
+                ReadOnlyMemory<string> isDefinedFunctions = orderByItem.Accept(CosmosElementToIsSystemFunctionsVisitor.Singleton, sortOrder == SortOrder.Ascending);
                 foreach (string isDefinedFunction in isDefinedFunctions.Span)
                 {
                     AppendToBuilders(builders, " OR ");
@@ -925,7 +923,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
 
                         bool wasInequality;
                         // We need to add the filter for within the same type.
-                        if (!(orderByItem is CosmosUndefined))
+                        if (orderByItem is CosmosUndefined)
                         {
                             ComparisionWithUndefinedFilters filters = new ComparisionWithUndefinedFilters(expression);
 
@@ -1005,9 +1003,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
                         if (wasInequality)
                         {
                             // Now we need to include all the types that match the sort order.
-                            ReadOnlyMemory<string> isDefinedFunctions = orderByItem == default
-                                ? CosmosElementToIsSystemFunctionsVisitor.VisitUndefined(sortOrder == SortOrder.Ascending)
-                                : orderByItem.Accept(CosmosElementToIsSystemFunctionsVisitor.Singleton, sortOrder == SortOrder.Ascending);
+                            ReadOnlyMemory<string> isDefinedFunctions = orderByItem.Accept(CosmosElementToIsSystemFunctionsVisitor.Singleton, sortOrder == SortOrder.Ascending);
                             foreach (string isDefinedFunction in isDefinedFunctions.Span)
                             {
                                 AppendToBuilders(builders, " OR ");
@@ -1257,9 +1253,9 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
                 return GetIsDefinedFunctions(SortOrder.Null, isAscending);
             }
 
-            public ReadOnlyMemory<string> Visit(CosmosUndefined cosmosUndefined, bool input)
+            public ReadOnlyMemory<string> Visit(CosmosUndefined cosmosUndefined, bool isAscending)
             {
-                throw new NotImplementedException();
+                return isAscending ? SystemFunctionSortOrder.Slice(start: 1) : ReadOnlyMemory<string>.Empty;
             }
 
             public ReadOnlyMemory<string> Visit(CosmosNumber cosmosNumber, bool isAscending)
@@ -1275,11 +1271,6 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
             public ReadOnlyMemory<string> Visit(CosmosString cosmosString, bool isAscending)
             {
                 return GetIsDefinedFunctions(SortOrder.String, isAscending);
-            }
-
-            public static ReadOnlyMemory<string> VisitUndefined(bool isAscending)
-            {
-                return isAscending ? SystemFunctionSortOrder.Slice(start: 1) : ReadOnlyMemory<string>.Empty;
             }
 
             private static ReadOnlyMemory<string> GetIsDefinedFunctions(int index, bool isAscending)

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/OrderByCrossPartitionQueryPipelineStage.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/OrderByCrossPartitionQueryPipelineStage.cs
@@ -837,7 +837,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
                 AppendToBuilders(builders, "( ");
 
                 // We need to add the filter for within the same type.
-                if (orderByItem != default)
+                if (!(orderByItem is CosmosUndefined))
                 {
                     StringBuilder sb = new StringBuilder();
                     CosmosElementToQueryLiteral cosmosElementToQueryLiteral = new CosmosElementToQueryLiteral(sb);
@@ -925,7 +925,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
 
                         bool wasInequality;
                         // We need to add the filter for within the same type.
-                        if (orderByItem == default)
+                        if (!(orderByItem is CosmosUndefined))
                         {
                             ComparisionWithUndefinedFilters filters = new ComparisionWithUndefinedFilters(expression);
 
@@ -1255,6 +1255,11 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
             public ReadOnlyMemory<string> Visit(CosmosNull cosmosNull, bool isAscending)
             {
                 return GetIsDefinedFunctions(SortOrder.Null, isAscending);
+            }
+
+            public ReadOnlyMemory<string> Visit(CosmosUndefined cosmosUndefined, bool input)
+            {
+                throw new NotImplementedException();
             }
 
             public ReadOnlyMemory<string> Visit(CosmosNumber cosmosNumber, bool isAscending)

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/OrderByEnumeratorComparer.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/OrderByEnumeratorComparer.cs
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
 
             if (sortOrders.Count == 0)
             {
-                throw new ArgumentException("Sort Orders array can not be empty for an order by comparerer.");
+                throw new ArgumentException("Sort Orders array can not be empty for an order by comparer.");
             }
 
             this.sortOrders = new List<SortOrder>(sortOrders);

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/OrderByItem.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/OrderByItem.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
             {
                 if (!this.cosmosObject.TryGetValue(ItemName, out CosmosElement cosmosElement))
                 {
-                    cosmosElement = null;
+                    cosmosElement = CosmosUndefined.Instance;
                 }
 
                 return cosmosElement;

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/OrderByItem.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/OrderByItem.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
             {
                 if (!this.cosmosObject.TryGetValue(ItemName, out CosmosElement cosmosElement))
                 {
-                    cosmosElement = CosmosUndefined.Instance;
+                    cosmosElement = CosmosUndefined.Create();
                 }
 
                 return cosmosElement;

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/OrderByQueryResult.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/OrderByQueryResult.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
             {
                 if (!this.cosmosObject.TryGetValue("payload", out CosmosElement cosmosElement))
                 {
-                    return CosmosUndefined.Instance;
+                    return CosmosUndefined.Create();
                 }
 
                 return cosmosElement;

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/OrderByQueryResult.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/OrderByQueryResult.cs
@@ -104,7 +104,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
             {
                 if (!this.cosmosObject.TryGetValue("payload", out CosmosElement cosmosElement))
                 {
-                    throw new InvalidOperationException($"Underlying object does not have an 'payload' field.");
+                    return CosmosUndefined.Instance;
                 }
 
                 return cosmosElement;

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Distinct/DistinctHash.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Distinct/DistinctHash.cs
@@ -41,6 +41,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Distinct
 
             private static class HashSeeds
             {
+                public static readonly UInt128 Undefined = UInt128.Create(0xDEAD, 0xBEEF);
                 public static readonly UInt128 Null = UInt128.Create(0x1380f68bb3b0cfe4, 0x156c918bf564ee48);
                 public static readonly UInt128 False = UInt128.Create(0xc1be517fe893b40c, 0xe9fc8a4c531cd0dd);
                 public static readonly UInt128 True = UInt128.Create(0xf86d4abf9a412e74, 0x788488365c8a985d);
@@ -55,6 +56,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Distinct
 
             private static class RootCache
             {
+                public static readonly UInt128 Undefined = MurmurHash3.Hash128(HashSeeds.Undefined, RootHashSeed);
                 public static readonly UInt128 Null = MurmurHash3.Hash128(HashSeeds.Null, RootHashSeed);
                 public static readonly UInt128 False = MurmurHash3.Hash128(HashSeeds.False, RootHashSeed);
                 public static readonly UInt128 True = MurmurHash3.Hash128(HashSeeds.True, RootHashSeed);
@@ -127,6 +129,16 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Distinct
                 }
 
                 return MurmurHash3.Hash128(HashSeeds.Null, seed);
+            }
+
+            public UInt128 Visit(CosmosUndefined cosmosUndefined, UInt128 seed)
+            {
+                if (seed == RootHashSeed)
+                {
+                    return RootCache.Undefined;
+                }
+
+                return MurmurHash3.Hash128(HashSeeds.Undefined, seed);
             }
 
             public UInt128 Visit(CosmosNumber cosmosNumber, UInt128 seed)

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Distinct/DistinctHash.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Distinct/DistinctHash.cs
@@ -22,17 +22,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Distinct
 
         private static UInt128 GetHash(CosmosElement cosmosElement, UInt128 seed)
         {
-            if (cosmosElement == null)
-            {
-                return GetUndefinedHash(seed);
-            }
-
             return cosmosElement.Accept(CosmosElementHasher.Singleton, seed);
-        }
-
-        private static UInt128 GetUndefinedHash(UInt128 seed)
-        {
-            return seed;
         }
 
         private sealed class CosmosElementHasher : ICosmosElementVisitor<UInt128, UInt128>
@@ -41,7 +31,6 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Distinct
 
             private static class HashSeeds
             {
-                public static readonly UInt128 Undefined = UInt128.Create(0xDEAD, 0xBEEF);
                 public static readonly UInt128 Null = UInt128.Create(0x1380f68bb3b0cfe4, 0x156c918bf564ee48);
                 public static readonly UInt128 False = UInt128.Create(0xc1be517fe893b40c, 0xe9fc8a4c531cd0dd);
                 public static readonly UInt128 True = UInt128.Create(0xf86d4abf9a412e74, 0x788488365c8a985d);
@@ -56,7 +45,6 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Distinct
 
             private static class RootCache
             {
-                public static readonly UInt128 Undefined = MurmurHash3.Hash128(HashSeeds.Undefined, RootHashSeed);
                 public static readonly UInt128 Null = MurmurHash3.Hash128(HashSeeds.Null, RootHashSeed);
                 public static readonly UInt128 False = MurmurHash3.Hash128(HashSeeds.False, RootHashSeed);
                 public static readonly UInt128 True = MurmurHash3.Hash128(HashSeeds.True, RootHashSeed);
@@ -82,13 +70,16 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Distinct
                 {
                     CosmosElement arrayItem = cosmosArray[index];
 
-                    // Order of array items matter in equality check, so we add the index just to be safe.
-                    // For now we know that murmurhash will correctly give a different hash for 
-                    // [true, false, true] and [true, true, false]
-                    // due to the way the seed works.
-                    // But we add the index just incase that property does not hold in the future.
-                    UInt128 arrayItemSeed = HashSeeds.ArrayIndex + index;
-                    hash = MurmurHash3.Hash128(arrayItem.Accept(this, arrayItemSeed), hash);
+                    if (arrayItem is not CosmosUndefined)
+                    {
+                        // Order of array items matter in equality check, so we add the index just to be safe.
+                        // For now we know that murmurhash will correctly give a different hash for 
+                        // [true, false, true] and [true, true, false]
+                        // due to the way the seed works.
+                        // But we add the index just incase that property does not hold in the future.
+                        UInt128 arrayItemSeed = HashSeeds.ArrayIndex + index;
+                        hash = MurmurHash3.Hash128(arrayItem.Accept(this, arrayItemSeed), hash);
+                    }
                 }
 
                 return hash;
@@ -133,12 +124,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Distinct
 
             public UInt128 Visit(CosmosUndefined cosmosUndefined, UInt128 seed)
             {
-                if (seed == RootHashSeed)
-                {
-                    return RootCache.Undefined;
-                }
-
-                return MurmurHash3.Hash128(HashSeeds.Undefined, seed);
+                // undefined is ignored while hashing
+                return seed;
             }
 
             public UInt128 Visit(CosmosNumber cosmosNumber, UInt128 seed)
@@ -183,16 +170,19 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Distinct
                 // This is consistent with equality comparison.
                 foreach (KeyValuePair<string, CosmosElement> kvp in cosmosObject)
                 {
-                    UInt128 nameHash = MurmurHash3.Hash128(kvp.Key, MurmurHash3.Hash128(HashSeeds.String, HashSeeds.PropertyName));
-                    UInt128 propertyHash = kvp.Value.Accept(this, nameHash);
+                    if (kvp.Value is not CosmosUndefined)
+                    {
+                        UInt128 nameHash = MurmurHash3.Hash128(kvp.Key, MurmurHash3.Hash128(HashSeeds.String, HashSeeds.PropertyName));
+                        UInt128 propertyHash = kvp.Value.Accept(this, nameHash);
 
-                    //// xor is symmetric meaning that a ^ b = b ^ a
-                    //// Which is great since now we can add the property hashes to the intermediate hash
-                    //// in any order and get the same result, which upholds our definition of equality.
-                    //// Note that we don't have to worry about a ^ a = 0 = b ^ b for duplicate property values,
-                    //// since the hash of property values are seeded with the hash of property names,
-                    //// which are unique within an object.
-                    intermediateHash ^= propertyHash;
+                        //// xor is symmetric meaning that a ^ b = b ^ a
+                        //// Which is great since now we can add the property hashes to the intermediate hash
+                        //// in any order and get the same result, which upholds our definition of equality.
+                        //// Note that we don't have to worry about a ^ a = 0 = b ^ b for duplicate property values,
+                        //// since the hash of property values are seeded with the hash of property names,
+                        //// which are unique within an object.
+                        intermediateHash ^= propertyHash;
+                    }
                 }
 
                 // Only if the object was not empty do we want to bring in the intermediate hash.

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/GroupBy/GroupByQueryPipelineStage.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/GroupBy/GroupByQueryPipelineStage.cs
@@ -152,7 +152,12 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.GroupBy
 
             public bool TryGetPayload(out CosmosElement payload)
             {
-                return this.cosmosObject.TryGetValue(PayloadPropertyName, out payload);
+                if (!this.cosmosObject.TryGetValue(PayloadPropertyName, out payload))
+                {
+                    payload = CosmosUndefined.Create();
+                }
+
+                return true;
             }
         }
 

--- a/Microsoft.Azure.Cosmos/src/Serializer/CosmosElementSerializer.cs
+++ b/Microsoft.Azure.Cosmos/src/Serializer/CosmosElementSerializer.cs
@@ -145,7 +145,10 @@ namespace Microsoft.Azure.Cosmos.Serializer
 
             foreach (CosmosElement element in cosmosElements)
             {
-                element.WriteTo(jsonWriter);
+                if (element is not CosmosUndefined)
+                {
+                    element.WriteTo(jsonWriter);
+                }
             }
 
             jsonWriter.WriteArrayEnd();

--- a/Microsoft.Azure.Cosmos/src/Serializer/CosmosElementSerializer.cs
+++ b/Microsoft.Azure.Cosmos/src/Serializer/CosmosElementSerializer.cs
@@ -145,10 +145,7 @@ namespace Microsoft.Azure.Cosmos.Serializer
 
             foreach (CosmosElement element in cosmosElements)
             {
-                if (element is not CosmosUndefined)
-                {
-                    element.WriteTo(jsonWriter);
-                }
+                element.WriteTo(jsonWriter);
             }
 
             jsonWriter.WriteArrayEnd();

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/AggregateQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/AggregateQueryTests.cs
@@ -98,7 +98,7 @@
                         predicate: $"IS_NUMBER(r.{aggregateTestArgs.PartitionKey})"),
                     new AggregateQueryArguments(
                         aggregateOperator: "AVG",
-                        expectedValue: CosmosUndefined.Instance,
+                        expectedValue: CosmosUndefined.Create(),
                         predicate: "true"),
                     new AggregateQueryArguments(
                         aggregateOperator: "COUNT",
@@ -118,7 +118,7 @@
                         predicate: $"IS_NUMBER(r.{aggregateTestArgs.PartitionKey})"),
                     new AggregateQueryArguments(
                         aggregateOperator: "SUM",
-                        expectedValue: CosmosUndefined.Instance,
+                        expectedValue: CosmosUndefined.Create(),
                         predicate: $"true"),
                 };
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/CosmosUndefinedQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/CosmosUndefinedQueryTests.cs
@@ -1,12 +1,17 @@
 namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
 {
+    using System;
     using System.Collections;
     using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.IO;
     using System.Linq;
     using System.Runtime.CompilerServices;
     using System.Runtime.InteropServices;
+    using System.Text;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.CosmosElements;
+    using Microsoft.Azure.Cosmos.CosmosElements.Numbers;
     using Microsoft.Azure.Cosmos.Json;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -22,35 +27,92 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
 
         private const int MixedTypeCount = 5;
 
+        private static readonly IEnumerable<string> Documents = CreateDocuments(DocumentCount);
+
         [TestMethod]
         public async Task OrderByUndefinedProjectUndefined()
         {
-            IEnumerable<string> documents = CreateDocuments();
-
-            static async Task TypedImplementation(Container container, IReadOnlyList<CosmosObject> _)
+            UndefinedProjectionTestCase[] testCases = new[]
             {
-                string query = "SELECT c.AlwaysUndefinedField FROM c ORDER BY c.AlwaysUndefinedField";
+                MakeUndefinedProjectionTest(
+                    query: "SELECT c.AlwaysUndefinedField FROM c ORDER BY c.AlwaysUndefinedField",
+                    expectedCount: DocumentCount),
+                MakeUndefinedProjectionTest(
+                    query: "SELECT VALUE c.AlwaysUndefinedField FROM c ORDER BY c.AlwaysUndefinedField",
+                    expectedCount: 0)
+            };
 
-                List<UndefinedProjection> results = await QueryWithContinuationTokensAsync<UndefinedProjection>(container, query);
-                Assert.AreEqual(DocumentCount, results.Count);
-                Assert.IsTrue(results.All(x => x is UndefinedProjection));
+            static async Task TypedImplementation(Container container, IReadOnlyList<CosmosObject> _, UndefinedProjectionTestCase[] testCases)
+            {
+                foreach (UndefinedProjectionTestCase testCase in testCases)
+                {
+                    foreach (int pageSize in new[] { 5, 10, -1 })
+                    {
+                        List<UndefinedProjection> results = await RunQueryAsync<UndefinedProjection>(
+                            container,
+                            testCase.Query,
+                            new QueryRequestOptions { MaxItemCount = pageSize });
+    
+                        Assert.AreEqual(testCase.ExpectedResultCount, results.Count);
+                        Assert.IsTrue(results.All(x => x is UndefinedProjection));
+                    }
+                }
             }
 
-            await this.CreateIngestQueryDeleteAsync(
-                ConnectionModes.Direct,
-                CollectionTypes.MultiPartition,
-                documents,
-                TypedImplementation);
+            await this.CreateIngestQueryDeleteAsync<UndefinedProjectionTestCase[]>(
+                ConnectionModes.Direct | ConnectionModes.Gateway,
+                CollectionTypes.MultiPartition | CollectionTypes.SinglePartition | CollectionTypes.NonPartitioned,
+                Documents,
+                TypedImplementation,
+                testCases);
         }
 
-
-        private static IEnumerable<string> CreateDocuments()
+        [TestMethod]
+        public async Task GroupByUndefined()
         {
-            List<MixedTypeDocument> documents = new List<MixedTypeDocument>();
+            GroupByUndefinedTestCase[] testCases = new[]
+            {
+                MakeGroupByTest(
+                    query: "SELECT c.AlwaysUndefinedField as MixedTypeField, COUNT(1) as ExpectedCount FROM c GROUP BY c.AlwaysUndefinedField",
+                    groups: new List<GroupByProjection>()
+                    {
+                        MakeGrouping(
+                            key: null,
+                            value: DocumentCount)
+                    })
+            };
+
+            static async Task TypedImplementation(Container container, IReadOnlyList<CosmosObject> _, GroupByUndefinedTestCase[] testCases)
+            {
+                foreach (GroupByUndefinedTestCase testCase in testCases)
+                {
+                    foreach (int pageSize in new[] { 5, 10, -1 })
+                    {
+                        List<GroupByProjection> actual = await QueryWithoutContinuationTokensAsync<GroupByProjection>(
+                            container,
+                            testCase.Query,
+                            new QueryRequestOptions { MaxItemCount = pageSize, MaxConcurrency = 0 });
+
+                        CollectionAssert.AreEquivalent(testCase.ExpectedGroups, actual);
+                    }
+                }
+            }
+
+            await this.CreateIngestQueryDeleteAsync<GroupByUndefinedTestCase[]>(
+                ConnectionModes.Direct | ConnectionModes.Gateway,
+                CollectionTypes.MultiPartition | CollectionTypes.SinglePartition | CollectionTypes.NonPartitioned,
+                Documents,
+                TypedImplementation,
+                testCases);
+        }
+
+        private static IEnumerable<string> CreateDocuments(int count)
+        {
+            List<string> documents = new List<string>();
 
             int booleanCount = 0;
             int integerCount = 0;
-            for (int index = 0; index < DocumentCount; ++index)
+            for (int index = 0; index < count; ++index)
             {
                 CosmosElement mixedTypeElement;
                 switch (index % MixedTypeCount)
@@ -68,7 +130,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
                         break;
 
                     case 3:
-                        mixedTypeElement = CosmosNumber.Parse((++integerCount).ToString());
+                        mixedTypeElement = CosmosNumber64.Create(++integerCount);
                         break;
 
                     case 4:
@@ -82,21 +144,130 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
                 }
 
                 MixedTypeDocument document = new MixedTypeDocument(index, mixedTypeElement);
-                documents.Add(document);
+                documents.Add(document.ToString());
             }
 
-            return documents.Select(x => x.ToString());
+            return documents;
         }
 
-        private readonly struct UntypedTestCase
+        private readonly struct UndefinedProjectionTestCase
         {
+            public UndefinedProjectionTestCase(string query, int expectedResultCount)
+            {
+                this.Query = query;
+                this.ExpectedResultCount = expectedResultCount;
+            }
+
             public string Query { get; }
 
-            public int PageSize { get; }
+            public int ExpectedResultCount { get; }
         }
 
-        private class UndefinedProjection
+        private static UndefinedProjectionTestCase MakeUndefinedProjectionTest(string query, int expectedCount)
         {
+            return new UndefinedProjectionTestCase(query, expectedCount);
+        }
+
+        private readonly struct GroupByUndefinedTestCase
+        {
+            public GroupByUndefinedTestCase(string query, List<GroupByProjection> groups)
+            {
+                this.Query = query;
+                this.ExpectedGroups = groups;
+            }
+
+            public string Query { get; }
+
+            public List<GroupByProjection> ExpectedGroups { get; }
+        }
+
+        private static GroupByUndefinedTestCase MakeGroupByTest(string query, List<GroupByProjection> groups)
+        {
+            return new GroupByUndefinedTestCase(query, groups);
+        }
+
+        private class GroupByProjection : IEquatable<GroupByProjection>
+        {
+            public CosmosElement MixedTypeField { get; set; }
+
+            public int ExpectedCount { get; set; }
+
+            public static bool operator ==(GroupByProjection left, GroupByProjection right)
+            {
+                bool result;
+                if(left is null && right is null)
+                {
+                    result = true;
+                }
+                else if(left is null || right is null)
+                {
+                    result = false;
+                }
+                else
+                {
+                    result = left.Equals(right);
+                }
+
+                return result;
+            }
+
+            public static bool operator !=(GroupByProjection left, GroupByProjection right)
+            {
+                return !(left == right);
+            }
+
+            public bool Equals(GroupByProjection other)
+            {
+                bool result;
+                if(other is null)
+                {
+                    result = false;
+                }
+                else
+                {
+                    result = this.ExpectedCount == other.ExpectedCount;
+                    if (this.MixedTypeField == null && other.MixedTypeField == null)
+                    {
+                    }
+                    else if (this.MixedTypeField == null || other.MixedTypeField == null)
+                    {
+                        result = false;
+                    }
+                    else
+                    {
+                        result = result && this.MixedTypeField.Equals(other.MixedTypeField);
+                    }
+                }
+
+                return result;
+            }
+
+            public override bool Equals(object other)
+            {
+                return (other is not null) && (other is GroupByProjection projection)
+                    && this.Equals(projection);
+            }
+
+            public override int GetHashCode()
+            {
+                HashCode hash = new HashCode();
+                hash.Add(this.ExpectedCount);
+                hash.Add(this.MixedTypeField);
+                return hash.ToHashCode();
+            }
+        }
+
+        private static GroupByProjection MakeGrouping(CosmosElement key, int value)
+        {
+            return new GroupByProjection() { MixedTypeField = key, ExpectedCount = value };
+        }
+
+        private class UndefinedProjection : IEquatable<UndefinedProjection>
+        {
+            public bool Equals(UndefinedProjection other)
+            {
+                return true;
+            }
         }
 
         private class MixedTypeDocument

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/CosmosUndefinedQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/CosmosUndefinedQueryTests.cs
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
                 switch (index % MixedTypeCount)
                 {
                     case 0:
-                        mixedTypeElement = CosmosUndefined.Instance;
+                        mixedTypeElement = CosmosUndefined.Create();
                         break;
 
                     case 1:

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/CosmosUndefinedQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/CosmosUndefinedQueryTests.cs
@@ -1,0 +1,140 @@
+namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
+{
+    using System.Collections;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Runtime.CompilerServices;
+    using System.Runtime.InteropServices;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.CosmosElements;
+    using Microsoft.Azure.Cosmos.Json;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    [TestCategory("Query")]
+    public sealed class CosmosUndefinedQueryTests : QueryTestsBase
+    {
+        // Kinds of tests that we need to run:
+        // 1. typed response
+        // 2. typed response with custom serializer
+        // 3. untyped response
+        private const int DocumentCount = 400;
+
+        private const int MixedTypeCount = 5;
+
+        [TestMethod]
+        public async Task OrderByUndefinedProjectUndefined()
+        {
+            IEnumerable<string> documents = CreateDocuments();
+
+            static async Task TypedImplementation(Container container, IReadOnlyList<CosmosObject> _)
+            {
+                string query = "SELECT c.AlwaysUndefinedField FROM c ORDER BY c.AlwaysUndefinedField";
+
+                List<UndefinedProjection> results = await QueryWithContinuationTokensAsync<UndefinedProjection>(container, query);
+                Assert.AreEqual(DocumentCount, results.Count);
+                Assert.IsTrue(results.All(x => x is UndefinedProjection));
+            }
+
+            await this.CreateIngestQueryDeleteAsync(
+                ConnectionModes.Direct,
+                CollectionTypes.MultiPartition,
+                documents,
+                TypedImplementation);
+        }
+
+
+        private static IEnumerable<string> CreateDocuments()
+        {
+            List<MixedTypeDocument> documents = new List<MixedTypeDocument>();
+
+            int booleanCount = 0;
+            int integerCount = 0;
+            for (int index = 0; index < DocumentCount; ++index)
+            {
+                CosmosElement mixedTypeElement;
+                switch (index % MixedTypeCount)
+                {
+                    case 0:
+                        mixedTypeElement = CosmosUndefined.Instance;
+                        break;
+
+                    case 1:
+                        mixedTypeElement = CosmosNull.Create();
+                        break;
+
+                    case 2:
+                        mixedTypeElement = CosmosBoolean.Create(++booleanCount % 2 == 0);
+                        break;
+
+                    case 3:
+                        mixedTypeElement = CosmosNumber.Parse((++integerCount).ToString());
+                        break;
+
+                    case 4:
+                        mixedTypeElement = CosmosString.Create((++integerCount).ToString());
+                        break;
+
+                    default:
+                        mixedTypeElement = null;
+                        Assert.Fail("Illegal value found for mixed type");
+                        break;
+                }
+
+                MixedTypeDocument document = new MixedTypeDocument(index, mixedTypeElement);
+                documents.Add(document);
+            }
+
+            return documents.Select(x => x.ToString());
+        }
+
+        private readonly struct UntypedTestCase
+        {
+            public string Query { get; }
+
+            public int PageSize { get; }
+        }
+
+        private class UndefinedProjection
+        {
+        }
+
+        private class MixedTypeDocument
+        {
+            public int IntegerField { get; set; }
+
+            public CosmosElement MixedTypeField { get; set; }
+
+            public string AlwaysUndefinedField { get; set; }
+
+            public MixedTypeDocument()
+            {
+            }
+
+            public MixedTypeDocument(int integerField, CosmosElement mixedTypeField)
+            {
+                this.IntegerField = integerField;
+                this.MixedTypeField = mixedTypeField;
+            }
+
+            public override string ToString()
+            {
+                IJsonWriter writer = JsonWriter.Create(JsonSerializationFormat.Text);
+                writer.WriteObjectStart();
+
+                writer.WriteFieldName(nameof(this.IntegerField));
+                writer.WriteNumber64Value(this.IntegerField);
+
+                if (this.MixedTypeField is not CosmosUndefined)
+                {
+                    writer.WriteFieldName(nameof(this.MixedTypeField));
+                    this.MixedTypeField.WriteTo(writer);
+                }
+
+                writer.WriteObjectEnd();
+
+                return Utf8StringHelpers.ToString(writer.GetResult());
+            }
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/GroupByQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/GroupByQueryTests.cs
@@ -338,6 +338,22 @@
                         .Select(grouping => grouping.Key)
                         .ToList()
                 ),
+
+                // ------------------------------------------
+                // GROUP BY undefined
+                // ------------------------------------------
+
+                (
+                    "SELECT COUNT(1) as count, c.DoesNotExist as DoesNotExist FROM c GROUP BY c.DoesNotExist",
+                    new[]
+                    {
+                        CosmosObject.Create(
+                            new Dictionary<string, CosmosElement>()
+                            {
+                                { "count", CosmosNumber64.Create(documents.Count) }
+                            })
+                    }
+                ),
             };
 
             // Test query correctness.

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/OrderByQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/OrderByQueryTests.cs
@@ -1114,7 +1114,7 @@
                 MixedTypedDocument mixedTypeDocument = OrderByQueryTests.GenerateMixedTypeDocument(random);
                 for (int j = 0; j < numberOfDuplicates; j++)
                 {
-                    if (mixedTypeDocument.MixedTypeField != null)
+                    if (mixedTypeDocument.MixedTypeField is not CosmosUndefined)
                     {
                         documents.Add(JsonConvert.SerializeObject(mixedTypeDocument));
                     }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/OrderByQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/OrderByQueryTests.cs
@@ -1213,7 +1213,7 @@
                 // Array
                 5 => CosmosArray.Create(new List<CosmosElement>()),
                 // Undefined
-                6 => null,
+                6 => CosmosUndefined.Instance,
                 _ => throw new ArgumentException(),
             };
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/OrderByQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/OrderByQueryTests.cs
@@ -962,7 +962,7 @@
                         {
                             if (!((CosmosObject)x).TryGetValue(possiblyUndefinedFieldName, out CosmosElement cosmosElement))
                             {
-                                cosmosElement = null;
+                                cosmosElement = CosmosUndefined.Create();
                             }
 
                             return cosmosElement;
@@ -973,7 +973,7 @@
                         {
                             if (!x.TryGetValue(possiblyUndefinedFieldName, out CosmosElement cosmosElement))
                             {
-                                cosmosElement = null;
+                                cosmosElement = CosmosUndefined.Create();
                             }
 
                             return cosmosElement;
@@ -1029,7 +1029,7 @@
                                     {
                                         if (!((CosmosObject)x).TryGetValue(switchColumns ? possiblyUndefinedFieldName : alwaysDefinedFieldName, out CosmosElement cosmosElement))
                                         {
-                                            cosmosElement = null;
+                                            cosmosElement = CosmosUndefined.Create();
                                         }
 
                                         return cosmosElement;
@@ -1039,7 +1039,7 @@
                                     {
                                         if (!((CosmosObject)x).TryGetValue(switchColumns ? possiblyUndefinedFieldName : alwaysDefinedFieldName, out CosmosElement cosmosElement))
                                         {
-                                            cosmosElement = null;
+                                            cosmosElement = CosmosUndefined.Create();
                                         }
 
                                         return cosmosElement;
@@ -1051,7 +1051,7 @@
                                     {
                                         if (!((CosmosObject)x).TryGetValue(switchColumns ? alwaysDefinedFieldName : possiblyUndefinedFieldName, out CosmosElement cosmosElement))
                                         {
-                                            cosmosElement = null;
+                                            cosmosElement = CosmosUndefined.Create();
                                         }
 
                                         return cosmosElement;
@@ -1061,7 +1061,7 @@
                                     {
                                         if (!((CosmosObject)x).TryGetValue(switchColumns ? alwaysDefinedFieldName : possiblyUndefinedFieldName, out CosmosElement cosmosElement))
                                         {
-                                            cosmosElement = null;
+                                            cosmosElement = CosmosUndefined.Create();
                                         }
 
                                         return cosmosElement;
@@ -1384,7 +1384,7 @@
                         {
                             if (!x.TryGetValue(nameof(MixedTypedDocument.MixedTypeField), out CosmosElement cosmosElement))
                             {
-                                cosmosElement = null;
+                                cosmosElement = CosmosUndefined.Create();
                             }
 
                             return cosmosElement;
@@ -1396,7 +1396,7 @@
                         {
                             if (!x.TryGetValue(nameof(MixedTypedDocument.MixedTypeField), out CosmosElement cosmosElement))
                             {
-                                cosmosElement = null;
+                                cosmosElement = CosmosUndefined.Create();
                             }
 
                             return cosmosElement;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/OrderByQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/OrderByQueryTests.cs
@@ -1213,7 +1213,7 @@
                 // Array
                 5 => CosmosArray.Create(new List<CosmosElement>()),
                 // Undefined
-                6 => CosmosUndefined.Instance,
+                6 => CosmosUndefined.Create(),
                 _ => throw new ArgumentException(),
             };
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/QueryTestsBase.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/QueryTestsBase.cs
@@ -811,11 +811,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
                     {
                         List<CosmosElement> first = queryExecutionResults[queryDrainingMode1];
                         List<CosmosElement> second = queryExecutionResults[queryDrainingMode2];
-                        Assert.IsTrue(
-                            first.SequenceEqual(second),
-                            $"{query} returned different results.\n" +
-                            $"{queryDrainingMode1}: {JsonConvert.SerializeObject(first)}\n" +
-                            $"{queryDrainingMode2}: {JsonConvert.SerializeObject(second)}\n");
+                        Assert.IsTrue(first.SequenceEqual(second));
                     }
                 }
             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/QueryTestsBase.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/QueryTestsBase.cs
@@ -744,7 +744,15 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
             string query,
             QueryRequestOptions queryRequestOptions = null)
         {
-            return RunQueryCombinationsAsync(
+            return RunQueryAsync<CosmosElement>(container, query, queryRequestOptions);
+        }
+
+        internal static Task<List<T>> RunQueryAsync<T>(
+            Container container,
+            string query,
+            QueryRequestOptions queryRequestOptions = null)
+        {
+            return RunQueryCombinationsAsync<T>(
                 container,
                 query,
                 queryRequestOptions,
@@ -760,7 +768,16 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
             CosmosElementContinuationToken = 4,
         }
 
-        internal static async Task<List<CosmosElement>> RunQueryCombinationsAsync(
+        internal static Task<List<CosmosElement>> RunQueryCombinationsAsync(
+            Container container,
+            string query,
+            QueryRequestOptions queryRequestOptions,
+            QueryDrainingMode queryDrainingMode)
+        {
+            return RunQueryCombinationsAsync<CosmosElement>(container, query, queryRequestOptions, queryDrainingMode);
+        }
+
+            internal static async Task<List<T>> RunQueryCombinationsAsync<T>(
             Container container,
             string query,
             QueryRequestOptions queryRequestOptions,
@@ -771,11 +788,11 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
                 throw new ArgumentOutOfRangeException(nameof(queryDrainingMode));
             }
 
-            Dictionary<QueryDrainingMode, List<CosmosElement>> queryExecutionResults = new Dictionary<QueryDrainingMode, List<CosmosElement>>();
+            Dictionary<QueryDrainingMode, List<T>> queryExecutionResults = new Dictionary<QueryDrainingMode, List<T>>();
 
             if (queryDrainingMode.HasFlag(QueryDrainingMode.HoldState))
             {
-                List<CosmosElement> queryResultsWithoutContinuationToken = await QueryWithoutContinuationTokensAsync<CosmosElement>(
+                List<T> queryResultsWithoutContinuationToken = await QueryWithoutContinuationTokensAsync<T>(
                     container,
                     query,
                     queryRequestOptions);
@@ -785,7 +802,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
 
             if (queryDrainingMode.HasFlag(QueryDrainingMode.ContinuationToken))
             {
-                List<CosmosElement> queryResultsWithContinuationTokens = await QueryWithContinuationTokensAsync<CosmosElement>(
+                List<T> queryResultsWithContinuationTokens = await QueryWithContinuationTokensAsync<T>(
                     container,
                     query,
                     queryRequestOptions);
@@ -795,7 +812,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
 
             if (queryDrainingMode.HasFlag(QueryDrainingMode.CosmosElementContinuationToken))
             {
-                List<CosmosElement> queryResultsWithCosmosElementContinuationToken = await QueryWithCosmosElementContinuationTokenAsync<CosmosElement>(
+                List<T> queryResultsWithCosmosElementContinuationToken = await QueryWithCosmosElementContinuationTokenAsync<T>(
                     container,
                     query,
                     queryRequestOptions);
@@ -809,8 +826,8 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
                 {
                     if (queryDrainingMode1 != queryDrainingMode2)
                     {
-                        List<CosmosElement> first = queryExecutionResults[queryDrainingMode1];
-                        List<CosmosElement> second = queryExecutionResults[queryDrainingMode2];
+                        List<T> first = queryExecutionResults[queryDrainingMode1];
+                        List<T> second = queryExecutionResults[queryDrainingMode2];
                         Assert.IsTrue(first.SequenceEqual(second));
                     }
                 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/InMemoryContainer.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/InMemoryContainer.cs
@@ -1508,6 +1508,11 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
             {
                 return SqlLiteralScalarExpression.Create(SqlStringLiteral.Create(cosmosString.Value));
             }
+
+            public SqlScalarExpression Visit(CosmosUndefined cosmosUndefined)
+            {
+                return SqlLiteralScalarExpression.Create(SqlUndefinedLiteral.Create());
+            }
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/ContinuationTokens/OrderByContinuationTokenTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/ContinuationTokens/OrderByContinuationTokenTests.cs
@@ -6,9 +6,12 @@ namespace Microsoft.Azure.Cosmos.Query
 {
     using System;
     using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
     using System.Text;
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.CosmosElements.Numbers;
+    using Microsoft.Azure.Cosmos.Json;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.Parallel;
@@ -51,6 +54,32 @@ namespace Microsoft.Azure.Cosmos.Query
             OrderByContinuationToken orderByContinuationTokenFromCosmosElement = tryOrderByContinuationTokenFromCosmosElement.Result;
             Assert.IsNotNull(orderByContinuationTokenFromCosmosElement);
             Assert.AreEqual(cosmosElementToken.ToString(), OrderByContinuationToken.ToCosmosElement(orderByContinuationTokenFromCosmosElement).ToString());
+        }
+
+        [TestMethod]
+        public void TestOrderByUndefined()
+        {
+            string testResponse = @"{""_rid"":""CuECAN5Z6bM="",""Documents"":[{""_rid"":""CuECAN5Z6bMOAAAAAAAAAA=="",""orderByItems"":[{}]},{""_rid"":""CuECAN5Z6bMNAAAAAAAAAA=="",""orderByItems"":[{}]},{""_rid"":""CuECAN5Z6bMMAAAAAAAAAA=="",""orderByItems"":[{}]},{""_rid"":""CuECAN5Z6bMLAAAAAAAAAA=="",""orderByItems"":[{}]},{""_rid"":""CuECAN5Z6bMKAAAAAAAAAA=="",""orderByItems"":[{}]},{""_rid"":""CuECAN5Z6bMJAAAAAAAAAA=="",""orderByItems"":[{}]},{""_rid"":""CuECAN5Z6bMIAAAAAAAAAA=="",""orderByItems"":[{}]},{""_rid"":""CuECAN5Z6bMHAAAAAAAAAA=="",""orderByItems"":[{}]},{""_rid"":""CuECAN5Z6bMGAAAAAAAAAA=="",""orderByItems"":[{}]},{""_rid"":""CuECAN5Z6bMFAAAAAAAAAA=="",""orderByItems"":[{}]},{""_rid"":""CuECAN5Z6bMEAAAAAAAAAA=="",""orderByItems"":[{}]},{""_rid"":""CuECAN5Z6bMDAAAAAAAAAA=="",""orderByItems"":[{}]},{""_rid"":""CuECAN5Z6bMCAAAAAAAAAA=="",""orderByItems"":[{}]},{""_rid"":""CuECAN5Z6bMBAAAAAAAAAA=="",""orderByItems"":[{}]}],""_count"":14}";
+
+            MemoryStream memoryStream = new MemoryStream(Encoding.UTF8.GetBytes(testResponse));
+
+            CosmosArray documents = CosmosQueryClientCore.ParseElementsFromRestStream(
+                memoryStream,
+                Documents.ResourceType.Document,
+                new CosmosSerializationFormatOptions(
+                    "JsonText",
+                    (content) => JsonNavigator.Create(content),
+                    () => JsonWriter.Create(JsonSerializationFormat.Text)));
+
+            List<OrderByQueryResult> orderByQueryResults = documents.Select(x => new OrderByQueryResult(x)).ToList();
+            Assert.AreEqual(14, orderByQueryResults.Count);
+
+            foreach (OrderByQueryResult orderByQueryResult in orderByQueryResults)
+            {
+                Assert.IsTrue(orderByQueryResult.Payload.Equals(CosmosUndefined.Instance));
+                Assert.AreEqual(1, orderByQueryResult.OrderByItems.Count());
+                Assert.IsTrue(orderByQueryResult.OrderByItems.First().Item.Equals(CosmosUndefined.Instance));
+            }
         }
 
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/ContinuationTokens/OrderByContinuationTokenTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/ContinuationTokens/OrderByContinuationTokenTests.cs
@@ -57,32 +57,6 @@ namespace Microsoft.Azure.Cosmos.Query
         }
 
         [TestMethod]
-        public void TestOrderByUndefined()
-        {
-            string testResponse = @"{""_rid"":""CuECAN5Z6bM="",""Documents"":[{""_rid"":""CuECAN5Z6bMOAAAAAAAAAA=="",""orderByItems"":[{}]},{""_rid"":""CuECAN5Z6bMNAAAAAAAAAA=="",""orderByItems"":[{}]},{""_rid"":""CuECAN5Z6bMMAAAAAAAAAA=="",""orderByItems"":[{}]},{""_rid"":""CuECAN5Z6bMLAAAAAAAAAA=="",""orderByItems"":[{}]},{""_rid"":""CuECAN5Z6bMKAAAAAAAAAA=="",""orderByItems"":[{}]},{""_rid"":""CuECAN5Z6bMJAAAAAAAAAA=="",""orderByItems"":[{}]},{""_rid"":""CuECAN5Z6bMIAAAAAAAAAA=="",""orderByItems"":[{}]},{""_rid"":""CuECAN5Z6bMHAAAAAAAAAA=="",""orderByItems"":[{}]},{""_rid"":""CuECAN5Z6bMGAAAAAAAAAA=="",""orderByItems"":[{}]},{""_rid"":""CuECAN5Z6bMFAAAAAAAAAA=="",""orderByItems"":[{}]},{""_rid"":""CuECAN5Z6bMEAAAAAAAAAA=="",""orderByItems"":[{}]},{""_rid"":""CuECAN5Z6bMDAAAAAAAAAA=="",""orderByItems"":[{}]},{""_rid"":""CuECAN5Z6bMCAAAAAAAAAA=="",""orderByItems"":[{}]},{""_rid"":""CuECAN5Z6bMBAAAAAAAAAA=="",""orderByItems"":[{}]}],""_count"":14}";
-
-            MemoryStream memoryStream = new MemoryStream(Encoding.UTF8.GetBytes(testResponse));
-
-            CosmosArray documents = CosmosQueryClientCore.ParseElementsFromRestStream(
-                memoryStream,
-                Documents.ResourceType.Document,
-                new CosmosSerializationFormatOptions(
-                    "JsonText",
-                    (content) => JsonNavigator.Create(content),
-                    () => JsonWriter.Create(JsonSerializationFormat.Text)));
-
-            List<OrderByQueryResult> orderByQueryResults = documents.Select(x => new OrderByQueryResult(x)).ToList();
-            Assert.AreEqual(14, orderByQueryResults.Count);
-
-            foreach (OrderByQueryResult orderByQueryResult in orderByQueryResults)
-            {
-                Assert.IsTrue(orderByQueryResult.Payload.Equals(CosmosUndefined.Instance));
-                Assert.AreEqual(1, orderByQueryResult.OrderByItems.Count());
-                Assert.IsTrue(orderByQueryResult.OrderByItems.First().Item.Equals(CosmosUndefined.Instance));
-            }
-        }
-
-        [TestMethod]
         public void TestOrderByQueryLiterals()
         {
             StringBuilder sb = new StringBuilder();

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/ContinuationTokens/OrderByQueryResultTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/ContinuationTokens/OrderByQueryResultTests.cs
@@ -42,9 +42,9 @@ namespace Microsoft.Azure.Cosmos.Query
 
             foreach (OrderByQueryResult orderByQueryResult in orderByQueryResults)
             {
-                Assert.IsTrue(orderByQueryResult.Payload.Equals(CosmosUndefined.Instance));
+                Assert.IsTrue(orderByQueryResult.Payload.Equals(CosmosUndefined.Create()));
                 Assert.AreEqual(1, orderByQueryResult.OrderByItems.Count());
-                Assert.IsTrue(orderByQueryResult.OrderByItems.First().Item.Equals(CosmosUndefined.Instance));
+                Assert.IsTrue(orderByQueryResult.OrderByItems.First().Item.Equals(CosmosUndefined.Create()));
             }
         }
     }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/ContinuationTokens/OrderByQueryResultTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/ContinuationTokens/OrderByQueryResultTests.cs
@@ -1,0 +1,51 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Query
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Text;
+    using Microsoft.Azure.Cosmos.CosmosElements;
+    using Microsoft.Azure.Cosmos.CosmosElements.Numbers;
+    using Microsoft.Azure.Cosmos.Json;
+    using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.Parallel;
+    using Microsoft.Azure.Documents.Routing;
+    using VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class OrderByQueryResultTests
+    {
+        [TestMethod]
+        [Owner("ndeshpan")]
+        public void TestOrderByUndefined()
+        {
+            string testResponse = @"{""_rid"":""CuECAN5Z6bM="",""Documents"":[{""_rid"":""CuECAN5Z6bMOAAAAAAAAAA=="",""orderByItems"":[{}]},{""_rid"":""CuECAN5Z6bMNAAAAAAAAAA=="",""orderByItems"":[{}]},{""_rid"":""CuECAN5Z6bMMAAAAAAAAAA=="",""orderByItems"":[{}]},{""_rid"":""CuECAN5Z6bMLAAAAAAAAAA=="",""orderByItems"":[{}]},{""_rid"":""CuECAN5Z6bMKAAAAAAAAAA=="",""orderByItems"":[{}]},{""_rid"":""CuECAN5Z6bMJAAAAAAAAAA=="",""orderByItems"":[{}]},{""_rid"":""CuECAN5Z6bMIAAAAAAAAAA=="",""orderByItems"":[{}]},{""_rid"":""CuECAN5Z6bMHAAAAAAAAAA=="",""orderByItems"":[{}]},{""_rid"":""CuECAN5Z6bMGAAAAAAAAAA=="",""orderByItems"":[{}]},{""_rid"":""CuECAN5Z6bMFAAAAAAAAAA=="",""orderByItems"":[{}]},{""_rid"":""CuECAN5Z6bMEAAAAAAAAAA=="",""orderByItems"":[{}]},{""_rid"":""CuECAN5Z6bMDAAAAAAAAAA=="",""orderByItems"":[{}]},{""_rid"":""CuECAN5Z6bMCAAAAAAAAAA=="",""orderByItems"":[{}]},{""_rid"":""CuECAN5Z6bMBAAAAAAAAAA=="",""orderByItems"":[{}]}],""_count"":14}";
+
+            MemoryStream memoryStream = new MemoryStream(Encoding.UTF8.GetBytes(testResponse));
+
+            CosmosArray documents = CosmosQueryClientCore.ParseElementsFromRestStream(
+                memoryStream,
+                Documents.ResourceType.Document,
+                new CosmosSerializationFormatOptions(
+                    "JsonText",
+                    (content) => JsonNavigator.Create(content),
+                    () => JsonWriter.Create(JsonSerializationFormat.Text)));
+
+            List<OrderByQueryResult> orderByQueryResults = documents.Select(x => new OrderByQueryResult(x)).ToList();
+            Assert.AreEqual(14, orderByQueryResults.Count);
+
+            foreach (OrderByQueryResult orderByQueryResult in orderByQueryResults)
+            {
+                Assert.IsTrue(orderByQueryResult.Payload.Equals(CosmosUndefined.Instance));
+                Assert.AreEqual(1, orderByQueryResult.OrderByItems.Count());
+                Assert.IsTrue(orderByQueryResult.OrderByItems.First().Item.Equals(CosmosUndefined.Instance));
+            }
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OfflineEngine/AggregateProjectionTransformer.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OfflineEngine/AggregateProjectionTransformer.cs
@@ -410,6 +410,11 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
                 SqlStringLiteral literal = SqlStringLiteral.Create(cosmosString.Value);
                 return SqlLiteralScalarExpression.Create(literal);
             }
+
+            public SqlScalarExpression Visit(CosmosUndefined cosmosUndefined)
+            {
+                return SqlLiteralScalarExpression.Create(SqlUndefinedLiteral.Create());
+            }
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OfflineEngine/AggregateProjectionTransformer.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OfflineEngine/AggregateProjectionTransformer.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
     /// </summary>
     internal sealed class AggregateProjectionTransformer
     {
-        private static readonly CosmosNumber Undefined = null;
+        private static readonly CosmosElement Undefined = CosmosUndefined.Instance;
 
         private readonly AggregateProjectionTransformerVisitor visitor;
 
@@ -203,13 +203,13 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
 
                             case Aggregate.Avg:
                             case Aggregate.Sum:
-                                CosmosNumber sum = CosmosNumber64.Create(0);
+                                CosmosElement sum = CosmosNumber64.Create(0);
                                 double count = 0;
                                 foreach (CosmosElement result in results)
                                 {
-                                    if ((result is CosmosNumber resultAsNumber) && (sum != Undefined))
+                                    if ((result is CosmosNumber resultAsNumber) && (sum is CosmosNumber num))
                                     {
-                                        sum = CosmosNumber64.Create(Number64.ToDouble(sum.Value) + Number64.ToDouble(resultAsNumber.Value));
+                                        sum = CosmosNumber64.Create(Number64.ToDouble(num.Value) + Number64.ToDouble(resultAsNumber.Value));
                                         count++;
                                     }
                                     else
@@ -218,7 +218,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
                                     }
                                 }
 
-                                if (sum != Undefined)
+                                if (sum is CosmosNumber number)
                                 {
                                     if (aggregate == Aggregate.Avg)
                                     {
@@ -228,12 +228,12 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
                                         }
                                         else
                                         {
-                                            aggregationResult = CosmosNumber64.Create(Number64.ToDouble(sum.Value) / count);
+                                            aggregationResult = CosmosNumber64.Create(Number64.ToDouble(number.Value) / count);
                                         }
                                     }
                                     else
                                     {
-                                        aggregationResult = CosmosNumber64.Create(Number64.ToDouble(sum.Value));
+                                        aggregationResult = CosmosNumber64.Create(Number64.ToDouble(number.Value));
                                     }
                                 }
                                 else

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OfflineEngine/AggregateProjectionTransformer.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OfflineEngine/AggregateProjectionTransformer.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
     /// </summary>
     internal sealed class AggregateProjectionTransformer
     {
-        private static readonly CosmosElement Undefined = CosmosUndefined.Instance;
+        private static readonly CosmosElement Undefined = CosmosUndefined.Create();
 
         private readonly AggregateProjectionTransformerVisitor visitor;
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OfflineEngine/BuiltinFunctionEvaluator.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OfflineEngine/BuiltinFunctionEvaluator.cs
@@ -16,8 +16,6 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
 
     internal static class BuiltinFunctionEvaluator
     {
-        private static readonly CosmosElement Undefined = CosmosUndefined.Instance;
-
         private static readonly HashSet<BuiltinFunctionName> NullableFunctions = new HashSet<BuiltinFunctionName>()
         {
             BuiltinFunctionName.IS_ARRAY,
@@ -95,9 +93,9 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
             }
 
             // TODO: make the nullable function check based on the function signature and parameters.
-            if (arguments.Any((arg) => arg == Undefined) && !NullableFunctions.Contains(builtinFunction))
+            if (arguments.Any((arg) => arg is CosmosUndefined) && !NullableFunctions.Contains(builtinFunction))
             {
-                return Undefined;
+                return CosmosUndefined.Create();
             }
 
             CosmosElement result;
@@ -502,12 +500,12 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
         {
             if (!(first is CosmosArray firstArray))
             {
-                return Undefined;
+                return CosmosUndefined.Create();
             }
 
             if (!(second is CosmosArray secondArray))
             {
-                return Undefined;
+                return CosmosUndefined.Create();
             }
 
             if (arrays != null)
@@ -516,7 +514,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
                 {
                     if (!(array is CosmosArray))
                     {
-                        return Undefined;
+                        return CosmosUndefined.Create();
                     }
                 }
             }
@@ -558,24 +556,24 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
             CosmosElement needle,
             CosmosElement partialMatchToken = null)
         {
-            if (partialMatchToken == null || partialMatchToken == Undefined)
+            if (partialMatchToken == null || partialMatchToken is CosmosUndefined)
             {
                 partialMatchToken = CosmosBoolean.Create(false);
             }
 
             if (!(partialMatchToken is CosmosBoolean partialMatchAsBoolean))
             {
-                return Undefined;
+                return CosmosUndefined.Create();
             }
 
             if (!(haystack is CosmosArray haystackAsArray))
             {
-                return Undefined;
+                return CosmosUndefined.Create();
             }
 
-            if (needle == Undefined)
+            if (needle is CosmosUndefined)
             {
-                return Undefined;
+                return CosmosUndefined.Create();
             }
 
             bool contains = false;
@@ -627,7 +625,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
         {
             if (!(value is CosmosArray cosmosArray))
             {
-                return Undefined;
+                return CosmosUndefined.Create();
             }
 
             return CosmosNumber64.Create(cosmosArray.Count);
@@ -652,22 +650,22 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
 
             if (!(value is CosmosArray valueAsArray))
             {
-                return Undefined;
+                return CosmosUndefined.Create();
             }
 
             if (!(startIndex is CosmosNumber startIndexAsNumber))
             {
-                return Undefined;
+                return CosmosUndefined.Create();
             }
 
             if (!(count is CosmosNumber countAsNumber))
             {
-                return Undefined;
+                return CosmosUndefined.Create();
             }
 
             if (!startIndexAsNumber.Value.IsInteger)
             {
-                return Undefined;
+                return CosmosUndefined.Create();
             }
 
             long startIndexAsInteger = Number64.ToLong(startIndexAsNumber.Value);
@@ -683,7 +681,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
 
             if (!countAsNumber.Value.IsInteger)
             {
-                return Undefined;
+                return CosmosUndefined.Create();
             }
 
             long countAsInteger = Number64.ToLong(countAsNumber.Value);
@@ -757,12 +755,12 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
         {
             if (!(string1 is CosmosString cosmosString1))
             {
-                return Undefined;
+                return CosmosUndefined.Create();
             }
 
             if (!(string2 is CosmosString cosmosString2))
             {
-                return Undefined;
+                return CosmosUndefined.Create();
             }
 
             if (otherStrings != null)
@@ -771,7 +769,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
                 {
                     if (!(otherString is CosmosString))
                     {
-                        return Undefined;
+                        return CosmosUndefined.Create();
                     }
                 }
             }
@@ -885,7 +883,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
         /// </summary>
         /// <param name="value">The expression to check if it is defined.</param>
         /// <returns>A Boolean indicating if the property has been assigned a value.</returns>
-        private static CosmosElement IS_DEFINED(CosmosElement value) => CosmosBoolean.Create(value != Undefined);
+        private static CosmosElement IS_DEFINED(CosmosElement value) => CosmosBoolean.Create(value is not CosmosUndefined);
 
         /// <summary>
         /// Returns a Boolean indicating if the type of the value is null.
@@ -1021,22 +1019,22 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
         {
             if (!(stringValue is CosmosString stringValueValue))
             {
-                return Undefined;
+                return CosmosUndefined.Create();
             }
 
             if (!(subString is CosmosString subStringValue))
             {
-                return Undefined;
+                return CosmosUndefined.Create();
             }
 
             if (subStringValue.Value.IsEmpty)
             {
-                return Undefined;
+                return CosmosUndefined.Create();
             }
 
             if (!(replacement is CosmosString replacementValue))
             {
-                return Undefined;
+                return CosmosUndefined.Create();
             }
 
             return CosmosString.Create(stringValueValue.Value.ToString().Replace(subStringValue.Value, replacementValue.Value));
@@ -1054,17 +1052,17 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
         {
             if (!(str is CosmosString strValue))
             {
-                return Undefined;
+                return CosmosUndefined.Create();
             }
 
             if (!(repeatCount is CosmosNumber repeatCountValue))
             {
-                return Undefined;
+                return CosmosUndefined.Create();
             }
 
             if (repeatCountValue.Value < 0)
             {
-                return Undefined;
+                return CosmosUndefined.Create();
             }
 
             long repeatCountAsLong = Number64.ToLong(repeatCountValue.Value);
@@ -1075,13 +1073,13 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
                 {
                     if ((strValue.Value.ToString().Length * repeatCountAsLong) > 10000)
                     {
-                        return Undefined;
+                        return CosmosUndefined.Create();
                     }
                 }
             }
             catch (ArithmeticException)
             {
-                return Undefined;
+                return CosmosUndefined.Create();
             }
 
             StringBuilder stringBuilder = new StringBuilder();
@@ -1114,17 +1112,17 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
         {
             if (!(value is CosmosString stringValue))
             {
-                return Undefined;
+                return CosmosUndefined.Create();
             }
 
             if (!(length is CosmosNumber lengthValue))
             {
-                return Undefined;
+                return CosmosUndefined.Create();
             }
 
             if (!lengthValue.Value.IsInteger)
             {
-                return Undefined;
+                return CosmosUndefined.Create();
             }
 
             CosmosElement offset = CosmosNumber64.Create(Math.Max(stringValue.Value.ToString().Length - Number64.ToLong(lengthValue.Value), 0));
@@ -1378,7 +1376,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
         {
             if (!(argument is CosmosNumber argumentAsNumber))
             {
-                return Undefined;
+                return CosmosUndefined.Create();
             }
 
             return CosmosNumber64.Create(numberFunction(Number64.ToDouble(argumentAsNumber.Value)));
@@ -1391,12 +1389,12 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
         {
             if (!(argument1 is CosmosNumber argumentAsNumber1))
             {
-                return Undefined;
+                return CosmosUndefined.Create();
             }
 
             if (!(argument2 is CosmosNumber argumentAsNumber2))
             {
-                return Undefined;
+                return CosmosUndefined.Create();
             }
 
             return CosmosNumber64.Create(numberFunction(
@@ -1410,7 +1408,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
         {
             if (!(argument is CosmosString argumentAsString))
             {
-                return Undefined;
+                return CosmosUndefined.Create();
             }
 
             return stringFunction(argumentAsString.Value);
@@ -1423,12 +1421,12 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
         {
             if (!(argument1 is CosmosString argumentAsString1))
             {
-                return Undefined;
+                return CosmosUndefined.Create();
             }
 
             if (!(argument2 is CosmosString argumentAsString2))
             {
-                return Undefined;
+                return CosmosUndefined.Create();
             }
 
             return stringFunction(argumentAsString1.Value, argumentAsString2.Value);
@@ -1441,17 +1439,17 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
         {
             if (!(stringArgument is CosmosString stringArgumentValue))
             {
-                return Undefined;
+                return CosmosUndefined.Create();
             }
 
             if (!(startIndex is CosmosNumber startIndexAsNumber))
             {
-                return Undefined;
+                return CosmosUndefined.Create();
             }
 
             if (!(length is CosmosNumber lengthAsNumber))
             {
-                return Undefined;
+                return CosmosUndefined.Create();
             }
 
             if (stringArgumentValue.Value.IsEmpty)
@@ -1461,12 +1459,12 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
 
             if (!startIndexAsNumber.Value.IsInteger)
             {
-                return Undefined;
+                return CosmosUndefined.Create();
             }
 
             if (!lengthAsNumber.Value.IsInteger)
             {
-                return Undefined;
+                return CosmosUndefined.Create();
             }
 
             long startIndexAsInteger = Number64.ToLong(startIndexAsNumber.Value);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OfflineEngine/BuiltinFunctionEvaluator.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OfflineEngine/BuiltinFunctionEvaluator.cs
@@ -16,7 +16,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
 
     internal static class BuiltinFunctionEvaluator
     {
-        private static readonly CosmosElement Undefined = null;
+        private static readonly CosmosElement Undefined = CosmosUndefined.Instance;
 
         private static readonly HashSet<BuiltinFunctionName> NullableFunctions = new HashSet<BuiltinFunctionName>()
         {
@@ -95,7 +95,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
             }
 
             // TODO: make the nullable function check based on the function signature and parameters.
-            if (arguments.Any((arugment) => arugment == Undefined) && !NullableFunctions.Contains(builtinFunction))
+            if (arguments.Any((arg) => arg == Undefined) && !NullableFunctions.Contains(builtinFunction))
             {
                 return Undefined;
             }
@@ -558,7 +558,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
             CosmosElement needle,
             CosmosElement partialMatchToken = null)
         {
-            if (partialMatchToken == Undefined)
+            if (partialMatchToken == null || partialMatchToken == Undefined)
             {
                 partialMatchToken = CosmosBoolean.Create(false);
             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OfflineEngine/CosmosElementToJsonType.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OfflineEngine/CosmosElementToJsonType.cs
@@ -26,5 +26,7 @@
         public JsonType Visit(CosmosObject cosmosObject) => JsonType.Object;
 
         public JsonType Visit(CosmosString cosmosString) => JsonType.String;
+
+        public JsonType Visit(CosmosUndefined cosmosUndefined) => JsonType.Undefined;
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OfflineEngine/InvalidJsonValueDetector.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OfflineEngine/InvalidJsonValueDetector.cs
@@ -68,5 +68,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
         }
 
         public bool Visit(CosmosString cosmosString) => false;
+
+        public bool Visit(CosmosUndefined cosmosUndefined) => false;
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OfflineEngine/JsonType.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OfflineEngine/JsonType.cs
@@ -7,6 +7,7 @@
         Null,
         Number,
         Object,
-        String
+        String,
+        Undefined
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OfflineEngine/ScalarExpressionEvaluator.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OfflineEngine/ScalarExpressionEvaluator.cs
@@ -20,7 +20,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
     {
         public static readonly ScalarExpressionEvaluator Singleton = new ScalarExpressionEvaluator();
 
-        private static readonly CosmosElement Undefined = null;
+        private static readonly CosmosElement Undefined = CosmosUndefined.Instance;
 
         private ScalarExpressionEvaluator()
         {
@@ -594,7 +594,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
 
             public override CosmosElement Visit(SqlStringLiteral literal) => CosmosString.Create(literal.Value);
 
-            public override CosmosElement Visit(SqlUndefinedLiteral literal) => null;
+            public override CosmosElement Visit(SqlUndefinedLiteral literal) => CosmosUndefined.Instance;
 
             public override CosmosElement Visit(SqlNullLiteral literal) => CosmosNull.Create();
 
@@ -662,6 +662,8 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
             public CosmosElement Visit(CosmosNumber cosmosNumber, CosmosElement indexer) => Undefined;
 
             public CosmosElement Visit(CosmosString cosmosString, CosmosElement indexer) => Undefined;
+
+            public CosmosElement Visit(CosmosUndefined cosmosUndefined, CosmosElement input) => Undefined;
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OfflineEngine/ScalarExpressionEvaluator.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OfflineEngine/ScalarExpressionEvaluator.cs
@@ -20,8 +20,6 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
     {
         public static readonly ScalarExpressionEvaluator Singleton = new ScalarExpressionEvaluator();
 
-        private static readonly CosmosElement Undefined = CosmosUndefined.Instance;
-
         private ScalarExpressionEvaluator()
         {
         }
@@ -34,7 +32,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
             foreach (SqlScalarExpression item in scalarExpression.Items)
             {
                 CosmosElement value = item.Accept(this, document);
-                if (value != Undefined)
+                if (value is not CosmosUndefined)
                 {
                     arrayItems.Add(value);
                 }
@@ -119,7 +117,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
                     break;
 
                 case SqlBinaryScalarOperatorKind.Coalesce:
-                    if (left != Undefined)
+                    if (left is not CosmosUndefined)
                     {
                         result = left;
                     }
@@ -190,7 +188,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
             CosmosElement left = scalarExpression.Left.Accept(this, document);
             CosmosElement right = scalarExpression.Right.Accept(this, document);
 
-            return left != Undefined ? left : right;
+            return left is not CosmosUndefined ? left : right;
         }
 
         public override CosmosElement Visit(SqlConditionalScalarExpression scalarExpression, CosmosElement document)
@@ -238,9 +236,9 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
         public override CosmosElement Visit(SqlInScalarExpression scalarExpression, CosmosElement document)
         {
             CosmosElement expression = scalarExpression.Needle.Accept(this, document);
-            if (expression == Undefined)
+            if (expression is CosmosUndefined)
             {
-                return Undefined;
+                return expression;
             }
 
             HashSet<CosmosElement> items = new HashSet<CosmosElement>();
@@ -284,7 +282,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
             {
                 string key = sqlObjectProperty.Name.Value;
                 CosmosElement value = sqlObjectProperty.Value.Accept(this, document);
-                if (value != Undefined)
+                if (value is not CosmosUndefined)
                 {
                     properties[key] = value;
                 }
@@ -337,7 +335,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
             else
             {
                 // cardinality = 0
-                result = Undefined;
+                result = CosmosUndefined.Create();
             }
 
             return result;
@@ -380,12 +378,12 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
         {
             if (!(left is CosmosNumber leftAsNumber))
             {
-                return Undefined;
+                return CosmosUndefined.Create();
             }
 
             if (!(right is CosmosNumber rightAsNumber))
             {
-                return Undefined;
+                return CosmosUndefined.Create();
             }
 
             double result = operation(Number64.ToDouble(leftAsNumber.Value), Number64.ToDouble(rightAsNumber.Value));
@@ -410,12 +408,12 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
 
             if (!leftIsBoolean)
             {
-                return Undefined;
+                return CosmosUndefined.Create();
             }
 
             if (!rightIsBoolean)
             {
-                return Undefined;
+                return CosmosUndefined.Create();
             }
 
             bool result = (left as CosmosBoolean).Value && (right as CosmosBoolean).Value;
@@ -440,12 +438,12 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
 
             if (!leftIsBoolean)
             {
-                return Undefined;
+                return CosmosUndefined.Create();
             }
 
             if (!rightIsBoolean)
             {
-                return Undefined;
+                return CosmosUndefined.Create();
             }
 
             bool result = (left as CosmosBoolean).Value || (right as CosmosBoolean).Value;
@@ -459,12 +457,12 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
         {
             if (!(left is CosmosString leftAsString))
             {
-                return Undefined;
+                return CosmosUndefined.Create();
             }
 
             if (!(right is CosmosString rightAsString))
             {
-                return Undefined;
+                return CosmosUndefined.Create();
             }
 
             string result = operation(leftAsString.Value, rightAsString.Value);
@@ -478,7 +476,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
         {
             if (!Utils.TryCompare(left, right, out int comparison))
             {
-                return Undefined;
+                return CosmosUndefined.Create();
             }
 
             bool result = inequalityFunction(comparison);
@@ -490,9 +488,9 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
             CosmosElement left,
             CosmosElement right)
         {
-            if ((left == Undefined) || (right == Undefined))
+            if ((left is CosmosUndefined) || (right is CosmosUndefined))
             {
-                return Undefined;
+                return CosmosUndefined.Create();
             }
 
             return CosmosBoolean.Create(equalityFunction(left == right));
@@ -504,7 +502,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
         {
             if (!(operand is CosmosNumber operandAsNumber))
             {
-                return Undefined;
+                return CosmosUndefined.Create();
             }
 
             double result = unaryOperation(Number64.ToDouble(operandAsNumber.Value));
@@ -517,7 +515,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
         {
             if (!(operand is CosmosBoolean operandAsBoolean))
             {
-                return Undefined;
+                return CosmosUndefined.Create();
             }
 
             bool result = unaryOperation(operandAsBoolean.Value);
@@ -578,9 +576,9 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
 
         private static CosmosElement IndexIntoMember(CosmosElement member, CosmosElement indexer)
         {
-            if ((member == Undefined) || (indexer == Undefined))
+            if ((member is CosmosUndefined) || (indexer is CosmosUndefined))
             {
-                return Undefined;
+                return CosmosUndefined.Create();
             }
 
             return member.Accept(MemberIndexerVisitor.Singleton, indexer);
@@ -594,7 +592,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
 
             public override CosmosElement Visit(SqlStringLiteral literal) => CosmosString.Create(literal.Value);
 
-            public override CosmosElement Visit(SqlUndefinedLiteral literal) => CosmosUndefined.Instance;
+            public override CosmosElement Visit(SqlUndefinedLiteral literal) => CosmosUndefined.Create();
 
             public override CosmosElement Visit(SqlNullLiteral literal) => CosmosNull.Create();
 
@@ -613,7 +611,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
             {
                 if (!(indexer is CosmosNumber indexerAsNumber))
                 {
-                    return Undefined;
+                    return CosmosUndefined.Create();
                 }
 
                 if (!indexerAsNumber.Value.IsInteger)
@@ -629,7 +627,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
 
                 if (numberIndexValue >= cosmosArray.Count)
                 {
-                    return Undefined;
+                    return CosmosUndefined.Create();
                 }
 
                 return cosmosArray[(int)numberIndexValue];
@@ -639,31 +637,31 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
             {
                 if (!(indexer is CosmosString indexerAsString))
                 {
-                    return Undefined;
+                    return CosmosUndefined.Create();
                 }
 
                 string stringIndexValue = indexerAsString.Value;
                 if (!cosmosObject.TryGetValue(stringIndexValue, out CosmosElement propertyValue))
                 {
-                    return Undefined;
+                    return CosmosUndefined.Create();
                 }
 
                 return propertyValue;
             }
 
-            public CosmosElement Visit(CosmosBinary cosmosBinary, CosmosElement indexer) => Undefined;
+            public CosmosElement Visit(CosmosBinary cosmosBinary, CosmosElement indexer) => CosmosUndefined.Create();
 
-            public CosmosElement Visit(CosmosBoolean cosmosBoolean, CosmosElement indexer) => Undefined;
+            public CosmosElement Visit(CosmosBoolean cosmosBoolean, CosmosElement indexer) => CosmosUndefined.Create();
 
-            public CosmosElement Visit(CosmosGuid cosmosGuid, CosmosElement indexer) => Undefined;
+            public CosmosElement Visit(CosmosGuid cosmosGuid, CosmosElement indexer) => CosmosUndefined.Create();
 
-            public CosmosElement Visit(CosmosNull cosmosNull, CosmosElement indexer) => Undefined;
+            public CosmosElement Visit(CosmosNull cosmosNull, CosmosElement indexer) => CosmosUndefined.Create();
 
-            public CosmosElement Visit(CosmosNumber cosmosNumber, CosmosElement indexer) => Undefined;
+            public CosmosElement Visit(CosmosNumber cosmosNumber, CosmosElement indexer) => CosmosUndefined.Create();
 
-            public CosmosElement Visit(CosmosString cosmosString, CosmosElement indexer) => Undefined;
+            public CosmosElement Visit(CosmosString cosmosString, CosmosElement indexer) => CosmosUndefined.Create();
 
-            public CosmosElement Visit(CosmosUndefined cosmosUndefined, CosmosElement input) => Undefined;
+            public CosmosElement Visit(CosmosUndefined cosmosUndefined, CosmosElement input) => CosmosUndefined.Create();
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OfflineEngine/SqlInterpreter.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OfflineEngine/SqlInterpreter.cs
@@ -17,8 +17,6 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
 
     internal static class SqlInterpreter
     {
-        private static readonly CosmosElement Undefined = CosmosUndefined.Instance;
-
         private static readonly CosmosElement[] NoFromClauseDataSource = new CosmosElement[]
         {
             // Single object with a dummy rid 
@@ -182,7 +180,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
                     CosmosElement aggregationResult = transformedSpec.Accept(
                         Projector.Singleton,
                         dataSource.FirstOrDefault());
-                    if (aggregationResult != Undefined)
+                    if (aggregationResult is not CosmosUndefined)
                     {
                         dataSource = new CosmosElement[] { aggregationResult };
                     }
@@ -197,7 +195,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
                         .Select(element => sqlSelectClause.SelectSpec.Accept(
                             Projector.Singleton,
                             element))
-                        .Where(projection => projection != Undefined);
+                        .Where(projection => projection is not CosmosUndefined);
                 }
 
                 if (dataSource.Any())
@@ -308,7 +306,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngine
             {
                 dataSource = dataSource.Where(element => firstItem.Expression.Accept(
                     ScalarExpressionEvaluator.Singleton,
-                    element) != Undefined);
+                    element) is not CosmosUndefined);
             }
 
             IOrderedEnumerable<CosmosElement> orderedDataSource;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OfflineEngineTests/BuiltinFunctionEvaluatorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OfflineEngineTests/BuiltinFunctionEvaluatorTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngineTests
     [TestClass]
     public class BuiltinFunctionEvaluatorTests
     {
-        private static readonly CosmosElement Undefined = CosmosUndefined.Instance;
+        private static readonly CosmosElement Undefined = CosmosUndefined.Create();
 
         private static readonly SqlLiteralScalarExpression five = SqlLiteralScalarExpression.Create(SqlNumberLiteral.Create(5));
         private static readonly SqlLiteralScalarExpression six = SqlLiteralScalarExpression.Create(SqlNumberLiteral.Create(6));

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OfflineEngineTests/BuiltinFunctionEvaluatorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OfflineEngineTests/BuiltinFunctionEvaluatorTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngineTests
     [TestClass]
     public class BuiltinFunctionEvaluatorTests
     {
-        private static readonly CosmosElement Undefined = null;
+        private static readonly CosmosElement Undefined = CosmosUndefined.Instance;
 
         private static readonly SqlLiteralScalarExpression five = SqlLiteralScalarExpression.Create(SqlNumberLiteral.Create(5));
         private static readonly SqlLiteralScalarExpression six = SqlLiteralScalarExpression.Create(SqlNumberLiteral.Create(6));

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OfflineEngineTests/ScalarExpressionEvaluatorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OfflineEngineTests/ScalarExpressionEvaluatorTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngineTests
     [TestClass]
     public class ScalarExpressionEvaluatorTests
     {
-        private static readonly CosmosElement Undefined = null;
+        private static readonly CosmosElement Undefined = CosmosUndefined.Instance;
 
         [TestMethod]
         [Owner("brchon")]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OfflineEngineTests/ScalarExpressionEvaluatorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OfflineEngineTests/ScalarExpressionEvaluatorTests.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngineTests
     [TestClass]
     public class ScalarExpressionEvaluatorTests
     {
-        private static readonly CosmosElement Undefined = CosmosUndefined.Instance;
+        private static readonly CosmosElement Undefined = CosmosUndefined.Create();
 
         [TestMethod]
         [Owner("brchon")]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OfflineEngineTests/SqlInterpreterTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OfflineEngineTests/SqlInterpreterTests.cs
@@ -1090,25 +1090,19 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.OfflineEngineTests
         }
 
         private static void AssertEvaluation(
-            IEnumerable<CosmosElement> expected,
+            IEnumerable<CosmosElement> expectedElements,
             SqlQuery sqlQuery,
             IEnumerable<CosmosElement> dataSource,
             IReadOnlyDictionary<string, PartitionKeyRange> ridToPartitionKeyRange = null)
         {
-            IEnumerable<CosmosElement> actual = SqlInterpreter.ExecuteQuery(
+            List<CosmosElement> actual = SqlInterpreter.ExecuteQuery(
                 dataSource,
                 sqlQuery,
-                ridToPartitionKeyRange);
-            if (expected.Count() != actual.Count())
-            {
-                Assert.Fail($"Expected had {expected.Count()} results while Actual has {actual.Count()} results.");
-            }
+                ridToPartitionKeyRange).ToList();
 
-            IEnumerable<Tuple<CosmosElement, CosmosElement>> expectedActuals = expected.Zip(actual, (first, second) => new Tuple<CosmosElement, CosmosElement>(first, second));
-            foreach (Tuple<CosmosElement, CosmosElement> expectedActual in expectedActuals)
-            {
-                Assert.AreEqual(expectedActual.Item1, expectedActual.Item2);
-            }
+            List<CosmosElement> expected = expectedElements.ToList();
+
+            CollectionAssert.AreEqual(expected, actual);
         }
 
         private static void AssertEvaluationNoOrder(


### PR DESCRIPTION
## Description

Currently `undefined` values are sometimes represented by `null` in the query pipeline. At other times, `undefined` values are unhandled. In this change we use a more formal approach of representing `undefined` by a strong type called `CosmosUndefined` which is a `CosmosElement`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Closing issues

To automatically close an issue: closes #IssueNumber