### PR TITLE
CosmosSystemTextJsonSerializer: Refactors typeof(T) to input.GetType()

### DIFF
--- a/Microsoft.Azure.Cosmos.Samples/Usage/SystemTextJson/CosmosSystemTextJsonSerializer.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/SystemTextJson/CosmosSystemTextJsonSerializer.cs
@@ -40,7 +40,7 @@
         public override Stream ToStream<T>(T input)
         {
             MemoryStream streamPayload = new MemoryStream();
-            this.systemTextJsonSerializer.Serialize(streamPayload, input, typeof(T), default);
+            this.systemTextJsonSerializer.Serialize(streamPayload, input, input.GetType(), default);
             streamPayload.Position = 0;
             return streamPayload;
         }


### PR DESCRIPTION
# Pull Request Template

## Description

Code changes to `CosmosSystemTextJsonSerializer` in the `SystemTextJson` sample to use the `GetType()` method rather than the `typeof(T)` method. This does not change any functionality however will allow for more flexibility when it comes to inheritance or dynamic typing.

## Type of change

Please delete options that are not relevant.

- [] New feature (non-breaking change which adds functionality)

## Closing issues

To automatically close an issue: closes #3347