### PR TITLE
Client Telemetry: Adds functionality to collect telemetry for collection cache

### DIFF
--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -923,6 +923,8 @@ namespace Microsoft.Azure.Cosmos
                 this.sendingRequest,
                 this.receivedResponse);
 
+            this.InitializeClientTelemetry();
+
             // Loading VM Information (non blocking call and initialization won't fail if this call fails)
             VmMetadataApiHandler.TryInitialize(this.httpClient);
 
@@ -988,8 +990,6 @@ namespace Microsoft.Azure.Cosmos
         private async Task<bool> GetInitializationTaskAsync(IStoreClientFactory storeClientFactory)
         {
             await this.InitializeGatewayConfigurationReaderAsync();
-
-            this.InitializeClientTelemetry();
 
             if (this.desiredConsistencyLevel.HasValue)
             {

--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -1043,13 +1043,13 @@ namespace Microsoft.Azure.Cosmos
                         preferredRegions: this.ConnectionPolicy.PreferredLocations,
                         globalEndpointManager: this.GlobalEndpointManager);
 
+                    DefaultTrace.TraceInformation("Client Telemetry Enabled.");
                 }
                 catch (Exception ex)
                 {
                     DefaultTrace.TraceInformation($"Error While starting Telemetry Job : {ex.Message}. Hence disabling Client Telemetry");
                     this.ConnectionPolicy.EnableClientTelemetry = false;
                 }
-
             }
             else
             {

--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -134,7 +134,6 @@ namespace Microsoft.Azure.Cosmos
         private bool enableCpuMonitor = DefaultEnableCpuMonitor;
         private int rntbdMaxConcurrentOpeningConnectionCount = 5;
         private string clientId;
-        private IReadOnlyList<string> applicationPreferredRegions;
 
         //Consistency
         private Documents.ConsistencyLevel? desiredConsistencyLevel;
@@ -422,7 +421,6 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="storeClientFactory">Factory that creates store clients sharing the same transport client to optimize network resource reuse across multiple document clients in the same process.</param>
         /// <param name="isLocalQuorumConsistency">Flag to allow Quorum Read with Eventual Consistency Account</param>
         /// <param name="cosmosClientId"></param>
-        /// <param name="applicationPreferredRegions"></param>
         /// <remarks>
         /// The service endpoint can be obtained from the Azure Management Portal.
         /// If you are connecting using one of the Master Keys, these can be obtained along with the endpoint from the Azure Management Portal
@@ -448,8 +446,7 @@ namespace Microsoft.Azure.Cosmos
                               Func<TransportClient, TransportClient> transportClientHandlerFactory = null,
                               IStoreClientFactory storeClientFactory = null,
                               bool isLocalQuorumConsistency = false,
-                              string cosmosClientId = null,
-                              IReadOnlyList<string> applicationPreferredRegions = null)
+                              string cosmosClientId = null)
         {
             if (sendingRequestEventArgs != null)
             {
@@ -481,8 +478,7 @@ namespace Microsoft.Azure.Cosmos
                 sessionContainer: sessionContainer,
                 enableCpuMonitor: enableCpuMonitor,
                 storeClientFactory: storeClientFactory,
-                cosmosClientId: cosmosClientId,
-                applicationPreferredRegions: applicationPreferredRegions);
+                cosmosClientId: cosmosClientId);
         }
 
         /// <summary>
@@ -664,8 +660,7 @@ namespace Microsoft.Azure.Cosmos
             bool? enableCpuMonitor = null,
             IStoreClientFactory storeClientFactory = null,
             TokenCredential tokenCredential = null,
-            string cosmosClientId = null,
-            IReadOnlyList<string> applicationPreferredRegions = null)
+            string cosmosClientId = null)
         {
             if (serviceEndpoint == null)
             {
@@ -673,7 +668,6 @@ namespace Microsoft.Azure.Cosmos
             }
 
             this.clientId = cosmosClientId;
-            this.applicationPreferredRegions = applicationPreferredRegions;
 
             this.queryPartitionProvider = new AsyncLazy<QueryPartitionProvider>(async () =>
             {
@@ -1046,7 +1040,7 @@ namespace Microsoft.Azure.Cosmos
                         connectionMode: this.ConnectionPolicy.ConnectionMode,
                         authorizationTokenProvider: this.cosmosAuthorization,
                         diagnosticsHelper: DiagnosticsHandlerHelper.Instance,
-                        preferredRegions: this.applicationPreferredRegions,
+                        preferredRegions: this.ConnectionPolicy.PreferredLocations,
                         globalEndpointManager: this.GlobalEndpointManager);
 
                 }

--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -923,10 +923,10 @@ namespace Microsoft.Azure.Cosmos
                 this.sendingRequest,
                 this.receivedResponse);
 
-            this.InitializeClientTelemetry();
-
             // Loading VM Information (non blocking call and initialization won't fail if this call fails)
             VmMetadataApiHandler.TryInitialize(this.httpClient);
