### PR TITLE
CosmosClient Initialization: Adds implementation for opening Rntbd connections to backend replica nodes in Direct mode.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
 		<ClientOfficialVersion>3.31.0</ClientOfficialVersion>
 		<ClientPreviewVersion>3.31.0</ClientPreviewVersion>
 		<ClientPreviewSuffixVersion>preview</ClientPreviewSuffixVersion>
-		<DirectVersion>3.29.1</DirectVersion>
+		<DirectVersion>3.29.2</DirectVersion>
 		<EncryptionOfficialVersion>2.0.0</EncryptionOfficialVersion>
 		<EncryptionPreviewVersion>2.0.0</EncryptionPreviewVersion>
 		<EncryptionPreviewSuffixVersion>preview</EncryptionPreviewSuffixVersion>

--- a/Microsoft.Azure.Cosmos/src/CosmosClient.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClient.cs
@@ -1373,10 +1373,10 @@ namespace Microsoft.Azure.Cosmos
                         databaseId,
                         containerId);
 
-                    tasks.Add(this.InitializeContainerUsingRntbdAsync(
-                        databaseId,
-                        container.LinkUri,
-                        cancellationToken));
+                    tasks.Add(this.ClientContext.InitializeContainerUsingRntbdAsync(
+                        databaseId: databaseId,
+                        containerLinkUri: container.LinkUri,
+                        cancellationToken: cancellationToken));
                 }
 
                 await Task.WhenAll(tasks);
@@ -1409,24 +1409,6 @@ namespace Microsoft.Azure.Cosmos
             }
 
             return 0;
-        }
-
-        /// <summary>
-        /// Initializes the given container by establishing the
-        /// Rntbd connection to all of the backend backend replica nodes.
-        /// </summary>
-        /// <param name="databaseId">A string containing the cosmos database identifier.</param>
-        /// <param name="containerLinkUri">A string containing the cosmos container link uri.</param>
-        /// <param name="cancellationToken">An instance of the <see cref="CancellationToken"/>.</param>
-        private async Task InitializeContainerUsingRntbdAsync(
-            string databaseId,
-            string containerLinkUri,
-            CancellationToken cancellationToken = default)
-        {
-            await this.ClientContext.InitializeContainerUsingRntbdAsync(
-                databaseId,
-                containerLinkUri,
-                cancellationToken);
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -1481,10 +1481,6 @@ namespace Microsoft.Azure.Cosmos
                     nameof(databaseName) :
                     nameof(containerLinkUri);
 
-                DefaultTrace.TraceError("Failed to open connections to backend replicas. {0} cannot be left empty. '{1}'",
-                    resourceName,
-                    System.Diagnostics.Trace.CorrelationManager.ActivityId);
-
                 throw new ArgumentNullException(resourceName);
             }
 
@@ -1497,13 +1493,8 @@ namespace Microsoft.Azure.Cosmos
                         containerLinkUri,
                         cancellationToken);
                 }
-                catch (Exception ex)
+                catch (Exception)
                 {
-                    DefaultTrace.TraceError("Failed to open connections to backend replicas for container: {0} with exception: {1}. '{2}'",
-                        containerLinkUri,
-                        ex.Message,
-                        System.Diagnostics.Trace.CorrelationManager.ActivityId);
-
                     throw;
                 }
             }

--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -1474,22 +1474,36 @@ namespace Microsoft.Azure.Cosmos
             string containerLinkUri,
             CancellationToken cancellationToken)
         {
-            if (databaseName == null)
+            if (string.IsNullOrEmpty(databaseName) ||
+                string.IsNullOrEmpty(containerLinkUri))
             {
-                throw new ArgumentNullException(nameof(databaseName));
-            }
+                string resource = string.IsNullOrEmpty(databaseName) ?
+                    "databaseName" :
+                    "containerLinkUri";
 
-            if (containerLinkUri == null)
-            {
-                throw new ArgumentNullException(nameof(containerLinkUri));
+                DefaultTrace.TraceWarning("Failed to open connections to backend replicas. {0} cannot be left empty. '{1}'",
+                    resource,
+                    System.Diagnostics.Trace.CorrelationManager.ActivityId);
+
+                return;
             }
 
             if (this.StoreModel != null)
             {
-                await this.StoreModel.OpenConnectionsToAllReplicasAsync(
-                    databaseName,
-                    containerLinkUri,
-                    cancellationToken);
+                try
+                {
+                    await this.StoreModel.OpenConnectionsToAllReplicasAsync(
+                        databaseName,
+                        containerLinkUri,
+                        cancellationToken);
+                }
+                catch (Exception ex)
+                {
+                    DefaultTrace.TraceWarning("Failed to open connections to backend replicas for container: {0} with exception: {1}. '{2}'",
+                        containerLinkUri,
+                        ex.Message,
+                        System.Diagnostics.Trace.CorrelationManager.ActivityId);
+                }
             }
         }
 

