### PR TITLE
Query: Fixes performance regression on target partition on some ORDER BY queries with continuation

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/OrderByCrossPartitionQueryPipelineStage.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/OrderByCrossPartitionQueryPipelineStage.cs
@@ -1029,7 +1029,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
 
             // For the target filter we can make an optimization to just return "true",
             // since we already have the backend continuation token to resume with.
-            return (left.ToString(), TrueFilter, right.ToString());
+            return (left.ToString(), target.ToString(), right.ToString());
         }
 
         private static async Task<TryCatch<(bool doneFiltering, int itemsLeftToSkip, TryCatch<OrderByQueryPage> monadicQueryByPage)>> FilterNextAsync(

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/OrderByCrossPartitionQueryPipelineStage.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/OrderByCrossPartitionQueryPipelineStage.cs
@@ -1027,8 +1027,6 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
                 }
             }
 
-            // For the target filter we can make an optimization to just return "true",
-            // since we already have the backend continuation token to resume with.
             return (left.ToString(), target.ToString(), right.ToString());
         }
 


### PR DESCRIPTION
## Description

Fixes performance regression introduced by #1289

The lack of query filters being sent to the target partition can cause excess round trips as the sdk tries to skip over values that have already been seen.

In case of CRM ([ICM 342678670](https://portal.microsofticm.com/imp/v3/incidents/details/342678670/home)) it lead to over 12k round trips. After the fix, there were only 31 round trips.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