+
+            this.InitializeClientTelemetry();
 
             if (sessionContainer != null)
             {

--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -1001,7 +1001,12 @@ namespace Microsoft.Azure.Cosmos
 
             this.GatewayStoreModel = gatewayStoreModel;
 
-            this.collectionCache = new ClientCollectionCache(this.sessionContainer, this.GatewayStoreModel, this, this.retryPolicy);
+            this.collectionCache = new ClientCollectionCache(
+                    sessionContainer: this.sessionContainer, 
+                    storeModel: this.GatewayStoreModel, 
+                    tokenProvider: this, 
+                    retryPolicy: this.retryPolicy,
+                    clientTelemetry: this.clientTelemetry);
             this.partitionKeyRangeCache = new PartitionKeyRangeCache(this, this.GatewayStoreModel, this.collectionCache);
             this.ResetSessionTokenRetryPolicy = new ResetSessionTokenRetryPolicyFactory(this.sessionContainer, this.collectionCache, this.retryPolicy);
 

--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -644,7 +644,12 @@ namespace Microsoft.Azure.Cosmos
             catch (DocumentClientException ex)
             {
                 // Clear the caches to ensure that we don't have partial results
-                this.collectionCache = new ClientCollectionCache(this.sessionContainer, this.GatewayStoreModel, this, this.retryPolicy);
+                this.collectionCache = new ClientCollectionCache(
+                    sessionContainer: this.sessionContainer, 
+                    storeModel: this.GatewayStoreModel, 
+                    tokenProvider: this, 
+                    retryPolicy: this.retryPolicy,
+                    clientTelemetry: this.clientTelemetry);
                 this.partitionKeyRangeCache = new PartitionKeyRangeCache(this, this.GatewayStoreModel, this.collectionCache);
 
                 DefaultTrace.TraceWarning("{0} occurred while OpenAsync. Exception Message: {1}", ex.ToString(), ex.Message);

--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -140,7 +140,7 @@ namespace Microsoft.Azure.Cosmos
         private Documents.ConsistencyLevel? desiredConsistencyLevel;
 
         internal CosmosAccountServiceConfiguration accountServiceConfiguration { get; private set; }
-        internal ClientTelemetry clientTelemetry { get; private set; }
+        internal ClientTelemetry clientTelemetry { get; set; }
 
         private ClientCollectionCache collectionCache;
 

--- a/Microsoft.Azure.Cosmos/src/Handler/ClientPipelineBuilder.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/ClientPipelineBuilder.cs
@@ -45,8 +45,6 @@ namespace Microsoft.Azure.Cosmos
 #if !INTERNAL
             this.diagnosticsHandler = new DiagnosticsHandler();
             Debug.Assert(this.diagnosticsHandler.InnerHandler == null, nameof(this.diagnosticsHandler));
-#else
-            this.diagnosticsHandler = null;
 #endif
             if (telemetry != null)
             {

--- a/Microsoft.Azure.Cosmos/src/Handler/ClientPipelineBuilder.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/ClientPipelineBuilder.cs
@@ -45,16 +45,14 @@ namespace Microsoft.Azure.Cosmos
 #if !INTERNAL
             this.diagnosticsHandler = new DiagnosticsHandler();
             Debug.Assert(this.diagnosticsHandler.InnerHandler == null, nameof(this.diagnosticsHandler));
-
+#else
+            this.diagnosticsHandler = null;
+#endif
             if (telemetry != null)
             {
                 this.telemetryHandler = new TelemetryHandler(telemetry);
                 Debug.Assert(this.telemetryHandler.InnerHandler == null, nameof(this.telemetryHandler));
             }
-#else
-            this.diagnosticsHandler = null;
-            this.telemetryHandler = null;
-#endif
 
             this.UseRetryPolicy();
             this.AddCustomHandlers(customHandlers);

--- a/Microsoft.Azure.Cosmos/src/Handler/ClientPipelineBuilder.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/ClientPipelineBuilder.cs
@@ -45,6 +45,8 @@ namespace Microsoft.Azure.Cosmos
 #if !INTERNAL
             this.diagnosticsHandler = new DiagnosticsHandler();
             Debug.Assert(this.diagnosticsHandler.InnerHandler == null, nameof(this.diagnosticsHandler));
+#else
+            this.diagnosticsHandler = null;
 #endif
             if (telemetry != null)
             {

--- a/Microsoft.Azure.Cosmos/src/Handler/TelemetryHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/TelemetryHandler.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.Cosmos.Handlers
                 try
                 {
                     this.telemetry
-                        .Collect(
+                        .CollectOperationInfo(
                                 cosmosDiagnostics: response.Diagnostics,
                                 statusCode: response.StatusCode,
                                 responseSizeInBytes: this.GetPayloadSize(response),

--- a/Microsoft.Azure.Cosmos/src/Handler/TelemetryHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/TelemetryHandler.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Azure.Cosmos.Handlers
             {
                 try
                 {
+                    Console.WriteLine("inside TelemetryHandler.............");
                     this.telemetry
                         .Collect(
                                 cosmosDiagnostics: response.Diagnostics,

--- a/Microsoft.Azure.Cosmos/src/Handler/TelemetryHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/TelemetryHandler.cs
@@ -29,7 +29,6 @@ namespace Microsoft.Azure.Cosmos.Handlers
             {
                 try
                 {
-                    Console.WriteLine("inside TelemetryHandler.............");
                     this.telemetry
                         .Collect(
                                 cosmosDiagnostics: response.Diagnostics,
@@ -41,7 +40,7 @@ namespace Microsoft.Azure.Cosmos.Handlers
                                 resourceType: request.ResourceType,
                                 consistencyLevel: request.Headers?[Documents.HttpConstants.HttpHeaders.ConsistencyLevel],
                                 requestCharge: response.Headers.RequestCharge,
-                                subStatusCode: response.Headers.SubStatusCodeLiteral);
+                                subStatusCode: response.Headers.SubStatusCode);
                 }
                 catch (Exception ex)
                 {

--- a/Microsoft.Azure.Cosmos/src/Resource/ClientContextCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/ClientContextCore.cs
@@ -29,7 +29,6 @@ namespace Microsoft.Azure.Cosmos
         private readonly CosmosResponseFactoryInternal responseFactory;
         private readonly RequestInvokerHandler requestHandler;
         private readonly CosmosClientOptions clientOptions;
-        private readonly ClientTelemetry telemetry;
 
         private readonly string userAgent;
         private bool isDisposed = false;
@@ -53,7 +52,6 @@ namespace Microsoft.Azure.Cosmos
             this.documentClient = documentClient;
             this.userAgent = userAgent;
             this.batchExecutorCache = batchExecutorCache;
-            this.telemetry = telemetry;
         }
 
         internal static CosmosClientContext Create(
@@ -432,7 +430,6 @@ namespace Microsoft.Azure.Cosmos
             {
                 if (disposing)
                 {
-                    this.telemetry?.Dispose();
                     this.batchExecutorCache.Dispose();
                     this.DocumentClient.Dispose();
                 }

--- a/Microsoft.Azure.Cosmos/src/Resource/ClientContextCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/ClientContextCore.cs
@@ -80,8 +80,7 @@ namespace Microsoft.Azure.Cosmos
                desiredConsistencyLevel: clientOptions.GetDocumentsConsistencyLevel(),
                handler: httpMessageHandler,
                sessionContainer: clientOptions.SessionContainer,
-               cosmosClientId: cosmosClient.Id,
-               applicationPreferredRegions: clientOptions.ApplicationPreferredRegions);
+               cosmosClientId: cosmosClient.Id);
 
             return ClientContextCore.Create(
                 cosmosClient,

--- a/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/CosmosException.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/CosmosException.cs
@@ -291,7 +291,7 @@ namespace Microsoft.Azure.Cosmos
         {
             scope.AddAttribute(OpenTelemetryAttributeKeys.StatusCode, exception.StatusCode);
             scope.AddAttribute(OpenTelemetryAttributeKeys.RequestCharge, exception.RequestCharge);
-            scope.AddAttribute(OpenTelemetryAttributeKeys.Region, ClientTelemetryHelper.GetContactedRegions(exception.Diagnostics));
+            scope.AddAttribute(OpenTelemetryAttributeKeys.Region, ClientTelemetryHelper.GetContactedRegions(exception.Diagnostics.GetContactedRegions()));
             scope.AddAttribute(OpenTelemetryAttributeKeys.ExceptionMessage, exception.Message);
 
             CosmosDbEventSource.RecordDiagnosticsForExceptions(exception.Diagnostics);

--- a/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/CosmosException.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/CosmosException.cs
@@ -291,7 +291,8 @@ namespace Microsoft.Azure.Cosmos
         {
             scope.AddAttribute(OpenTelemetryAttributeKeys.StatusCode, exception.StatusCode);
             scope.AddAttribute(OpenTelemetryAttributeKeys.RequestCharge, exception.RequestCharge);
-            scope.AddAttribute(OpenTelemetryAttributeKeys.Region, ClientTelemetryHelper.GetContactedRegions(exception.Diagnostics.GetContactedRegions()));
+            scope.AddAttribute(OpenTelemetryAttributeKeys.Region, 
+                ClientTelemetryHelper.GetContactedRegions(exception.Diagnostics?.GetContactedRegions()));
             scope.AddAttribute(OpenTelemetryAttributeKeys.ExceptionMessage, exception.Message);
 
             CosmosDbEventSource.RecordDiagnosticsForExceptions(exception.Diagnostics);

--- a/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/CosmosNullReferenceException.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/CosmosNullReferenceException.cs
@@ -79,7 +79,8 @@ namespace Microsoft.Azure.Cosmos
 
         internal static void RecordOtelAttributes(CosmosNullReferenceException exception, DiagnosticScope scope)
         {
-            scope.AddAttribute(OpenTelemetryAttributeKeys.Region, ClientTelemetryHelper.GetContactedRegions(exception.Diagnostics.GetContactedRegions()));
+            scope.AddAttribute(OpenTelemetryAttributeKeys.Region, 
+                ClientTelemetryHelper.GetContactedRegions(exception.Diagnostics?.GetContactedRegions()));
             scope.AddAttribute(OpenTelemetryAttributeKeys.ExceptionMessage, exception.GetBaseException().Message);
 
             CosmosDbEventSource.RecordDiagnosticsForExceptions(exception.Diagnostics);

--- a/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/CosmosNullReferenceException.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/CosmosNullReferenceException.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Azure.Cosmos
 
         internal static void RecordOtelAttributes(CosmosNullReferenceException exception, DiagnosticScope scope)
         {
-            scope.AddAttribute(OpenTelemetryAttributeKeys.Region, ClientTelemetryHelper.GetContactedRegions(exception.Diagnostics));
+            scope.AddAttribute(OpenTelemetryAttributeKeys.Region, ClientTelemetryHelper.GetContactedRegions(exception.Diagnostics.GetContactedRegions()));
             scope.AddAttribute(OpenTelemetryAttributeKeys.ExceptionMessage, exception.GetBaseException().Message);
 
             CosmosDbEventSource.RecordDiagnosticsForExceptions(exception.Diagnostics);

--- a/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/CosmosObjectDisposedException.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/CosmosObjectDisposedException.cs
@@ -96,7 +96,8 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="scope"></param>
         internal static void RecordOtelAttributes(CosmosObjectDisposedException exception, DiagnosticScope scope)
         {
-            scope.AddAttribute(OpenTelemetryAttributeKeys.Region, ClientTelemetryHelper.GetContactedRegions(exception.Diagnostics.GetContactedRegions()));
+            scope.AddAttribute(OpenTelemetryAttributeKeys.Region, 
+                ClientTelemetryHelper.GetContactedRegions(exception.Diagnostics?.GetContactedRegions()));
             scope.AddAttribute(OpenTelemetryAttributeKeys.ExceptionMessage, exception.Message);
 
             CosmosDbEventSource.RecordDiagnosticsForExceptions(exception.Diagnostics);

--- a/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/CosmosObjectDisposedException.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/CosmosObjectDisposedException.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="scope"></param>
         internal static void RecordOtelAttributes(CosmosObjectDisposedException exception, DiagnosticScope scope)
         {
-            scope.AddAttribute(OpenTelemetryAttributeKeys.Region, ClientTelemetryHelper.GetContactedRegions(exception.Diagnostics));
+            scope.AddAttribute(OpenTelemetryAttributeKeys.Region, ClientTelemetryHelper.GetContactedRegions(exception.Diagnostics.GetContactedRegions()));
             scope.AddAttribute(OpenTelemetryAttributeKeys.ExceptionMessage, exception.Message);
 
             CosmosDbEventSource.RecordDiagnosticsForExceptions(exception.Diagnostics);

--- a/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/CosmosOperationCanceledException.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/CosmosOperationCanceledException.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="scope"></param>
         internal static void RecordOtelAttributes(CosmosOperationCanceledException exception, DiagnosticScope scope)
         {
-            scope.AddAttribute(OpenTelemetryAttributeKeys.Region, ClientTelemetryHelper.GetContactedRegions(exception.Diagnostics));
+            scope.AddAttribute(OpenTelemetryAttributeKeys.Region, ClientTelemetryHelper.GetContactedRegions(exception.Diagnostics.GetContactedRegions()));
             scope.AddAttribute(OpenTelemetryAttributeKeys.ExceptionMessage, exception.GetBaseException().Message);
 
             CosmosDbEventSource.RecordDiagnosticsForExceptions(exception.Diagnostics);

--- a/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/CosmosOperationCanceledException.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/CosmosOperationCanceledException.cs
@@ -135,8 +135,10 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="scope"></param>
         internal static void RecordOtelAttributes(CosmosOperationCanceledException exception, DiagnosticScope scope)
         {
-            scope.AddAttribute(OpenTelemetryAttributeKeys.Region, ClientTelemetryHelper.GetContactedRegions(exception.Diagnostics.GetContactedRegions()));
-            scope.AddAttribute(OpenTelemetryAttributeKeys.ExceptionMessage, exception.GetBaseException().Message);
+            scope.AddAttribute(OpenTelemetryAttributeKeys.Region, 
+                ClientTelemetryHelper.GetContactedRegions(exception.Diagnostics?.GetContactedRegions()));
+            scope.AddAttribute(OpenTelemetryAttributeKeys.ExceptionMessage, 
+                exception.GetBaseException().Message);
 
             CosmosDbEventSource.RecordDiagnosticsForExceptions(exception.Diagnostics);
         }

--- a/Microsoft.Azure.Cosmos/src/Routing/ClientCollectionCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/ClientCollectionCache.cs
@@ -214,7 +214,9 @@ namespace Microsoft.Azure.Cosmos.Routing
                                 await this.storeModel.ProcessMessageAsync(request))
                             {
                                 ContainerProperties containerProperties = CosmosResource.FromStream<ContainerProperties>(response);
-                                
+
+                                ClientCollectionCache.GetDatabaseAndCollectionName(collectionLink, out string databaseName, out string collectionName);
+
                                 if (this.clientTelemetry != null)
                                 {
                                     this.clientTelemetry.CollectCacheInfo(
@@ -222,11 +224,11 @@ namespace Microsoft.Azure.Cosmos.Routing
                                                     regionsContactedList: response.RequestStats.RegionsContacted,
                                                     requestLatency: response.RequestStats.RequestLatency,
                                                     statusCode: response.StatusCode,
-                                                    containerId: containerProperties.Id,
+                                                    containerId: collectionName,
                                                     operationType: request.OperationType,
                                                     resourceType: request.ResourceType,
-                                                    subStatusCode: response.SubStatusCode);
-
+                                                    subStatusCode: response.SubStatusCode,
+                                                    databaseId: databaseName);
                                 }
 
                                 return containerProperties;
@@ -240,6 +242,13 @@ namespace Microsoft.Azure.Cosmos.Routing
                     }
                 }
             }
+        }
+
+        private static void GetDatabaseAndCollectionName(string path, out string databaseName, out string collectionName)
+        {
+            string[] segments = path.Split(new char[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+
+            PathsHelper.ParseDatabaseNameAndCollectionNameFromUrlSegments(segments, out databaseName, out collectionName);
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Routing/ClientCollectionCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/ClientCollectionCache.cs
@@ -19,6 +19,8 @@ namespace Microsoft.Azure.Cosmos.Routing
     /// </summary>
     internal class ClientCollectionCache : CollectionCache
     {
+        private const string TelemetrySourceName = "ClientCollectionCache";
+
         private readonly IStoreModel storeModel;
         private readonly ICosmosAuthorizationTokenProvider tokenProvider;
         private readonly IRetryPolicyFactory retryPolicy;
@@ -216,7 +218,7 @@ namespace Microsoft.Azure.Cosmos.Routing
                                 if (this.clientTelemetry != null)
                                 {
                                     this.clientTelemetry.Collect(
-                                                    cacheRefreshSource: "ClientCollectionCache",
+                                                    cacheRefreshSource: ClientCollectionCache.TelemetrySourceName,
                                                     regionsContactedList: response.RequestStats.RegionsContacted,
                                                     requestLatency: response.RequestStats.RequestLatency,
                                                     statusCode: response.StatusCode,

--- a/Microsoft.Azure.Cosmos/src/Routing/ClientCollectionCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/ClientCollectionCache.cs
@@ -211,6 +211,7 @@ namespace Microsoft.Azure.Cosmos.Routing
                             using (DocumentServiceResponse response =
                                 await this.storeModel.ProcessMessageAsync(request))
                             {
+                                ContainerProperties containerProperties = CosmosResource.FromStream<ContainerProperties>(response);
 
                                 this.clientTelemetry.Collect(
                                     cacheRefreshSource: "ClientCollectionCache",
@@ -219,8 +220,10 @@ namespace Microsoft.Azure.Cosmos.Routing
                                     resourceType: request.ResourceType,
                                     regionsContactedList: response.RequestStats.RegionsContacted,
                                     requestLatency: response.RequestStats.RequestLatency,
-                                    subStatusCode: response.SubStatusCode.ToSubStatusCodeString());
-                                return CosmosResource.FromStream<ContainerProperties>(response);
+                                    subStatusCode: response.SubStatusCode.ToSubStatusCodeString(),
+                                    containerId: containerProperties.Id);
+
+                                return containerProperties;
                             }
                         }
                         catch (DocumentClientException ex)

--- a/Microsoft.Azure.Cosmos/src/Routing/ClientCollectionCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/ClientCollectionCache.cs
@@ -215,10 +215,9 @@ namespace Microsoft.Azure.Cosmos.Routing
                             {
                                 ContainerProperties containerProperties = CosmosResource.FromStream<ContainerProperties>(response);
 
-                                ClientCollectionCache.GetDatabaseAndCollectionName(collectionLink, out string databaseName, out string collectionName);
-
                                 if (this.clientTelemetry != null)
                                 {
+                                    ClientCollectionCache.GetDatabaseAndCollectionName(collectionLink, out string databaseName, out string collectionName);
                                     this.clientTelemetry.CollectCacheInfo(
                                                     cacheRefreshSource: ClientCollectionCache.TelemetrySourceName,
                                                     regionsContactedList: response.RequestStats.RegionsContacted,

--- a/Microsoft.Azure.Cosmos/src/Routing/ClientCollectionCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/ClientCollectionCache.cs
@@ -212,16 +212,20 @@ namespace Microsoft.Azure.Cosmos.Routing
                                 await this.storeModel.ProcessMessageAsync(request))
                             {
                                 ContainerProperties containerProperties = CosmosResource.FromStream<ContainerProperties>(response);
+                                
+                                if (this.clientTelemetry != null)
+                                {
+                                    this.clientTelemetry.Collect(
+                                                    cacheRefreshSource: "ClientCollectionCache",
+                                                    statusCode: response.StatusCode,
+                                                    operationType: request.OperationType,
+                                                    resourceType: request.ResourceType,
+                                                    regionsContactedList: response.RequestStats.RegionsContacted,
+                                                    requestLatency: response.RequestStats.RequestLatency,
+                                                    subStatusCode: response.SubStatusCode.ToSubStatusCodeString(),
+                                                    containerId: containerProperties.Id);
 
-                                this.clientTelemetry.Collect(
-                                    cacheRefreshSource: "ClientCollectionCache",
-                                    statusCode: response.StatusCode,
-                                    operationType: request.OperationType,
-                                    resourceType: request.ResourceType,
-                                    regionsContactedList: response.RequestStats.RegionsContacted,
-                                    requestLatency: response.RequestStats.RequestLatency,
-                                    subStatusCode: response.SubStatusCode.ToSubStatusCodeString(),
-                                    containerId: containerProperties.Id);
+                                }
 
                                 return containerProperties;
                             }

--- a/Microsoft.Azure.Cosmos/src/Routing/ClientCollectionCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/ClientCollectionCache.cs
@@ -217,7 +217,7 @@ namespace Microsoft.Azure.Cosmos.Routing
                                 
                                 if (this.clientTelemetry != null)
                                 {
-                                    this.clientTelemetry.Collect(
+                                    this.clientTelemetry.CollectCacheInfo(
                                                     cacheRefreshSource: ClientCollectionCache.TelemetrySourceName,
                                                     regionsContactedList: response.RequestStats.RegionsContacted,
                                                     requestLatency: response.RequestStats.RequestLatency,

--- a/Microsoft.Azure.Cosmos/src/Routing/ClientCollectionCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/ClientCollectionCache.cs
@@ -222,7 +222,7 @@ namespace Microsoft.Azure.Cosmos.Routing
                                                     resourceType: request.ResourceType,
                                                     regionsContactedList: response.RequestStats.RegionsContacted,
                                                     requestLatency: response.RequestStats.RequestLatency,
-                                                    subStatusCode: response.SubStatusCode.ToSubStatusCodeString(),
+                                                    subStatusCode: response.SubStatusCode,
                                                     containerId: containerProperties.Id);
 
                                 }

--- a/Microsoft.Azure.Cosmos/src/Routing/ClientCollectionCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/ClientCollectionCache.cs
@@ -217,13 +217,13 @@ namespace Microsoft.Azure.Cosmos.Routing
                                 {
                                     this.clientTelemetry.Collect(
                                                     cacheRefreshSource: "ClientCollectionCache",
-                                                    statusCode: response.StatusCode,
-                                                    operationType: request.OperationType,
-                                                    resourceType: request.ResourceType,
                                                     regionsContactedList: response.RequestStats.RegionsContacted,
                                                     requestLatency: response.RequestStats.RequestLatency,
-                                                    subStatusCode: response.SubStatusCode,
-                                                    containerId: containerProperties.Id);
+                                                    statusCode: response.StatusCode,
+                                                    containerId: containerProperties.Id,
+                                                    operationType: request.OperationType,
+                                                    resourceType: request.ResourceType,
+                                                    subStatusCode: response.SubStatusCode);
 
                                 }
 

--- a/Microsoft.Azure.Cosmos/src/Telemetry/AzureVMMetadata.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/AzureVMMetadata.cs
@@ -5,6 +5,7 @@
 namespace Microsoft.Azure.Cosmos.Telemetry
 {
     using System;
+    using Microsoft.Azure.Cosmos.Telemetry.Models;
     using Newtonsoft.Json;
 
     [Serializable]

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
@@ -195,17 +195,19 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         }
 
         /// <summary>
-        /// Collects Telemetry Information.
+        /// Collects Cache Telemetry Information.
         /// </summary>
         internal void Collect(string cacheRefreshSource,
-                            HttpStatusCode statusCode,
-                            OperationType operationType,
-                            ResourceType resourceType,
                             HashSet<(string regionName, Uri uri)> regionsContactedList,
                             TimeSpan? requestLatency,
-                            SubStatusCodes subStatusCode,
+                            HttpStatusCode statusCode,
                             string containerId,
-                            string databaseId = null)
+                            OperationType operationType,
+                            ResourceType resourceType,
+                            SubStatusCodes subStatusCode,
+                            string databaseId = null,
+                            long responseSizeInBytes = 0,
+                            string consistencyLevel = null )
         {
             if (string.IsNullOrEmpty(cacheRefreshSource))
             {
@@ -219,8 +221,8 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             // Recording Request Latency
             CacheRefreshInfo payloadKey = new CacheRefreshInfo(cacheRefreshSource: cacheRefreshSource,
                                             regionsContacted: regionsContacted?.ToString(),
-                                            responseSizeInBytes: null,
-                                            consistency: null,
+                                            responseSizeInBytes: responseSizeInBytes,
+                                            consistency: consistencyLevel,
                                             databaseName: databaseId,
                                             containerName: containerId,
                                             operation: operationType,

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
@@ -60,6 +60,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         /// </summary>
         internal ClientTelemetry()
         {
+            this.cancellationTokenSource = new CancellationTokenSource();
         }
 
         /// <summary>
@@ -204,7 +205,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         /// <summary>
         /// Collects Cache Telemetry Information.
         /// </summary>
-        internal void Collect(string cacheRefreshSource,
+        internal void CollectCacheInfo(string cacheRefreshSource,
                             HashSet<(string regionName, Uri uri)> regionsContactedList,
                             TimeSpan? requestLatency,
                             HttpStatusCode statusCode,
@@ -223,7 +224,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
 
             DefaultTrace.TraceVerbose($"Collecting cacheRefreshSource {cacheRefreshSource} data for Telemetry.");
 
-            string regionsContacted = ClientTelemetryHelper.GetContactedRegions(new List<(string regionName, Uri uri)>(regionsContactedList));
+            string regionsContacted = ClientTelemetryHelper.GetContactedRegions(regionsContactedList);
 
             // Recording Request Latency
             CacheRefreshInfo payloadKey = new CacheRefreshInfo(cacheRefreshSource: cacheRefreshSource,
@@ -264,7 +265,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         /// <param name="consistencyLevel"></param>
         /// <param name="requestCharge"></param>
         /// <param name="subStatusCode"></param>
-        internal void Collect(CosmosDiagnostics cosmosDiagnostics,
+        internal void CollectOperationInfo(CosmosDiagnostics cosmosDiagnostics,
                             HttpStatusCode statusCode,
                             long responseSizeInBytes,
                             string containerId,
@@ -447,8 +448,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         /// </summary>
         public void Dispose()
         {
-            if (this.cancellationTokenSource != null && 
-                    !this.cancellationTokenSource.IsCancellationRequested)
+            if (!this.cancellationTokenSource.IsCancellationRequested)
             {
                 this.cancellationTokenSource.Cancel();
                 this.cancellationTokenSource.Dispose();

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
@@ -122,8 +122,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                 userAgent: userAgent, 
                 connectionMode: connectionMode,
                 preferredRegions: preferredRegions,
-                aggregationIntervalInSec: (int)observingWindow.TotalSeconds,
-                machineId: VmMetadataApiHandler.GetMachineId());
+                aggregationIntervalInSec: (int)observingWindow.TotalSeconds);
 
             this.cancellationTokenSource = new CancellationTokenSource();
             this.globalEndpointManager = globalEndpointManager;
@@ -164,6 +163,8 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                     }
                     
                     await Task.Delay(observingWindow, this.cancellationTokenSource.Token);
+
+                    this.clientTelemetryInfo.MachineId = VmMetadataApiHandler.GetMachineId();
 
                     // Load host information from cache
                     Compute vmInformation = VmMetadataApiHandler.GetMachineInfo();
@@ -213,7 +214,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                             OperationType operationType,
                             ResourceType resourceType,
                             SubStatusCodes subStatusCode,
-                            string databaseId = null,
+                            string databaseId,
                             long responseSizeInBytes = 0,
                             string consistencyLevel = null )
         {

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
@@ -203,10 +203,15 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                             ResourceType resourceType,
                             HashSet<(string regionName, Uri uri)> regionsContactedList,
                             TimeSpan? requestLatency,
-                            string subStatusCode,
+                            SubStatusCodes subStatusCode,
                             string containerId,
                             string databaseId = null)
         {
+            if (string.IsNullOrEmpty(cacheRefreshSource))
+            {
+                throw new ArgumentNullException(nameof(cacheRefreshSource));
+            }
+
             DefaultTrace.TraceVerbose($"Collecting cacheRefreshSource {cacheRefreshSource} data for Telemetry.");
 
             string regionsContacted = ClientTelemetryHelper.GetContactedRegions(new List<(string regionName, Uri uri)>(regionsContactedList));
@@ -221,7 +226,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                                             operation: operationType,
                                             resource: resourceType,
                                             statusCode: (int)statusCode,
-                                            subStatusCode: subStatusCode);
+                                            subStatusCode: (int)subStatusCode);
 
             LongConcurrentHistogram latency = this.cacheRefreshInfoMap
                     .GetOrAdd(payloadKey, new LongConcurrentHistogram(ClientTelemetryOptions.RequestLatencyMin,
@@ -259,7 +264,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                             ResourceType resourceType,
                             string consistencyLevel,
                             double requestCharge,
-                            string subStatusCode)
+                            SubStatusCodes subStatusCode)
         {
             DefaultTrace.TraceVerbose("Collecting Operation data for Telemetry.");
 
@@ -279,7 +284,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                                             operation: operationType,
                                             resource: resourceType,
                                             statusCode: (int)statusCode,
-                                            subStatusCode: subStatusCode);
+                                            subStatusCode: (int)subStatusCode);
 
             (LongConcurrentHistogram latency, LongConcurrentHistogram requestcharge) = this.operationInfoMap
                     .GetOrAdd(payloadKey, x => (latency: new LongConcurrentHistogram(ClientTelemetryOptions.RequestLatencyMin,

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
@@ -56,6 +56,13 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         private int numberOfFailures = 0;
 
         /// <summary>
+        /// Only for Mocking in tests
+        /// </summary>
+        internal ClientTelemetry()
+        {
+        }
+
+        /// <summary>
         /// Factory method to intiakize telemetry object and start observer task
         /// </summary>
         /// <param name="clientId"></param>
@@ -440,7 +447,8 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         /// </summary>
         public void Dispose()
         {
-            if (!this.cancellationTokenSource.IsCancellationRequested)
+            if (this.cancellationTokenSource != null && 
+                    !this.cancellationTokenSource.IsCancellationRequested)
             {
                 this.cancellationTokenSource.Cancel();
                 this.cancellationTokenSource.Dispose();

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
@@ -196,7 +196,9 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                             ResourceType resourceType,
                             HashSet<(string regionName, Uri uri)> regionsContactedList,
                             TimeSpan? requestLatency,
-                            string subStatusCode)
+                            string subStatusCode,
+                            string containerId,
+                            string databaseId = null)
         {
             DefaultTrace.TraceVerbose($"Collecting cacheRefreshSource {cacheRefreshSource} data for Telemetry.");
 
@@ -206,8 +208,8 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             OperationInfo payloadKey = new OperationInfo(regionsContacted: regionsContacted?.ToString(),
                                             responseSizeInBytes: null,
                                             consistency: null,
-                                            databaseName: null,
-                                            containerName: null,
+                                            databaseName: databaseId,
+                                            containerName: containerId,
                                             operation: operationType,
                                             resource: resourceType,
                                             statusCode: (int)statusCode,

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
@@ -16,7 +16,6 @@ namespace Microsoft.Azure.Cosmos.Telemetry
     using HdrHistogram;
     using Microsoft.Azure.Cosmos.Core.Trace;
     using Microsoft.Azure.Cosmos.Routing;
-    using Microsoft.Azure.Cosmos.Serialization.HybridRow;
     using Microsoft.Azure.Cosmos.Telemetry.Models;
     using Microsoft.Azure.Documents;
     using Microsoft.Azure.Documents.Collections;
@@ -182,7 +181,6 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                        = Interlocked.Exchange(ref this.cacheRefreshInfoMap, new ConcurrentDictionary<CacheRefreshInfo, LongConcurrentHistogram>());
 
                     this.clientTelemetryInfo.OperationInfo = ClientTelemetryHelper.ToListWithMetricsInfo(operationInfoSnapshot);
-
                     this.clientTelemetryInfo.CacheRefreshInfo = ClientTelemetryHelper.ToListWithMetricsInfo(cacheRefreshInfoSnapshot);
 
                     await this.SendAsync();

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryHelper.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryHelper.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Net.Http;
     using System.Text;
     using System.Threading;
@@ -142,6 +143,11 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                 return null;
             }
 
+            if (regionList.Count == 1)
+            {
+                return regionList.ElementAt(0).regionName;
+            }
+            
             StringBuilder regionsContacted = new StringBuilder();
             foreach ((string name, _) in regionList)
             {

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryHelper.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryHelper.cs
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                 return;
             }
 
-            DefaultTrace.TraceInformation("System Usage recorded by telemetry is : {0}", systemUsageHistory);
+            DefaultTrace.TraceVerbose("System Usage recorded by telemetry is : {0}", systemUsageHistory);
 
             systemInfoCollection.Add(TelemetrySystemUsage.GetCpuInfo(systemUsageHistory.Values));
             systemInfoCollection.Add(TelemetrySystemUsage.GetMemoryRemainingInfo(systemUsageHistory.Values));
@@ -84,7 +84,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                 IDictionary<OperationInfo, 
                 (LongConcurrentHistogram latency, LongConcurrentHistogram requestcharge)> metrics)
         {
-            DefaultTrace.TraceInformation("Aggregating operation information to list started");
+            DefaultTrace.TraceVerbose("Aggregating operation information to list started");
 
             List<OperationInfo> payloadWithMetricInformation = new List<OperationInfo>();
             foreach (KeyValuePair<OperationInfo, (LongConcurrentHistogram latency, LongConcurrentHistogram requestcharge)> entry in metrics)
@@ -114,7 +114,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         /// <returns>Collection of ReportPayload</returns>
         internal static List<CacheRefreshInfo> ToListWithMetricsInfo(IDictionary<CacheRefreshInfo, LongConcurrentHistogram> metrics)
         {
-            DefaultTrace.TraceInformation("Aggregating CacheRefreshInfo information to list started");
+            DefaultTrace.TraceVerbose("Aggregating CacheRefreshInfo information to list started");
 
             List<CacheRefreshInfo> payloadWithMetricInformation = new List<CacheRefreshInfo>();
             foreach (KeyValuePair<CacheRefreshInfo, LongConcurrentHistogram> entry in metrics)
@@ -126,7 +126,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                 payloadWithMetricInformation.Add(payloadForLatency);
             }
 
-            DefaultTrace.TraceInformation("Aggregating CacheRefreshInfo information to list done");
+            DefaultTrace.TraceVerbose("Aggregating CacheRefreshInfo information to list done");
 
             return payloadWithMetricInformation;
         }
@@ -135,7 +135,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         /// Get comma separated list of regions contacted from the diagnostic
         /// </summary>
         /// <returns>Comma separated region list</returns>
-        internal static string GetContactedRegions(IReadOnlyList<(string regionName, Uri uri)> regionList)
+        internal static string GetContactedRegions(IReadOnlyCollection<(string regionName, Uri uri)> regionList)
         {
             if (regionList == null || regionList.Count == 0)
             {
@@ -144,7 +144,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
 
             if (regionList.Count == 1)
             {
-                return regionList[0].regionName;
+                return regionList.GetEnumerator().Current.regionName;
             }
 
             StringBuilder regionsContacted = new StringBuilder();

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryHelper.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryHelper.cs
@@ -142,11 +142,6 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                 return null;
             }
 
-            if (regionList.Count == 1)
-            {
-                return regionList.GetEnumerator().Current.regionName;
-            }
-
             StringBuilder regionsContacted = new StringBuilder();
             foreach ((string name, _) in regionList)
             {

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryHelper.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryHelper.cs
@@ -109,12 +109,9 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         /// <summary>
         /// Get comma separated list of regions contacted from the diagnostic
         /// </summary>
-        /// <param name="cosmosDiagnostics"></param>
         /// <returns>Comma separated region list</returns>
-        internal static string GetContactedRegions(CosmosDiagnostics cosmosDiagnostics)
+        internal static string GetContactedRegions(IReadOnlyList<(string regionName, Uri uri)> regionList)
         {
-            IReadOnlyList<(string regionName, Uri uri)> regionList = cosmosDiagnostics.GetContactedRegions();
-
             if (regionList == null || regionList.Count == 0)
             {
                 return null;

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryHelper.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryHelper.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
     using System.Threading.Tasks;
     using HdrHistogram;
     using Microsoft.Azure.Cosmos.Core.Trace;
+    using Microsoft.Azure.Cosmos.Routing;
     using Microsoft.Azure.Documents;
     using Microsoft.Azure.Documents.Rntbd;
 
@@ -20,14 +21,14 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         /// Task to get Account Properties from cache if available otherwise make a network call.
         /// </summary>
         /// <returns>Async Task</returns>
-        internal static async Task<AccountProperties> SetAccountNameAsync(DocumentClient documentclient)
+        internal static async Task<AccountProperties> SetAccountNameAsync(GlobalEndpointManager globalEndpointManager)
         {
             DefaultTrace.TraceVerbose("Getting Account Information for Telemetry.");
             try
             {
-                if (documentclient.GlobalEndpointManager != null)
+                if (globalEndpointManager != null)
                 {
-                    return await documentclient.GlobalEndpointManager.GetDatabaseAccountAsync();
+                    return await globalEndpointManager.GetDatabaseAccountAsync();
                 }
             }
             catch (Exception ex)

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryOptions.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
 {
     using System;
     using Microsoft.Azure.Cosmos.Core.Trace;
+    using Microsoft.Azure.Cosmos.Telemetry.Models;
     using Microsoft.Azure.Documents;
     using Newtonsoft.Json;
     using Util;

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryProperties.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryProperties.cs
@@ -69,7 +69,10 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                                    string userAgent,
                                    ConnectionMode connectionMode,
                                    IReadOnlyList<string> preferredRegions,
-                                   int aggregationIntervalInSec)
+                                   int aggregationIntervalInSec,
+                                   string machineId,
+                                   string applicationRegion,
+                                   string hostEnvInfo)
         {
             this.ClientId = clientId;
             this.ProcessId = processId;
@@ -82,6 +85,9 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             this.SystemInfo = new List<SystemInfo>();
             this.PreferredRegions = preferredRegions;
             this.AggregationIntervalInSec = aggregationIntervalInSec;
+            this.MachineId = machineId;
+            this.ApplicationRegion = applicationRegion;
+            this.HostEnvInfo = hostEnvInfo;
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Telemetry/Models/AzureVMMetadata.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/Models/AzureVMMetadata.cs
@@ -2,10 +2,9 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 //------------------------------------------------------------
 
-namespace Microsoft.Azure.Cosmos.Telemetry
+namespace Microsoft.Azure.Cosmos.Telemetry.Models
 {
     using System;
-    using Microsoft.Azure.Cosmos.Telemetry.Models;
     using Newtonsoft.Json;
 
     [Serializable]

--- a/Microsoft.Azure.Cosmos/src/Telemetry/Models/CacheRefreshInfo.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/Models/CacheRefreshInfo.cs
@@ -5,8 +5,6 @@
 namespace Microsoft.Azure.Cosmos.Telemetry.Models
 {
     using System;
-    using HdrHistogram;
-    using Microsoft.Azure.Cosmos.Telemetry;
     using Microsoft.Azure.Documents;
     using Newtonsoft.Json;
 
@@ -18,10 +16,6 @@ namespace Microsoft.Azure.Cosmos.Telemetry.Models
 
         internal CacheRefreshInfo(string metricsName, string unitName)
             : base(metricsName, unitName)
-        {
-        }
-
-        internal CacheRefreshInfo()
         {
         }
 
@@ -59,12 +53,9 @@ namespace Microsoft.Azure.Cosmos.Telemetry.Models
 
         public override bool Equals(object obj)
         {
-            bool isequal = base.Equals(obj) && obj is CacheRefreshInfo payload &&
-                   ((this.CacheRefreshSource == null && payload.CacheRefreshSource == null) || 
-                        (this.CacheRefreshSource != null && payload.CacheRefreshSource != null && 
-                            this.CacheRefreshSource.Equals(payload.CacheRefreshSource)));
-
-            return isequal;
+            return base.Equals(obj) && 
+                obj is CacheRefreshInfo payload &&
+                String.CompareOrdinal(this.CacheRefreshSource, payload.CacheRefreshSource) == 0;
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Telemetry/Models/CacheRefreshInfo.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/Models/CacheRefreshInfo.cs
@@ -1,0 +1,10 @@
+﻿namespace Microsoft.Azure.Cosmos.Telemetry.Models
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+
+    internal class CacheRefreshInfo
+    {
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Telemetry/Models/CacheRefreshInfo.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/Models/CacheRefreshInfo.cs
@@ -36,51 +36,33 @@ namespace Microsoft.Azure.Cosmos.Telemetry.Models
             int? statusCode,
             int subStatusCode,
             string cacheRefreshSource)
+            : base(
+                  regionsContacted: regionsContacted,
+                  responseSizeInBytes: responseSizeInBytes,
+                  consistency: consistency,
+                  databaseName: databaseName,
+                  containerName: containerName,
+                  operation: operation,
+                  resource: resource,
+                  statusCode: statusCode,
+                  subStatusCode: subStatusCode)
         {
-            this.RegionsContacted = regionsContacted;
-            if (responseSizeInBytes != null)
-            {
-                this.GreaterThan1Kb = responseSizeInBytes > ClientTelemetryOptions.OneKbToBytes;
-            }
-            this.Consistency = consistency;
-            this.DatabaseName = databaseName;
-            this.ContainerName = containerName;
-            this.Operation = operation?.ToOperationTypeString();
-            this.Resource = resource?.ToResourceTypeString();
-            this.StatusCode = statusCode;
-            this.SubStatusCode = subStatusCode;
             this.CacheRefreshSource = cacheRefreshSource;
         }
 
         public override int GetHashCode()
         {
-            int hash = 3;
-            hash = (hash * 7) ^ (this.RegionsContacted == null ? 0 : this.RegionsContacted.GetHashCode());
-            hash = (hash * 7) ^ (this.GreaterThan1Kb == null ? 0 : this.GreaterThan1Kb.GetHashCode());
-            hash = (hash * 7) ^ (this.Consistency == null ? 0 : this.Consistency.GetHashCode());
-            hash = (hash * 7) ^ (this.DatabaseName == null ? 0 : this.DatabaseName.GetHashCode());
-            hash = (hash * 7) ^ (this.ContainerName == null ? 0 : this.ContainerName.GetHashCode());
-            hash = (hash * 7) ^ (this.Operation == null ? 0 : this.Operation.GetHashCode());
-            hash = (hash * 7) ^ (this.Resource == null ? 0 : this.Resource.GetHashCode());
-            hash = (hash * 7) ^ (this.StatusCode == null ? 0 : this.StatusCode.GetHashCode());
-            hash = (hash * 7) ^ (this.SubStatusCode.GetHashCode());
+            int hash = base.GetHashCode();
             hash = (hash * 7) ^ (this.CacheRefreshSource == null ? 0 : this.CacheRefreshSource.GetHashCode());
             return hash;
         }
 
         public override bool Equals(object obj)
         {
-            bool isequal = obj is CacheRefreshInfo payload &&
-                   ((this.RegionsContacted == null && payload.RegionsContacted == null) || (this.RegionsContacted != null && payload.RegionsContacted != null && this.RegionsContacted.Equals(payload.RegionsContacted))) &&
-                   ((this.GreaterThan1Kb == null && payload.GreaterThan1Kb == null) || (this.GreaterThan1Kb != null && payload.GreaterThan1Kb != null && this.GreaterThan1Kb.Equals(payload.GreaterThan1Kb))) &&
-                   ((this.Consistency == null && payload.Consistency == null) || (this.Consistency != null && payload.Consistency != null && this.Consistency.Equals(payload.Consistency))) &&
-                   ((this.DatabaseName == null && payload.DatabaseName == null) || (this.DatabaseName != null && payload.DatabaseName != null && this.DatabaseName.Equals(payload.DatabaseName))) &&
-                   ((this.ContainerName == null && payload.ContainerName == null) || (this.ContainerName != null && payload.ContainerName != null && this.ContainerName.Equals(payload.ContainerName))) &&
-                   ((this.Operation == null && payload.Operation == null) || (this.Operation != null && payload.Operation != null && this.Operation.Equals(payload.Operation))) &&
-                   ((this.Resource == null && payload.Resource == null) || (this.Resource != null && payload.Resource != null && this.Resource.Equals(payload.Resource))) &&
-                   ((this.StatusCode == null && payload.StatusCode == null) || (this.StatusCode != null && payload.StatusCode != null && this.StatusCode.Equals(payload.StatusCode))) &&
-                   ((this.CacheRefreshSource == null && payload.CacheRefreshSource == null) || (this.CacheRefreshSource != null && payload.CacheRefreshSource != null && this.CacheRefreshSource.Equals(payload.CacheRefreshSource))) &&
-                   this.SubStatusCode == payload.SubStatusCode;
+            bool isequal = base.Equals(obj) && obj is CacheRefreshInfo payload &&
+                   ((this.CacheRefreshSource == null && payload.CacheRefreshSource == null) || 
+                        (this.CacheRefreshSource != null && payload.CacheRefreshSource != null && 
+                            this.CacheRefreshSource.Equals(payload.CacheRefreshSource)));
 
             return isequal;
         }

--- a/Microsoft.Azure.Cosmos/src/Telemetry/Models/CacheRefreshInfo.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/Models/CacheRefreshInfo.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry.Models
         {
         }
 
+        [JsonConstructor]
         internal CacheRefreshInfo(string regionsContacted,
             long? responseSizeInBytes,
             string consistency,
@@ -33,7 +34,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry.Models
             OperationType? operation,
             ResourceType? resource,
             int? statusCode,
-            string subStatusCode,
+            int subStatusCode,
             string cacheRefreshSource)
         {
             this.RegionsContacted = regionsContacted;
@@ -62,7 +63,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry.Models
             hash = (hash * 7) ^ (this.Operation == null ? 0 : this.Operation.GetHashCode());
             hash = (hash * 7) ^ (this.Resource == null ? 0 : this.Resource.GetHashCode());
             hash = (hash * 7) ^ (this.StatusCode == null ? 0 : this.StatusCode.GetHashCode());
-            hash = (hash * 7) ^ (this.SubStatusCode == null ? 0 : this.SubStatusCode.GetHashCode());
+            hash = (hash * 7) ^ (this.SubStatusCode.GetHashCode());
             hash = (hash * 7) ^ (this.CacheRefreshSource == null ? 0 : this.CacheRefreshSource.GetHashCode());
             return hash;
         }
@@ -70,16 +71,16 @@ namespace Microsoft.Azure.Cosmos.Telemetry.Models
         public override bool Equals(object obj)
         {
             bool isequal = obj is CacheRefreshInfo payload &&
-                   (this.RegionsContacted == null && payload.RegionsContacted == null || this.RegionsContacted != null && payload.RegionsContacted != null && this.RegionsContacted.Equals(payload.RegionsContacted)) &&
-                   (this.GreaterThan1Kb == null && payload.GreaterThan1Kb == null || this.GreaterThan1Kb != null && payload.GreaterThan1Kb != null && this.GreaterThan1Kb.Equals(payload.GreaterThan1Kb)) &&
-                   (this.Consistency == null && payload.Consistency == null || this.Consistency != null && payload.Consistency != null && this.Consistency.Equals(payload.Consistency)) &&
-                   (this.DatabaseName == null && payload.DatabaseName == null || this.DatabaseName != null && payload.DatabaseName != null && this.DatabaseName.Equals(payload.DatabaseName)) &&
-                   (this.ContainerName == null && payload.ContainerName == null || this.ContainerName != null && payload.ContainerName != null && this.ContainerName.Equals(payload.ContainerName)) &&
-                   (this.Operation == null && payload.Operation == null || this.Operation != null && payload.Operation != null && this.Operation.Equals(payload.Operation)) &&
-                   (this.Resource == null && payload.Resource == null || this.Resource != null && payload.Resource != null && this.Resource.Equals(payload.Resource)) &&
-                   (this.StatusCode == null && payload.StatusCode == null || this.StatusCode != null && payload.StatusCode != null && this.StatusCode.Equals(payload.StatusCode)) &&
-                   (this.CacheRefreshSource == null && payload.CacheRefreshSource == null || this.CacheRefreshSource != null && payload.CacheRefreshSource != null && this.CacheRefreshSource.Equals(payload.CacheRefreshSource)) &&
-                   (this.SubStatusCode == null && payload.SubStatusCode == null || this.SubStatusCode != null && payload.SubStatusCode != null && this.SubStatusCode.Equals(payload.SubStatusCode));
+                   ((this.RegionsContacted == null && payload.RegionsContacted == null) || (this.RegionsContacted != null && payload.RegionsContacted != null && this.RegionsContacted.Equals(payload.RegionsContacted))) &&
+                   ((this.GreaterThan1Kb == null && payload.GreaterThan1Kb == null) || (this.GreaterThan1Kb != null && payload.GreaterThan1Kb != null && this.GreaterThan1Kb.Equals(payload.GreaterThan1Kb))) &&
+                   ((this.Consistency == null && payload.Consistency == null) || (this.Consistency != null && payload.Consistency != null && this.Consistency.Equals(payload.Consistency))) &&
+                   ((this.DatabaseName == null && payload.DatabaseName == null) || (this.DatabaseName != null && payload.DatabaseName != null && this.DatabaseName.Equals(payload.DatabaseName))) &&
+                   ((this.ContainerName == null && payload.ContainerName == null) || (this.ContainerName != null && payload.ContainerName != null && this.ContainerName.Equals(payload.ContainerName))) &&
+                   ((this.Operation == null && payload.Operation == null) || (this.Operation != null && payload.Operation != null && this.Operation.Equals(payload.Operation))) &&
+                   ((this.Resource == null && payload.Resource == null) || (this.Resource != null && payload.Resource != null && this.Resource.Equals(payload.Resource))) &&
+                   ((this.StatusCode == null && payload.StatusCode == null) || (this.StatusCode != null && payload.StatusCode != null && this.StatusCode.Equals(payload.StatusCode))) &&
+                   ((this.CacheRefreshSource == null && payload.CacheRefreshSource == null) || (this.CacheRefreshSource != null && payload.CacheRefreshSource != null && this.CacheRefreshSource.Equals(payload.CacheRefreshSource))) &&
+                   this.SubStatusCode == payload.SubStatusCode;
 
             return isequal;
         }

--- a/Microsoft.Azure.Cosmos/src/Telemetry/Models/CacheRefreshInfo.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/Models/CacheRefreshInfo.cs
@@ -1,10 +1,83 @@
-﻿namespace Microsoft.Azure.Cosmos.Telemetry.Models
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Telemetry.Models
 {
     using System;
-    using System.Collections.Generic;
-    using System.Text;
+    using HdrHistogram;
+    using Microsoft.Azure.Cosmos.Telemetry;
+    using Microsoft.Azure.Documents;
+    using Newtonsoft.Json;
 
-    internal class CacheRefreshInfo
+    [Serializable]
+    internal sealed class CacheRefreshInfo : OperationInfo
     {
+        [JsonProperty(PropertyName = "cacheRefreshSource")]
+        internal string CacheRefreshSource { get; }
+
+        internal CacheRefreshInfo(string metricsName, string unitName)
+            : base(metricsName, unitName)
+        {
+        }
+
+        internal CacheRefreshInfo(string regionsContacted,
+            long? responseSizeInBytes,
+            string consistency,
+            string databaseName,
+            string containerName,
+            OperationType? operation,
+            ResourceType? resource,
+            int? statusCode,
+            string subStatusCode,
+            string cacheRefreshSource)
+        {
+            this.RegionsContacted = regionsContacted;
+            if (responseSizeInBytes != null)
+            {
+                this.GreaterThan1Kb = responseSizeInBytes > ClientTelemetryOptions.OneKbToBytes;
+            }
+            this.Consistency = consistency;
+            this.DatabaseName = databaseName;
+            this.ContainerName = containerName;
+            this.Operation = operation?.ToOperationTypeString();
+            this.Resource = resource?.ToResourceTypeString();
+            this.StatusCode = statusCode;
+            this.SubStatusCode = subStatusCode;
+            this.CacheRefreshSource = cacheRefreshSource;
+        }
+
+        public override int GetHashCode()
+        {
+            int hash = 3;
+            hash = (hash * 7) ^ (this.RegionsContacted == null ? 0 : this.RegionsContacted.GetHashCode());
+            hash = (hash * 7) ^ (this.GreaterThan1Kb == null ? 0 : this.GreaterThan1Kb.GetHashCode());
+            hash = (hash * 7) ^ (this.Consistency == null ? 0 : this.Consistency.GetHashCode());
+            hash = (hash * 7) ^ (this.DatabaseName == null ? 0 : this.DatabaseName.GetHashCode());
+            hash = (hash * 7) ^ (this.ContainerName == null ? 0 : this.ContainerName.GetHashCode());
+            hash = (hash * 7) ^ (this.Operation == null ? 0 : this.Operation.GetHashCode());
+            hash = (hash * 7) ^ (this.Resource == null ? 0 : this.Resource.GetHashCode());
+            hash = (hash * 7) ^ (this.StatusCode == null ? 0 : this.StatusCode.GetHashCode());
+            hash = (hash * 7) ^ (this.SubStatusCode == null ? 0 : this.SubStatusCode.GetHashCode());
+            hash = (hash * 7) ^ (this.CacheRefreshSource == null ? 0 : this.CacheRefreshSource.GetHashCode());
+            return hash;
+        }
+
+        public override bool Equals(object obj)
+        {
+            bool isequal = obj is CacheRefreshInfo payload &&
+                   (this.RegionsContacted == null && payload.RegionsContacted == null || this.RegionsContacted != null && payload.RegionsContacted != null && this.RegionsContacted.Equals(payload.RegionsContacted)) &&
+                   (this.GreaterThan1Kb == null && payload.GreaterThan1Kb == null || this.GreaterThan1Kb != null && payload.GreaterThan1Kb != null && this.GreaterThan1Kb.Equals(payload.GreaterThan1Kb)) &&
+                   (this.Consistency == null && payload.Consistency == null || this.Consistency != null && payload.Consistency != null && this.Consistency.Equals(payload.Consistency)) &&
+                   (this.DatabaseName == null && payload.DatabaseName == null || this.DatabaseName != null && payload.DatabaseName != null && this.DatabaseName.Equals(payload.DatabaseName)) &&
+                   (this.ContainerName == null && payload.ContainerName == null || this.ContainerName != null && payload.ContainerName != null && this.ContainerName.Equals(payload.ContainerName)) &&
+                   (this.Operation == null && payload.Operation == null || this.Operation != null && payload.Operation != null && this.Operation.Equals(payload.Operation)) &&
+                   (this.Resource == null && payload.Resource == null || this.Resource != null && payload.Resource != null && this.Resource.Equals(payload.Resource)) &&
+                   (this.StatusCode == null && payload.StatusCode == null || this.StatusCode != null && payload.StatusCode != null && this.StatusCode.Equals(payload.StatusCode)) &&
+                   (this.CacheRefreshSource == null && payload.CacheRefreshSource == null || this.CacheRefreshSource != null && payload.CacheRefreshSource != null && this.CacheRefreshSource.Equals(payload.CacheRefreshSource)) &&
+                   (this.SubStatusCode == null && payload.SubStatusCode == null || this.SubStatusCode != null && payload.SubStatusCode != null && this.SubStatusCode.Equals(payload.SubStatusCode));
+
+            return isequal;
+        }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Telemetry/Models/CacheRefreshInfo.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/Models/CacheRefreshInfo.cs
@@ -21,6 +21,10 @@ namespace Microsoft.Azure.Cosmos.Telemetry.Models
         {
         }
 
+        internal CacheRefreshInfo()
+        {
+        }
+
         internal CacheRefreshInfo(string regionsContacted,
             long? responseSizeInBytes,
             string consistency,

--- a/Microsoft.Azure.Cosmos/src/Telemetry/Models/ClientTelemetryProperties.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/Models/ClientTelemetryProperties.cs
@@ -7,7 +7,6 @@ namespace Microsoft.Azure.Cosmos.Telemetry.Models
     using System;
     using System.Collections.Generic;
     using Newtonsoft.Json;
-    using Newtonsoft.Json.Converters;
     using Newtonsoft.Json.Serialization;
 
     [Serializable]
@@ -69,21 +68,16 @@ namespace Microsoft.Azure.Cosmos.Telemetry.Models
                                    string userAgent,
                                    ConnectionMode connectionMode,
                                    IReadOnlyList<string> preferredRegions,
-                                   int aggregationIntervalInSec,
-                                   string machineId)
+                                   int aggregationIntervalInSec)
         {
             this.ClientId = clientId;
             this.ProcessId = processId;
             this.UserAgent = userAgent;
             this.ConnectionMode = connectionMode.ToString().ToUpperInvariant();
-            if (connectionMode == Cosmos.ConnectionMode.Direct)
-            {
-                this.IsDirectConnectionMode = true;
-            }
+            this.IsDirectConnectionMode = connectionMode == Cosmos.ConnectionMode.Direct;
             this.SystemInfo = new List<SystemInfo>();
             this.PreferredRegions = preferredRegions;
             this.AggregationIntervalInSec = aggregationIntervalInSec;
-            this.MachineId = machineId;
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Telemetry/Models/ClientTelemetryProperties.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/Models/ClientTelemetryProperties.cs
@@ -2,7 +2,7 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 //------------------------------------------------------------
 
-namespace Microsoft.Azure.Cosmos.Telemetry
+namespace Microsoft.Azure.Cosmos.Telemetry.Models
 {
     using System;
     using System.Collections.Generic;
@@ -56,7 +56,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         internal List<SystemInfo> SystemInfo { get; set; }
 
         [JsonProperty(PropertyName = "cacheRefreshInfo")]
-        private List<OperationInfo> CacheRefreshInfo { get; set; }
+        internal List<CacheRefreshInfo> CacheRefreshInfo { get; set; }
 
         [JsonProperty(PropertyName = "operationInfo")]
         internal List<OperationInfo> OperationInfo { get; set; }
@@ -78,9 +78,9 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             this.ProcessId = processId;
             this.UserAgent = userAgent;
             this.ConnectionMode = connectionMode.ToString().ToUpperInvariant();
-            if (connectionMode == Microsoft.Azure.Cosmos.ConnectionMode.Direct)
+            if (connectionMode == Cosmos.ConnectionMode.Direct)
             {
-                this.IsDirectConnectionMode = true;   
+                this.IsDirectConnectionMode = true;
             }
             this.SystemInfo = new List<SystemInfo>();
             this.PreferredRegions = preferredRegions;
@@ -105,7 +105,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             bool? acceleratedNetworking,
             IReadOnlyList<string> preferredRegions,
             List<SystemInfo> systemInfo,
-            List<OperationInfo> cacheRefreshInfo,
+            List<CacheRefreshInfo> cacheRefreshInfo,
             List<OperationInfo> operationInfo,
             string machineId)
         {

--- a/Microsoft.Azure.Cosmos/src/Telemetry/Models/ClientTelemetryProperties.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/Models/ClientTelemetryProperties.cs
@@ -70,9 +70,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry.Models
                                    ConnectionMode connectionMode,
                                    IReadOnlyList<string> preferredRegions,
                                    int aggregationIntervalInSec,
-                                   string machineId,
-                                   string applicationRegion,
-                                   string hostEnvInfo)
+                                   string machineId)
         {
             this.ClientId = clientId;
             this.ProcessId = processId;
@@ -86,8 +84,6 @@ namespace Microsoft.Azure.Cosmos.Telemetry.Models
             this.PreferredRegions = preferredRegions;
             this.AggregationIntervalInSec = aggregationIntervalInSec;
             this.MachineId = machineId;
-            this.ApplicationRegion = applicationRegion;
-            this.HostEnvInfo = hostEnvInfo;
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Telemetry/Models/Compute.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/Models/Compute.cs
@@ -2,7 +2,7 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 //------------------------------------------------------------
 
-namespace Microsoft.Azure.Cosmos.Telemetry
+namespace Microsoft.Azure.Cosmos.Telemetry.Models
 {
     using System;
     using Newtonsoft.Json;
@@ -13,11 +13,11 @@ namespace Microsoft.Azure.Cosmos.Telemetry
     {
         [JsonConstructor]
         public Compute(
-            string vMId, 
-            string location, 
-            string sKU, 
-            string azEnvironment, 
-            string oSType, 
+            string vMId,
+            string location,
+            string sKU,
+            string azEnvironment,
+            string oSType,
             string vMSize)
         {
             this.Location = location;

--- a/Microsoft.Azure.Cosmos/src/Telemetry/Models/MetricInfo.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/Models/MetricInfo.cs
@@ -2,11 +2,12 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 //------------------------------------------------------------
 
-namespace Microsoft.Azure.Cosmos.Telemetry
+namespace Microsoft.Azure.Cosmos.Telemetry.Models
 {
     using System;
     using System.Collections.Generic;
     using HdrHistogram;
+    using Microsoft.Azure.Cosmos.Telemetry;
     using Microsoft.Azure.Cosmos.Util;
     using Newtonsoft.Json;
 
@@ -19,12 +20,12 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             this.UnitName = unitName;
         }
 
-        public MetricInfo(string metricsName, 
-            string unitName, 
-            double mean = 0, 
-            long count = 0, 
-            long min = 0, 
-            long max = 0, 
+        public MetricInfo(string metricsName,
+            string unitName,
+            double mean = 0,
+            long count = 0,
+            long min = 0,
+            long max = 0,
             IReadOnlyDictionary<double, double> percentiles = null)
             : this(metricsName, unitName)
         {
@@ -36,10 +37,10 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         }
 
         [JsonProperty(PropertyName = "metricsName")]
-        internal String MetricsName { get; }
+        internal string MetricsName { get; }
 
         [JsonProperty(PropertyName = "unitName")]
-        internal String UnitName { get; }
+        internal string UnitName { get; }
 
         [JsonProperty(PropertyName = "mean")]
         internal double Mean { get; set; }

--- a/Microsoft.Azure.Cosmos/src/Telemetry/Models/OperationInfo.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/Models/OperationInfo.cs
@@ -2,10 +2,11 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 //------------------------------------------------------------
 
-namespace Microsoft.Azure.Cosmos.Telemetry
+namespace Microsoft.Azure.Cosmos.Telemetry.Models
 {
     using System;
     using HdrHistogram;
+    using Microsoft.Azure.Cosmos.Telemetry;
     using Microsoft.Azure.Documents;
     using Newtonsoft.Json;
 
@@ -50,13 +51,13 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             this.MetricInfo = new MetricInfo(metricsName, unitName);
         }
 
-        internal OperationInfo(string regionsContacted, 
-            long? responseSizeInBytes,            
-            string consistency, 
-            string databaseName, 
-            string containerName, 
-            OperationType? operation, 
-            ResourceType? resource, 
+        internal OperationInfo(string regionsContacted,
+            long? responseSizeInBytes,
+            string consistency,
+            string databaseName,
+            string containerName,
+            OperationType? operation,
+            ResourceType? resource,
             int? statusCode,
             string subStatusCode,
             string cacheRefreshSource = null)
@@ -76,13 +77,13 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             this.CacheRefreshSource = cacheRefreshSource;
         }
 
-        public OperationInfo(string regionsContacted, 
-            bool? greaterThan1Kb, 
-            string databaseName, 
-            string containerName, 
-            string operation, 
-            string resource, 
-            string consistency, 
+        public OperationInfo(string regionsContacted,
+            bool? greaterThan1Kb,
+            string databaseName,
+            string containerName,
+            string operation,
+            string resource,
+            string consistency,
             int? statusCode,
             string subStatusCode,
             MetricInfo metricInfo)
@@ -116,30 +117,30 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         public override int GetHashCode()
         {
             int hash = 3;
-            hash = (hash * 7) ^ (this.RegionsContacted == null ? 0 : this.RegionsContacted.GetHashCode());
-            hash = (hash * 7) ^ (this.GreaterThan1Kb == null ? 0 : this.GreaterThan1Kb.GetHashCode());
-            hash = (hash * 7) ^ (this.Consistency == null ? 0 : this.Consistency.GetHashCode());
-            hash = (hash * 7) ^ (this.DatabaseName == null ? 0 : this.DatabaseName.GetHashCode());
-            hash = (hash * 7) ^ (this.ContainerName == null ? 0 : this.ContainerName.GetHashCode());
-            hash = (hash * 7) ^ (this.Operation == null ? 0 : this.Operation.GetHashCode());
-            hash = (hash * 7) ^ (this.Resource == null ? 0 : this.Resource.GetHashCode());
-            hash = (hash * 7) ^ (this.StatusCode == null ? 0 : this.StatusCode.GetHashCode());
-            hash = (hash * 7) ^ (this.SubStatusCode == null ? 0 : this.SubStatusCode.GetHashCode());
+            hash = hash * 7 ^ (this.RegionsContacted == null ? 0 : this.RegionsContacted.GetHashCode());
+            hash = hash * 7 ^ (this.GreaterThan1Kb == null ? 0 : this.GreaterThan1Kb.GetHashCode());
+            hash = hash * 7 ^ (this.Consistency == null ? 0 : this.Consistency.GetHashCode());
+            hash = hash * 7 ^ (this.DatabaseName == null ? 0 : this.DatabaseName.GetHashCode());
+            hash = hash * 7 ^ (this.ContainerName == null ? 0 : this.ContainerName.GetHashCode());
+            hash = hash * 7 ^ (this.Operation == null ? 0 : this.Operation.GetHashCode());
+            hash = hash * 7 ^ (this.Resource == null ? 0 : this.Resource.GetHashCode());
+            hash = hash * 7 ^ (this.StatusCode == null ? 0 : this.StatusCode.GetHashCode());
+            hash = hash * 7 ^ (this.SubStatusCode == null ? 0 : this.SubStatusCode.GetHashCode());
             return hash;
         }
 
         public override bool Equals(object obj)
         {
             bool isequal = obj is OperationInfo payload &&
-                   ((this.RegionsContacted == null && payload.RegionsContacted == null) || (this.RegionsContacted != null && payload.RegionsContacted != null && this.RegionsContacted.Equals(payload.RegionsContacted))) &&
-                   ((this.GreaterThan1Kb == null && payload.GreaterThan1Kb == null ) || (this.GreaterThan1Kb != null && payload.GreaterThan1Kb != null && this.GreaterThan1Kb.Equals(payload.GreaterThan1Kb))) &&
-                   ((this.Consistency == null && payload.Consistency == null) || (this.Consistency != null && payload.Consistency != null && this.Consistency.Equals(payload.Consistency))) &&
-                   ((this.DatabaseName == null && payload.DatabaseName == null) || (this.DatabaseName != null && payload.DatabaseName != null && this.DatabaseName.Equals(payload.DatabaseName))) &&
-                   ((this.ContainerName == null && payload.ContainerName == null) || (this.ContainerName != null && payload.ContainerName != null && this.ContainerName.Equals(payload.ContainerName))) &&
-                   ((this.Operation == null && payload.Operation == null) || (this.Operation != null && payload.Operation != null && this.Operation.Equals(payload.Operation))) &&
-                   ((this.Resource == null && payload.Resource == null) || (this.Resource != null && payload.Resource != null && this.Resource.Equals(payload.Resource))) &&
-                   ((this.StatusCode == null && payload.StatusCode == null) || (this.StatusCode != null && payload.StatusCode != null && this.StatusCode.Equals(payload.StatusCode))) &&
-                   ((this.SubStatusCode == null && payload.SubStatusCode == null) || (this.SubStatusCode != null && payload.SubStatusCode != null && this.SubStatusCode.Equals(payload.SubStatusCode)));
+                   (this.RegionsContacted == null && payload.RegionsContacted == null || this.RegionsContacted != null && payload.RegionsContacted != null && this.RegionsContacted.Equals(payload.RegionsContacted)) &&
+                   (this.GreaterThan1Kb == null && payload.GreaterThan1Kb == null || this.GreaterThan1Kb != null && payload.GreaterThan1Kb != null && this.GreaterThan1Kb.Equals(payload.GreaterThan1Kb)) &&
+                   (this.Consistency == null && payload.Consistency == null || this.Consistency != null && payload.Consistency != null && this.Consistency.Equals(payload.Consistency)) &&
+                   (this.DatabaseName == null && payload.DatabaseName == null || this.DatabaseName != null && payload.DatabaseName != null && this.DatabaseName.Equals(payload.DatabaseName)) &&
+                   (this.ContainerName == null && payload.ContainerName == null || this.ContainerName != null && payload.ContainerName != null && this.ContainerName.Equals(payload.ContainerName)) &&
+                   (this.Operation == null && payload.Operation == null || this.Operation != null && payload.Operation != null && this.Operation.Equals(payload.Operation)) &&
+                   (this.Resource == null && payload.Resource == null || this.Resource != null && payload.Resource != null && this.Resource.Equals(payload.Resource)) &&
+                   (this.StatusCode == null && payload.StatusCode == null || this.StatusCode != null && payload.StatusCode != null && this.StatusCode.Equals(payload.StatusCode)) &&
+                   (this.SubStatusCode == null && payload.SubStatusCode == null || this.SubStatusCode != null && payload.SubStatusCode != null && this.SubStatusCode.Equals(payload.SubStatusCode));
 
             return isequal;
         }

--- a/Microsoft.Azure.Cosmos/src/Telemetry/Models/OperationInfo.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/Models/OperationInfo.cs
@@ -14,31 +14,31 @@ namespace Microsoft.Azure.Cosmos.Telemetry.Models
     internal class OperationInfo
     {
         [JsonProperty(PropertyName = "regionsContacted")]
-        internal string RegionsContacted { get; set; }
+        internal string RegionsContacted { get; }
 
         [JsonProperty(PropertyName = "greaterThan1Kb")]
         internal bool? GreaterThan1Kb { get; set; }
 
         [JsonProperty(PropertyName = "databaseName")]
-        internal string DatabaseName { get; set; }
+        internal string DatabaseName { get; }
 
         [JsonProperty(PropertyName = "containerName")]
-        internal string ContainerName { get; set; }
+        internal string ContainerName { get; }
 
         [JsonProperty(PropertyName = "operation")]
-        internal string Operation { get; set; }
+        internal string Operation { get; }
 
         [JsonProperty(PropertyName = "resource")]
-        internal string Resource { get; set; }
+        internal string Resource { get; }
 
         [JsonProperty(PropertyName = "consistency")]
-        internal string Consistency { get; set; }
+        internal string Consistency { get; }
 
         [JsonProperty(PropertyName = "statusCode")]
-        public int? StatusCode { get; set; }
+        public int? StatusCode { get; }
 
         [JsonProperty(PropertyName = "subStatusCode")]
-        public int SubStatusCode { get; set; }
+        public int SubStatusCode { get; }
 
         [JsonProperty(PropertyName = "metricInfo")]
         internal MetricInfo MetricInfo { get; set; }

--- a/Microsoft.Azure.Cosmos/src/Telemetry/Models/OperationInfo.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/Models/OperationInfo.cs
@@ -11,40 +11,41 @@ namespace Microsoft.Azure.Cosmos.Telemetry.Models
     using Newtonsoft.Json;
 
     [Serializable]
-    internal sealed class OperationInfo
+    internal class OperationInfo
     {
         [JsonProperty(PropertyName = "regionsContacted")]
-        internal string RegionsContacted { get; }
+        internal string RegionsContacted { get; set; }
 
         [JsonProperty(PropertyName = "greaterThan1Kb")]
         internal bool? GreaterThan1Kb { get; set; }
 
         [JsonProperty(PropertyName = "databaseName")]
-        private string DatabaseName { get; }
+        internal string DatabaseName { get; set; }
 
         [JsonProperty(PropertyName = "containerName")]
-        private string ContainerName { get; }
+        internal string ContainerName { get; set; }
 
         [JsonProperty(PropertyName = "operation")]
-        internal string Operation { get; }
+        internal string Operation { get; set; }
 
         [JsonProperty(PropertyName = "resource")]
-        internal string Resource { get; }
+        internal string Resource { get; set; }
 
         [JsonProperty(PropertyName = "consistency")]
-        internal string Consistency { get; }
+        internal string Consistency { get; set; }
 
         [JsonProperty(PropertyName = "statusCode")]
-        public int? StatusCode { get; }
+        public int? StatusCode { get; set; }
 
         [JsonProperty(PropertyName = "subStatusCode")]
-        public string SubStatusCode { get; }
-
-        [JsonProperty(PropertyName = "cacheRefreshSource")]
-        internal string CacheRefreshSource { get; }
+        public string SubStatusCode { get; set; }
 
         [JsonProperty(PropertyName = "metricInfo")]
         internal MetricInfo MetricInfo { get; set; }
+
+        internal OperationInfo()
+        {
+        }
 
         internal OperationInfo(string metricsName, string unitName)
         {
@@ -59,8 +60,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry.Models
             OperationType? operation,
             ResourceType? resource,
             int? statusCode,
-            string subStatusCode,
-            string cacheRefreshSource = null)
+            string subStatusCode)
         {
             this.RegionsContacted = regionsContacted;
             if (responseSizeInBytes != null)
@@ -74,7 +74,6 @@ namespace Microsoft.Azure.Cosmos.Telemetry.Models
             this.Resource = resource?.ToResourceTypeString();
             this.StatusCode = statusCode;
             this.SubStatusCode = subStatusCode;
-            this.CacheRefreshSource = cacheRefreshSource;
         }
 
         public OperationInfo(string regionsContacted,

--- a/Microsoft.Azure.Cosmos/src/Telemetry/Models/OperationInfo.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/Models/OperationInfo.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry.Models
         public int? StatusCode { get; set; }
 
         [JsonProperty(PropertyName = "subStatusCode")]
-        public string SubStatusCode { get; set; }
+        public int SubStatusCode { get; set; }
 
         [JsonProperty(PropertyName = "metricInfo")]
         internal MetricInfo MetricInfo { get; set; }
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry.Models
             OperationType? operation,
             ResourceType? resource,
             int? statusCode,
-            string subStatusCode)
+            int subStatusCode)
         {
             this.RegionsContacted = regionsContacted;
             if (responseSizeInBytes != null)
@@ -84,7 +84,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry.Models
             string resource,
             string consistency,
             int? statusCode,
-            string subStatusCode,
+            int subStatusCode,
             MetricInfo metricInfo)
         {
             this.RegionsContacted = regionsContacted;
@@ -116,30 +116,30 @@ namespace Microsoft.Azure.Cosmos.Telemetry.Models
         public override int GetHashCode()
         {
             int hash = 3;
-            hash = hash * 7 ^ (this.RegionsContacted == null ? 0 : this.RegionsContacted.GetHashCode());
-            hash = hash * 7 ^ (this.GreaterThan1Kb == null ? 0 : this.GreaterThan1Kb.GetHashCode());
-            hash = hash * 7 ^ (this.Consistency == null ? 0 : this.Consistency.GetHashCode());
-            hash = hash * 7 ^ (this.DatabaseName == null ? 0 : this.DatabaseName.GetHashCode());
-            hash = hash * 7 ^ (this.ContainerName == null ? 0 : this.ContainerName.GetHashCode());
-            hash = hash * 7 ^ (this.Operation == null ? 0 : this.Operation.GetHashCode());
-            hash = hash * 7 ^ (this.Resource == null ? 0 : this.Resource.GetHashCode());
-            hash = hash * 7 ^ (this.StatusCode == null ? 0 : this.StatusCode.GetHashCode());
-            hash = hash * 7 ^ (this.SubStatusCode == null ? 0 : this.SubStatusCode.GetHashCode());
+            hash = (hash * 7) ^ (this.RegionsContacted == null ? 0 : this.RegionsContacted.GetHashCode());
+            hash = (hash * 7) ^ (this.GreaterThan1Kb == null ? 0 : this.GreaterThan1Kb.GetHashCode());
+            hash = (hash * 7) ^ (this.Consistency == null ? 0 : this.Consistency.GetHashCode());
+            hash = (hash * 7) ^ (this.DatabaseName == null ? 0 : this.DatabaseName.GetHashCode());
+            hash = (hash * 7) ^ (this.ContainerName == null ? 0 : this.ContainerName.GetHashCode());
+            hash = (hash * 7) ^ (this.Operation == null ? 0 : this.Operation.GetHashCode());
+            hash = (hash * 7) ^ (this.Resource == null ? 0 : this.Resource.GetHashCode());
+            hash = (hash * 7) ^ (this.StatusCode == null ? 0 : this.StatusCode.GetHashCode());
+            hash = (hash * 7) ^ (this.SubStatusCode.GetHashCode());
             return hash;
         }
 
         public override bool Equals(object obj)
         {
             bool isequal = obj is OperationInfo payload &&
-                   (this.RegionsContacted == null && payload.RegionsContacted == null || this.RegionsContacted != null && payload.RegionsContacted != null && this.RegionsContacted.Equals(payload.RegionsContacted)) &&
-                   (this.GreaterThan1Kb == null && payload.GreaterThan1Kb == null || this.GreaterThan1Kb != null && payload.GreaterThan1Kb != null && this.GreaterThan1Kb.Equals(payload.GreaterThan1Kb)) &&
-                   (this.Consistency == null && payload.Consistency == null || this.Consistency != null && payload.Consistency != null && this.Consistency.Equals(payload.Consistency)) &&
-                   (this.DatabaseName == null && payload.DatabaseName == null || this.DatabaseName != null && payload.DatabaseName != null && this.DatabaseName.Equals(payload.DatabaseName)) &&
-                   (this.ContainerName == null && payload.ContainerName == null || this.ContainerName != null && payload.ContainerName != null && this.ContainerName.Equals(payload.ContainerName)) &&
-                   (this.Operation == null && payload.Operation == null || this.Operation != null && payload.Operation != null && this.Operation.Equals(payload.Operation)) &&
-                   (this.Resource == null && payload.Resource == null || this.Resource != null && payload.Resource != null && this.Resource.Equals(payload.Resource)) &&
-                   (this.StatusCode == null && payload.StatusCode == null || this.StatusCode != null && payload.StatusCode != null && this.StatusCode.Equals(payload.StatusCode)) &&
-                   (this.SubStatusCode == null && payload.SubStatusCode == null || this.SubStatusCode != null && payload.SubStatusCode != null && this.SubStatusCode.Equals(payload.SubStatusCode));
+                   ((this.RegionsContacted == null && payload.RegionsContacted == null) || (this.RegionsContacted != null && payload.RegionsContacted != null && this.RegionsContacted.Equals(payload.RegionsContacted))) &&
+                   ((this.GreaterThan1Kb == null && payload.GreaterThan1Kb == null) || (this.GreaterThan1Kb != null && payload.GreaterThan1Kb != null && this.GreaterThan1Kb.Equals(payload.GreaterThan1Kb))) &&
+                   ((this.Consistency == null && payload.Consistency == null) || (this.Consistency != null && payload.Consistency != null && this.Consistency.Equals(payload.Consistency))) &&
+                   ((this.DatabaseName == null && payload.DatabaseName == null) || (this.DatabaseName != null && payload.DatabaseName != null && this.DatabaseName.Equals(payload.DatabaseName))) &&
+                   ((this.ContainerName == null && payload.ContainerName == null) || (this.ContainerName != null && payload.ContainerName != null && this.ContainerName.Equals(payload.ContainerName))) &&
+                   ((this.Operation == null && payload.Operation == null) || (this.Operation != null && payload.Operation != null && this.Operation.Equals(payload.Operation))) &&
+                   ((this.Resource == null && payload.Resource == null) || (this.Resource != null && payload.Resource != null && this.Resource.Equals(payload.Resource))) &&
+                   ((this.StatusCode == null && payload.StatusCode == null) || (this.StatusCode != null && payload.StatusCode != null && this.StatusCode.Equals(payload.StatusCode))) &&
+                   this.SubStatusCode.Equals(payload.SubStatusCode);
 
             return isequal;
         }

--- a/Microsoft.Azure.Cosmos/src/Telemetry/Models/OperationInfo.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/Models/OperationInfo.cs
@@ -43,10 +43,6 @@ namespace Microsoft.Azure.Cosmos.Telemetry.Models
         [JsonProperty(PropertyName = "metricInfo")]
         internal MetricInfo MetricInfo { get; set; }
 
-        internal OperationInfo()
-        {
-        }
-
         internal OperationInfo(string metricsName, string unitName)
         {
             this.MetricInfo = new MetricInfo(metricsName, unitName);

--- a/Microsoft.Azure.Cosmos/src/Telemetry/Models/SystemInfo.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/Models/SystemInfo.cs
@@ -2,7 +2,7 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 //------------------------------------------------------------
 
-namespace Microsoft.Azure.Cosmos.Telemetry
+namespace Microsoft.Azure.Cosmos.Telemetry.Models
 {
     using System;
     using HdrHistogram;

--- a/Microsoft.Azure.Cosmos/src/Telemetry/OpenTelemetry/OpenTelemetryCoreRecorder.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/OpenTelemetry/OpenTelemetryCoreRecorder.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
 
                 if (response.Diagnostics != null)
                 {
-                    this.scope.AddAttribute(OpenTelemetryAttributeKeys.Region, ClientTelemetryHelper.GetContactedRegions(response.Diagnostics) ?? OpenTelemetryAttributes.NotAvailable);
+                    this.scope.AddAttribute(OpenTelemetryAttributeKeys.Region, ClientTelemetryHelper.GetContactedRegions(response.Diagnostics.GetContactedRegions()) ?? OpenTelemetryAttributes.NotAvailable);
                     CosmosDbEventSource.RecordDiagnosticsForRequests(this.config, response);
                 }
                 else

--- a/Microsoft.Azure.Cosmos/src/Telemetry/OperationInfo.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/OperationInfo.cs
@@ -39,6 +39,9 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         [JsonProperty(PropertyName = "subStatusCode")]
         public string SubStatusCode { get; }
 
+        [JsonProperty(PropertyName = "cacheRefreshSource")]
+        internal string CacheRefreshSource { get; }
+
         [JsonProperty(PropertyName = "metricInfo")]
         internal MetricInfo MetricInfo { get; set; }
 
@@ -55,7 +58,8 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             OperationType? operation, 
             ResourceType? resource, 
             int? statusCode,
-            string subStatusCode)
+            string subStatusCode,
+            string cacheRefreshSource = null)
         {
             this.RegionsContacted = regionsContacted;
             if (responseSizeInBytes != null)
@@ -69,6 +73,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             this.Resource = resource?.ToResourceTypeString();
             this.StatusCode = statusCode;
             this.SubStatusCode = subStatusCode;
+            this.CacheRefreshSource = cacheRefreshSource;
         }
 
         public OperationInfo(string regionsContacted, 

--- a/Microsoft.Azure.Cosmos/src/Telemetry/TelemetrySystemUsage.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/TelemetrySystemUsage.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
     using System;
     using System.Collections.Generic;
     using HdrHistogram;
+    using Microsoft.Azure.Cosmos.Telemetry.Models;
     using Microsoft.Azure.Documents.Rntbd;
 
     /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Telemetry/VmMetadataApiHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/VmMetadataApiHandler.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
     using System.Text;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Core.Trace;
+    using Microsoft.Azure.Cosmos.Telemetry.Models;
     using Microsoft.Azure.Documents;
     using Newtonsoft.Json.Linq;
     using Util;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
@@ -803,6 +803,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             while (localCopyOfActualInfo == null);
 
             List<OperationInfo> actualOperationList = new List<OperationInfo>();
+            List<CacheRefreshInfo> actualCacheRefreshInfoList = new List<CacheRefreshInfo>();
             List<SystemInfo> actualSystemInformation = new List<SystemInfo>();
 
             if (localCopyOfActualInfo[0].ConnectionMode == ConnectionMode.Direct.ToString().ToUpperInvariant())

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
     using System.Globalization;
     using System.Linq;
     using Cosmos.Util;
+    using Microsoft.Azure.Cosmos.Telemetry.Models;
 
     [TestClass]
     public class ClientTelemetryTests : BaseCosmosClientHelper

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
@@ -24,7 +24,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
     using System.Linq;
     using Cosmos.Util;
     using Microsoft.Azure.Cosmos.Telemetry.Models;
-    using global::Azure;
 
     [TestClass]
     public class ClientTelemetryTests : BaseCosmosClientHelper
@@ -72,8 +71,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                         HttpResponseMessage result = new HttpResponseMessage(HttpStatusCode.OK);
 
                         string jsonObject = request.Content.ReadAsStringAsync().GetAwaiter().GetResult();
-
-                        Console.WriteLine(jsonObject);
                         lock (this.actualInfo)
                         {
                             this.actualInfo.Add(JsonConvert.DeserializeObject<ClientTelemetryProperties>(jsonObject));

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
@@ -797,7 +797,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                         break;
                     }
 
-                    Assert.IsTrue(stopwatch.Elapsed.TotalMinutes < 1, $"The expected operation count({expectedOperationCount}) was never hit, Actual Operation Count is {actualOperationSet.Count}.  ActualInfo:{JsonConvert.SerializeObject(this.actualInfo)}");
+                    Assert.IsTrue(stopwatch.Elapsed.TotalSeconds < 10, $"The expected operation count({expectedOperationCount}) was never hit, Actual Operation Count is {actualOperationSet.Count}.  ActualInfo:{JsonConvert.SerializeObject(this.actualInfo)}");
                 }
             }
             while (localCopyOfActualInfo == null);
@@ -902,7 +902,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             if (expectedOperationRecordCountMap != null)
             {
-                Assert.IsTrue(expectedOperationRecordCountMap.EqualsTo<string,long>(actualOperationRecordCountMap), $"actual record i.e. ({actualOperationRecordCountMap}) for operation does not match with expected record i.e. ({expectedOperationRecordCountMap})");
+                    Assert.IsTrue(expectedOperationRecordCountMap.EqualsTo<string,long>(actualOperationRecordCountMap), $"actual record i.e. ({actualOperationRecordCountMap}) for operation does not match with expected record i.e. ({expectedOperationRecordCountMap})");
             }
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                         HttpResponseMessage result = new HttpResponseMessage(HttpStatusCode.OK);
 
                         string jsonObject = request.Content.ReadAsStringAsync().GetAwaiter().GetResult();
-                        Console.WriteLine(jsonObject);
+
                         lock (this.actualInfo)
                         {
                             this.actualInfo.Add(JsonConvert.DeserializeObject<ClientTelemetryProperties>(jsonObject));

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
@@ -10,7 +10,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
     using System.Threading.Tasks;
     using System.Net;
     using System.Net.Http;
-    using System.Diagnostics;
     using System.Reflection;
     using Microsoft.Azure.Cosmos.Fluent;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -784,11 +783,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     // Setting the number of unique OperationInfo irrespective of response size as response size is varying in case of queries.
                     this.actualInfo
                         .ForEach(x => x.OperationInfo
-                                       .ForEach(y =>
-                                       {
-                                           y.GreaterThan1Kb = false;
-                                           actualOperationSet.Add(y);
-                                       }));
+                                .ForEach(y =>
+                                {
+                                    y.GreaterThan1Kb = false;
+                                    actualOperationSet.Add(y);
+                                }));
 
                     if (actualOperationSet.Count == expectedOperationCount / 2)
                     {
@@ -797,13 +796,12 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                         break;
                     }
 
-                    Assert.IsTrue(stopwatch.Elapsed.TotalSeconds < 10, $"The expected operation count({expectedOperationCount}) was never hit, Actual Operation Count is {actualOperationSet.Count}.  ActualInfo:{JsonConvert.SerializeObject(this.actualInfo)}");
+                    Assert.IsTrue(stopwatch.Elapsed.TotalMinutes < 1, $"The expected operation count({expectedOperationCount}) was never hit, Actual Operation Count is {actualOperationSet.Count}.  ActualInfo:{JsonConvert.SerializeObject(this.actualInfo)}");
                 }
             }
             while (localCopyOfActualInfo == null);
 
             List<OperationInfo> actualOperationList = new List<OperationInfo>();
-            List<CacheRefreshInfo> actualCacheRefreshInfoList = new List<CacheRefreshInfo>();
             List<SystemInfo> actualSystemInformation = new List<SystemInfo>();
 
             if (localCopyOfActualInfo[0].ConnectionMode == ConnectionMode.Direct.ToString().ToUpperInvariant())

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
@@ -71,6 +71,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                         HttpResponseMessage result = new HttpResponseMessage(HttpStatusCode.OK);
 
                         string jsonObject = request.Content.ReadAsStringAsync().GetAwaiter().GetResult();
+                        Console.WriteLine(jsonObject);
                         lock (this.actualInfo)
                         {
                             this.actualInfo.Add(JsonConvert.DeserializeObject<ClientTelemetryProperties>(jsonObject));

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
@@ -987,7 +987,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Assert.IsNotNull(cacheRefreshInfo.StatusCode, "StatusCode is null");
                 Assert.IsNotNull(cacheRefreshInfo.SubStatusCode);
                 Assert.IsNull(cacheRefreshInfo.Consistency);
-
+                Assert.IsNotNull(cacheRefreshInfo.ContainerName, "ContainerName is null");
                 Assert.IsNotNull(cacheRefreshInfo.MetricInfo, "MetricInfo is null");
                 Assert.IsNotNull(cacheRefreshInfo.MetricInfo.MetricsName, "MetricsName is null");
                 Assert.IsNotNull(cacheRefreshInfo.MetricInfo.UnitName, "UnitName is null");

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Benchmarks/RegionContactedInDiagnosticsBenchmark.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Benchmarks/RegionContactedInDiagnosticsBenchmark.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Azure.Cosmos.Performance.Tests.Benchmarks
                 throw new ArgumentNullException(nameof(cosmosDiagnostics));
             }
 
-            ClientTelemetryHelper.GetContactedRegions(cosmosDiagnostics);
+            ClientTelemetryHelper.GetContactedRegions(cosmosDiagnostics.GetContactedRegions());
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Mocks/MockDocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Mocks/MockDocumentClient.cs
@@ -153,7 +153,7 @@ namespace Microsoft.Azure.Cosmos.Performance.Tests
 
         private void Init()
         {
-            this.collectionCache = new Mock<ClientCollectionCache>(null, new ServerStoreModel(null), null, null);
+            this.collectionCache = new Mock<ClientCollectionCache>(null, new ServerStoreModel(null), null, null, null);
 
             ContainerProperties containerProperties = ContainerProperties.CreateWithResourceId("test");
             containerProperties.PartitionKey = partitionKeyDefinition;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ClientTelemetryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ClientTelemetryTests.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Azure.Cosmos.Tests
     using Microsoft.Azure.Cosmos.Telemetry;
     using System.Collections.Generic;
     using System.Xml.Serialization;
+    using Microsoft.Azure.Cosmos.Telemetry.Models;
 
     /// <summary>
     /// Tests for <see cref="ClientTelemetry"/>.

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ClientTelemetryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ClientTelemetryTests.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         [TestMethod]
         public void CheckJsonSerializerContract()
         {
-            string json = JsonConvert.SerializeObject(new ClientTelemetryProperties("clientId", "", null, ConnectionMode.Direct, null, 10), ClientTelemetryOptions.JsonSerializerSettings);
+            string json = JsonConvert.SerializeObject(new ClientTelemetryProperties("clientId", "", null, ConnectionMode.Direct, null, 10, null, null, null), ClientTelemetryOptions.JsonSerializerSettings);
             Assert.AreEqual("{\"clientId\":\"clientId\",\"processId\":\"\",\"connectionMode\":\"DIRECT\",\"aggregationIntervalInSec\":10,\"systemInfo\":[]}", json);
         }
 
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             {
                 "region1"
             };
-            string json = JsonConvert.SerializeObject(new ClientTelemetryProperties("clientId", "", null, ConnectionMode.Direct, preferredRegion, 1), ClientTelemetryOptions.JsonSerializerSettings);
+            string json = JsonConvert.SerializeObject(new ClientTelemetryProperties("clientId", "", null, ConnectionMode.Direct, preferredRegion, 1, null, null, null), ClientTelemetryOptions.JsonSerializerSettings);
             Assert.AreEqual("{\"clientId\":\"clientId\",\"processId\":\"\",\"connectionMode\":\"DIRECT\",\"preferredRegions\":[\"region1\"],\"aggregationIntervalInSec\":1,\"systemInfo\":[]}", json);
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ClientTelemetryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ClientTelemetryTests.cs
@@ -5,16 +5,11 @@
 namespace Microsoft.Azure.Cosmos.Tests
 {
     using System;
-    using System.Net;
-    using System.Text;
-    using System.Threading.Tasks;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using HdrHistogram;
-    using System.Net.Http;
     using Newtonsoft.Json;
     using Microsoft.Azure.Cosmos.Telemetry;
     using System.Collections.Generic;
-    using System.Xml.Serialization;
     using Microsoft.Azure.Cosmos.Telemetry.Models;
 
     /// <summary>
@@ -90,7 +85,12 @@ namespace Microsoft.Azure.Cosmos.Tests
         [TestMethod]
         public void CheckJsonSerializerContract()
         {
-            string json = JsonConvert.SerializeObject(new ClientTelemetryProperties("clientId", "", null, ConnectionMode.Direct, null, 10, null), ClientTelemetryOptions.JsonSerializerSettings);
+            string json = JsonConvert.SerializeObject(new ClientTelemetryProperties(clientId: "clientId", 
+                processId: "", 
+                userAgent: null, 
+                connectionMode: ConnectionMode.Direct, 
+                preferredRegions: null, 
+                aggregationIntervalInSec: 10), ClientTelemetryOptions.JsonSerializerSettings);
             Assert.AreEqual("{\"clientId\":\"clientId\",\"processId\":\"\",\"connectionMode\":\"DIRECT\",\"aggregationIntervalInSec\":10,\"systemInfo\":[]}", json);
         }
 
@@ -101,7 +101,12 @@ namespace Microsoft.Azure.Cosmos.Tests
             {
                 "region1"
             };
-            string json = JsonConvert.SerializeObject(new ClientTelemetryProperties("clientId", "", null, ConnectionMode.Direct, preferredRegion, 1, null), ClientTelemetryOptions.JsonSerializerSettings);
+            string json = JsonConvert.SerializeObject(new ClientTelemetryProperties(clientId: "clientId", 
+                processId: "", 
+                userAgent: null, 
+                connectionMode: ConnectionMode.Direct, 
+                preferredRegions: preferredRegion,
+                aggregationIntervalInSec: 1), ClientTelemetryOptions.JsonSerializerSettings);
             Assert.AreEqual("{\"clientId\":\"clientId\",\"processId\":\"\",\"connectionMode\":\"DIRECT\",\"preferredRegions\":[\"region1\"],\"aggregationIntervalInSec\":1,\"systemInfo\":[]}", json);
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ClientTelemetryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ClientTelemetryTests.cs
@@ -90,7 +90,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         [TestMethod]
         public void CheckJsonSerializerContract()
         {
-            string json = JsonConvert.SerializeObject(new ClientTelemetryProperties("clientId", "", null, ConnectionMode.Direct, null, 10, null, null, null), ClientTelemetryOptions.JsonSerializerSettings);
+            string json = JsonConvert.SerializeObject(new ClientTelemetryProperties("clientId", "", null, ConnectionMode.Direct, null, 10, null), ClientTelemetryOptions.JsonSerializerSettings);
             Assert.AreEqual("{\"clientId\":\"clientId\",\"processId\":\"\",\"connectionMode\":\"DIRECT\",\"aggregationIntervalInSec\":10,\"systemInfo\":[]}", json);
         }
 
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             {
                 "region1"
             };
-            string json = JsonConvert.SerializeObject(new ClientTelemetryProperties("clientId", "", null, ConnectionMode.Direct, preferredRegion, 1, null, null, null), ClientTelemetryOptions.JsonSerializerSettings);
+            string json = JsonConvert.SerializeObject(new ClientTelemetryProperties("clientId", "", null, ConnectionMode.Direct, preferredRegion, 1, null), ClientTelemetryOptions.JsonSerializerSettings);
             Assert.AreEqual("{\"clientId\":\"clientId\",\"processId\":\"\",\"connectionMode\":\"DIRECT\",\"preferredRegions\":[\"region1\"],\"aggregationIntervalInSec\":1,\"systemInfo\":[]}", json);
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
@@ -505,7 +505,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                     authKeyOrResourceToken: MockCosmosUtil.RandomInvalidCorrectlyFormatedAuthKey)
                     .WithApplicationRegion(notAValidAzureRegion);
 
-                ArgumentException argumentException = Assert.ThrowsException<ArgumentException>(() => cosmosClientBuilder.Build(new MockDocumentClient()));
+                ArgumentException argumentException = Assert.ThrowsException<ArgumentException>(() => cosmosClientBuilder.Build());
 
                 Assert.IsTrue(argumentException.Message.Contains(notAValidAzureRegion), $"Expected error message to contain {notAValidAzureRegion} but got: {argumentException.Message}");
             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GatewayStoreModelTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GatewayStoreModelTest.cs
@@ -212,7 +212,7 @@ namespace Microsoft.Azure.Cosmos
                            ConsistencyLevel.Session,
                            new Mock<ISessionContainer>().Object,
                            partitionKeyRangeCache: new Mock<PartitionKeyRangeCache>(null, null, null).Object,
-                           clientCollectionCache: new Mock<ClientCollectionCache>(new SessionContainer("testhost"), gatewayStoreModel, null, null).Object,
+                           clientCollectionCache: new Mock<ClientCollectionCache>(new SessionContainer("testhost"), gatewayStoreModel, null, null, null).Object,
                            globalEndpointManager: Mock.Of<IGlobalEndpointManager>());
 
                         Assert.IsNull(dsr.Headers[HttpConstants.HttpHeaders.SessionToken]);
@@ -239,7 +239,7 @@ namespace Microsoft.Azure.Cosmos
                     ConsistencyLevel.Session,
                     new Mock<ISessionContainer>().Object,
                     partitionKeyRangeCache: new Mock<PartitionKeyRangeCache>(null, null, null).Object,
-                    clientCollectionCache: new Mock<ClientCollectionCache>(new SessionContainer("testhost"), gatewayStoreModel, null, null).Object,
+                    clientCollectionCache: new Mock<ClientCollectionCache>(new SessionContainer("testhost"), gatewayStoreModel, null, null, null).Object,
                     globalEndpointManager: Mock.Of<IGlobalEndpointManager>());
 
                 Assert.IsNull(dsrQueryPlan.Headers[HttpConstants.HttpHeaders.SessionToken]);
@@ -293,7 +293,7 @@ namespace Microsoft.Azure.Cosmos
                                 ConsistencyLevel.Session,
                                 new Mock<ISessionContainer>().Object,
                                 partitionKeyRangeCache: new Mock<PartitionKeyRangeCache>(null, null, null).Object,
-                                clientCollectionCache: new Mock<ClientCollectionCache>(new SessionContainer("testhost"), gatewayStoreModel, null, null).Object,
+                                clientCollectionCache: new Mock<ClientCollectionCache>(new SessionContainer("testhost"), gatewayStoreModel, null, null, null).Object,
                                 globalEndpointManager: Mock.Of<IGlobalEndpointManager>());
 
                             Assert.AreEqual(dsrSessionToken, dsr.Headers[HttpConstants.HttpHeaders.SessionToken]);
@@ -323,7 +323,7 @@ namespace Microsoft.Azure.Cosmos
                                 ConsistencyLevel.Session,
                                 sessionContainer,
                                 partitionKeyRangeCache: new Mock<PartitionKeyRangeCache>(null, null, null).Object,
-                                clientCollectionCache: new Mock<ClientCollectionCache>(new SessionContainer("testhost"), gatewayStoreModel, null, null).Object,
+                                clientCollectionCache: new Mock<ClientCollectionCache>(new SessionContainer("testhost"), gatewayStoreModel, null, null, null).Object,
                                 globalEndpointManager: globalEndpointManager.Object);
 
                             if (dsrNoSessionToken.IsReadOnlyRequest || dsrNoSessionToken.OperationType == OperationType.Batch || multiMaster)
@@ -411,7 +411,7 @@ namespace Microsoft.Azure.Cosmos
                     ConsistencyLevel.Session,
                     new Mock<ISessionContainer>().Object,
                     partitionKeyRangeCache: new Mock<PartitionKeyRangeCache>(null, null, null).Object,
-                    clientCollectionCache: new Mock<ClientCollectionCache>(new SessionContainer("testhost"), gatewayStoreModel, null, null).Object,
+                    clientCollectionCache: new Mock<ClientCollectionCache>(new SessionContainer("testhost"), gatewayStoreModel, null, null, null).Object,
                     globalEndpointManager: Mock.Of<IGlobalEndpointManager>());
 
                 Assert.AreEqual(sessionToken, dsrSprocExecute.Headers[HttpConstants.HttpHeaders.SessionToken]);
@@ -450,7 +450,7 @@ namespace Microsoft.Azure.Cosmos
                     ConsistencyLevel.Session,
                     sessionContainer,
                     partitionKeyRangeCache: new Mock<PartitionKeyRangeCache>(null, null, null).Object,
-                    clientCollectionCache: new Mock<ClientCollectionCache>(new SessionContainer("testhost"), gatewayStoreModel, null, null).Object,
+                    clientCollectionCache: new Mock<ClientCollectionCache>(new SessionContainer("testhost"), gatewayStoreModel, null, null, null).Object,
                     globalEndpointManager: globalEndpointManager.Object);
 
                 if (isWriteRequest && multiMaster)
@@ -903,7 +903,7 @@ namespace Microsoft.Azure.Cosmos
                 eventSource,
                 null,
                 MockCosmosUtil.CreateCosmosHttpClient(() => new HttpClient()));
-            Mock<ClientCollectionCache> clientCollectionCache = new Mock<ClientCollectionCache>(new SessionContainer("testhost"), storeModel, null, null);
+            Mock<ClientCollectionCache> clientCollectionCache = new Mock<ClientCollectionCache>(new SessionContainer("testhost"), storeModel, null, null, null);
             Mock<PartitionKeyRangeCache> partitionKeyRangeCache = new Mock<PartitionKeyRangeCache>(null, storeModel, clientCollectionCache.Object);
 
             sessionContainer.SetSessionToken(
@@ -998,7 +998,7 @@ namespace Microsoft.Azure.Cosmos
                 null,
                 MockCosmosUtil.CreateCosmosHttpClient(() => new HttpClient(messageHandler)));
 
-            Mock<ClientCollectionCache> clientCollectionCache = new Mock<ClientCollectionCache>(new SessionContainer("testhost"), storeModel, null, null);
+            Mock<ClientCollectionCache> clientCollectionCache = new Mock<ClientCollectionCache>(new SessionContainer("testhost"), storeModel, null, null, null);
 
             Mock<PartitionKeyRangeCache> partitionKeyRangeCache = new Mock<PartitionKeyRangeCache>(null, storeModel, clientCollectionCache.Object);
             storeModel.SetCaches(partitionKeyRangeCache.Object, clientCollectionCache.Object);
@@ -1069,7 +1069,7 @@ namespace Microsoft.Azure.Cosmos
                     ConsistencyLevel.Session,
                     sessionContainer,
                     partitionKeyRangeCache: new Mock<PartitionKeyRangeCache>(null, null, null).Object,
-                    clientCollectionCache: new Mock<ClientCollectionCache>(sessionContainer, gatewayStoreModel, null, null).Object,
+                    clientCollectionCache: new Mock<ClientCollectionCache>(sessionContainer, gatewayStoreModel, null, null, null).Object,
                     globalEndpointManager: globalEndpointManager.Object);
 
                 Assert.AreEqual($"{childPKRangeId}:{parentSession}", documentServiceRequestToChild.Headers[HttpConstants.HttpHeaders.SessionToken]);
@@ -1135,7 +1135,7 @@ namespace Microsoft.Azure.Cosmos
                     ConsistencyLevel.Session,
                     sessionContainer,
                     partitionKeyRangeCache: new Mock<PartitionKeyRangeCache>(null, null, null).Object,
-                    clientCollectionCache: new Mock<ClientCollectionCache>(sessionContainer, gatewayStoreModel, null, null).Object,
+                    clientCollectionCache: new Mock<ClientCollectionCache>(sessionContainer, gatewayStoreModel, null, null, null).Object,
                     globalEndpointManager: globalEndpointManager.Object);
 
                 Assert.AreEqual($"{childPKRangeId}:{tokenWithAllMax}", documentServiceRequestToChild.Headers[HttpConstants.HttpHeaders.SessionToken]);
@@ -1204,7 +1204,7 @@ namespace Microsoft.Azure.Cosmos
                 null,
                 MockCosmosUtil.CreateCosmosHttpClient(() => new HttpClient(httpMessageHandler)));
 
-            ClientCollectionCache clientCollectionCache = new Mock<ClientCollectionCache>(new SessionContainer("testhost"), storeModel, null, null).Object;
+            ClientCollectionCache clientCollectionCache = new Mock<ClientCollectionCache>(new SessionContainer("testhost"), storeModel, null, null, null).Object;
             PartitionKeyRangeCache partitionKeyRangeCache = new Mock<PartitionKeyRangeCache>(null, storeModel, clientCollectionCache).Object;
             storeModel.SetCaches(partitionKeyRangeCache, clientCollectionCache);
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/HandlerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/HandlerTests.cs
@@ -52,8 +52,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         [TestMethod]
         public void HandlerOrderIfTelemetryIsEnabled()
         {
-            Environment.SetEnvironmentVariable(ClientTelemetryOptions.EnvPropsClientTelemetryEnabled, "true");
-            using CosmosClient client = MockCosmosUtil.CreateMockCosmosClient();
+            using CosmosClient client = MockCosmosUtil.CreateMockCosmosClient(enableTelemetry: true);
 
             Type[] types = new Type[]
             {
@@ -67,12 +66,10 @@ namespace Microsoft.Azure.Cosmos.Tests
             RequestHandler handler = client.RequestHandler;
             foreach (Type type in types)
             {
-                Assert.IsTrue(type.Equals(handler.GetType()));
+                Assert.IsTrue(type.Equals(handler.GetType()), $"{type} is not equal to {handler.GetType()}");
                 handler = handler.InnerHandler;
             }
             Assert.IsNull(handler);
-
-            Environment.SetEnvironmentVariable(ClientTelemetryOptions.EnvPropsClientTelemetryEnabled, null);
         }
 
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Tracing/ContactedRegionsTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Tracing/ContactedRegionsTests.cs
@@ -71,7 +71,7 @@
         {
             CosmosDiagnostics diagnostics = new CosmosTraceDiagnostics(this.CreateTestTraceTree());
 
-            string regionsContacted  = ClientTelemetryHelper.GetContactedRegions(diagnostics);            
+            string regionsContacted  = ClientTelemetryHelper.GetContactedRegions(diagnostics.GetContactedRegions());            
             Assert.IsNotNull(regionsContacted);
             Assert.AreEqual("Central US,Central India,East US 2,France Central", regionsContacted);
             
@@ -91,7 +91,7 @@
            
             CosmosDiagnostics diagnostics = new CosmosTraceDiagnostics(trace);
 
-            string regionsContacted = ClientTelemetryHelper.GetContactedRegions(diagnostics);
+            string regionsContacted = ClientTelemetryHelper.GetContactedRegions(diagnostics.GetContactedRegions());
             Assert.IsNotNull(regionsContacted);
             Assert.AreEqual("France Central", regionsContacted);
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Utils/MockCosmosUtil.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Utils/MockCosmosUtil.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Azure.Cosmos.Tests
     using Microsoft.Azure.Cosmos;
     using Microsoft.Azure.Cosmos.Fluent;
     using Microsoft.Azure.Cosmos.Routing;
+    using Microsoft.Azure.Cosmos.Telemetry;
     using Microsoft.Azure.Cosmos.Tracing;
     using Microsoft.Azure.Documents;
     using Microsoft.Azure.Documents.Collections;
@@ -38,6 +39,8 @@ namespace Microsoft.Azure.Cosmos.Tests
             customizeClientBuilder?.Invoke(cosmosClientBuilder);
             if(enableTelemetry)
             {
+                documentClient.clientTelemetry = new Mock<ClientTelemetry>().Object;
+
                 cosmosClientBuilder.WithTelemetryEnabled();
             }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Utils/MockDocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Utils/MockDocumentClient.cs
@@ -161,7 +161,7 @@ JsonConvert.DeserializeObject<Dictionary<string, object>>("{\"maxSqlQueryInputLe
 
         private void Init()
         {
-            this.collectionCache = new Mock<ClientCollectionCache>(new SessionContainer("testhost"), new ServerStoreModel(null), null, null);
+            this.collectionCache = new Mock<ClientCollectionCache>(new SessionContainer("testhost"), new ServerStoreModel(null), null, null, null);
             const string pkPath = "/pk";
             this.collectionCache.Setup
                     (m =>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/VmMetadataApiHandlerTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/VmMetadataApiHandlerTest.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Azure.Cosmos
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Core.Trace;
     using Microsoft.Azure.Cosmos.Telemetry;
+    using Microsoft.Azure.Cosmos.Telemetry.Models;
     using Microsoft.Azure.Cosmos.Tests;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Moq;


### PR DESCRIPTION
## Description

As part of this PR following changes have been made:
1. Added _"Collection Read information"_ from `ClientCollectionCache`. Client Telemetry Payload will have this section. Backend service already support this.
![image](https://user-images.githubusercontent.com/6362382/195128401-c622c64c-9787-4332-81ac-60a8c06b9e2e.png)
2. Change type of SubStatusCode from `string` to `integer`
3. Refactored Code to initializing/Running Client Telemetry Job during `DocumentClient` initialization instead of `ClientContextCore`
4. Moved all the Client Telemetry Models into a new folder i.e. Models

## Type of change
- [] New feature (non-breaking change which adds functionality)