### PR TITLE
Client Telemetry : Refactors code to compute hash of VM ID and Process Name information

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
     using Microsoft.Azure.Documents.Collections;
     using Microsoft.Azure.Documents.Rntbd;
     using Newtonsoft.Json;
+    using Util;
 
     /// <summary>
     /// This class collects and send all the telemetry information.
@@ -99,7 +100,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
 
             this.clientTelemetryInfo = new ClientTelemetryProperties(
                 clientId: clientId, 
-                processId: System.Diagnostics.Process.GetCurrentProcess().ProcessName, 
+                processId: CosmosUtils.ComputeHash(System.Diagnostics.Process.GetCurrentProcess().ProcessName), 
                 userAgent: userAgent, 
                 connectionMode: connectionMode,
                 preferredRegions: preferredRegions,

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
 
             this.clientTelemetryInfo = new ClientTelemetryProperties(
                 clientId: clientId, 
-                processId: CosmosUtils.ComputeHash(System.Diagnostics.Process.GetCurrentProcess().ProcessName), 
+                processId: HashingExtension.ComputeHash(System.Diagnostics.Process.GetCurrentProcess().ProcessName), 
                 userAgent: userAgent, 
                 connectionMode: connectionMode,
                 preferredRegions: preferredRegions,

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryOptions.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
     using Microsoft.Azure.Cosmos.Core.Trace;
     using Microsoft.Azure.Documents;
     using Newtonsoft.Json;
+    using Util;
 
     internal static class ClientTelemetryOptions
     {

--- a/Microsoft.Azure.Cosmos/src/Telemetry/Compute.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/Compute.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             this.AzEnvironment = azEnvironment;
             this.OSType = oSType;
             this.VMSize = vMSize;
-            this.VMId = $"{VmMetadataApiHandler.HashedVmIdPrefix}{CosmosUtils.ComputeHash(vMId)}";
+            this.VMId = $"{VmMetadataApiHandler.HashedVmIdPrefix}{HashingExtension.ComputeHash(vMId)}";
         }
 
         [JsonProperty(PropertyName = "location")]

--- a/Microsoft.Azure.Cosmos/src/Telemetry/Compute.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/Compute.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             this.AzEnvironment = azEnvironment;
             this.OSType = oSType;
             this.VMSize = vMSize;
-            this.VMId = "vmId:" + CosmosUtils.ComputeHash(vMId);
+            this.VMId = VmMetadataApiHandler.HashedVmIdPrefix + CosmosUtils.ComputeHash(vMId);
         }
 
         [JsonProperty(PropertyName = "location")]

--- a/Microsoft.Azure.Cosmos/src/Telemetry/Compute.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/Compute.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
 {
     using System;
     using Newtonsoft.Json;
+    using Util;
 
     [Serializable]
     internal sealed class Compute
@@ -24,7 +25,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             this.AzEnvironment = azEnvironment;
             this.OSType = oSType;
             this.VMSize = vMSize;
-            this.VMId = "vmId:" + vMId;
+            this.VMId = "vmId:" + CosmosUtils.ComputeHash(vMId);
         }
 
         [JsonProperty(PropertyName = "location")]

--- a/Microsoft.Azure.Cosmos/src/Telemetry/Compute.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/Compute.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             this.AzEnvironment = azEnvironment;
             this.OSType = oSType;
             this.VMSize = vMSize;
-            this.VMId = VmMetadataApiHandler.HashedVmIdPrefix + CosmosUtils.ComputeHash(vMId);
+            this.VMId = $"{VmMetadataApiHandler.HashedVmIdPrefix}{CosmosUtils.ComputeHash(vMId)}";
         }
 
         [JsonProperty(PropertyName = "location")]

--- a/Microsoft.Azure.Cosmos/src/Telemetry/VmMetadataApiHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/VmMetadataApiHandler.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
     using Microsoft.Azure.Cosmos.Core.Trace;
     using Microsoft.Azure.Documents;
     using Newtonsoft.Json.Linq;
