### PR TITLE
[Internal]Client Telemetry: Refactors code to remove hashing from VM Id

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Telemetry/Models/Compute.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/Models/Compute.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry.Models
             this.AzEnvironment = azEnvironment;
             this.OSType = oSType;
             this.VMSize = vMSize;
-            this.VMId = $"{VmMetadataApiHandler.HashedVmIdPrefix}{HashingExtension.ComputeHash(vMId)}";
+            this.VMId = $"{VmMetadataApiHandler.VmIdPrefix}{vMId}";
         }
 
         [JsonProperty(PropertyName = "location")]

--- a/Microsoft.Azure.Cosmos/src/Telemetry/VmMetadataApiHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/VmMetadataApiHandler.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
     internal static class VmMetadataApiHandler
     {
         internal const string HashedMachineNamePrefix = "hashedMachineName:";
-        internal const string HashedVmIdPrefix = "hashedVmId:";
+        internal const string VmIdPrefix = "vmId:";
         internal const string UuidPrefix = "uuid:";
 
         internal static readonly Uri vmMetadataEndpointUrl = new ("http://169.254.169.254/metadata/instance?api-version=2020-06-01");

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
@@ -991,11 +991,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             {
                 if (isAzureInstance.Value)
                 {
-                    Assert.AreEqual($"{VmMetadataApiHandler.HashedVmIdPrefix}{HashingExtension.ComputeHash("d0cb93eb-214b-4c2b-bd3d-cc93e90d9efd")}", machineId.First(), $"Generated Machine id is : {machineId.First()}");
+                    Assert.AreEqual($"{VmMetadataApiHandler.VmIdPrefix}{"d0cb93eb-214b-4c2b-bd3d-cc93e90d9efd"}", machineId.First(), $"Generated Machine id is : {machineId.First()}");
                 }
                 else
                 {
-                    Assert.AreNotEqual($"{VmMetadataApiHandler.HashedVmIdPrefix}{HashingExtension.ComputeHash("d0cb93eb-214b-4c2b-bd3d-cc93e90d9efd")}", machineId.First(), $"Generated Machine id is : {machineId.First()}");
+                    Assert.AreNotEqual($"{VmMetadataApiHandler.VmIdPrefix}{"d0cb93eb-214b-4c2b-bd3d-cc93e90d9efd"}", machineId.First(), $"Generated Machine id is : {machineId.First()}");
                     Assert.AreEqual(1, machineId.Count, $"Multiple Machine Id has been generated i.e {JsonConvert.SerializeObject(machineId)}");
                 }
             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/VmMetadataApiHandlerTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/VmMetadataApiHandlerTest.cs
@@ -58,7 +58,7 @@ namespace Microsoft.Azure.Cosmos
             VmMetadataApiHandler.TryInitialize(cosmoshttpClient);
 
             await Task.Delay(2000);
-            Assert.AreEqual($"{VmMetadataApiHandler.HashedVmIdPrefix}{HashingExtension.ComputeHash("d0cb93eb-214b-4c2b-bd3d-cc93e90d9efd")}", VmMetadataApiHandler.GetMachineId());
+            Assert.AreEqual($"{VmMetadataApiHandler.VmIdPrefix}{"d0cb93eb-214b-4c2b-bd3d-cc93e90d9efd"}", VmMetadataApiHandler.GetMachineId());
             Assert.AreEqual(VmMetadataApiHandler.GetMachineRegion(), "eastus");
         }
 
@@ -130,7 +130,7 @@ namespace Microsoft.Azure.Cosmos
             Assert.AreEqual("AzurePublicCloud", metadata.Compute.AzEnvironment);
             Assert.AreEqual("Linux", metadata.Compute.OSType);
             Assert.AreEqual("Standard_D2s_v3", metadata.Compute.VMSize);
-            Assert.AreEqual($"{VmMetadataApiHandler.HashedVmIdPrefix}{HashingExtension.ComputeHash("d0cb93eb-214b-4c2b-bd3d-cc93e90d9efd")}", metadata.Compute.VMId);
+            Assert.AreEqual($"{VmMetadataApiHandler.VmIdPrefix}{"d0cb93eb-214b-4c2b-bd3d-cc93e90d9efd"}", metadata.Compute.VMId);
         }
 
         [TestMethod]


### PR DESCRIPTION
## Description

Before this PR, we were hashing VM ID due to security concern but in recent talk with security team it is decided that VM ID is not PII hence can be store as it is without Hashing.

## Type of change
- [] Bug fix (non-breaking change which fixes an issue)
