### PR TITLE
[Internal] Documentation: Removes invalid comment from ReadThroughputAsync

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/Database/Database.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Database/Database.cs
@@ -124,9 +124,6 @@ namespace Microsoft.Azure.Cosmos
         /// <value>
         /// The provisioned throughput for this database.
         /// </value>
-        /// <remarks>
-        /// Null value indicates a database with no throughput provisioned.
-        /// </remarks>
         /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/request-units">Request Units</seealso>
         /// <seealso href="https://docs.microsoft.com/azure/cosmos-db/set-throughput#set-throughput-on-a-database">Set throughput on a database</seealso>
         /// <example>


### PR DESCRIPTION
Reference: https://github.com/Azure/azure-cosmos-dotnet-v3/pull/3496#issuecomment-1289888018

The method throws if the throughput is not assigned, it doesn't return `null`