### PR TITLE
Change Feed Processor: Fixes LeaseLostException leaks on notification APIs

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedManagement/PartitionControllerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedManagement/PartitionControllerCore.cs
@@ -70,12 +70,14 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedManagement
             catch (Exception ex)
             {
                 await this.RemoveLeaseAsync(lease: lease, wasAcquired: false).ConfigureAwait(false);
-                if (ex is LeaseLostException leaseLostException
-                    && leaseLostException.InnerException != null)
+                if (ex is LeaseLostException leaseLostException)
                 {
                     // LeaseLostException by itself is not loggable, unless it contains a related inner exception
                     // For cases when the lease or container has been deleted or the lease has been stolen
-                    await this.monitor.NotifyErrorAsync(lease.CurrentLeaseToken, leaseLostException.InnerException);
+                    if (leaseLostException.InnerException != null)
+                    {
+                        await this.monitor.NotifyErrorAsync(lease.CurrentLeaseToken, leaseLostException.InnerException);
+                    }
                 }
                 else
                 {

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedManagement/PartitionControllerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedManagement/PartitionControllerCore.cs
@@ -70,18 +70,20 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedManagement
             catch (Exception ex)
             {
                 await this.RemoveLeaseAsync(lease: lease, wasAcquired: false).ConfigureAwait(false);
-                if (ex is LeaseLostException leaseLostException)
+                switch (ex)
                 {
-                    // LeaseLostException by itself is not loggable, unless it contains a related inner exception
-                    // For cases when the lease or container has been deleted or the lease has been stolen
-                    if (leaseLostException.InnerException != null)
-                    {
-                        await this.monitor.NotifyErrorAsync(lease.CurrentLeaseToken, leaseLostException.InnerException);
-                    }
-                }
-                else
-                {
-                    await this.monitor.NotifyErrorAsync(lease.CurrentLeaseToken, ex);
+                    case LeaseLostException leaseLostException:
+                        // LeaseLostException by itself is not loggable, unless it contains a related inner exception
+                        // For cases when the lease or container has been deleted or the lease has been stolen
+                        if (leaseLostException.InnerException != null)
+                        {
+                            await this.monitor.NotifyErrorAsync(lease.CurrentLeaseToken, leaseLostException.InnerException);
+                        }
+                        break;
+
+                    default:
+                        await this.monitor.NotifyErrorAsync(lease.CurrentLeaseToken, ex);
+                        break;
                 }
 
                 throw;

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseUpdaterCosmos.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseUpdaterCosmos.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
                 catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
                 {
                     DefaultTrace.TraceInformation("Lease with token {0} no longer exists", lease.CurrentLeaseToken);
-                    throw new LeaseLostException(lease, true);
+                    throw new LeaseLostException(lease, ex, isGone: true);
                 }
             }
 
@@ -94,7 +94,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
                 DefaultTrace.TraceWarning("Lease operation exception, status code: {0}", ex.StatusCode);
                 if (ex.StatusCode == HttpStatusCode.NotFound)
                 {
-                    throw new LeaseLostException(lease, true);
+                    throw new LeaseLostException(lease, ex, isGone: true);
                 }
 
                 if (ex.StatusCode == HttpStatusCode.PreconditionFailed)
@@ -104,7 +104,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
 
                 if (ex.StatusCode == HttpStatusCode.Conflict)
                 {
-                    throw new LeaseLostException(lease, ex, false);
+                    throw new LeaseLostException(lease, ex, isGone: false);
                 }
 
                 throw;

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseUpdaterCosmos.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseUpdaterCosmos.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
                 catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
                 {
                     DefaultTrace.TraceInformation("Lease with token {0} no longer exists", lease.CurrentLeaseToken);
-                    throw new LeaseLostException(lease, ex, isGone: true);
+                    throw new LeaseLostException(lease: lease, innerException: ex, isGone: true);
                 }
             }
 
@@ -94,7 +94,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
                 DefaultTrace.TraceWarning("Lease operation exception, status code: {0}", ex.StatusCode);
                 if (ex.StatusCode == HttpStatusCode.NotFound)
                 {
-                    throw new LeaseLostException(lease, ex, isGone: true);
+                    throw new LeaseLostException(lease: lease, innerException: ex, isGone: true);
                 }
 
                 if (ex.StatusCode == HttpStatusCode.PreconditionFailed)
@@ -104,7 +104,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
 
                 if (ex.StatusCode == HttpStatusCode.Conflict)
                 {
-                    throw new LeaseLostException(lease, ex, isGone: false);
+                    throw new LeaseLostException(lease: lease, innerException: ex, isGone: false);
                 }
 
                 throw;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseManagerCosmosTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseManagerCosmosTests.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
 {
     using System;
     using System.IO;
+    using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.ChangeFeed.Exceptions;
@@ -310,7 +311,6 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         /// <summary>
         /// Verifies that if the updater read a different Owner from the captured in memory, throws a LeaseLost
         /// </summary>
-        [ExpectedException(typeof(LeaseLostException))]
         [TestMethod]
         public async Task IfOwnerChangedThrow()
         {
@@ -350,7 +350,10 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
                 options,
                 Mock.Of<RequestOptionsFactory>());
 
-            await documentServiceLeaseManagerCosmos.AcquireAsync(lease);
+            LeaseLostException leaseLost = await Assert.ThrowsExceptionAsync<LeaseLostException>(() => documentServiceLeaseManagerCosmos.AcquireAsync(lease));
+
+            Assert.IsTrue(leaseLost.InnerException is CosmosException innerCosmosException
+                && innerCosmosException.StatusCode == HttpStatusCode.PreconditionFailed);
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseUpdaterCosmosTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseUpdaterCosmosTests.cs
@@ -169,7 +169,6 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         }
 
         [TestMethod]
-        [ExpectedException(typeof(LeaseLostException))]
         public async Task ThrowsOnConflict()
         {
             string itemId = "1";
@@ -209,15 +208,17 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
                 });
 
             DocumentServiceLeaseUpdaterCosmos updater = new DocumentServiceLeaseUpdaterCosmos(DocumentServiceLeaseUpdaterCosmosTests.GetMockedContainer(mockedItems));
