### PR TITLE
Query: Adds diagnostic info regarding optimal page size and target range count

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CosmosQueryExecutionContextFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CosmosQueryExecutionContextFactory.cs
@@ -371,6 +371,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
                     inputParameters,
                     partitionedQueryExecutionInfo,
                     targetRanges,
+                    trace,
                     cancellationToken);
             }
 
@@ -426,10 +427,13 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
             CosmosQueryContext cosmosQueryContext,
             InputParameters inputParameters,
             PartitionedQueryExecutionInfo partitionedQueryExecutionInfo,
-            List<Documents.PartitionKeyRange> targetRanges, 
+            List<Documents.PartitionKeyRange> targetRanges,
+            ITrace trace,
             CancellationToken cancellationToken)
         {
             QueryInfo queryInfo = partitionedQueryExecutionInfo.QueryInfo;
+
+            trace.AddDatum(nameof(inputParameters.MaxItemCount), inputParameters.MaxItemCount);
 
             // We need to compute the optimal initial page size for order-by queries
             long optimalPageSize = inputParameters.MaxItemCount;
@@ -456,6 +460,9 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
             Debug.Assert(
                 (optimalPageSize > 0) && (optimalPageSize <= int.MaxValue),
                 $"Invalid MaxItemCount {optimalPageSize}");
+
+            trace.AddDatum("OptimalPageSize", optimalPageSize);
+            trace.AddDatum("TargetRangeCount", targetRanges.Count);
 
             return PipelineFactory.MonadicCreate(
                 executionEnvironment: inputParameters.ExecutionEnvironment,


### PR DESCRIPTION
## Description

Adds diagnostic info regarding optimal page size and target range count to the trace. From [ICM 355724064](https://portal.microsofticm.com/imp/v3/incidents/details/355724064/home), the claim is that the optimal page size calculated by the sdk is much smaller than what it should be based on the `MaxItemCount` provided by the customer. These diagnostics will help us verify the claim.


## Type of change

- [x] Diagnostics (non-breaking change which adds diagnostic information)