### PR TITLE
[Internal] nugetconfig: Fixes NuGet.config presence

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
[Internal] nugetconfig: Ensure NuGet.config presence

Explicitly adding a nuget.config file to the root of the repository with just a <clear/> element to resolve the CFS0011 issue raised by internal feedscan tooling.