+    using Util;
 
     /// <summary>
     /// Task to collect virtual machine metadata information. using instance metedata service API.
@@ -139,35 +140,11 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             return VmMetadataApiHandler.azMetadata?.Compute?.AzEnvironment ?? VmMetadataApiHandler.nonAzureCloud;
         }
 
-        /// <summary>
-        /// Hash a passed Value
-        /// </summary>
-        /// <param name="rawData"></param>
-        /// <returns>hashed Value</returns>
-        internal static string ComputeHash(string rawData)
-        {
-            if (string.IsNullOrEmpty(rawData))
-            {
-                throw new ArgumentNullException(nameof(rawData));
-            }
-
-            // Create a SHA256    
-            using (SHA256 sha256Hash = SHA256.Create())
-            {
-                // ComputeHash - returns byte array  
-                byte[] bytes = sha256Hash.ComputeHash(Encoding.UTF8.GetBytes(rawData));
-                Array.Resize(ref bytes, 16);
-
-                // Convert byte array to a string   
-                return new Guid(bytes).ToString();
-            }
-        }
-
         private static readonly Lazy<string> uniqueId = new Lazy<string>(() =>
         {
             try
             {
-                return "hashedMachineName:" + VmMetadataApiHandler.ComputeHash(Environment.MachineName);
+                return "hashedMachineName:" + CosmosUtils.ComputeHash(Environment.MachineName);
             }
             catch (Exception ex)
             {

--- a/Microsoft.Azure.Cosmos/src/Telemetry/VmMetadataApiHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/VmMetadataApiHandler.cs
@@ -149,14 +149,14 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         {
             try
             {
-                return VmMetadataApiHandler.HashedMachineNamePrefix + CosmosUtils.ComputeHash(Environment.MachineName);
+                return $"{VmMetadataApiHandler.HashedMachineNamePrefix}{CosmosUtils.ComputeHash(Environment.MachineName)}";
             }
             catch (Exception ex)
             {
                 DefaultTrace.TraceWarning("Error while generating hashed machine name " + ex.Message);
             }
 
-            return VmMetadataApiHandler.UuidPrefix + Guid.NewGuid().ToString();
+            return $"{VmMetadataApiHandler.UuidPrefix}{Guid.NewGuid()}";
         });
 
     }

--- a/Microsoft.Azure.Cosmos/src/Telemetry/VmMetadataApiHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/VmMetadataApiHandler.cs
@@ -21,7 +21,12 @@ namespace Microsoft.Azure.Cosmos.Telemetry
     /// </summary>
     internal static class VmMetadataApiHandler
     {
+        internal const string HashedMachineNamePrefix = "hashedMachineName:";
+        internal const string HashedVmIdPrefix = "hashedVmId:";
+        internal const string UuidPrefix = "uuid:";
+
         internal static readonly Uri vmMetadataEndpointUrl = new ("http://169.254.169.254/metadata/instance?api-version=2020-06-01");
+
         private static readonly string nonAzureCloud = "NonAzureVM";
 
         private static readonly object lockObject = new object();
@@ -144,14 +149,14 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         {
             try
             {
-                return "hashedMachineName:" + CosmosUtils.ComputeHash(Environment.MachineName);
+                return VmMetadataApiHandler.HashedMachineNamePrefix + CosmosUtils.ComputeHash(Environment.MachineName);
             }
             catch (Exception ex)
             {
                 DefaultTrace.TraceWarning("Error while generating hashed machine name " + ex.Message);
             }
 
-            return "uuid:" + Guid.NewGuid().ToString();
+            return VmMetadataApiHandler.UuidPrefix + Guid.NewGuid().ToString();
         });
 
     }

