### PR TITLE
[Internal] Query: Fixes DocumentClient to update QueryPartitionProvider with configuration changes

### DIFF
--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -6362,7 +6362,10 @@ namespace Microsoft.Azure.Cosmos
                                                                                                clientSideRequestStatistics: null);
                 this.UseMultipleWriteLocations = this.ConnectionPolicy.UseMultipleWriteLocations && databaseAccount.EnableMultipleWriteLocations;
 
-                (await this.QueryPartitionProvider).Update(databaseAccount.QueryEngineConfiguration);
+                if (this.queryPartitionProvider.IsValueCreated)
+                {
+                    (await this.QueryPartitionProvider).Update(databaseAccount.QueryEngineConfiguration);
+                }
 
                 return databaseAccount;
             }

--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -6361,6 +6361,9 @@ namespace Microsoft.Azure.Cosmos
                 AccountProperties databaseAccount = await gatewayModel.GetDatabaseAccountAsync(CreateRequestMessage,
                                                                                                clientSideRequestStatistics: null);
                 this.UseMultipleWriteLocations = this.ConnectionPolicy.UseMultipleWriteLocations && databaseAccount.EnableMultipleWriteLocations;
+
+                (await this.QueryPartitionProvider).Update(databaseAccount.QueryEngineConfiguration);
+
                 return databaseAccount;
             }
 

--- a/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryPartitionProvider.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryPartitionProvider.cs
@@ -88,7 +88,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
                 {
                     string newConfiguration = JsonConvert.SerializeObject(queryengineConfiguration);
 
-                    if (!String.Equals(this.queryengineConfiguration, newConfiguration))
+                    if (!string.Equals(this.queryengineConfiguration, newConfiguration))
                     {
                         this.queryengineConfiguration = newConfiguration;
 

--- a/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryPartitionProvider.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryPartitionProvider.cs
@@ -86,16 +86,21 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
             {
                 lock (this.serviceProviderStateLock)
                 {
-                    this.queryengineConfiguration = JsonConvert.SerializeObject(queryengineConfiguration);
+                    string newConfiguration = JsonConvert.SerializeObject(queryengineConfiguration);
 
-                    if (!this.disposed && this.serviceProvider != IntPtr.Zero)
+                    if (!String.Equals(this.queryengineConfiguration, newConfiguration))
                     {
-                        uint errorCode = ServiceInteropWrapper.UpdateServiceProvider(
-                            this.serviceProvider,
-                            this.queryengineConfiguration);
+                        this.queryengineConfiguration = newConfiguration;
 
-                        Exception exception = Marshal.GetExceptionForHR((int)errorCode);
-                        if (exception != null) throw exception;
+                        if (!this.disposed && this.serviceProvider != IntPtr.Zero)
+                        {
+                            uint errorCode = ServiceInteropWrapper.UpdateServiceProvider(
+                                this.serviceProvider,
+                                this.queryengineConfiguration);
+
+                            Exception exception = Marshal.GetExceptionForHR((int)errorCode);
+                            if (exception != null) throw exception;
+                        }
                     }
                 }
             }

--- a/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryPartitionProvider.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryPartitionProvider.cs
@@ -360,18 +360,16 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
 
             if (disposing)
             {
-                // Free managed objects
-            }
-
-            lock (this.serviceProviderStateLock)
-            {
-                if (this.serviceProvider != IntPtr.Zero)
+                lock (this.serviceProviderStateLock)
                 {
-                    Marshal.Release(this.serviceProvider);
-                    this.serviceProvider = IntPtr.Zero;
-                }
+                    if (this.serviceProvider != IntPtr.Zero)
+                    {
+                        Marshal.Release(this.serviceProvider);
+                        this.serviceProvider = IntPtr.Zero;
+                    }
 
-                this.disposed = true;
+                    this.disposed = true;
+                }
             }
         }
     }

