### PR TITLE
[JsonPatch] Implementation of the Move Operation in accordance with the JSONPATCH RFC6902.

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Patch/PatchConstants.cs
+++ b/Microsoft.Azure.Cosmos/src/Patch/PatchConstants.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Azure.Cosmos
             public const string OperationType = "op";
             public const string Path = "path";
             public const string Value = "value";
+            public const string From = "from";
         }
 
         public static class PatchSpecAttributes
@@ -28,6 +29,7 @@ namespace Microsoft.Azure.Cosmos
             public const string Replace = "replace";
             public const string Set = "set";
             public const string Increment = "incr";
+            public const string Move = "move";
         }
 
         public static string ToEnumMemberString(this PatchOperationType patchOperationType)
@@ -44,6 +46,8 @@ namespace Microsoft.Azure.Cosmos
                     return PatchConstants.OperationTypeNames.Set;
                 case PatchOperationType.Increment:
                     return PatchConstants.OperationTypeNames.Increment;
+                case PatchOperationType.Move:
+                    return PatchConstants.OperationTypeNames.Move;
                 default:
                     throw new ArgumentException($"Unknown Patch operation type '{patchOperationType}'.");
             }

--- a/Microsoft.Azure.Cosmos/src/Patch/PatchOperation.cs
+++ b/Microsoft.Azure.Cosmos/src/Patch/PatchOperation.cs
@@ -26,6 +26,12 @@ namespace Microsoft.Azure.Cosmos
         public abstract string Path { get; }
 
         /// <summary>
+        /// Source location reference (used in case of move)
+        /// </summary>
+        [JsonProperty(PropertyName = PatchConstants.PropertyNames.From)]
+        public abstract string From { get; }
+
+        /// <summary>
         /// Serializes the value parameter, if specified for the PatchOperation.
         /// </summary>
         /// <param name="cosmosSerializer">Serializer to be used.</param>
@@ -133,6 +139,22 @@ namespace Microsoft.Azure.Cosmos
                 PatchOperationType.Increment,
                 path,
                 value);
+        }
+        
+        /// <summary>
+        /// Create <see cref="PatchOperation"/> to move an object/value.
+        /// </summary>
+        /// <param name="path">Target location reference.</param>
+        /// <param name="from">The source location of the object/value.</param>
+        /// <returns>PatchOperation instance for specified input.</returns>
+        public static PatchOperation Move(
+            string path,
+            string from)
+        {
+            return new PatchOperationCore<string>(
+                PatchOperationType.Move,
+                path,
+                from);
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Patch/PatchOperation.cs
+++ b/Microsoft.Azure.Cosmos/src/Patch/PatchOperation.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.Cosmos
         /// Source location reference (used in case of move)
         /// </summary>
         [JsonProperty(PropertyName = PatchConstants.PropertyNames.From)]
-        public abstract string From { get; }
+        public virtual string From { get; set; } = null;
 
         /// <summary>
         /// Serializes the value parameter, if specified for the PatchOperation.
@@ -140,16 +140,16 @@ namespace Microsoft.Azure.Cosmos
                 path,
                 value);
         }
-        
+
         /// <summary>
         /// Create <see cref="PatchOperation"/> to move an object/value.
         /// </summary>
-        /// <param name="path">Target location reference.</param>
         /// <param name="from">The source location of the object/value.</param>
