### PR TITLE
Add option to manage the lease of change feed processor on azure storage container

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedProcessorBuilder.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedProcessorBuilder.cs
@@ -5,6 +5,7 @@
 namespace Microsoft.Azure.Cosmos
 {
     using System;
+    using global::Azure.Storage.Blobs;
     using Microsoft.Azure.Cosmos.ChangeFeed.Configuration;
     using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;
     using static Microsoft.Azure.Cosmos.Container;
@@ -30,7 +31,7 @@ namespace Microsoft.Azure.Cosmos
 
         private ContainerInternal leaseContainer;
         private string InstanceName;
-        private string azureContaierUri;
+        private BlobContainerClient azureContainer;
         private DocumentServiceLeaseStoreManager leaseStoreManager;
         private bool isBuilt;
 
@@ -192,11 +193,11 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Sets the azure storage lease container to hold the leases state
         /// </summary>
-        /// <param name="azureContaierUri">Uri of azure container (with secrets).</param>
+        /// <param name="azureContainer">BlobContainerClient of the lease blob container.</param>
         /// <returns>The instance of <see cref="ChangeFeedProcessorBuilder"/> to use.</returns>
-        public ChangeFeedProcessorBuilder WithAzureStorageLeaseContainer(string azureContaierUri)
+        public ChangeFeedProcessorBuilder WithAzureStorageLeaseContainer(BlobContainerClient azureContainer)
         {
-            this.azureContaierUri = azureContaierUri;
+            this.azureContainer = azureContainer;
             return this;
         }
 
@@ -292,7 +293,7 @@ namespace Microsoft.Azure.Cosmos
                 throw new InvalidOperationException(nameof(this.monitoredContainer) + " was not specified");
             }
 
-            if (this.leaseContainer == null && this.leaseStoreManager == null && this.azureContaierUri == null)
+            if (this.leaseContainer == null && this.leaseStoreManager == null && this.azureContainer == null)
             {
                 throw new InvalidOperationException($"Defining the lease store by WithLeaseContainer or WithInMemoryLeaseContainer is required.");
             }
@@ -302,9 +303,9 @@ namespace Microsoft.Azure.Cosmos
                 throw new InvalidOperationException("Processor name not specified during creation.");
             }
 
