### PR TITLE
CosmosClient Initialization: Fixes TokenCredentialCache to respect cancellation token

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Authorization/TokenCredentialCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Authorization/TokenCredentialCache.cs
@@ -190,7 +190,7 @@ namespace Microsoft.Azure.Cosmos
                         {
                             this.cachedAccessToken = await this.tokenCredential.GetTokenAsync(
                                 requestContext: this.tokenRequestContext,
-                                cancellationToken: default);
+                                cancellationToken: this.cancellationToken);
 
                             if (!this.cachedAccessToken.HasValue)
                             {

--- a/Microsoft.Azure.Cosmos/src/CosmosClient.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClient.cs
@@ -1342,7 +1342,7 @@ namespace Microsoft.Azure.Cosmos
                options: requestOptions);
         }
 
-        private async Task InitializeContainersAsync(IReadOnlyList<(string databaseId, string containerId)> containers,
+        internal async Task InitializeContainersAsync(IReadOnlyList<(string databaseId, string containerId)> containers,
                                           CancellationToken cancellationToken)
         {
             try
@@ -1419,7 +1419,7 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Dispose of cosmos client
         /// </summary>
-        public void Dispose()
+        public virtual void Dispose()
         {
             this.Dispose(true);
         }

--- a/Microsoft.Azure.Cosmos/src/CosmosClient.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClient.cs
@@ -1419,7 +1419,7 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Dispose of cosmos client
         /// </summary>
-        public virtual void Dispose()
+        public void Dispose()
         {
             this.Dispose(true);
         }
@@ -1428,7 +1428,7 @@ namespace Microsoft.Azure.Cosmos
         /// Dispose of cosmos client
         /// </summary>
         /// <param name="disposing">True if disposing</param>
-        protected virtual void Dispose(bool disposing)
+        internal virtual void Dispose(bool disposing)
         {
             lock (this.disposedLock)
             {

--- a/Microsoft.Azure.Cosmos/src/CosmosClient.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClient.cs
@@ -1428,7 +1428,7 @@ namespace Microsoft.Azure.Cosmos
         /// Dispose of cosmos client
         /// </summary>
         /// <param name="disposing">True if disposing</param>
-        internal virtual void Dispose(bool disposing)
+        protected virtual void Dispose(bool disposing)
         {
             lock (this.disposedLock)
             {

--- a/Microsoft.Azure.Cosmos/src/CosmosClient.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClient.cs
@@ -1342,7 +1342,7 @@ namespace Microsoft.Azure.Cosmos
                options: requestOptions);
         }
 
-        private Task InitializeContainersAsync(IReadOnlyList<(string databaseId, string containerId)> containers,
+        private async Task InitializeContainersAsync(IReadOnlyList<(string databaseId, string containerId)> containers,
                                           CancellationToken cancellationToken)
         {
             try
@@ -1353,7 +1353,7 @@ namespace Microsoft.Azure.Cosmos
                     tasks.Add(this.InitializeContainerAsync(databaseId, containerId, cancellationToken));
                 }
 
-                return Task.WhenAll(tasks);
+                await Task.WhenAll(tasks);
             }
             catch
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientCreateAndInitializeTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientCreateAndInitializeTest.cs
@@ -184,6 +184,7 @@
             CosmosException ex = await Assert.ThrowsExceptionAsync<CosmosException>(() => cosmosClient.Object.InitializeContainersAsync(containers, this.cancellationToken));
 
             // Assert.
+            Assert.IsNotNull(ex);
             Assert.IsTrue(ex.StatusCode == HttpStatusCode.NotFound);
             cosmosClient.Verify(x => x.Dispose(true), Times.Once);
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientCreateAndInitializeTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientCreateAndInitializeTest.cs
@@ -160,7 +160,6 @@
         }
 
         [TestMethod]
-        [ExpectedException(typeof(CosmosException))]
         public async Task InitializeContainersAsync_WhenThrowsException_ShouldDisposeCosmosClient()
         {
             // Arrange.
@@ -181,18 +180,12 @@
                 .Setup(x => x.GetContainer(It.IsAny<string>(), It.IsAny<string>()))
                 .Throws(cosmosException);
 
-            try
-            {
-                // Act.
-                await cosmosClient.Object.InitializeContainersAsync(containers, this.cancellationToken);
-            }
-            catch (CosmosException ex)
-            {
-                // Assert.
-                Assert.IsTrue(ex.StatusCode == HttpStatusCode.NotFound);
-                cosmosClient.Verify(x => x.Dispose(), Times.Exactly(1));
-                throw ex;
-            }
+            // Act.
+            CosmosException ex = await Assert.ThrowsExceptionAsync<CosmosException>(() => cosmosClient.Object.InitializeContainersAsync(containers, this.cancellationToken));
+
+            // Assert.
+            Assert.IsTrue(ex.StatusCode == HttpStatusCode.NotFound);
+            cosmosClient.Verify(x => x.Dispose(true), Times.Once);
         }
     }
 }


### PR DESCRIPTION
# Pull Request Template

## Description

- Code changes to make `InitializeContainersAsync` method asynchronous. This will make sure the `Dispose()` method will be called, in the event there are any exception occurs.
- Updated `TokenCredentialCache` to use the current context cancellation token.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #3392