### PR TITLE
Internal: Fixes ClientTelemetry to use StoreResponseNameValueCollection

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
@@ -316,7 +316,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
 
                 async ValueTask<HttpRequestMessage> CreateRequestMessage()
                 {
-                    INameValueCollection headersCollection = new NameValueCollectionWrapperFactory().CreateNewNameValueCollection();
+                    INameValueCollection headersCollection = new StoreResponseNameValueCollection();
                     await this.tokenProvider.AddAuthorizationHeaderAsync(
                             headersCollection,
                             endpointUrl,


### PR DESCRIPTION
NameValueCollectionWrapperFactory is dead code and getting removed.

ClientTelemetry is using NameValueCollectionWrapperFactory for auth header related generation. Its usage moved to StoreResponseNameValueCollection.

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Include samples if adding new API, and include relevant motivation and context. List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber