### PR TITLE
PartitionKey: Fixes NullRef in toString handling for None for PartitionKey.ToString()

### DIFF
--- a/Microsoft.Azure.Cosmos/src/FeedRange/FeedRanges/FeedRangePartitionKey.cs
+++ b/Microsoft.Azure.Cosmos/src/FeedRange/FeedRanges/FeedRangePartitionKey.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Azure.Cosmos
         {
             if (this.PartitionKey.IsNone)
             {
-                return "None";
+                return PartitionKey.NoneString;
             }
 
             return this.PartitionKey.InternalKey.ToJsonString();

--- a/Microsoft.Azure.Cosmos/src/PartitionKey.cs
+++ b/Microsoft.Azure.Cosmos/src/PartitionKey.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// String representation of None for use when representing Partition Key as none.
         /// </summary>
-        private const string NoneString = "None";
+        internal const string NoneString = "None";
 
         /// <summary>
         /// Creates a new partition key value.

--- a/Microsoft.Azure.Cosmos/src/PartitionKey.cs
+++ b/Microsoft.Azure.Cosmos/src/PartitionKey.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.Azure.Cosmos
 {
     using System;
+    using System.Runtime.CompilerServices;
     using Microsoft.Azure.Documents.Routing;
 
     /// <summary>
@@ -47,6 +48,11 @@ namespace Microsoft.Azure.Cosmos
         /// Gets the boolean to verify partitionKey is None.
         /// </summary>
         internal bool IsNone { get; }
+
+        /// <summary>
+        /// String representation of None for use when representing Partition Key as none.
+        /// </summary>
+        private const string NoneString = "None";
 
         /// <summary>
         /// Creates a new partition key value.
@@ -175,7 +181,7 @@ namespace Microsoft.Azure.Cosmos
         {
             if (this.IsNone)
             {
-                return "None";
+                return NoneString;
             }
             
             if (this.InternalKey == null)

--- a/Microsoft.Azure.Cosmos/src/PartitionKey.cs
+++ b/Microsoft.Azure.Cosmos/src/PartitionKey.cs
@@ -4,7 +4,6 @@
 namespace Microsoft.Azure.Cosmos
 {
     using System;
-    using System.Runtime.CompilerServices;
     using Microsoft.Azure.Documents.Routing;
 
     /// <summary>

--- a/Microsoft.Azure.Cosmos/src/PartitionKey.cs
+++ b/Microsoft.Azure.Cosmos/src/PartitionKey.cs
@@ -173,6 +173,11 @@ namespace Microsoft.Azure.Cosmos
         /// <returns>The string representation of the partition key value</returns>
         public override string ToString()
         {
+            if (this.IsNone)
+            {
+                return "None";
+            }
+            
             if (this.InternalKey == null)
             {
                 return PartitionKey.NullPartitionKeyInternal.ToJsonString();

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyTests.cs
@@ -89,6 +89,15 @@ namespace Microsoft.Azure.Cosmos.Tests
         }
 
         [TestMethod]
+        public void NoneToStringNotNullRef()
+        {
+            const string noneString = "None";
+            Cosmos.PartitionKey noneKey = Cosmos.PartitionKey.None;
+
+            Assert.AreEqual(noneString, noneKey.ToString());
+        }
+
+        [TestMethod]
         public void RoundTripTests()
         {
             Cosmos.PartitionKey[] partitionKeys = new Cosmos.PartitionKey[]


### PR DESCRIPTION
# Pull Request Template

## Description

Missing ToString() handling for PartitionKey.None results in NullRef Exception as opposed to more useful content.  Breaks some logging scenarios.  Identified by @ray2k.

This bugfix is similar to the one merged from: #3480 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Closing issues
