### PR TITLE
[Internal] Nuget: fix removing nuget.config files

### DIFF
--- a/Microsoft.Azure.Cosmos.Samples/Usage/NuGet.config
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/NuGet.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
- </packageSources>
-</configuration>

--- a/NuGet.config
+++ b/NuGet.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<configuration>
-  <packageSources>
-    <add key="NuGet" value="https://api.nuget.org/v3/index.json" />
- </packageSources>
-</configuration>


### PR DESCRIPTION
[Internal] Nuget: fix removing nuget.config files

Nuget.Config files were added to consume private feed sources before (myget) which is no more a requirement. 
Cleaning it up part CFS (Central Feed Service) governance alert