### PR TITLE
[Preview] Change Feed: Refactors Change Feed Contract to rename TimeToLiveExpired

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/FullFidelity/ChangeFeedMetadata.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/FullFidelity/ChangeFeedMetadata.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Used to distinquish explicit deletes (e.g. via DeleteItem) from deletes caused by TTL expiration (a collection may define time-to-live policy for documents).
         /// </summary>
-        [JsonProperty(PropertyName = "isTimeToLiveExpired", NullValueHandling= NullValueHandling.Ignore)]
+        [JsonProperty(PropertyName = "timeToLiveExpired", NullValueHandling= NullValueHandling.Ignore)]
         public bool IsTimeToLiveExpired { get; }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Resource/FullFidelity/ChangeFeedMetadata.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/FullFidelity/ChangeFeedMetadata.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Used to distinquish explicit deletes (e.g. via DeleteItem) from deletes caused by TTL expiration (a collection may define time-to-live policy for documents).
         /// </summary>
-        [JsonProperty(PropertyName = "timeToLiveExpired", NullValueHandling= NullValueHandling.Ignore)]
-        public bool TimeToLiveExpired { get; }
+        [JsonProperty(PropertyName = "isTimeToLiveExpired", NullValueHandling= NullValueHandling.Ignore)]
+        public bool IsTimeToLiveExpired { get; }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/FeedToken/ChangeFeedIteratorCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/FeedToken/ChangeFeedIteratorCoreTests.cs
@@ -500,15 +500,9 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.FeedRanges
             int count = 0;
             while (true)
             {
-                ChangeFeedStartFrom startFrom;
-                if (continuation == null)
-                {
-                    startFrom = ChangeFeedStartFrom.Beginning();
-                }
-                else
-                {
-                    startFrom = ChangeFeedStartFrom.ContinuationToken(continuation);
-                }
+                ChangeFeedStartFrom startFrom = continuation == null ?
+                    ChangeFeedStartFrom.Beginning() :
+                    ChangeFeedStartFrom.ContinuationToken(continuation);
 
                 ChangeFeedIteratorCore feedIterator = itemsCore.GetChangeFeedStreamIterator(startFrom, ChangeFeedMode.Incremental) as ChangeFeedIteratorCore;
                 using (ResponseMessage responseMessage = await feedIterator.ReadNextAsync(this.cancellationToken))
@@ -864,7 +858,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.FeedRanges
                         Assert.AreNotEqual(notExpected: default, actual: createOperation.Metadata.ConflictResolutionTimestamp);
                         Assert.AreNotEqual(notExpected: default, actual: createOperation.Metadata.Lsn);
                         Assert.AreEqual(expected: default, actual: createOperation.Metadata.PreviousLsn);
-                        Assert.IsFalse(createOperation.Metadata.TimeToLiveExpired);
+                        Assert.IsFalse(createOperation.Metadata.IsTimeToLiveExpired);
 
                         ChangeFeedItemChange<Item> replaceOperation = itemChanges.ElementAtOrDefault(1);
 
@@ -878,7 +872,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.FeedRanges
                         Assert.AreNotEqual(notExpected: default, actual: replaceOperation.Metadata.ConflictResolutionTimestamp);
                         Assert.AreNotEqual(notExpected: default, actual: replaceOperation.Metadata.Lsn);
                         Assert.AreNotEqual(notExpected: default, actual: replaceOperation.Metadata.PreviousLsn);
-                        Assert.IsFalse(replaceOperation.Metadata.TimeToLiveExpired);
+                        Assert.IsFalse(replaceOperation.Metadata.IsTimeToLiveExpired);
 
                         break;
                     }
@@ -943,7 +937,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.FeedRanges
                         Assert.AreNotEqual(notExpected: default, actual: firstCreateOperation.Metadata.ConflictResolutionTimestamp);
                         Assert.AreNotEqual(notExpected: default, actual: firstCreateOperation.Metadata.Lsn);
                         Assert.AreEqual(expected: default, actual: firstCreateOperation.Metadata.PreviousLsn);
-                        Assert.IsFalse(firstCreateOperation.Metadata.TimeToLiveExpired);
+                        Assert.IsFalse(firstCreateOperation.Metadata.IsTimeToLiveExpired);
 
                         ChangeFeedItemChange<Item> createOperation = resources[1];
 
@@ -956,7 +950,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.FeedRanges
                         Assert.AreNotEqual(notExpected: default, actual: createOperation.Metadata.ConflictResolutionTimestamp);
                         Assert.AreNotEqual(notExpected: default, actual: createOperation.Metadata.Lsn);
                         Assert.AreEqual(expected: default, actual: createOperation.Metadata.PreviousLsn);
-                        Assert.IsFalse(createOperation.Metadata.TimeToLiveExpired);
+                        Assert.IsFalse(createOperation.Metadata.IsTimeToLiveExpired);
 
                         ChangeFeedItemChange<Item> replaceOperation = resources[2];
 
@@ -969,7 +963,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.FeedRanges
                         Assert.AreNotEqual(notExpected: default, actual: replaceOperation.Metadata.ConflictResolutionTimestamp);
                         Assert.AreNotEqual(notExpected: default, actual: replaceOperation.Metadata.Lsn);
                         Assert.AreNotEqual(notExpected: default, actual: replaceOperation.Metadata.PreviousLsn);
