### PR TITLE
Documentation: Adds link to supported operations doc for PatchOperationType Enum

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Patch/PatchOperationType.cs
+++ b/Microsoft.Azure.Cosmos/src/Patch/PatchOperationType.cs
@@ -11,6 +11,9 @@ namespace Microsoft.Azure.Cosmos
     /// <summary>
     /// Type of Patch operation.
     /// </summary>
+    /// <remarks>
+    /// For more information, see <see href="https://docs.microsoft.com/azure/cosmos-db/partial-document-update#supported-operations">Partial document update in Azure Cosmos DB: Supported operations</see>
+    /// </remarks>
     [JsonConverter(typeof(StringEnumConverter))]
 
     public enum PatchOperationType


### PR DESCRIPTION
## Description

This PR adds a link the official doc for supported operations to the [`PatchOperationType` Enum reference doc](https://docs.microsoft.com/en-us/dotnet/api/microsoft.azure.cosmos.patchoperationtype?view=azure-dotnet).

## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update

## Closing issues

resolves Azure/azure-sdk-for-net#30972