-            if (this.azureContaierUri != null)
+            if (this.azureContainer != null)
             {
-                this.leaseStoreManager = new DocumentServiceLeaseStoreManagerAzureStorage(this.monitoredContainer, this.azureContaierUri, this.InstanceName);
+                this.leaseStoreManager = new DocumentServiceLeaseStoreManagerAzureStorage(this.monitoredContainer, this.azureContainer, this.InstanceName);
             }
 
             this.applyBuilderConfiguration(this.leaseStoreManager, this.leaseContainer, this.InstanceName, this.changeFeedLeaseOptions, this.changeFeedProcessorOptions, this.monitoredContainer);

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseContainerAzureStorage.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseContainerAzureStorage.cs
@@ -1,0 +1,69 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Text;
+    using System.Text.Json;
+    using System.Threading.Tasks;
+    using global::Azure.Storage.Blobs;
+    using Microsoft.Azure.Cosmos.ChangeFeed.Utils;
+
+    internal sealed class DocumentServiceLeaseContainerAzureStorage : DocumentServiceLeaseContainer
+    {
+        private readonly BlobContainerClient container;
+        private readonly string hostName;
+
+        public DocumentServiceLeaseContainerAzureStorage(
+            BlobContainerClient container,
+            string hostName)
+        {
+            this.container = container;
+            this.hostName = hostName;
+        }
+
+        public override async Task<IReadOnlyList<DocumentServiceLease>> GetAllLeasesAsync()
+        {
+            return await this.ListDocumentsAsync().ConfigureAwait(false);
+        }
+
+        public override async Task<IEnumerable<DocumentServiceLease>> GetOwnedLeasesAsync()
+        {
+            List<DocumentServiceLease> ownedLeases = new List<DocumentServiceLease>();
+            foreach (DocumentServiceLease lease in await this.GetAllLeasesAsync().ConfigureAwait(false))
+            {
+                if (string.Compare(lease.Owner, this.hostName, StringComparison.OrdinalIgnoreCase) == 0)
+                {
+                    ownedLeases.Add(lease);
+                }
+            }
+
+            return ownedLeases;
+        }
+
+        private async Task<IReadOnlyList<DocumentServiceLease>> ListDocumentsAsync()
+        {
+            List<DocumentServiceLease> leases = new ();
+            await foreach (var blobItem in this.container.GetBlobsAsync())
+            {
+                if (blobItem.Name == DocumentServiceLeaseStoreAzureStorage.InitializationBlobName)
+                {
+                    continue;
+                }
+                using (MemoryStream blobContentStream = new MemoryStream())
+                {
+                    await this.container.GetBlobClient(blobItem.Name).DownloadToAsync(blobContentStream);
+                    blobContentStream.Position = 0;
+                    DocumentServiceLease lease = CosmosContainerExtensions.DefaultJsonSerializer.FromStream<DocumentServiceLease>(blobContentStream);
+                    leases.Add(lease);
+                }
+            }
+
+            return leases;
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseContainerAzureStorage.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseContainerAzureStorage.cs
@@ -7,11 +7,10 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
     using System;
     using System.Collections.Generic;
     using System.IO;
-    using System.Text;
-    using System.Text.Json;
     using System.Threading.Tasks;
     using global::Azure.Storage.Blobs;
-    using Microsoft.Azure.Cosmos.ChangeFeed.Utils;
+    using global::Azure.Storage.Blobs.Models;
+    using Utils;
 
     internal sealed class DocumentServiceLeaseContainerAzureStorage : DocumentServiceLeaseContainer
     {
@@ -48,7 +47,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
         private async Task<IReadOnlyList<DocumentServiceLease>> ListDocumentsAsync()
         {
             List<DocumentServiceLease> leases = new ();
-            await foreach (var blobItem in this.container.GetBlobsAsync())
+            await foreach (BlobItem blobItem in this.container.GetBlobsAsync())
             {
                 if (blobItem.Name == DocumentServiceLeaseStoreAzureStorage.InitializationBlobName)
                 {

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseManagerAzureStorage.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseManagerAzureStorage.cs
@@ -1,0 +1,290 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
+{
+    using System;
+    using System.IO;
+    using System.Net;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using global::Azure.Storage.Blobs;
+    using Microsoft.Azure.Cosmos.ChangeFeed.Exceptions;
+    using Microsoft.Azure.Cosmos.ChangeFeed.Utils;
+    using Microsoft.Azure.Cosmos.Core.Trace;
+    using Microsoft.Azure.Cosmos.Query.Core;
+    using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Routing;
+    using Microsoft.Azure.Cosmos.Tracing;
+    using Microsoft.Azure.Documents;
+
+    /// <summary>
+    /// <see cref="DocumentServiceLeaseManager"/> implementation that uses Azure Cosmos DB service
+    /// </summary>
+    internal sealed class DocumentServiceLeaseManagerAzureStorage : DocumentServiceLeaseManager
+    {
+        private readonly ContainerInternal monitoredContainer;
+        private readonly BlobContainerClient leaseContainer;
+        private readonly DocumentServiceLeaseUpdater leaseUpdater;
+        private readonly string hostName;
+        private readonly AsyncLazy<TryCatch<string>> lazyContainerRid;
+        private PartitionKeyRangeCache partitionKeyRangeCache;
+
+        public DocumentServiceLeaseManagerAzureStorage(
+            ContainerInternal monitoredContainer,
+            BlobContainerClient leaseContainer,
+            DocumentServiceLeaseUpdater leaseUpdater,
+            string hostName)
+        {
+            this.monitoredContainer = monitoredContainer;
+            this.leaseContainer = leaseContainer;
+            this.leaseUpdater = leaseUpdater;
+            this.hostName = hostName;
+            this.lazyContainerRid = new AsyncLazy<TryCatch<string>>(valueFactory: (trace, innerCancellationToken) => this.TryInitializeContainerRIdAsync(innerCancellationToken));
+        }
+
+        public override async Task<DocumentServiceLease> AcquireAsync(DocumentServiceLease lease)
+        {
+            if (lease == null)
+            {
+                throw new ArgumentNullException(nameof(lease));
+            }
+
+            string oldOwner = lease.Owner;
+
+            // We need to add the range information to any older leases
+            // This would not happen with new created leases but we need to be back compat
+            if (lease.FeedRange == null)
+            {
+                if (!this.lazyContainerRid.ValueInitialized)
+                {
+                    TryCatch<string> tryInitializeContainerRId = await this.lazyContainerRid.GetValueAsync(NoOpTrace.Singleton, default);
+                    if (!tryInitializeContainerRId.Succeeded)
+                    {
+                        throw tryInitializeContainerRId.Exception.InnerException;
+                    }
+
+                    this.partitionKeyRangeCache = await this.monitoredContainer.ClientContext.DocumentClient.GetPartitionKeyRangeCacheAsync(NoOpTrace.Singleton);
+                }
+
+                PartitionKeyRange partitionKeyRange = await this.partitionKeyRangeCache.TryGetPartitionKeyRangeByIdAsync(
+                    this.lazyContainerRid.Result.Result, 
+                    lease.CurrentLeaseToken,
+                    NoOpTrace.Singleton);
+
+                if (partitionKeyRange != null)
+                {
+                    lease.FeedRange = new FeedRangeEpk(partitionKeyRange.ToRange());
+                }
+            }
+
+            return await this.leaseUpdater.UpdateLeaseAsync(
+                lease,
+                lease.Id,
+                Cosmos.PartitionKey.Null,
+                serverLease =>
+                {
+                    if (serverLease.Owner != oldOwner)
+                    {
+                        DefaultTrace.TraceInformation("{0} lease token was taken over by owner '{1}'", lease.CurrentLeaseToken, serverLease.Owner);
+                        throw new LeaseLostException(lease);
+                    }
+                    serverLease.Owner = this.hostName;
+                    serverLease.Properties = lease.Properties;
+                    return serverLease;
+                }).ConfigureAwait(false);
+        }
+
+        public override Task<DocumentServiceLease> CreateLeaseIfNotExistAsync(
+            PartitionKeyRange partitionKeyRange, 
+            string continuationToken)
+        {
+            if (partitionKeyRange == null)
+            {
+                throw new ArgumentNullException(nameof(partitionKeyRange));
+            }
+
+            string leaseToken = partitionKeyRange.Id;
+            DocumentServiceLeaseCore documentServiceLease = new DocumentServiceLeaseCore
+            {
+                LeaseId = leaseToken,
+                LeaseToken = leaseToken,
+                ContinuationToken = continuationToken,
+                FeedRange = new FeedRangeEpk(partitionKeyRange.ToRange())
+            };
+            
+            return this.TryCreateDocumentServiceLeaseAsync(documentServiceLease);
+        }
+
+        public override Task<DocumentServiceLease> CreateLeaseIfNotExistAsync(
+            FeedRangeEpk feedRange,
+            string continuationToken)
+        {
+            if (feedRange == null)
+            {
+                throw new ArgumentNullException(nameof(feedRange));
+            }
+
+            string leaseToken = $"{feedRange.Range.Min}-{feedRange.Range.Max}";
+            DocumentServiceLeaseCoreEpk documentServiceLease = new DocumentServiceLeaseCoreEpk
+            {
+                LeaseId = leaseToken,
+                LeaseToken = leaseToken,
+                ContinuationToken = continuationToken,
+                FeedRange = feedRange
+            };
+            
+            return this.TryCreateDocumentServiceLeaseAsync(documentServiceLease);
+        }
+
+        public override async Task ReleaseAsync(DocumentServiceLease lease)
+        {
+            if (lease == null)
+            {
+                throw new ArgumentNullException(nameof(lease));
+            }
+
+            DocumentServiceLease refreshedLease;
+            try
+            {
+                refreshedLease = await this.TryGetLeaseAsync(lease).ConfigureAwait(false);
+            }
+            catch (CosmosException cosmosException) 
+            when (cosmosException.StatusCode == HttpStatusCode.NotFound && cosmosException.SubStatusCode == (int)SubStatusCodes.Unknown)
+            {
+                // Lease is being released after a split, the split itself delete the lease, this is expected
+                return;
+            }
+
+            if (refreshedLease == null)
+            {
+                DefaultTrace.TraceInformation("Lease with token {0} failed to release lease. The lease is gone already.", lease.CurrentLeaseToken);
+                throw new LeaseLostException(lease);
+            }
+
+            await this.leaseUpdater.UpdateLeaseAsync(
+                refreshedLease,
+                refreshedLease.Id,
+                new Cosmos.PartitionKey(),
+                serverLease =>
+                {
+                    if (serverLease.Owner != lease.Owner)
+                    {
+                        DefaultTrace.TraceInformation("Lease with token {0} no need to release lease. The lease was already taken by another host '{1}'.", lease.CurrentLeaseToken, serverLease.Owner);
+                        throw new LeaseLostException(lease);
+                    }
+                    serverLease.Owner = null;
+                    return serverLease;
+                }).ConfigureAwait(false);
+        }
+
+        public override async Task DeleteAsync(DocumentServiceLease lease)
+        {
+            if (lease?.Id == null)
+            {
+                throw new ArgumentNullException(nameof(lease));
+            }
+
+            await this.leaseContainer.DeleteBlobAsync(lease.Id).ConfigureAwait(false);
+        }
+
+        public override async Task<DocumentServiceLease> RenewAsync(DocumentServiceLease lease)
+        {
+            if (lease == null)
+                throw new ArgumentNullException(nameof(lease));
+
+            // Get fresh lease. The assumption here is that checkpointing is done with higher frequency than lease renewal so almost
+            // certainly the lease was updated in between.
+            DocumentServiceLease refreshedLease = await this.TryGetLeaseAsync(lease).ConfigureAwait(false);
+            if (refreshedLease == null)
+            {
+                DefaultTrace.TraceInformation("Lease with token {0} failed to renew lease. The lease is gone already.", lease.CurrentLeaseToken);
+                throw new LeaseLostException(lease);
+            }
+
+            return await this.leaseUpdater.UpdateLeaseAsync(
+                refreshedLease,
+                refreshedLease.Id,
+                Cosmos.PartitionKey.Null,
+                serverLease =>
+                {
+                    if (serverLease.Owner != lease.Owner)
+                    {
+                        DefaultTrace.TraceInformation("Lease with token {0} was taken over by owner '{1}'", lease.CurrentLeaseToken, serverLease.Owner);
+                        throw new LeaseLostException(lease);
+                    }
+                    return serverLease;
+                }).ConfigureAwait(false);
+        }
+
+        public override async Task<DocumentServiceLease> UpdatePropertiesAsync(DocumentServiceLease lease)
+        {
+            if (lease == null) throw new ArgumentNullException(nameof(lease));
+
+            if (lease.Owner != this.hostName)
+            {
+                DefaultTrace.TraceInformation("Lease with token '{0}' was taken over by owner '{1}' before lease properties update", lease.CurrentLeaseToken, lease.Owner);
+                throw new LeaseLostException(lease);
+            }
+
+            return await this.leaseUpdater.UpdateLeaseAsync(
+                lease,
+                lease.Id,
+                Cosmos.PartitionKey.Null,
+                serverLease =>
+                {
+                    if (serverLease.Owner != lease.Owner)
+                    {
+                        DefaultTrace.TraceInformation("Lease with token '{0}' was taken over by owner '{1}'", lease.CurrentLeaseToken, serverLease.Owner);
+                        throw new LeaseLostException(lease);
+                    }
+                    serverLease.Properties = lease.Properties;
+                    return serverLease;
+                }).ConfigureAwait(false);
+        }
+
+        private async Task<DocumentServiceLease> TryCreateDocumentServiceLeaseAsync(DocumentServiceLease documentServiceLease)
+        {
+            var blob = this.leaseContainer.GetBlobClient(documentServiceLease.Id);
+            try
+            {
+                using (Stream stream = CosmosContainerExtensions.DefaultJsonSerializer.ToStream(documentServiceLease))
+                {
+                    await blob.UploadAsync(stream);
+                    DefaultTrace.TraceInformation("Created lease with lease token {0}.", documentServiceLease.CurrentLeaseToken);
+                    return documentServiceLease;
+                }
+            }
+            catch (Exception)
+            {
+                DefaultTrace.TraceInformation("Some other host created lease for {0}.", documentServiceLease.CurrentLeaseToken);
+                return null;
+            }
+        }
+
+        private async Task<DocumentServiceLease> TryGetLeaseAsync(DocumentServiceLease lease)
+        {
+            var blob = this.leaseContainer.GetBlobClient(lease.Id);
+            var stream = (await blob.DownloadAsync()).Value.Content;
+            stream.Position = 0;
+            return CosmosContainerExtensions.DefaultJsonSerializer.FromStream<DocumentServiceLease>(stream);
+        }
+
+        private async Task<TryCatch<string>> TryInitializeContainerRIdAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                string containerRId = await this.monitoredContainer.GetCachedRIDAsync(
+                    forceRefresh: false,
+                    NoOpTrace.Singleton,
+                    cancellationToken: cancellationToken);
+                return TryCatch<string>.FromResult(containerRId);
+            }
+            catch (CosmosException cosmosException)
+            {
+                return TryCatch<string>.FromException(cosmosException);
+            }
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseStoreAzureStorage.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseStoreAzureStorage.cs
@@ -1,0 +1,97 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Threading.Tasks;
+    using global::Azure;
+    using global::Azure.Storage.Blobs;
+    using global::Azure.Storage.Blobs.Models;
+    using global::Azure.Storage.Blobs.Specialized;
+    using Microsoft.Azure.Cosmos.ChangeFeed.Utils;
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// Implementation of <see cref="DocumentServiceLeaseStore"/> for state in Azure Cosmos DB
+    /// </summary>
+    internal sealed class DocumentServiceLeaseStoreAzureStorage : DocumentServiceLeaseStore
+    {
+        internal const string InitializationBlobName = "InitializationBlob";
+        private const string InitializationStateName = "InitializationState";
+        private const string InitializationStateCompleted = "Completed";
+        
+        private readonly BlobContainerClient container;
+        private string leaseId;
+
+        public DocumentServiceLeaseStoreAzureStorage(
+            BlobContainerClient container)
+        {
+            this.container = container;
+        }
+
+        public override async Task<bool> IsInitializedAsync()
+        {
+            var blob = this.container.GetBlobClient(InitializationBlobName);
+            try
+            {
+                if (!await blob.ExistsAsync())
+                {
+                    await blob.UploadAsync(new MemoryStream());
+                }
+                var properties = await blob.GetPropertiesAsync();
+                if (properties.Value.Metadata.TryGetValue(InitializationStateName, out var value) && value == InitializationStateCompleted)
+                {
+                    return true;
+                }
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+
+            return false;
+        }
+
+        public override async Task MarkInitializedAsync()
+        {
+            var blob = this.container.GetBlobClient(InitializationBlobName);
+            var result = await blob.SetMetadataAsync(new Dictionary<string, string> {{InitializationStateName, InitializationStateCompleted}}, 
+                new BlobRequestConditions{LeaseId = this.leaseId}).ConfigureAwait(false);
+        }
+
+        public override async Task<bool> AcquireInitializationLockAsync(TimeSpan lockTime)
+        {
+            try
+            {
+                var blob = this.container.GetBlobClient(InitializationBlobName);
+                BlobLeaseClient blobLeaseClient = blob.GetBlobLeaseClient();
+                var response = await blobLeaseClient.AcquireAsync(lockTime);
+                this.leaseId = response.Value.LeaseId;
+                return true;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+
+        public override async Task<bool> ReleaseInitializationLockAsync()
+        {
+            try
+            {
+                var blob = this.container.GetBlobClient(InitializationBlobName);
+                BlobLeaseClient blobLeaseClient = blob.GetBlobLeaseClient(this.leaseId);
+                await blobLeaseClient.ReleaseAsync();
+                return true;
+            }
+            catch (Exception)
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseStoreManagerAzureStorage.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseStoreManagerAzureStorage.cs
@@ -1,0 +1,79 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
+{
+    using System;
+    using global::Azure.Storage.Blobs;
+    using Microsoft.Azure.Cosmos;
+
+    /// <summary>
+    /// Lease manager that is using Azure Document Service as lease storage.
+    /// Documents in lease collection are organized as this:
+    /// ChangeFeed.federation|database_rid|collection_rid.info            -- container
+    /// ChangeFeed.federation|database_rid|collection_rid..partitionId1   -- each partition
+    /// ChangeFeed.federation|database_rid|collection_rid..partitionId2
+    ///                                         ...
+    /// </summary>
+    internal sealed class DocumentServiceLeaseStoreManagerAzureStorage : DocumentServiceLeaseStoreManager
+    {
+        private readonly DocumentServiceLeaseStore leaseStore;
+        private readonly DocumentServiceLeaseManager leaseManager;
+        private readonly DocumentServiceLeaseCheckpointer leaseCheckpointer;
+        private readonly DocumentServiceLeaseContainer leaseContainer;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DocumentServiceLeaseStoreManagerCosmos"/> class.
+        /// </summary>
+        public DocumentServiceLeaseStoreManagerAzureStorage(
+            ContainerInternal monitoredContainer,
+            string containerUri,
+            string hostName) // For testing purposes only.
+        {
+            if (string.IsNullOrEmpty(hostName)) throw new ArgumentNullException(nameof(hostName));
+            if (monitoredContainer == null) throw new ArgumentNullException(nameof(monitoredContainer));
+            if (string.IsNullOrEmpty(containerUri)) throw new ArgumentNullException(nameof(containerUri));
+            
+            var leaseContainer = new BlobContainerClient(new Uri(containerUri));
+            var leaseUpdater = new DocumentServiceLeaseUpdaterAzureStorage(leaseContainer); 
+            
+            this.leaseStore = new DocumentServiceLeaseStoreAzureStorage(
+                leaseContainer);
+
+            this.leaseManager = new DocumentServiceLeaseManagerAzureStorage(
+                monitoredContainer,
+                leaseContainer,
+                leaseUpdater,
+                hostName);
+
+            this.leaseCheckpointer = new DocumentServiceLeaseCheckpointerCore(
+                leaseUpdater,
+                new NoneRequestOptionsFactory());
+
+            this.leaseContainer = new DocumentServiceLeaseContainerAzureStorage(
+                leaseContainer,
+                hostName);
+        }
+
+        public override DocumentServiceLeaseStore LeaseStore => this.leaseStore;
+
+        public override DocumentServiceLeaseManager LeaseManager => this.leaseManager;
+
+        public override DocumentServiceLeaseCheckpointer LeaseCheckpointer => this.leaseCheckpointer;
+
+        public override DocumentServiceLeaseContainer LeaseContainer => this.leaseContainer;
+    }
+    
+    internal class NoneRequestOptionsFactory : RequestOptionsFactory
+    {
+        public override PartitionKey GetPartitionKey(string itemId, string partitionKey)
+        {
+            return PartitionKey.None;
+        }
+
+        public override void AddPartitionKeyIfNeeded(Action<string> partitionKeySetter, string partitionKey)
+        {
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseStoreManagerAzureStorage.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseStoreManagerAzureStorage.cs
@@ -6,10 +6,9 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
 {
     using System;
     using global::Azure.Storage.Blobs;
-    using Microsoft.Azure.Cosmos;
 
     /// <summary>
-    /// Lease manager that is using Azure Document Service as lease storage.
+    /// Lease manager that is using Azure Blob Storage Service as lease storage.
     /// Documents in lease collection are organized as this:
     /// ChangeFeed.federation|database_rid|collection_rid.info            -- container
     /// ChangeFeed.federation|database_rid|collection_rid..partitionId1   -- each partition
@@ -24,7 +23,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
         private readonly DocumentServiceLeaseContainer leaseContainer;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="DocumentServiceLeaseStoreManagerCosmos"/> class.
+        /// Initializes a new instance of the <see cref="DocumentServiceLeaseStoreManagerAzureStorage"/> class.
         /// </summary>
         public DocumentServiceLeaseStoreManagerAzureStorage(
             ContainerInternal monitoredContainer,
@@ -35,8 +34,8 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
             if (monitoredContainer == null) throw new ArgumentNullException(nameof(monitoredContainer));
             if (string.IsNullOrEmpty(containerUri)) throw new ArgumentNullException(nameof(containerUri));
             
-            var leaseContainer = new BlobContainerClient(new Uri(containerUri));
-            var leaseUpdater = new DocumentServiceLeaseUpdaterAzureStorage(leaseContainer); 
+            BlobContainerClient leaseContainer = new BlobContainerClient(new Uri(containerUri));
+            DocumentServiceLeaseUpdaterAzureStorage leaseUpdater = new DocumentServiceLeaseUpdaterAzureStorage(leaseContainer); 
             
             this.leaseStore = new DocumentServiceLeaseStoreAzureStorage(
                 leaseContainer);

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseStoreManagerAzureStorage.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseStoreManagerAzureStorage.cs
@@ -27,14 +27,13 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
         /// </summary>
         public DocumentServiceLeaseStoreManagerAzureStorage(
             ContainerInternal monitoredContainer,
-            string containerUri,
+            BlobContainerClient leaseContainer,
             string hostName) // For testing purposes only.
         {
-            if (string.IsNullOrEmpty(hostName)) throw new ArgumentNullException(nameof(hostName));
             if (monitoredContainer == null) throw new ArgumentNullException(nameof(monitoredContainer));
-            if (string.IsNullOrEmpty(containerUri)) throw new ArgumentNullException(nameof(containerUri));
+            if (leaseContainer == null) throw new ArgumentNullException(nameof(leaseContainer));
+            if (string.IsNullOrEmpty(hostName)) throw new ArgumentNullException(nameof(hostName));
             
-            BlobContainerClient leaseContainer = new BlobContainerClient(new Uri(containerUri));
             DocumentServiceLeaseUpdaterAzureStorage leaseUpdater = new DocumentServiceLeaseUpdaterAzureStorage(leaseContainer); 
             
             this.leaseStore = new DocumentServiceLeaseStoreAzureStorage(

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseUpdaterAzureStorage.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseUpdaterAzureStorage.cs
@@ -1,0 +1,122 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Net;
+    using System.Threading.Tasks;
+    using global::Azure;
+    using global::Azure.Storage.Blobs;
+    using global::Azure.Storage.Blobs.Models;
+    using global::Azure.Storage.Blobs.Specialized;
+    using Microsoft.Azure.Cosmos;
+    using Microsoft.Azure.Cosmos.ChangeFeed.Exceptions;
+    using Microsoft.Azure.Cosmos.ChangeFeed.Utils;
+    using Microsoft.Azure.Cosmos.Core.Trace;
+
+    /// <summary>
+    /// <see cref="DocumentServiceLeaseUpdater"/> that uses Azure Cosmos DB
+    /// </summary>
+    internal sealed class DocumentServiceLeaseUpdaterAzureStorage : DocumentServiceLeaseUpdater
+    {
+        private const int RetryCountOnConflict = 5;
+        private readonly BlobContainerClient container;
+
+        public DocumentServiceLeaseUpdaterAzureStorage(BlobContainerClient container)
+        {
+            this.container = container ?? throw new ArgumentNullException(nameof(container));
+        }
+
+        public override async Task<DocumentServiceLease> UpdateLeaseAsync(
+            DocumentServiceLease cachedLease,
+            string itemId,
+            Cosmos.PartitionKey partitionKey,
+            Func<DocumentServiceLease, DocumentServiceLease> 
+                updateLease)
+        {
+            DocumentServiceLease lease = cachedLease;
+            for (int retryCount = RetryCountOnConflict; retryCount >= 0; retryCount--)
+            {
+                lease = updateLease(lease);
+                if (lease == null)
+                {
+                    return null;
+                }
+
+                lease.Timestamp = DateTime.UtcNow;
+                DocumentServiceLease leaseDocument = await this.TryReplaceLeaseAsync(lease, itemId).ConfigureAwait(false);
+                if (leaseDocument != null)
+                {
+                    return leaseDocument;
+                }
+
+                DefaultTrace.TraceInformation("Lease with token {0} update conflict. Reading the current version of lease.", lease.CurrentLeaseToken);
+
+                try
+                {
+                    BlobClient blob = this.container.GetBlobClient(itemId);
+                    Stream stream = (await blob.DownloadAsync()).Value.Content;
+                    stream.Position = 0;
+                    DocumentServiceLease serverLease = CosmosContainerExtensions.DefaultJsonSerializer.FromStream<DocumentServiceLease>(stream);
+
+                    DefaultTrace.TraceInformation(
+                    "Lease with token {0} update failed because the lease with concurrency token '{1}' was updated by host '{2}' with concurrency token '{3}'. Will retry, {4} retry(s) left.",
+                    lease.CurrentLeaseToken,
+                    lease.ConcurrencyToken,
+                    serverLease.Owner,
+                    serverLease.ConcurrencyToken,
+                    retryCount);
+
+                    lease = serverLease;
+                }
+                catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+                {
+                    DefaultTrace.TraceInformation("Lease with token {0} no longer exists", lease.CurrentLeaseToken);
+                    throw new LeaseLostException(lease, true);
+                }
+            }
+
+            throw new LeaseLostException(lease);
+        }
+
+        private async Task<DocumentServiceLease> TryReplaceLeaseAsync(
+            DocumentServiceLease lease,
+            string itemId)
+        {
+            try
+            {
+                BlobClient blob = this.container.GetBlobClient(itemId);
+                using (Stream stream = CosmosContainerExtensions.DefaultJsonSerializer.ToStream<DocumentServiceLease>(lease))
+                {
+                    await blob.UploadAsync(stream, conditions: new BlobRequestConditions {IfMatch = new ETag(lease.ConcurrencyToken)});
+                }
+
+                return lease;
+            }
+            catch (RequestFailedException ex)
+            {
+                DefaultTrace.TraceWarning("Lease operation exception, status code: {0}", ex.ErrorCode);
+                if (ex.Status == (int)HttpStatusCode.NotFound)
+                {
+                    throw new LeaseLostException(lease, true);
+                }
+
+                if (ex.Status == (int)HttpStatusCode.PreconditionFailed)
+                {
+                    return null;
+                }
+
+                if (ex.Status == (int)HttpStatusCode.Conflict)
+                {
+                    throw new LeaseLostException(lease, ex, false);
+                }
+
+                throw;
+            }
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
+++ b/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
@@ -108,6 +108,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Azure.Core" Version="1.19.0" />
+		<PackageReference Include="Azure.Storage.Blobs" Version="12.8.0" />
 		<PackageReference Include="System.Collections.Immutable" Version="1.7.0" />
 		<PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
 		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.0.0" />


### PR DESCRIPTION
# Pull Request Template

## Description

Add option to manage the lease of change feed processor on azure storage container. It's very important feature we are missing for our use case (CosmosDB => ADX data connection) and I think it will be useful for other cases as well.
 
## Type of change

- [] New feature (non-breaking change which adds functionality)
- [] This change requires a documentation update