### PR TITLE
[Internal] Benchmark: Refactors code to make Memory Stream capacity configurable.

### DIFF
--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/BenchmarkConfig.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/BenchmarkConfig.cs
@@ -143,7 +143,9 @@ namespace CosmosBenchmark
                 Utility.TeeTraceInformation($"{nameof(BenchmarkConfig)} arguments");
                 Utility.TeeTraceInformation($"IsServerGC: {GCSettings.IsServerGC}");
                 Utility.TeeTraceInformation("--------------------------------------------------------------------- ");
-                Utility.TeeTraceInformation(JsonHelper.ToString(this));
+                Utility.TeeTraceInformation(JsonHelper.ToString(
+                    input: this, 
+                    capacity: 2048));
                 Utility.TeeTraceInformation("--------------------------------------------------------------------- ");
                 Utility.TeeTraceInformation(string.Empty);
             }

--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/JsonHelper.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/JsonHelper.cs
@@ -17,9 +17,9 @@ namespace CosmosBenchmark
                 });
         private const int DefaultCapacity = 1024;
 
-        public static string ToString<T>(T input)
+        public static string ToString<T>(T input, int capacity = JsonHelper.DefaultCapacity)
         {
-            using (MemoryStream stream = JsonHelper.ToStream(input))
+            using (MemoryStream stream = JsonHelper.ToStream(input, capacity))
             using (StreamReader sr = new StreamReader(stream))
             {
                 return sr.ReadToEnd();
@@ -31,15 +31,15 @@ namespace CosmosBenchmark
             return JsonConvert.DeserializeObject<T>(payload);
         }
 
-        public static MemoryStream ToStream<T>(T input)
+        public static MemoryStream ToStream<T>(T input, int capacity = JsonHelper.DefaultCapacity)
         {
-            byte[] blob = System.Buffers.ArrayPool<byte>.Shared.Rent(JsonHelper.DefaultCapacity);
-            MemoryStream memStreamPayload = new MemoryStream(blob, 0, JsonHelper.DefaultCapacity, writable: true, publiclyVisible: true);
+            byte[] blob = System.Buffers.ArrayPool<byte>.Shared.Rent(capacity);
+            MemoryStream memStreamPayload = new MemoryStream(blob, 0, capacity, writable: true, publiclyVisible: true);
             memStreamPayload.SetLength(0);
             memStreamPayload.Position = 0;
             using (StreamWriter streamWriter = new StreamWriter(memStreamPayload,
                 encoding: JsonHelper.DefaultEncoding,
-                bufferSize: JsonHelper.DefaultCapacity,
+                bufferSize: capacity,
                 leaveOpen: true))
             {
                 using (JsonWriter writer = new JsonTextWriter(streamWriter))


### PR DESCRIPTION
## Description
Below exception has been thrown when serialized string size is more than default capacity(i.e 1024 bytes). As part of this PR increasing this limit only for the part where we are printing configs (for which below exception was thrown).

```
Unhandled exception. System.NotSupportedException: Memory stream is not expandable.
   at System.IO.MemoryStream.set_Capacity(Int32 value)
   at System.IO.MemoryStream.EnsureCapacity(Int32 value)
   at System.IO.MemoryStream.Write(ReadOnlySpan`1 buffer)
   at System.IO.StreamWriter.Flush(Boolean flushStream, Boolean flushEncoder)
   at System.IO.StreamWriter.Flush()
   at Newtonsoft.Json.JsonTextWriter.Flush()
   at CosmosBenchmark.JsonHelper.ToStream[T](T input) in /home/debdattakunda/stash/azure-cosmos-dotnet-v3/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/JsonHelper.cs:line 48
   at CosmosBenchmark.JsonHelper.ToString[T](T input) in /home/debdattakunda/stash/azure-cosmos-dotnet-v3/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/JsonHelper.cs:line 22
   at CosmosBenchmark.BenchmarkConfig.Print() in /home/debdattakunda/stash/azure-cosmos-dotnet-v3/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/BenchmarkConfig.cs:line 146
   at CosmosBenchmark.Program.Main(String[] args) in /home/debdattakunda/stash/azure-cosmos-dotnet-v3/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/Program.cs:line 44
   at CosmosBenchmark.Program.<Main>(String[] args)
```

## Type of change
- [] Bug fix (non-breaking change which fixes an issue)
