### PR TITLE
[Internal] Client Telemetry: Adds exception information in request diagnostics

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Handler/TelemetryHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/TelemetryHandler.cs
@@ -27,25 +27,20 @@ namespace Microsoft.Azure.Cosmos.Handlers
             ResponseMessage response = await base.SendAsync(request, cancellationToken);
             if (this.IsAllowed(request))
             {
-                try
-                {
-                    this.telemetry
-                        .CollectOperationInfo(
-                                cosmosDiagnostics: response.Diagnostics,
-                                statusCode: response.StatusCode,
-                                responseSizeInBytes: this.GetPayloadSize(response),
-                                containerId: request.ContainerId,
-                                databaseId: request.DatabaseId,
-                                operationType: request.OperationType,
-                                resourceType: request.ResourceType,
-                                consistencyLevel: request.Headers?[Documents.HttpConstants.HttpHeaders.ConsistencyLevel],
-                                requestCharge: response.Headers.RequestCharge,
-                                subStatusCode: response.Headers.SubStatusCode);
-                }
-                catch (Exception ex)
-                {
-                    DefaultTrace.TraceError("Error while collecting telemetry information : " + ex.Message);
-                }
+                this.telemetry
+                    .CollectOperationInfo(
+                            cosmosDiagnostics: response.Diagnostics,
+                            statusCode: response.StatusCode,
+                            responseSizeInBytes: this.GetPayloadSize(response),
+                            containerId: request.ContainerId,
+                            databaseId: request.DatabaseId,
+                            operationType: request.OperationType,
+                            resourceType: request.ResourceType,
+                            consistencyLevel: request.Headers?[Documents.HttpConstants.HttpHeaders.ConsistencyLevel],
+                            requestCharge: response.Headers.RequestCharge,
+                            subStatusCode: response.Headers.SubStatusCode,
+                            trace: request.Trace);
+                
             }
             return response;
         }

--- a/Microsoft.Azure.Cosmos/src/Resource/ClientContextCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/ClientContextCore.cs
@@ -11,8 +11,6 @@ namespace Microsoft.Azure.Cosmos
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.Azure.Cosmos.Core.Trace;
-    using Microsoft.Azure.Cosmos.Handler;
     using Microsoft.Azure.Cosmos.Handlers;
     using Microsoft.Azure.Cosmos.Resource.CosmosExceptions;
     using Microsoft.Azure.Cosmos.Routing;

--- a/Microsoft.Azure.Cosmos/src/Routing/ClientCollectionCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/ClientCollectionCache.cs
@@ -227,7 +227,8 @@ namespace Microsoft.Azure.Cosmos.Routing
                                                     operationType: request.OperationType,
                                                     resourceType: request.ResourceType,
                                                     subStatusCode: response.SubStatusCode,
-                                                    databaseId: databaseName);
+                                                    databaseId: databaseName,
+                                                    trace: childTrace);
                                 }
 
                                 return containerProperties;

--- a/Microsoft.Azure.Cosmos/src/Routing/ClientCollectionCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/ClientCollectionCache.cs
@@ -217,18 +217,25 @@ namespace Microsoft.Azure.Cosmos.Routing
 
                                 if (this.clientTelemetry != null)
                                 {
-                                    ClientCollectionCache.GetDatabaseAndCollectionName(collectionLink, out string databaseName, out string collectionName);
-                                    this.clientTelemetry.CollectCacheInfo(
-                                                    cacheRefreshSource: ClientCollectionCache.TelemetrySourceName,
-                                                    regionsContactedList: response.RequestStats.RegionsContacted,
-                                                    requestLatency: response.RequestStats.RequestLatency,
-                                                    statusCode: response.StatusCode,
-                                                    containerId: collectionName,
-                                                    operationType: request.OperationType,
-                                                    resourceType: request.ResourceType,
-                                                    subStatusCode: response.SubStatusCode,
-                                                    databaseId: databaseName,
-                                                    trace: childTrace);
+                                    try
+                                    {
+                                        ClientCollectionCache.GetDatabaseAndCollectionName(collectionLink, out string databaseName, out string collectionName);
+                                        this.clientTelemetry.CollectCacheInfo(
+                                                        cacheRefreshSource: ClientCollectionCache.TelemetrySourceName,
+                                                        regionsContactedList: response.RequestStats.RegionsContacted,
+                                                        requestLatency: response.RequestStats.RequestLatency,
+                                                        statusCode: response.StatusCode,
+                                                        containerId: collectionName,
+                                                        operationType: request.OperationType,
+                                                        resourceType: request.ResourceType,
+                                                        subStatusCode: response.SubStatusCode,
+                                                        databaseId: databaseName,
+                                                        trace: childTrace);
+                                    }
+                                    catch (Exception ex)
+                                    {
+                                        childTrace.AddDatum(ClientTelemetry.exceptionDatumKey, ex.Message);
+                                    }
                                 }
 
                                 return containerProperties;

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
@@ -33,8 +33,10 @@ namespace Microsoft.Azure.Cosmos.Telemetry
     internal class ClientTelemetry : IDisposable
     {
         private const int allowedNumberOfFailures = 3;
-        private const string exceptionDatumKey = "Client Telemetry Exception Message";
         
+        internal const string exceptionDatumKey = "Client Telemetry Exception";
+        internal const string warningDatumKey = "Client Telemetry Warning";
+
         private static readonly Uri endpointUrl = ClientTelemetryOptions.GetClientTelemetryEndpoint();
         private static readonly TimeSpan observingWindow = ClientTelemetryOptions.GetScheduledTimeSpan();
 


### PR DESCRIPTION
## Description
Client Telemetry is background job and if anything fails during request information collection then it should not affect the existing flow. Thats why we are not throwing any exception out of that.
But we need a mechanism to log exception if anything happens during collection. Hence, leveraging request diagnostics to log any exception comes up during collection.

It will look something like this:
![image](https://user-images.githubusercontent.com/6362382/197416784-3f5b9c04-b24b-44a0-a37e-fb996560b2db.png)

**Proposals for end-to-end error handling:**
There are 4 states of client telemetry or you can say failure points:
a) INITIALIZATING: When job starts
b) COLLECTING: When collect* function is called to collect the information. It is tightly coupled with the request
c) PROCESSING: When other things happen like transforming data etc.
d) SENDING: Sending telemetry data to telemetry service

So, proposal is 
1. Use diagnostics for logging: 
a) If there is a failure at a) c) d) step, it will log in the diagnostic Summary with `<State>:<Exception Message>` and it will appear in all the request diagnostics.
b) If there is failure at step b) then it will be logged under that request section (covering as part of this PR) because we might be collecting telemetry at different places e.g cache or request.
If everything is fine, there will be no trace of these exceptions in request diagnostics. So, we are not increasing request diagnostics size unnecessarily.

3. Use Open Telemetry: This might be useful or implementable in future. But idea is generating an independent error event on client telemetry failure which can be captured by event listener. It would also need code change at customer side if they are not using Open telemetry system like AppInsights.

## Type of change
- [] Bug fix (non-breaking change which fixes an issue)