-                        Assert.IsFalse(replaceOperation.Metadata.TimeToLiveExpired);
+                        Assert.IsFalse(replaceOperation.Metadata.IsTimeToLiveExpired);
 
                         ChangeFeedItemChange<Item> deleteOperation = resources[3];
 
@@ -1052,7 +1046,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.FeedRanges
                         Assert.AreNotEqual(notExpected: default, actual: createOperation.Metadata.ConflictResolutionTimestamp);
                         Assert.AreNotEqual(notExpected: default, actual: createOperation.Metadata.Lsn);
                         Assert.AreEqual(expected: default, actual: createOperation.Metadata.PreviousLsn);
-                        Assert.IsFalse(createOperation.Metadata.TimeToLiveExpired);
+                        Assert.IsFalse(createOperation.Metadata.IsTimeToLiveExpired);
 
                         ChangeFeedItemChange<Item> replaceOperation = itemChanges[1];
 
@@ -1066,7 +1060,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.FeedRanges
                         Assert.AreNotEqual(notExpected: default, actual: replaceOperation.Metadata.ConflictResolutionTimestamp);
                         Assert.AreNotEqual(notExpected: default, actual: replaceOperation.Metadata.Lsn);
                         Assert.AreNotEqual(notExpected: default, actual: replaceOperation.Metadata.PreviousLsn);
-                        Assert.IsFalse(replaceOperation.Metadata.TimeToLiveExpired);
+                        Assert.IsFalse(replaceOperation.Metadata.IsTimeToLiveExpired);
 
                         ChangeFeedItemChange<Item> deleteOperation = itemChanges[2];
 
@@ -1075,7 +1069,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.FeedRanges
                         Assert.AreNotEqual(notExpected: default, actual: deleteOperation.Metadata.ConflictResolutionTimestamp);
                         Assert.AreNotEqual(notExpected: default, actual: deleteOperation.Metadata.Lsn);
                         Assert.AreNotEqual(notExpected: default, actual: deleteOperation.Metadata.PreviousLsn);
-                        Assert.IsFalse(replaceOperation.Metadata.TimeToLiveExpired);
+                        Assert.IsFalse(replaceOperation.Metadata.IsTimeToLiveExpired);
 
                         break;
                     }
@@ -1121,13 +1115,13 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.FeedRanges
         public class ToDoActivityWithMetadata : ToDoActivity
         {
             [JsonProperty("_metadata")]
-            public ToDoActivityMetadata metadata { get; set; }
+            public ToDoActivityMetadata Metadata { get; set; }
         }
 
         public class ToDoActivityMetadata
         {
             [JsonProperty("operationType")]
-            public string operationType { get; set; }
+            public string OperationType { get; set; }
         }
 
         private class CancellationTokenRequestHandler : RequestHandler

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetPreviewSDKAPI.json
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetPreviewSDKAPI.json
@@ -84,7 +84,7 @@
           ],
           "MethodInfo": "Boolean get_IsTimeToLiveExpired();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
         },
-        "Boolean IsTimeToLiveExpired[Newtonsoft.Json.JsonPropertyAttribute(NullValueHandling = 1, PropertyName = \"isTimeToLiveExpired\")]": {
+        "Boolean IsTimeToLiveExpired[Newtonsoft.Json.JsonPropertyAttribute(NullValueHandling = 1, PropertyName = \"timeToLiveExpired\")]": {
           "Type": "Property",
           "Attributes": [
             "JsonPropertyAttribute"

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetPreviewSDKAPI.json
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetPreviewSDKAPI.json
@@ -77,19 +77,19 @@
     "Microsoft.Azure.Cosmos.ChangeFeedMetadata;System.Object;IsAbstract:False;IsSealed:False;IsInterface:False;IsEnum:False;IsClass:True;IsValueType:False;IsNested:False;IsGenericType:False;IsSerializable:False": {
       "Subclasses": {},
       "Members": {
-        "Boolean get_TimeToLiveExpired()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+        "Boolean get_IsTimeToLiveExpired()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
           "Type": "Method",
           "Attributes": [
             "CompilerGeneratedAttribute"
           ],
-          "MethodInfo": "Boolean get_TimeToLiveExpired();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+          "MethodInfo": "Boolean get_IsTimeToLiveExpired();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
         },
-        "Boolean TimeToLiveExpired[Newtonsoft.Json.JsonPropertyAttribute(NullValueHandling = 1, PropertyName = \"timeToLiveExpired\")]": {
+        "Boolean IsTimeToLiveExpired[Newtonsoft.Json.JsonPropertyAttribute(NullValueHandling = 1, PropertyName = \"isTimeToLiveExpired\")]": {
           "Type": "Property",
           "Attributes": [
             "JsonPropertyAttribute"
           ],
-          "MethodInfo": "Boolean TimeToLiveExpired;CanRead:True;CanWrite:False;Boolean get_TimeToLiveExpired();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+          "MethodInfo": "Boolean IsTimeToLiveExpired;CanRead:True;CanWrite:False;Boolean get_IsTimeToLiveExpired();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
         },
         "Int64 get_Lsn()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
           "Type": "Method",


### PR DESCRIPTION
# Pull Request Template

## Description

Contract changes to rename `TimeToLiveExpired` field to `IsTimeToLiveExpired`. This changes is required to make the variable naming consistent across the Java SDK.

## Closing issues

To automatically close an issue: closes #3393 