--- a/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryPartitionProvider.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryPartitionProvider.cs
@@ -360,16 +360,18 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
 
             if (disposing)
             {
-                lock (this.serviceProviderStateLock)
-                {
-                    if (this.serviceProvider != IntPtr.Zero)
-                    {
-                        Marshal.Release(this.serviceProvider);
-                        this.serviceProvider = IntPtr.Zero;
-                    }
+                // Free managed objects
+            }
 
-                    this.disposed = true;
+            lock (this.serviceProviderStateLock)
+            {
+                if (this.serviceProvider != IntPtr.Zero)
+                {
+                    Marshal.Release(this.serviceProvider);
+                    this.serviceProvider = IntPtr.Zero;
                 }
+
+                this.disposed = true;
             }
         }
     }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/QueryPartitionProviderTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/QueryPartitionProviderTests.cs
@@ -1,0 +1,62 @@
+﻿namespace Microsoft.Azure.Cosmos.Tests.Query
+{
+    using System;
+    using System.Collections.Generic;
+    using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Query.Core.QueryPlan;
+    using Microsoft.Azure.Cosmos.Query.Core;
+    using Microsoft.Azure.Documents;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Newtonsoft.Json;
+
+    [TestClass]
+    public class QueryPartitionProviderTests
+    {
+        private static readonly PartitionKeyDefinition PartitionKeyDefinition = new PartitionKeyDefinition()
+        {
+            Paths = new System.Collections.ObjectModel.Collection<string>()
+            {
+                "/id",
+            },
+            Kind = PartitionKind.Hash,
+        };
+
+        [TestMethod]
+        public void TestQueryPartitionProviderUpdate()
+        {
+            IDictionary<string, object> smallQueryConfiguration = new Dictionary<string, object>() { { "maxSqlQueryInputLength", 5 } };
+            IDictionary<string, object> largeQueryConfiguration = new Dictionary<string, object>() { { "maxSqlQueryInputLength", 524288 } };
+
+            QueryPartitionProvider queryPartitionProvider = new QueryPartitionProvider(smallQueryConfiguration);
+
+            string sqlQuerySpec = JsonConvert.SerializeObject(new SqlQuerySpec("SELECT * FROM c"));
+
+            TryCatch<PartitionedQueryExecutionInfo> tryGetQueryPlan = queryPartitionProvider.TryGetPartitionedQueryExecutionInfo(
+                    querySpecJsonString: sqlQuerySpec,
+                    partitionKeyDefinition: PartitionKeyDefinition,
+                    requireFormattableOrderByQuery: true,
+                    isContinuationExpected: false,
+                    allowNonValueAggregateQuery: true,
+                    hasLogicalPartitionKey: false,
+                    allowDCount: true,
+                    useSystemPrefix: false);
+
+            Assert.IsTrue(tryGetQueryPlan.Failed);
+            Assert.IsTrue(tryGetQueryPlan.Exception.ToString().Contains("The SQL query text exceeded the maximum limit of 5 characters"));
+
+            queryPartitionProvider.Update(largeQueryConfiguration);
+
+            tryGetQueryPlan = queryPartitionProvider.TryGetPartitionedQueryExecutionInfo(
+                            querySpecJsonString: sqlQuerySpec,
+                            partitionKeyDefinition: PartitionKeyDefinition,
+                            requireFormattableOrderByQuery: true,
+                            isContinuationExpected: false,
+                            allowNonValueAggregateQuery: true,
+                            hasLogicalPartitionKey: false,
+                            allowDCount: true,
+                            useSystemPrefix: false);
+
+            Assert.IsTrue(tryGetQueryPlan.Succeeded);
+        }
+    }
+}


### PR DESCRIPTION
When DocumentClient refreshes the database account and gets updates, query configuration changes need to be updated on the QueryPartitionProvider.

The Update() method is not being called, so when configuration changes are made, they are not being picked up by the query partition provider, and not making it into the service provider used by the query interop.

This change adds the call to Update so that configuration changes will be reflected in the query partition provider.