--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -1359,7 +1359,7 @@ namespace Microsoft.Azure.Cosmos
         /// <remarks>
         /// Test hook to enable unit test of DocumentClient.
         /// </remarks>
-        internal IStoreModel StoreModel { get; set; }
+        internal IStoreModelExtension StoreModel { get; set; }
 
         /// <summary>
         /// Gets and sets the gateway IStoreModel object.
@@ -1367,7 +1367,7 @@ namespace Microsoft.Azure.Cosmos
         /// <remarks>
         /// Test hook to enable unit test of DocumentClient.
         /// </remarks>
-        internal IStoreModel GatewayStoreModel { get; set; }
+        internal IStoreModelExtension GatewayStoreModel { get; set; }
 
         /// <summary>
         /// Gets and sets on execute scalar query callback
@@ -1459,6 +1459,37 @@ namespace Microsoft.Azure.Cosmos
             {
                 IStoreModel storeProxy = this.GetStoreProxy(request);
                 return await storeProxy.ProcessMessageAsync(request, cancellationToken);
+            }
+        }
+
+        /// <summary>
+        /// Establishes and Initializes the Rntbd connection to all the backend replica nodes
+        /// for the given database name and container.
+        /// </summary>
+        /// <param name="databaseName">A string containing the cosmos database name.</param>
+        /// <param name="containerLinkUri">A string containing the cosmos container link uri.</param>
+        /// <param name="cancellationToken">An instance of the <see cref="CancellationToken"/>.</param>
+        internal async Task OpenConnectionsToAllReplicasAsync(
+            string databaseName,
+            string containerLinkUri,
+            CancellationToken cancellationToken)
+        {
+            if (databaseName == null)
+            {
+                throw new ArgumentNullException(nameof(databaseName));
+            }
+
+            if (containerLinkUri == null)
+            {
+                throw new ArgumentNullException(nameof(containerLinkUri));
+            }
+
+            if (this.StoreModel != null)
+            {
+                await this.StoreModel.OpenConnectionsToAllReplicasAsync(
+                    databaseName,
+                    containerLinkUri,
+                    cancellationToken);
             }
         }
 

--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -1477,15 +1477,15 @@ namespace Microsoft.Azure.Cosmos
             if (string.IsNullOrEmpty(databaseName) ||
                 string.IsNullOrEmpty(containerLinkUri))
             {
-                string resource = string.IsNullOrEmpty(databaseName) ?
-                    "databaseName" :
-                    "containerLinkUri";
+                string resourceName = string.IsNullOrEmpty(databaseName) ?
+                    nameof(databaseName) :
+                    nameof(containerLinkUri);
 
-                DefaultTrace.TraceWarning("Failed to open connections to backend replicas. {0} cannot be left empty. '{1}'",
-                    resource,
+                DefaultTrace.TraceError("Failed to open connections to backend replicas. {0} cannot be left empty. '{1}'",
+                    resourceName,
                     System.Diagnostics.Trace.CorrelationManager.ActivityId);
 
-                return;
+                throw new ArgumentNullException(resourceName);
             }
 
             if (this.StoreModel != null)
@@ -1499,10 +1499,11 @@ namespace Microsoft.Azure.Cosmos
                 }
                 catch (Exception ex)
                 {
-                    DefaultTrace.TraceWarning("Failed to open connections to backend replicas for container: {0} with exception: {1}. '{2}'",
+                    DefaultTrace.TraceError("Failed to open connections to backend replicas for container: {0} with exception: {1}. '{2}'",
                         containerLinkUri,
                         ex.Message,
                         System.Diagnostics.Trace.CorrelationManager.ActivityId);
+                    throw ex;
                 }
             }
         }

--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -1503,7 +1503,8 @@ namespace Microsoft.Azure.Cosmos
                         containerLinkUri,
                         ex.Message,
                         System.Diagnostics.Trace.CorrelationManager.ActivityId);
-                    throw ex;
+
+                    throw;
                 }
             }
         }