--- a/Microsoft.Azure.Cosmos/src/Telemetry/VmMetadataApiHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/VmMetadataApiHandler.cs
@@ -149,7 +149,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         {
             try
             {
-                return $"{VmMetadataApiHandler.HashedMachineNamePrefix}{CosmosUtils.ComputeHash(Environment.MachineName)}";
+                return $"{VmMetadataApiHandler.HashedMachineNamePrefix}{HashingExtension.ComputeHash(Environment.MachineName)}";
             }
             catch (Exception ex)
             {

--- a/Microsoft.Azure.Cosmos/src/Util/CosmosUtils.cs
+++ b/Microsoft.Azure.Cosmos/src/Util/CosmosUtils.cs
@@ -1,0 +1,38 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Util
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Security.Cryptography;
+    using System.Text;
+
+    internal class CosmosUtils
+    {
+        /// <summary>
+        /// Hash a passed Value
+        /// </summary>
+        /// <param name="rawData"></param>
+        /// <returns>hashed Value</returns>
+        internal static string ComputeHash(string rawData)
+        {
+            if (string.IsNullOrEmpty(rawData))
+            {
+                throw new ArgumentNullException(nameof(rawData));
+            }
+
+            // Create a SHA256    
+            using (SHA256 sha256Hash = SHA256.Create())
+            {
+                // ComputeHash - returns byte array  
+                byte[] bytes = sha256Hash.ComputeHash(Encoding.UTF8.GetBytes(rawData));
+                Array.Resize(ref bytes, 16);
+
+                // Convert byte array to a string   
+                return new Guid(bytes).ToString();
+            }
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Util/HashingExtension.cs
+++ b/Microsoft.Azure.Cosmos/src/Util/HashingExtension.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Azure.Cosmos.Util
     using System.Security.Cryptography;
     using System.Text;
 
-    internal class CosmosUtils
+    internal class HashingExtension
     {
         /// <summary>
         /// Hash a passed Value

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
@@ -936,7 +936,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Assert.IsNull(telemetryInfo.AcceleratedNetworking);
                 Assert.IsNotNull(telemetryInfo.ClientId);
                 Assert.IsNotNull(telemetryInfo.ProcessId);
-                Assert.AreEqual(CosmosUtils.ComputeHash(System.Diagnostics.Process.GetCurrentProcess().ProcessName), telemetryInfo.ProcessId);
+                Assert.AreEqual(HashingExtension.ComputeHash(System.Diagnostics.Process.GetCurrentProcess().ProcessName), telemetryInfo.ProcessId);
                 Assert.IsNotNull(telemetryInfo.UserAgent);
                 Assert.IsNotNull(telemetryInfo.ConnectionMode);
 
@@ -950,11 +950,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             {
                 if (isAzureInstance.Value)
                 {
-                    Assert.AreEqual($"{VmMetadataApiHandler.HashedVmIdPrefix}{CosmosUtils.ComputeHash("d0cb93eb-214b-4c2b-bd3d-cc93e90d9efd")}", machineId.First(), $"Generated Machine id is : {machineId.First()}");
+                    Assert.AreEqual($"{VmMetadataApiHandler.HashedVmIdPrefix}{HashingExtension.ComputeHash("d0cb93eb-214b-4c2b-bd3d-cc93e90d9efd")}", machineId.First(), $"Generated Machine id is : {machineId.First()}");
                 }
                 else
                 {
-                    Assert.AreNotEqual($"{VmMetadataApiHandler.HashedVmIdPrefix}{CosmosUtils.ComputeHash("d0cb93eb-214b-4c2b-bd3d-cc93e90d9efd")}", machineId.First(), $"Generated Machine id is : {machineId.First()}");
+                    Assert.AreNotEqual($"{VmMetadataApiHandler.HashedVmIdPrefix}{HashingExtension.ComputeHash("d0cb93eb-214b-4c2b-bd3d-cc93e90d9efd")}", machineId.First(), $"Generated Machine id is : {machineId.First()}");
                     Assert.AreEqual(1, machineId.Count, $"Multiple Machine Id has been generated i.e {JsonConvert.SerializeObject(machineId)}");
                 }
             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
@@ -958,7 +958,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     Assert.AreEqual(1, machineId.Count, $"Multiple Machine Id has been generated i.e {JsonConvert.SerializeObject(machineId)}");
                 }
             }
-
         }
 
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
@@ -950,11 +950,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             {
                 if (isAzureInstance.Value)
                 {
-                    Assert.AreEqual($"vmId:{CosmosUtils.ComputeHash("d0cb93eb-214b-4c2b-bd3d-cc93e90d9efd")}", machineId.First(), $"Generated Machine id is : {machineId.First()}");
+                    Assert.AreEqual($"{VmMetadataApiHandler.HashedVmIdPrefix}{CosmosUtils.ComputeHash("d0cb93eb-214b-4c2b-bd3d-cc93e90d9efd")}", machineId.First(), $"Generated Machine id is : {machineId.First()}");
                 }
                 else
                 {
-                    Assert.AreNotEqual($"vmId:{CosmosUtils.ComputeHash("d0cb93eb-214b-4c2b-bd3d-cc93e90d9efd")}", machineId.First(), $"Generated Machine id is : {machineId.First()}");
+                    Assert.AreNotEqual($"{VmMetadataApiHandler.HashedVmIdPrefix}{CosmosUtils.ComputeHash("d0cb93eb-214b-4c2b-bd3d-cc93e90d9efd")}", machineId.First(), $"Generated Machine id is : {machineId.First()}");
                     Assert.AreEqual(1, machineId.Count, $"Multiple Machine Id has been generated i.e {JsonConvert.SerializeObject(machineId)}");
                 }
             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
@@ -23,6 +23,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
     using Documents.Rntbd;
     using System.Globalization;
     using System.Linq;
+    using Cosmos.Util;
 
     [TestClass]
     public class ClientTelemetryTests : BaseCosmosClientHelper
@@ -935,6 +936,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Assert.IsNull(telemetryInfo.AcceleratedNetworking);
                 Assert.IsNotNull(telemetryInfo.ClientId);
                 Assert.IsNotNull(telemetryInfo.ProcessId);
+                Assert.AreEqual(CosmosUtils.ComputeHash(System.Diagnostics.Process.GetCurrentProcess().ProcessName), telemetryInfo.ProcessId);
                 Assert.IsNotNull(telemetryInfo.UserAgent);
                 Assert.IsNotNull(telemetryInfo.ConnectionMode);
 
@@ -948,11 +950,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             {
                 if (isAzureInstance.Value)
                 {
-                    Assert.AreEqual("vmId:d0cb93eb-214b-4c2b-bd3d-cc93e90d9efd", machineId.First(), $"Generated Machine id is : {machineId.First()}");
+                    Assert.AreEqual($"vmId:{CosmosUtils.ComputeHash("d0cb93eb-214b-4c2b-bd3d-cc93e90d9efd")}", machineId.First(), $"Generated Machine id is : {machineId.First()}");
                 }
                 else
                 {
-                    Assert.AreNotEqual("vmId:d0cb93eb-214b-4c2b-bd3d-cc93e90d9efd", machineId.First(), $"Generated Machine id is : {machineId.First()}");
+                    Assert.AreNotEqual($"vmId:{CosmosUtils.ComputeHash("d0cb93eb-214b-4c2b-bd3d-cc93e90d9efd")}", machineId.First(), $"Generated Machine id is : {machineId.First()}");
                     Assert.AreEqual(1, machineId.Count, $"Multiple Machine Id has been generated i.e {JsonConvert.SerializeObject(machineId)}");
                 }
             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/VmMetadataApiHandlerTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/VmMetadataApiHandlerTest.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.Cosmos
             VmMetadataApiHandler.TryInitialize(cosmoshttpClient);
 
             await Task.Delay(2000);
-            Assert.AreEqual($"vmId:{CosmosUtils.ComputeHash("d0cb93eb-214b-4c2b-bd3d-cc93e90d9efd")}", VmMetadataApiHandler.GetMachineId());
+            Assert.AreEqual($"{VmMetadataApiHandler.HashedVmIdPrefix}{CosmosUtils.ComputeHash("d0cb93eb-214b-4c2b-bd3d-cc93e90d9efd")}", VmMetadataApiHandler.GetMachineId());
             Assert.AreEqual(VmMetadataApiHandler.GetMachineRegion(), "eastus");
         }
 
@@ -89,7 +89,7 @@ namespace Microsoft.Azure.Cosmos
         [TestMethod]
         public async Task GetHashedMachineNameAsMachineIdTest()
         {
-            string expectedMachineId = "hashedMachineName:" + CosmosUtils.ComputeHash(Environment.MachineName);
+            string expectedMachineId = VmMetadataApiHandler.HashedMachineNamePrefix + CosmosUtils.ComputeHash(Environment.MachineName);
 
             static Task<HttpResponseMessage> sendFunc(HttpRequestMessage request, CancellationToken cancellationToken) { throw new Exception("error while making API call"); };
 
@@ -129,7 +129,7 @@ namespace Microsoft.Azure.Cosmos
             Assert.AreEqual("AzurePublicCloud", metadata.Compute.AzEnvironment);
             Assert.AreEqual("Linux", metadata.Compute.OSType);
             Assert.AreEqual("Standard_D2s_v3", metadata.Compute.VMSize);
-            Assert.AreEqual($"vmId:{CosmosUtils.ComputeHash("d0cb93eb-214b-4c2b-bd3d-cc93e90d9efd")}", metadata.Compute.VMId);
+            Assert.AreEqual($"{VmMetadataApiHandler.HashedVmIdPrefix}{CosmosUtils.ComputeHash("d0cb93eb-214b-4c2b-bd3d-cc93e90d9efd")}", metadata.Compute.VMId);
         }
 
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/VmMetadataApiHandlerTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/VmMetadataApiHandlerTest.cs
@@ -57,7 +57,7 @@ namespace Microsoft.Azure.Cosmos
             VmMetadataApiHandler.TryInitialize(cosmoshttpClient);
 
             await Task.Delay(2000);
-            Assert.AreEqual($"{VmMetadataApiHandler.HashedVmIdPrefix}{CosmosUtils.ComputeHash("d0cb93eb-214b-4c2b-bd3d-cc93e90d9efd")}", VmMetadataApiHandler.GetMachineId());
+            Assert.AreEqual($"{VmMetadataApiHandler.HashedVmIdPrefix}{HashingExtension.ComputeHash("d0cb93eb-214b-4c2b-bd3d-cc93e90d9efd")}", VmMetadataApiHandler.GetMachineId());
             Assert.AreEqual(VmMetadataApiHandler.GetMachineRegion(), "eastus");
         }
 
@@ -89,7 +89,7 @@ namespace Microsoft.Azure.Cosmos
         [TestMethod]
         public async Task GetHashedMachineNameAsMachineIdTest()
         {
-            string expectedMachineId = VmMetadataApiHandler.HashedMachineNamePrefix + CosmosUtils.ComputeHash(Environment.MachineName);
+            string expectedMachineId = VmMetadataApiHandler.HashedMachineNamePrefix + HashingExtension.ComputeHash(Environment.MachineName);
 
             static Task<HttpResponseMessage> sendFunc(HttpRequestMessage request, CancellationToken cancellationToken) { throw new Exception("error while making API call"); };
 
@@ -106,7 +106,7 @@ namespace Microsoft.Azure.Cosmos
         [TestMethod]
         public void ComputeHashTest()
         {
-            string hashedValue = CosmosUtils.ComputeHash("abc");
+            string hashedValue = HashingExtension.ComputeHash("abc");
             Assert.AreEqual("bf1678ba-018f-eacf-4141-40de5dae2223", hashedValue);
         }
 
@@ -129,7 +129,7 @@ namespace Microsoft.Azure.Cosmos
             Assert.AreEqual("AzurePublicCloud", metadata.Compute.AzEnvironment);
             Assert.AreEqual("Linux", metadata.Compute.OSType);
             Assert.AreEqual("Standard_D2s_v3", metadata.Compute.VMSize);
-            Assert.AreEqual($"{VmMetadataApiHandler.HashedVmIdPrefix}{CosmosUtils.ComputeHash("d0cb93eb-214b-4c2b-bd3d-cc93e90d9efd")}", metadata.Compute.VMId);
+            Assert.AreEqual($"{VmMetadataApiHandler.HashedVmIdPrefix}{HashingExtension.ComputeHash("d0cb93eb-214b-4c2b-bd3d-cc93e90d9efd")}", metadata.Compute.VMId);
         }
 
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/VmMetadataApiHandlerTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/VmMetadataApiHandlerTest.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Azure.Cosmos
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Moq;
     using Newtonsoft.Json;
+    using Util;
 
     [TestClass]
     public class VmMetadataApiHandlerTest
@@ -56,7 +57,7 @@ namespace Microsoft.Azure.Cosmos
             VmMetadataApiHandler.TryInitialize(cosmoshttpClient);
 
             await Task.Delay(2000);
-            Assert.AreEqual("vmId:d0cb93eb-214b-4c2b-bd3d-cc93e90d9efd", VmMetadataApiHandler.GetMachineId());
+            Assert.AreEqual($"vmId:{CosmosUtils.ComputeHash("d0cb93eb-214b-4c2b-bd3d-cc93e90d9efd")}", VmMetadataApiHandler.GetMachineId());
             Assert.AreEqual(VmMetadataApiHandler.GetMachineRegion(), "eastus");
         }
 
@@ -88,7 +89,7 @@ namespace Microsoft.Azure.Cosmos
         [TestMethod]
         public async Task GetHashedMachineNameAsMachineIdTest()
         {
-            string expectedMachineId = "hashedMachineName:" + VmMetadataApiHandler.ComputeHash(Environment.MachineName);
+            string expectedMachineId = "hashedMachineName:" + CosmosUtils.ComputeHash(Environment.MachineName);
 
             static Task<HttpResponseMessage> sendFunc(HttpRequestMessage request, CancellationToken cancellationToken) { throw new Exception("error while making API call"); };
 
@@ -105,7 +106,7 @@ namespace Microsoft.Azure.Cosmos
         [TestMethod]
         public void ComputeHashTest()
         {
-            string hashedValue = VmMetadataApiHandler.ComputeHash("abc");
+            string hashedValue = CosmosUtils.ComputeHash("abc");
             Assert.AreEqual("bf1678ba-018f-eacf-4141-40de5dae2223", hashedValue);
         }
 
@@ -128,7 +129,7 @@ namespace Microsoft.Azure.Cosmos
             Assert.AreEqual("AzurePublicCloud", metadata.Compute.AzEnvironment);
             Assert.AreEqual("Linux", metadata.Compute.OSType);
             Assert.AreEqual("Standard_D2s_v3", metadata.Compute.VMSize);
-            Assert.AreEqual("vmId:d0cb93eb-214b-4c2b-bd3d-cc93e90d9efd", metadata.Compute.VMId);
+            Assert.AreEqual($"vmId:{CosmosUtils.ComputeHash("d0cb93eb-214b-4c2b-bd3d-cc93e90d9efd")}", metadata.Compute.VMId);
         }
 
         [TestMethod]


### PR DESCRIPTION
## Description
Compute Hash of below 2 values to avoid saving PII data
1) VM Id
2) Process Name

## Type of change
- [] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #3372 