### PR TITLE
Diagnostics: Fixes Ordering of ClientConfiguration Initialization

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Tracing/TraceData/ClientConfigurationTraceDatum.cs
+++ b/Microsoft.Azure.Cosmos/src/Tracing/TraceData/ClientConfigurationTraceDatum.cs
@@ -32,10 +32,10 @@ namespace Microsoft.Azure.Cosmos.Tracing.TraceData
             this.cachedNumberOfActiveClient = CosmosClient.NumberOfActiveClients;
             this.cachedUserAgentString = this.UserAgentContainer.UserAgent;
             this.cachedMachineId = VmMetadataApiHandler.GetMachineId();
-            this.cachedSerializedJson = this.GetSerializedDatum();
             this.ProcessorCount = Environment.ProcessorCount;
             this.ConnectionMode = cosmosClientContext.ClientOptions.ConnectionMode;
             this.cachedVMRegion = VmMetadataApiHandler.GetMachineRegion();
+            this.cachedSerializedJson = this.GetSerializedDatum();
         }
 
         public DateTime ClientCreatedDateTimeUtc { get; }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientCreateAndInitializeTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientCreateAndInitializeTest.cs
@@ -69,7 +69,6 @@
             CosmosClientOptions cosmosClientOptions = new CosmosClientOptions
             {
                 HttpClientFactory = () => new HttpClient(httpClientHandlerHelper),
-                ConnectionMode = ConnectionMode.Direct
             };
 
             CosmosClient cosmosClient = await CosmosClient.CreateAndInitializeAsync(endpoint, authKey, containers, cosmosClientOptions);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientCreateAndInitializeTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientCreateAndInitializeTest.cs
@@ -68,7 +68,8 @@
 
             CosmosClientOptions cosmosClientOptions = new CosmosClientOptions
             {
-                HttpClientFactory = () => new HttpClient(httpClientHandlerHelper)
+                HttpClientFactory = () => new HttpClient(httpClientHandlerHelper),
+                ConnectionMode = ConnectionMode.Direct
             };
 
             CosmosClient cosmosClient = await CosmosClient.CreateAndInitializeAsync(endpoint, authKey, containers, cosmosClientOptions);
@@ -77,6 +78,8 @@
 
             ContainerInternal container = (ContainerInternal)cosmosClient.GetContainer("ClientCreateAndInitializeDatabase", "ClientCreateAndInitializeContainer");
             ItemResponse<ToDoActivity> readResponse = await container.ReadItemAsync<ToDoActivity>("1", new Cosmos.PartitionKey("Status1"));
+            string diagnostics = readResponse.Diagnostics.ToString();
+            Assert.IsTrue(diagnostics.Contains("\"ConnectionMode\":\"Direct\""));
             Assert.AreEqual(httpCallsMade, httpCallsMadeAfterCreation);
             cosmosClient.Dispose();
         }


### PR DESCRIPTION
# Pull Request Template

## Description
The cachedSerializedJson from the client configuration was getting updated before the connection mode was initialized, so the default connection mode was getting output instead of the one set in the client options

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #3387