--- a/Microsoft.Azure.Cosmos/src/GatewayStoreModel.cs
+++ b/Microsoft.Azure.Cosmos/src/GatewayStoreModel.cs
@@ -485,7 +485,7 @@ namespace Microsoft.Azure.Cosmos
 
         public Task OpenConnectionsToAllReplicasAsync(string databaseName, string containerLinkUri, CancellationToken cancellationToken = default)
         {
-            throw new NotImplementedException();
+            return Task.CompletedTask;
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/GatewayStoreModel.cs
+++ b/Microsoft.Azure.Cosmos/src/GatewayStoreModel.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.Cosmos
     using Newtonsoft.Json;
 
     // Marking it as non-sealed in order to unit test it using Moq framework
-    internal class GatewayStoreModel : IStoreModel, IDisposable
+    internal class GatewayStoreModel : IStoreModelExtension, IDisposable
     {
         private static readonly string sessionConsistencyAsString = ConsistencyLevel.Session.ToString();
 
@@ -481,6 +481,11 @@ namespace Microsoft.Azure.Cosmos
         private Uri GetFeedUri(DocumentServiceRequest request)
         {
             return new Uri(this.endpointManager.ResolveServiceEndpoint(request), PathsHelper.GeneratePath(request.ResourceType, request, true));
+        }
+
+        public Task OpenConnectionsToAllReplicasAsync(string databaseName, string containerLinkUri, CancellationToken cancellationToken = default)
+        {
+            throw new NotImplementedException();
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Resource/ClientContextCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/ClientContextCore.cs
@@ -412,6 +412,19 @@ namespace Microsoft.Azure.Cosmos
             return this.batchExecutorCache.GetExecutorForContainer(container, this);
         }
 
+        /// <inheritdoc/>
+        internal override async Task InitializeContainerUsingRntbdAsync(
+            string databaseId,
+            string containerLinkUri,
+            CancellationToken cancellationToken)
+        {
+            await this.DocumentClient.EnsureValidClientAsync(NoOpTrace.Singleton);
+            await this.DocumentClient.OpenConnectionsToAllReplicasAsync(
+                databaseId,
+                containerLinkUri,
+                cancellationToken);
+        }
+
         public override void Dispose()
         {
             this.Dispose(true);

--- a/Microsoft.Azure.Cosmos/src/Resource/CosmosClientContext.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/CosmosClientContext.cs
@@ -116,6 +116,18 @@ namespace Microsoft.Azure.Cosmos
            ITrace trace,
            CancellationToken cancellationToken);
 
+        /// <summary>
+        /// Initializes the given container by establishing the
+        /// Rntbd connection to all of the backend replica nodes.
+        /// </summary>
+        /// <param name="databaseId">A string containing the cosmos database identifier.</param>
+        /// <param name="containerLinkUri">A string containing the cosmos container link uri.</param>
+        /// <param name="cancellationToken">An instance of the <see cref="CancellationToken"/>.</param>
+        internal abstract Task InitializeContainerUsingRntbdAsync(
+            string databaseId,
+            string containerLinkUri,
+            CancellationToken cancellationToken);
+
         public abstract void Dispose();
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
@@ -133,16 +133,14 @@ namespace Microsoft.Azure.Cosmos.Routing
                 }
             }
 
-            await Task.WhenAll(tasks);
-
-            foreach (Task<TryCatch<DocumentServiceResponse>> task in tasks)
+            foreach (TryCatch<DocumentServiceResponse> task in await Task.WhenAll(tasks))
             {
-                if (task.Result.Failed)
+                if (task.Failed)
                 {
                     continue;
                 }
 
-                using (DocumentServiceResponse response = task.Result.Result)
+                using (DocumentServiceResponse response = task.Result)
                 {
                     FeedResource<Address> addressFeed = response.GetResource<FeedResource<Address>>();
 
@@ -749,6 +747,15 @@ namespace Microsoft.Azure.Cosmos.Routing
             };
         }
 