-            DocumentServiceLease updatedLease = await updater.UpdateLeaseAsync(leaseToUpdate, itemId, partitionKey, serverLease =>
+            LeaseLostException leaseLost = await Assert.ThrowsExceptionAsync<LeaseLostException>(() => updater.UpdateLeaseAsync(leaseToUpdate, itemId, partitionKey, serverLease =>
             {
                 serverLease.Owner = "newHost";
                 return serverLease;
-            });
+            }));
+
+            Assert.IsTrue(leaseLost.InnerException is CosmosException innerCosmosException
+                && innerCosmosException.StatusCode == HttpStatusCode.Conflict);
         }
 
         [TestMethod]
-        [ExpectedException(typeof(LeaseLostException))]
         public async Task ThrowsOnNotFoundReplace()
         {
             string itemId = "1";
@@ -257,15 +258,17 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
                 });
 
             DocumentServiceLeaseUpdaterCosmos updater = new DocumentServiceLeaseUpdaterCosmos(DocumentServiceLeaseUpdaterCosmosTests.GetMockedContainer(mockedItems));
-            DocumentServiceLease updatedLease = await updater.UpdateLeaseAsync(leaseToUpdate, itemId, partitionKey, serverLease =>
+            LeaseLostException leaseLost = await Assert.ThrowsExceptionAsync<LeaseLostException>(() => updater.UpdateLeaseAsync(leaseToUpdate, itemId, partitionKey, serverLease =>
             {
                 serverLease.Owner = "newHost";
                 return serverLease;
-            });
+            }));
+
+            Assert.IsTrue(leaseLost.InnerException is CosmosException innerCosmosException
+                && innerCosmosException.StatusCode == HttpStatusCode.NotFound);
         }
 
         [TestMethod]
-        [ExpectedException(typeof(LeaseLostException))]
         public async Task ThrowsOnNotFoundRead()
         {
             string itemId = "1";
@@ -302,11 +305,14 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
                 });
 
             DocumentServiceLeaseUpdaterCosmos updater = new DocumentServiceLeaseUpdaterCosmos(DocumentServiceLeaseUpdaterCosmosTests.GetMockedContainer(mockedItems));
-            DocumentServiceLease updatedLease = await updater.UpdateLeaseAsync(leaseToUpdate, itemId, partitionKey, serverLease =>
+            LeaseLostException leaseLost = await Assert.ThrowsExceptionAsync<LeaseLostException>(() => updater.UpdateLeaseAsync(leaseToUpdate, itemId, partitionKey, serverLease =>
             {
                 serverLease.Owner = "newHost";
                 return serverLease;
-            });
+            }));
+
+            Assert.IsTrue(leaseLost.InnerException is CosmosException innerCosmosException
+                && innerCosmosException.StatusCode == HttpStatusCode.NotFound);
         }
 
         private static ContainerInternal GetMockedContainer(Mock<ContainerInternal> mockedContainer)


### PR DESCRIPTION
## Description

There were 3 conditions on which the Notification APIs were surfacing `LeaseLostException` to the user:

1. If the lease is not found (the document was deleted, which would indicate an invalid state): https://github.com/Azure/azure-cosmos-dotnet-v3/blob/master/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseUpdaterCosmos.cs#L66-L70
2. If there are constant conflicts beyond the retry scope (basically getting 412, which would indicate a very high concurrency of workers) https://github.com/Azure/azure-cosmos-dotnet-v3/blob/master/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseUpdaterCosmos.cs#L35
3. When a worker processed a batch and was about to checkpoint but the lease was stolen (https://github.com/Azure/azure-cosmos-dotnet-v3/blob/master/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseManagerCosmos.cs#L92) which would indicate that a batch will probably be reprocessed by another instance. 

This PR makes it so the notification APIs are called but with the InnerException related to the CosmosException (a NotFound, or a Conflict, or a PreconditionFailed error) instead of the LeaseLostException.

This way we avoid leaking the internal type but we don't miss notifying the problem.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Closing issues

Closes #3379 