### PR TITLE
[Internal] Pipelines: Fixes pipeline to not run on documentation

### DIFF
--- a/azure-pipelines-functional.yml
+++ b/azure-pipelines-functional.yml
@@ -10,6 +10,10 @@ pr:
     include:
     - Microsoft.Azure.Cosmos/*
     - NuGet.config
+    exclude:
+    - '*.md'
+    - 'docs/**/*'
+    - 'Microsoft.Azure.Cosmos/contracts/**/*'
 
 variables:
   DebugArguments: ' --filter "TestCategory!=Quarantine" --verbosity normal '

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -9,6 +9,10 @@ pr:
   paths:
     include:
     - '*'
+    exclude:
+    - '*.md'
+    - 'docs/**/*'
+    - 'Microsoft.Azure.Cosmos/contracts/**/*'
 
 variables:
   DebugArguments: ' --filter "TestCategory!=Quarantine & TestCategory!=Functional" --verbosity normal '
@@ -21,13 +25,6 @@ jobs:
   parameters:
     BuildConfiguration: Release
     VmImage: $(VmImage)
-    
-
-#- template:  templates/build-test.yml
-#  parameters:
-#    BuildConfiguration: Debug
-#    Arguments: $(DebugArguments)
-#    VmImage: $(VmImage)
 
 - template:  templates/nuget-pack.yml
   parameters:


### PR DESCRIPTION
This PR changes the YML definitions to avoid triggering on PRs that are simply modifying documentation or contract files (like release PRs).

This would reduce time-to-release and reduce instance usage on the pipelines (we have a limited number of agents so anything that reduces unnecessary runs allows other PRs to execute faster and not block).

The following patterns will be ignored:

- Modifications of MD files
- Files inside the `docs` folder
- Contract files inside `Microsoft.Azure.Cosmos/contracts`