+        /// <summary>
+        /// Utilizes the <see cref="TryCatch{TResult}"/> to get the server addresses. If an
+        /// exception is thrown during the invocation, it handles it gracefully and returns
+        /// a <see cref="TryCatch{TResult}"/> Task containing the exception.
+        /// </summary>
+        /// <param name="request">An instance of <see cref="DocumentServiceRequest"/> containing the request payload.</param>
+        /// <param name="collectionRid">A string containing the collection ids.</param>
+        /// <param name="partitionKeyRangeIds">An instance of <see cref="IEnumerable{T}"/> containing the list of partition key range ids.</param>
+        /// <returns>A task of <see cref="TryCatch{TResult}"/> containing the result.</returns>
         private async Task<TryCatch<DocumentServiceResponse>> GetAddressesAsync(
             DocumentServiceRequest request,
             string collectionRid,

--- a/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
@@ -23,9 +23,6 @@ namespace Microsoft.Azure.Cosmos.Routing
     using Microsoft.Azure.Documents.Rntbd;
     using Microsoft.Azure.Documents.Routing;
 
-    /// <summary>
-    /// Add applicable documentation.
-    /// </summary>
     internal class GatewayAddressCache : IAddressCache, IDisposable
     {
         private const string protocolFilterFormat = "{0} eq {1}";
@@ -199,22 +196,20 @@ namespace Microsoft.Azure.Cosmos.Routing
              Tuple<PartitionKeyRangeIdentity, PartitionAddressInformation> addressInfo,
              Func<Uri, Task> openConnectionHandlerAsync)
         {
-            List<string> physicalUris = (from AddressInformation address in addressInfo.Item2.AllAddresses
-                                         select address.PhysicalUri).ToList();
-            foreach (string physicalUri in physicalUris)
+            foreach (AddressInformation address in addressInfo.Item2.AllAddresses)
             {
-                DefaultTrace.TraceInformation("Attempting to open Rntbd connection to backend uri: {0}. '{1}'",
-                    physicalUri,
+                DefaultTrace.TraceVerbose("Attempting to open Rntbd connection to backend uri: {0}. '{1}'",
+                    address.PhysicalUri,
                     System.Diagnostics.Trace.CorrelationManager.ActivityId);
                 try
                 {
                     await openConnectionHandlerAsync(
-                        new Uri(physicalUri));
+                        new Uri(address.PhysicalUri));
                 }
                 catch (Exception ex)
                 {
                     DefaultTrace.TraceWarning("Failed to open Rntbd connection to backend uri: {0} with exception: {1}. '{2}'",
-                        physicalUri,
+                        address.PhysicalUri,
                         ex.Message,
                         System.Diagnostics.Trace.CorrelationManager.ActivityId);
                 }

--- a/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
@@ -13,7 +13,6 @@ namespace Microsoft.Azure.Cosmos.Routing
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
-    using global::Azure;
     using Microsoft.Azure.Cosmos.Common;
     using Microsoft.Azure.Cosmos.Core.Trace;
     using Microsoft.Azure.Cosmos.Tracing;
@@ -135,11 +134,11 @@ namespace Microsoft.Azure.Cosmos.Routing
                             collectionRid: collection.ResourceId,
                             partitionKeyRangeIds: partitionKeyRangeIdentities.Skip(i).Take(batchSize).Select(range => range.PartitionKeyRangeId),
                             forceRefresh: false)
-                        .ContinueWith(x =>
+                        .ContinueWith(task =>
                         {
-                            if (x.Exception != null || x.IsFaulted)
+                            if (task.Exception != null || task.IsFaulted)
                             {
-                                x.Exception.Handle(ex =>
+                                task.Exception.Handle(ex =>
                                 {
                                     DefaultTrace.TraceWarning("Failed to fetch the server addresses for: {0} with exception: {1}. '{2}'",
                                         collection.ResourceId,
@@ -148,9 +147,9 @@ namespace Microsoft.Azure.Cosmos.Routing
                                     return true;
                                 });
                             }
-                            else if (x.IsCompleted)
+                            else if (task.IsCompleted)
                             {
-                                responses.Add(x.Result);
+                                responses.Add(task.Result);
                             }
                         }));
                 }

--- a/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
@@ -156,7 +156,7 @@ namespace Microsoft.Azure.Cosmos.Routing
 
                         if (openConnectionHandler != null)
                         {
-                            await this.OpenConnectionsAsync(
+                            await this.OpenRntbdChannelsAsync(
                                 addressInfo,
                                 openConnectionHandler);
                         }
@@ -173,7 +173,7 @@ namespace Microsoft.Azure.Cosmos.Routing
         /// and it's corresponding address information.</param>
         /// <param name="openConnectionHandlerAsync">The transport client callback delegate to be invoked at a
         /// later point of time.</param>
-        private async Task OpenConnectionsAsync(
+        private async Task OpenRntbdChannelsAsync(
              Tuple<PartitionKeyRangeIdentity, PartitionAddressInformation> addressInfo,
              Func<Uri, Task> openConnectionHandlerAsync)
         {
@@ -181,10 +181,9 @@ namespace Microsoft.Azure.Cosmos.Routing
                                          select address.PhysicalUri).ToList();
             foreach (string physicalUri in physicalUris)
             {
-                Console.WriteLine("Opening Connection to: " + physicalUri);
                 DefaultTrace.TraceInformation("Attempting to open Rntbd connection to backend uri: {0}. '{1}'",
-                                    physicalUri,
-                                    System.Diagnostics.Trace.CorrelationManager.ActivityId);
+                    physicalUri,
+                    System.Diagnostics.Trace.CorrelationManager.ActivityId);
                 try
                 {
                     await openConnectionHandlerAsync(
@@ -192,11 +191,10 @@ namespace Microsoft.Azure.Cosmos.Routing
                 }
                 catch (Exception ex)
                 {
-                    Console.WriteLine($"Exception Occurred inside {nameof(GatewayAddressCache)}: " + ex.Message);
                     DefaultTrace.TraceWarning("Failed to open Rntbd connection to backend uri: {0} with exception: {1}. '{2}'",
-                                        physicalUri,
-                                        ex.Message,
-                                        System.Diagnostics.Trace.CorrelationManager.ActivityId);
+                        physicalUri,
+                        ex.Message,
+                        System.Diagnostics.Trace.CorrelationManager.ActivityId);
                 }
             }
         }

--- a/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
@@ -194,7 +194,7 @@ namespace Microsoft.Azure.Cosmos.Routing
                 {
                     DefaultTrace.TraceWarning("Failed to open Rntbd connection to backend uri: {0} with exception: {1}. '{2}'",
                         address.PhysicalUri,
-                        ex.Message,
+                        ex,
                         System.Diagnostics.Trace.CorrelationManager.ActivityId);
                 }
             }

--- a/Microsoft.Azure.Cosmos/src/Routing/GlobalAddressResolver.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GlobalAddressResolver.cs
@@ -140,11 +140,6 @@ namespace Microsoft.Azure.Cosmos.Routing
 
                 if (collection == null)
                 {
-                    DefaultTrace.TraceError("Could not resolve the collection: {0} for database: {1}. '{2}'",
-                        containerLinkUri,
-                        databaseName,
-                        System.Diagnostics.Trace.CorrelationManager.ActivityId);
-
                     throw CosmosExceptionFactory.Create(
                         statusCode: HttpStatusCode.NotFound,
                         message: $"Could not resolve the collection: {containerLinkUri} for database: {databaseName}.",
@@ -191,11 +186,6 @@ namespace Microsoft.Azure.Cosmos.Routing
             }
             catch (Exception ex)
             {
-                DefaultTrace.TraceError("Failed to open Rntbd connection to backend uri for container: {0} with exception: {1}. '{2}'",
-                    containerLinkUri,
-                    ex.Message,
-                    System.Diagnostics.Trace.CorrelationManager.ActivityId);
-
                 throw ex switch
                 {
                     DocumentClientException dce => CosmosExceptionFactory.Create(

--- a/Microsoft.Azure.Cosmos/src/Routing/GlobalAddressResolver.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GlobalAddressResolver.cs
@@ -7,8 +7,6 @@ namespace Microsoft.Azure.Cosmos.Routing
     using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
-    using System.Collections.ObjectModel;
-    using System.Diagnostics;
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
@@ -114,7 +112,13 @@ namespace Microsoft.Azure.Cosmos.Routing
             await Task.WhenAll(tasks);
         }
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Invokes the gateway address cache and passes the <see cref="Documents.Rntbd.TransportClient"/> deligate to be invoked from the same.
+        /// </summary>
+        /// <param name="databaseName">A string containing the name of the database.</param>
+        /// <param name="containerLinkUri">A string containing the container's link uri.</param>
+        /// <param name="openConnectionHandlerAsync">The transport client callback delegate to be invoked at a later point of time.</param>
+        /// <param name="cancellationToken">An Instance of the <see cref="CancellationToken"/>.</param>
         public async Task OpenConnectionsToAllReplicasAsync(
             string databaseName,
             string containerLinkUri,
@@ -176,11 +180,10 @@ namespace Microsoft.Azure.Cosmos.Routing
             }
             catch (Exception ex)
             {
-                Console.WriteLine($"Exception Occurred inside {nameof(GlobalAddressResolver)}: " + ex.Message);
                 DefaultTrace.TraceWarning("Failed to open Rntbd connection to backend uri for container: {0} with exception: {1}. '{2}'",
-                                    containerLinkUri,
-                                    ex.Message,
-                                    System.Diagnostics.Trace.CorrelationManager.ActivityId);
+                    containerLinkUri,
+                    ex.Message,
+                    System.Diagnostics.Trace.CorrelationManager.ActivityId);
             }
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientCreateAndInitializeTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientCreateAndInitializeTest.cs
@@ -238,6 +238,8 @@
                 cosmosClientOptions: cosmosClientOptions);
 
             // Assert.
+            Assert.AreEqual(5, httpCallsMade);
+
             IStoreClientFactory factory = (IStoreClientFactory)cosmosClient.DocumentClient.GetType()
                             .GetField("storeClientFactory", BindingFlags.NonPublic | BindingFlags.Instance)
                             .GetValue(cosmosClient.DocumentClient);
@@ -325,6 +327,7 @@
 
             // Assert.
             Assert.IsNotNull(cosmosClient);
+            Assert.AreEqual(1, httpCallsMade);
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientCreateAndInitializeTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientCreateAndInitializeTest.cs
@@ -311,7 +311,8 @@
             // Assert.
             Assert.IsNotNull(ce);
             Assert.AreEqual(HttpStatusCode.NotFound, ce.StatusCode);
-            Assert.IsTrue(ce.Message.Contains("The requested resource was not found"));
+            Console.WriteLine(ce.Message);
+            Assert.IsTrue(ce.Message.Contains("NotFound (404)"));
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientCreateAndInitializeTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientCreateAndInitializeTest.cs
@@ -285,11 +285,11 @@
 
         /// <summary>
         /// Test to validate that when <see cref="CosmosClient.CreateAndInitializeAsync()"/> is called with
-        /// the Gateway Mode enabled, no Rntbd connection is opened to the backend replicas.
+        /// the Gateway Mode enabled, the operation should not open any Rntbd connections to the backend replicas.
         /// </summary>
         [TestMethod]
         [Owner("dkunda")]
-        public async Task CreateAndInitializeAsync_WithGatewayModeEnabled_ShouldThrowException()
+        public async Task CreateAndInitializeAsync_WithGatewayModeEnabled_ShouldNotOpenConnectionToBackendReplicas()
         {
             // Arrange.
             int httpCallsMade = 0;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientCreateAndInitializeTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientCreateAndInitializeTest.cs
@@ -1,13 +1,14 @@
 ﻿namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 {
     using System;
+    using System.Collections.Concurrent;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Net;
     using System.Net.Http;
-    using System.Threading;
+    using System.Reflection;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Fluent;
-    using Microsoft.Azure.Cosmos.Routing;
     using Microsoft.Azure.Documents;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Moq;
@@ -193,6 +194,124 @@
             Assert.IsNotNull(ex);
             Assert.IsTrue(ex.StatusCode == HttpStatusCode.NotFound);
             cosmosClient.Verify();
+        }
+
+        /// <summary>
+        /// Test to validate that when <see cref="CosmosClient.CreateAndInitializeAsync()"/> is called with a
+        /// valid a valid database id and a container id that exists in the database, an attempt is made to open
+        /// the rntbd connections to the backend replicas and the connections are opened successfully.
+        /// </summary>
+        [TestMethod]
+        public async Task CreateAndInitializeAsync_WithValidDatabaseAndContainer_ShouldOpenRntbdConnectionsToBackendReplicas()
+        {
+            // Arrange.
+            int httpCallsMade = 0;
+            HttpClientHandlerHelper httpClientHandlerHelper = new ()
+            {
+                RequestCallBack = (request, cancellationToken) =>
+                {
+                    httpCallsMade++;
+                    return null;
+                }
+            };
+            List<(string, string)> containers = new () 
+            { 
+                (
+                "ClientCreateAndInitializeDatabase",
+                "ClientCreateAndInitializeContainer"
+                )
+            };
+
+            (string endpoint, string authKey) = TestCommon.GetAccountInfo();
+            CosmosClientOptions cosmosClientOptions = new ()
+            {
+                HttpClientFactory = () => new HttpClient(httpClientHandlerHelper),
+            };
+
+            // Act.
+            CosmosClient cosmosClient = await CosmosClient.CreateAndInitializeAsync(
+                accountEndpoint: endpoint,
+                authKeyOrResourceToken: authKey,
+                containers: containers,
+                cosmosClientOptions: cosmosClientOptions);
+
+            // Assert.
+            IStoreClientFactory factory = (IStoreClientFactory)cosmosClient.DocumentClient.GetType()
+                            .GetField("storeClientFactory", BindingFlags.NonPublic | BindingFlags.Instance)
+                            .GetValue(cosmosClient.DocumentClient);
+            StoreClientFactory storeClientFactory = (StoreClientFactory) factory;
+
+            TransportClient client = (TransportClient)storeClientFactory.GetType()
+                            .GetField("transportClient", BindingFlags.NonPublic | BindingFlags.Instance)
+                            .GetValue(storeClientFactory);
+            Documents.Rntbd.TransportClient transportClient = (Documents.Rntbd.TransportClient) client;
+
+            Documents.Rntbd.ChannelDictionary channelDict = (Documents.Rntbd.ChannelDictionary)transportClient.GetType()
+                            .GetField("channelDictionary", BindingFlags.NonPublic | BindingFlags.Instance)
+                            .GetValue(transportClient);
+
+            ConcurrentDictionary<Documents.Rntbd.ServerKey, Documents.Rntbd.IChannel> allChannels = (ConcurrentDictionary<Documents.Rntbd.ServerKey, Documents.Rntbd.IChannel>)channelDict.GetType()
+                .GetField("channels", BindingFlags.NonPublic | BindingFlags.Instance)
+                .GetValue(channelDict);
+
+            Assert.AreEqual(1, allChannels.Count);
+
+            Documents.Rntbd.LoadBalancingChannel loadBalancingChannel = (Documents.Rntbd.LoadBalancingChannel)allChannels[allChannels.Keys.First()];
+            Documents.Rntbd.LoadBalancingPartition loadBalancingPartition = (Documents.Rntbd.LoadBalancingPartition)loadBalancingChannel.GetType()
+                                    .GetField("singlePartition", BindingFlags.NonPublic | BindingFlags.Instance)
+                                    .GetValue(loadBalancingChannel);
+
+            Assert.IsNotNull(loadBalancingPartition);
+
+            int channelCapacity = (int)loadBalancingPartition.GetType()
+                .GetField("capacity", BindingFlags.NonPublic | BindingFlags.Instance)
+                .GetValue(loadBalancingPartition);
+
+            List<Documents.Rntbd.LbChannelState> openChannels = (List<Documents.Rntbd.LbChannelState>)loadBalancingPartition.GetType()
+                                    .GetField("openChannels", BindingFlags.NonPublic | BindingFlags.Instance)
+                                    .GetValue(loadBalancingPartition);
+
+            Assert.IsNotNull(openChannels);
+            Assert.AreEqual(30, channelCapacity);
+            Assert.AreEqual(1, openChannels.Count);
+
+            Documents.Rntbd.LbChannelState channelState = openChannels.First();
+
+            Assert.IsNotNull(channelState);
+            Assert.IsTrue(channelState.DeepHealthy);
+        }
+
+        /// <summary>
+        /// Test to validate that when <see cref="CosmosClient.CreateAndInitializeAsync()"/> is called with a
+        /// valid a valid database id and an invalid container that doesn't exists in the database, the cosmos
+        /// client initialization fails and a <see cref="CosmosException"/> is thrown with a 404 status code.
+        /// </summary>
+        [TestMethod]
+        public async Task CreateAndInitializeAsync_WithValidDatabaseAndInvalidContainer_ShouldThrowException()
+        {
+            // Arrange.
+            List<(string, string)> containers = new()
+            {
+                (
+                "ClientCreateAndInitializeDatabase",
+                "ClientCreateAndInitializeInvalidContainer"
+                )
+            };
+
+            (string endpoint, string authKey) = TestCommon.GetAccountInfo();
+            CosmosClientOptions cosmosClientOptions = new();
+
+            // Act.
+            CosmosException ce = await Assert.ThrowsExceptionAsync<CosmosException>(() => CosmosClient.CreateAndInitializeAsync(
+                accountEndpoint: endpoint,
+                authKeyOrResourceToken: authKey,
+                containers: containers,
+                cosmosClientOptions: cosmosClientOptions));
+
+            // Assert.
+            Assert.IsNotNull(ce);
+            Assert.AreEqual(HttpStatusCode.NotFound, ce.StatusCode);
+            Assert.IsTrue(ce.Message.Contains("The requested resource was not found"));
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientCreateAndInitializeTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientCreateAndInitializeTest.cs
@@ -198,7 +198,7 @@
 
         /// <summary>
         /// Test to validate that when <see cref="CosmosClient.CreateAndInitializeAsync()"/> is called with a
-        /// valid a valid database id and a container id that exists in the database, an attempt is made to open
+        /// valid database id and a container id that exists in the database, an attempt is made to open
         /// the rntbd connections to the backend replicas and the connections are opened successfully.
         /// </summary>
         [TestMethod]
@@ -283,7 +283,7 @@
 
         /// <summary>
         /// Test to validate that when <see cref="CosmosClient.CreateAndInitializeAsync()"/> is called with a
-        /// valid a valid database id and an invalid container that doesn't exists in the database, the cosmos
+        /// valid database id and an invalid container that doesn't exists in the database, the cosmos
         /// client initialization fails and a <see cref="CosmosException"/> is thrown with a 404 status code.
         /// </summary>
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosBasicQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosBasicQueryTests.cs
@@ -200,7 +200,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             using (await containerWithThrottle.ReadItemStreamAsync(firstItemIdAndPk, new PartitionKey(firstItemIdAndPk))) { }
 
             Documents.IStoreModel storeModel = clientWithThrottle.ClientContext.DocumentClient.StoreModel;
-            Mock<Documents.IStoreModel> mockStore = new Mock<Documents.IStoreModel>();
+            Mock<Documents.IStoreModelExtension> mockStore = new Mock<Documents.IStoreModelExtension>();
             clientWithThrottle.ClientContext.DocumentClient.StoreModel = mockStore.Object;
 
             // Cause 429 after the first call

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/DocumentClientUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/DocumentClientUnitTests.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         [TestMethod]
         public void RetryExceedingMaxTimeLimit()
         {
-            Mock<IStoreModel> mockStoreModel = new Mock<IStoreModel>();
+            Mock<IStoreModelExtension> mockStoreModel = new Mock<IStoreModelExtension>();
             mockStoreModel.Setup(model => model.ProcessMessageAsync(It.IsAny<DocumentServiceRequest>(), default(CancellationToken)))
                 .Throws(this.CreateTooManyRequestException(100));
 
@@ -98,7 +98,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
         private void TestRetryOnThrottled(int? numberOfRetries)
         {
-            Mock<IStoreModel> mockStoreModel = new Mock<IStoreModel>();
+            Mock<IStoreModelExtension> mockStoreModel = new Mock<IStoreModelExtension>();
             mockStoreModel.Setup(model => model.ProcessMessageAsync(It.IsAny<DocumentServiceRequest>(), default(CancellationToken)))
                 .Throws(this.CreateTooManyRequestException(100));
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/DocumentClientUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/DocumentClientUnitTests.cs
@@ -81,6 +81,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.IsTrue(throttled);
         }
 
+        /// <summary>
+        /// Test to validate that when <see cref="DocumentClient.OpenConnectionsToAllReplicasAsync()"/> invoked with
+        /// an empty database/ container name, a <see cref="ArgumentNullException"/> is thrown during cosmos client
+        /// initialization.
+        /// </summary>
         [TestMethod]
         [Owner("dkunda")]
         public async Task OpenConnectionsToAllReplicasAsync_WithEmptyDatabaseName_ShouldThrowExceptionDuringInitialization()
@@ -109,6 +114,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.AreEqual("Value cannot be null. (Parameter 'databaseName')", ane.Message);
         }
 
+        /// <summary>
+        /// Test to validate that when <see cref="DocumentClient.OpenConnectionsToAllReplicasAsync()"/> invoked and
+        /// the store model throws some internal exception, the exception is indeed bubbled up and thrown during
+        /// cosmos client initialization.
+        /// </summary>
         [TestMethod]
         [Owner("dkunda")]
         public async Task OpenConnectionsToAllReplicasAsync_WhenStoreModelThrowsInternalException_ShouldThrowExceptionDuringInitialization()

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Mocks/MockDocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Mocks/MockDocumentClient.cs
@@ -304,9 +304,9 @@ namespace Microsoft.Azure.Cosmos.Performance.Tests
             return true;
         }
 
-        private IStoreModel GetMockGatewayStoreModel()
+        private IStoreModelExtension GetMockGatewayStoreModel()
         {
-            Mock<IStoreModel> gatewayStoreModel = new Mock<IStoreModel>();
+            Mock<IStoreModelExtension> gatewayStoreModel = new Mock<IStoreModelExtension>();
 
             gatewayStoreModel.Setup(
                 storeModel => storeModel.ProcessMessageAsync(

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GatewayAddressCacheTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GatewayAddressCacheTests.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.Cosmos
             this.serviceName = new Uri(GatewayAddressCacheTests.DatabaseAccountApiEndpoint);
             this.serviceIdentity = new ServiceIdentity("federation1", this.serviceName, false);
 
-            List<PartitionKeyRange> result = new List<PartitionKeyRange>
+            List<PartitionKeyRange> partitionKeyRanges = new ()
             {
                 new PartitionKeyRange()
                 {
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.Cosmos
                     It.IsAny<Documents.Routing.Range<string>>(),
                     It.IsAny<ITrace>(),
                     It.IsAny<bool>()))
-                .Returns(Task.FromResult((IReadOnlyList<PartitionKeyRange>)result));
+                .Returns(Task.FromResult((IReadOnlyList<PartitionKeyRange>)partitionKeyRanges));
         }
 
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GatewayAddressCacheTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GatewayAddressCacheTests.cs
@@ -379,10 +379,7 @@ namespace Microsoft.Azure.Cosmos
             ContainerProperties containerProperties = ContainerProperties.CreateWithResourceId("ccZ1ANCszwk=");
             containerProperties.Id = "TestId";
             containerProperties.PartitionKeyPath = "/pk";
-            HttpClient httpClient = new(messageHandler)
-            {
-                Timeout = TimeSpan.FromSeconds(120)
-            };
+            HttpClient httpClient = new(messageHandler);
 
             GatewayAddressCache cache = new (
                 new Uri(GatewayAddressCacheTests.DatabaseAccountApiEndpoint),


### PR DESCRIPTION
# Pull Request Template

## Description

**Background:**

Currently, during the `CosmosClient.CreateAndInitializeAsync()`, the .net SDK uses a method called `InitializeContainerAsync()`, which leverages dummy query on all feed ranges to open connection, with retry capability to increase the chances of touching max replica. However, there are few drawbacks with current approach, which are highlighted below.

- It requires unnecessary query plan request to the gateway.
- This approach doesn't guarantee to touch all secondary replicas.
- Does not open connection to primary.
- Expensive in latency and RU.

**The Solution:**

Instead of using the dummy query during the initialization, we could leverage the Rntbd context negotiation to finish the connection establishment. This PR is adding the necessary implementation in the v3 SDK codebase, on top of the `Cosmos.Direct` package changes [v3.29.2](https://www.nuget.org/packages/Microsoft.Azure.Cosmos.Direct/3.29.2), which contains the methods that will help establishing the Rntbd connection to the backend replica nodes.

**Design:**

Please follow this [link](https://github.com/Azure/azure-cosmos-dotnet-v3/issues/3442)  to understand more on the problem statement and designing the solution.

## Type of change

Please delete options that are not relevant.

- [] New feature (non-breaking change which adds functionality)

## Closing issues

To automatically close an issue: closes #3443 