### PR TITLE
[Internal] PRLint: Fixes configuration to avoid PR being blocked

### DIFF
--- a/.github/workflows/prlint.yml
+++ b/.github/workflows/prlint.yml
@@ -8,12 +8,12 @@ jobs:
   pr-lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: morrisoncole/pr-lint-action@v1.6.1
+    - uses: morrisoncole/pr-lint-action@v1.7.0
       with:
         title-regex: '(\[Internal\]|\[v4\] )?.{3}.+: (Adds|Fixes|Refactors|Removes) .{3}.+'
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        on-failed-regex-fail-action: false
-        on-failed-regex-request-changes: true
+        on-failed-regex-fail-action: true
+        on-failed-regex-request-changes: false
         on-failed-regex-create-review: true
         on-failed-regex-comment: >
          Please follow the required format: \"[Internal] Category: (Adds|Fixes|Refactors|Removes) Description\"<br /><br />


### PR DESCRIPTION
Right now the PR-Lint cannot undo the review due to permissions issues, following https://github.com/MorrisonCole/pr-lint-action/issues/371#issuecomment-1250011920, we are setting `on-failed-regex-request-changes` to `false` and `on-failed-regex-fail-action` to true.