+        /// <param name="path">Target location reference.</param>
         /// <returns>PatchOperation instance for specified input.</returns>
         public static PatchOperation Move(
-            string path,
-            string from)
+            string from,
+            string path)
         {
             return new PatchOperationCore<string>(
                 PatchOperationType.Move,

--- a/Microsoft.Azure.Cosmos/src/Patch/PatchOperationCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Patch/PatchOperationCore.cs
@@ -26,5 +26,6 @@ namespace Microsoft.Azure.Cosmos
         public override PatchOperationType OperationType { get; }
 
         public override string Path { get; }
+        public override string From { get; }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Patch/PatchOperationCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Patch/PatchOperationCore.cs
@@ -26,6 +26,5 @@ namespace Microsoft.Azure.Cosmos
         public override PatchOperationType OperationType { get; }
 
         public override string Path { get; }
-        public override string From { get; }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Patch/PatchOperationCore{T}.cs
+++ b/Microsoft.Azure.Cosmos/src/Patch/PatchOperationCore{T}.cs
@@ -21,9 +21,9 @@ namespace Microsoft.Azure.Cosmos
             string path,
             T value)
         {
+            this.OperationType = operationType;
             if (operationType == PatchOperationType.Move)
             {
-                this.OperationType = operationType;
                 this.Path = string.IsNullOrWhiteSpace(path)
                     ? throw new ArgumentNullException(nameof(path))
                     : path;
@@ -34,7 +34,6 @@ namespace Microsoft.Azure.Cosmos
             }
             else
             {
-                this.OperationType = operationType;
                 this.Path = string.IsNullOrWhiteSpace(path)
                     ? throw new ArgumentNullException(nameof(path))
                     : path;

--- a/Microsoft.Azure.Cosmos/src/Patch/PatchOperationCore{T}.cs
+++ b/Microsoft.Azure.Cosmos/src/Patch/PatchOperationCore{T}.cs
@@ -14,17 +14,32 @@ namespace Microsoft.Azure.Cosmos
         /// </summary>
         /// <param name="operationType">Specifies the type of Patch operation.</param>
         /// <param name="path">Specifies the path to target location.</param>
-        /// <param name="value">Specifies the value to be used.</param>
+        /// <param name="value">Specifies the value to be used. In case of move operations it will be a string specifying the source
+        /// location.</param>
         public PatchOperationCore(
             PatchOperationType operationType,
             string path,
             T value)
         {
-            this.OperationType = operationType;
-            this.Path = string.IsNullOrWhiteSpace(path)
-                ? throw new ArgumentNullException(nameof(path))
-                : path;
-            this.Value = value; 
+            if (operationType == PatchOperationType.Move)
+            {
+                this.OperationType = operationType;
+                this.Path = string.IsNullOrWhiteSpace(path)
+                    ? throw new ArgumentNullException(nameof(path))
+                    : path;
+
+                this.From = string.IsNullOrWhiteSpace(value.ToString())
+                    ? throw new ArgumentNullException(nameof(value))
+                    : value.ToString();
+            }
+            else
+            {
+                this.OperationType = operationType;
+                this.Path = string.IsNullOrWhiteSpace(path)
+                    ? throw new ArgumentNullException(nameof(path))
+                    : path;
+                this.Value = value; 
+            }
         }
 
         public override T Value { get; }
@@ -32,6 +47,8 @@ namespace Microsoft.Azure.Cosmos
         public override PatchOperationType OperationType { get; }
 
         public override string Path { get; }
+
+        public override string From { get; }
 
         public override bool TrySerializeValueParameter(
             CosmosSerializer cosmosSerializer,

--- a/Microsoft.Azure.Cosmos/src/Patch/PatchOperationCore{T}.cs
+++ b/Microsoft.Azure.Cosmos/src/Patch/PatchOperationCore{T}.cs
@@ -10,16 +10,16 @@ namespace Microsoft.Azure.Cosmos
     internal sealed class PatchOperationCore<T> : PatchOperation<T>
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="PatchOperationCore{T}"/> class.
-        /// </summary>
-        /// <param name="operationType">Specifies the type of Patch operation.</param>
-        /// <param name="path">Specifies the path to target location.</param>
-        /// <param name="value">Specifies the value to be used. In case of move operations it will be a string specifying the source
-        /// location.</param>
+        /// Initializes a new instance of the <see cref="PatchOperationCore{T}"/> class.
+        /// </summary>
+        /// <param name="operationType">Specifies the type of Patch operation.</param>
+        /// <param name="path">Specifies the path to target location.</param>
+        /// <param name="value">Specifies the value to be used. In case of move operations it will be a string specifying the source
+        /// location.</param>
         public PatchOperationCore(
-            PatchOperationType operationType,
-            string path,
-            T value)
+          PatchOperationType operationType,
+          string path,
+          T value)
         {
             this.OperationType = operationType;
             if (operationType == PatchOperationType.Move)
@@ -27,27 +27,28 @@ namespace Microsoft.Azure.Cosmos
                 this.Path = string.IsNullOrWhiteSpace(path)
                     ? throw new ArgumentNullException(nameof(path))
                     : path;
-
-                this.From = string.IsNullOrWhiteSpace(value.ToString())
+                if (!(value is String valueAsString))
+                {
+                    throw new ArgumentException(
+                    $"Parameter {nameof(value)} must be of type String for patch operation type {nameof(PatchOperationType.Move)}");
+                }
+                this.From = string.IsNullOrWhiteSpace(valueAsString)
                     ? throw new ArgumentNullException(nameof(value))
-                    : value.ToString();
+                    : valueAsString;
             }
             else
             {
                 this.Path = string.IsNullOrWhiteSpace(path)
                     ? throw new ArgumentNullException(nameof(path))
                     : path;
-                this.Value = value; 
+                this.Value = value;
             }
         }
-
         public override T Value { get; }
 
         public override PatchOperationType OperationType { get; }
 
         public override string Path { get; }
-
-        public override string From { get; }
 
         public override bool TrySerializeValueParameter(
             CosmosSerializer cosmosSerializer,

--- a/Microsoft.Azure.Cosmos/src/Patch/PatchOperationType.cs
+++ b/Microsoft.Azure.Cosmos/src/Patch/PatchOperationType.cs
@@ -44,5 +44,11 @@ namespace Microsoft.Azure.Cosmos
         /// </summary>
         [EnumMember(Value = PatchConstants.OperationTypeNames.Increment)]
         Increment,
+
+        /// <summary>
+        /// Operation to move a object/value.
+        /// </summary>
+        [EnumMember(Value = PatchConstants.OperationTypeNames.Move)]
+        Move,
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Patch/PatchOperationType.cs
+++ b/Microsoft.Azure.Cosmos/src/Patch/PatchOperationType.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Azure.Cosmos
     /// </summary>
     [JsonConverter(typeof(StringEnumConverter))]
 
+    //Further enum additions are expected in the future, application needs should be authored to cover them.
     public enum PatchOperationType
     {
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Patch/PatchOperationsJsonConverter.cs
+++ b/Microsoft.Azure.Cosmos/src/Patch/PatchOperationsJsonConverter.cs
@@ -88,6 +88,12 @@ namespace Microsoft.Azure.Cosmos
                 writer.WritePropertyName(PatchConstants.PropertyNames.Path);
                 writer.WriteValue(operation.Path);
 
+                if (operation.OperationType == PatchOperationType.Move)
+                {
+                    writer.WritePropertyName(PatchConstants.PropertyNames.From);
+                    writer.WriteValue(operation.From);
+                }
+
                 if (operation.TrySerializeValueParameter(this.userSerializer, out Stream valueStream))
                 {
                     string valueParam;

--- a/Microsoft.Azure.Cosmos/src/Patch/PatchOperationsJsonConverter.cs
+++ b/Microsoft.Azure.Cosmos/src/Patch/PatchOperationsJsonConverter.cs
@@ -93,8 +93,7 @@ namespace Microsoft.Azure.Cosmos
                     writer.WritePropertyName(PatchConstants.PropertyNames.From);
                     writer.WriteValue(operation.From);
                 }
-
-                if (operation.TrySerializeValueParameter(this.userSerializer, out Stream valueStream))
+                else if (operation.TrySerializeValueParameter(this.userSerializer, out Stream valueStream))
                 {
                     string valueParam;
                     using (valueStream)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Batch/BatchSinglePartitionKeyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Batch/BatchSinglePartitionKeyTests.cs
@@ -693,7 +693,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             DateTime patchDate = new DateTime(2020, 07, 01, 01, 02, 03);
             List<PatchOperation> patchOperations = new List<PatchOperation>()
             {
-                PatchOperation.Add("/date", patchDate)
+                PatchOperation.Add("/date", patchDate),
+                PatchOperation.Move("/TodayDate", "/date")
+                //PatchOperation.Add("/noDate", patchDate)
             };
 
             BatchCore batch = (BatchCore)new BatchCore((ContainerInlineCore)customSerializationContainer, BatchTestBase.GetPartitionKey(this.PartitionKey1))
@@ -720,6 +722,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             Assert.IsNotNull(response.Resource);
             Assert.IsTrue(dateJson.Contains(response.Resource["date"].ToString()));
+            Assert.IsTrue(dateJson.Contains(response.Resource["TodayDate"].ToString()));
         }
 
         private async Task<TransactionalBatchResponse> RunCrudAsync(bool isStream, bool isSchematized, bool useEpk, Container container)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Batch/BatchSinglePartitionKeyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Batch/BatchSinglePartitionKeyTests.cs
@@ -695,7 +695,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             {
                 PatchOperation.Add("/date", patchDate),
                 PatchOperation.Move("/TodayDate", "/date")
-                //PatchOperation.Add("/noDate", patchDate)
             };
 
             BatchCore batch = (BatchCore)new BatchCore((ContainerInlineCore)customSerializationContainer, BatchTestBase.GetPartitionKey(this.PartitionKey1))
@@ -721,7 +720,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             Assert.IsNotNull(response.Resource);
-            Assert.IsTrue(dateJson.Contains(response.Resource["date"].ToString()));
+            Assert.IsNull(response.Resource["date"]);
             Assert.IsTrue(dateJson.Contains(response.Resource["TodayDate"].ToString()));
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Batch/BatchSinglePartitionKeyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Batch/BatchSinglePartitionKeyTests.cs
@@ -694,7 +694,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             List<PatchOperation> patchOperations = new List<PatchOperation>()
             {
                 PatchOperation.Add("/date", patchDate),
-                PatchOperation.Move("/TodayDate", "/date")
+                PatchOperation.Move("/date", "/TodayDate")
             };
 
             BatchCore batch = (BatchCore)new BatchCore((ContainerInlineCore)customSerializationContainer, BatchTestBase.GetPartitionKey(this.PartitionKey1))

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -1979,7 +1979,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.IsNull(response.Resource.children[1].nullableInt);
 
             patchOperations.Clear();
-            patchOperations.Add(PatchOperation.Add("/children/0/cost", 1));
+            patchOperations.Add(PatchOperation.Move("/newTaskNum", "/taskNum"));
             //patchOperations.Add(PatchOperation.Set("/random", value));
             // with content response
             response = await containerInternal.PatchItemAsync<ToDoActivity>(

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -1980,7 +1980,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             patchOperations.Clear();
             patchOperations.Add(PatchOperation.Add("/children/0/cost", 1));
-            //patchOperations.Add(PatchOperation.Set("/random", value));
             // with content response
             response = await containerInternal.PatchItemAsync<ToDoActivity>(
                 id: testItem.id,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -1979,7 +1979,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.IsNull(response.Resource.children[1].nullableInt);
 
             patchOperations.Clear();
-            patchOperations.Add(PatchOperation.Move("/newTaskNum", "/taskNum"));
+            patchOperations.Add(PatchOperation.Add("/children/0/cost", 1));
             //patchOperations.Add(PatchOperation.Set("/random", value));
             // with content response
             response = await containerInternal.PatchItemAsync<ToDoActivity>(
@@ -2002,6 +2002,22 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             Assert.IsNotNull(response.Resource);
             Assert.AreEqual(null, response.Resource.children[0].id);
+            
+            patchOperations.Clear();
+            patchOperations.Add(PatchOperation.Add("/children/1/description","Child#1"));
+            patchOperations.Add(PatchOperation.Move("/description", "/children/0/description"));
+            patchOperations.Add(PatchOperation.Move("/children/0/description", "/children/1/description"));
+            // with content response
+            response = await containerInternal.PatchItemAsync<ToDoActivity>(
+                id: testItem.id,
+                partitionKey: new Cosmos.PartitionKey(testItem.pk),
+                patchOperations: patchOperations);
+
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            Assert.IsNotNull(response.Resource);
+            Assert.AreEqual("testSet", response.Resource.description);
+            Assert.AreEqual("Child#1", response.Resource.children[0].description);
+            Assert.IsNull(response.Resource.children[1].description);
         }
 
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -2004,8 +2004,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             
             patchOperations.Clear();
             patchOperations.Add(PatchOperation.Add("/children/1/description","Child#1"));
-            patchOperations.Add(PatchOperation.Move("/description", "/children/0/description"));
-            patchOperations.Add(PatchOperation.Move("/children/0/description", "/children/1/description"));
+            patchOperations.Add(PatchOperation.Move("/children/0/description", "/description"));
+            patchOperations.Add(PatchOperation.Move("/children/1/description", "/children/0/description"));
             // with content response
             response = await containerInternal.PatchItemAsync<ToDoActivity>(
                 id: testItem.id,


### PR DESCRIPTION
# Pull Request Template

## Description

The move operation removes the value at a specified location and adds it to the target location.
It takes in 2 parameters "path" (destination path) and "from" (source path).
Functionally it is identical to an add operation at the destination followed by a remove at the source path.
This operation is discussed in the JSONPATCH RFC6902.

This PR is an extension of PR https://github.com/Azure/azure-cosmos-dotnet-v3/pull/3262 . It addresses the comments. 
## Type of change

Please delete options that are not relevant.

- [] New feature (non-breaking change which adds functionality)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber