### PR TITLE
Query: Fixes handling of CosmosUndefined, CosmosGuid and CosmosBinary in unordered DISTINCT

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Distinct/DistinctMap.UnorderedDistinctMap.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Distinct/DistinctMap.UnorderedDistinctMap.cs
@@ -72,7 +72,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Distinct
         /// This class does that with the additional optimization that it doesn't store the whole JSON.
         /// Instead this class takes a GUID like hash and store that instead.
         /// </summary>
-        private sealed class UnorderdDistinctMap : DistinctMap
+        private sealed class UnorderedDistinctMap : DistinctMap
         {
             /// <summary>
             /// Length of UInt128 (in bytes).
@@ -98,6 +98,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Distinct
                 public const string StringsLength16Plus = "StringsLength16+";
                 public const string Arrays = "Arrays";
                 public const string Object = "Object";
+                public const string Guids = "Guids";
+                public const string Blobs = "Blobs";
                 public const string SimpleValues = "SimpleValues";
             }
 
@@ -144,11 +146,23 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Distinct
             private readonly HashSet<UInt128> objects;
 
             /// <summary>
+            /// HashSet for all CosmosGuids seen.
+            /// This set only stores the hash, since we don't want to spend the space for storing large arrays.
+            /// </summary>
+            private readonly HashSet<UInt128> guids;
+
+            /// <summary>
+            /// HashSet for all CosmosBinarys seen.
+            /// This set only stores the hash, since we don't want to spend the space for storing large objects.
+            /// </summary>
+            private readonly HashSet<UInt128> blobs;
+
+            /// <summary>
             /// Stores all the simple values that we don't want to dedicate a hash set for.
             /// </summary>
             private SimpleValues simpleValues;
 
-            private UnorderdDistinctMap(
+            private UnorderedDistinctMap(
                 HashSet<Number64> numbers,
                 HashSet<uint> stringsLength4,
                 HashSet<ulong> stringsLength8,
@@ -156,6 +170,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Distinct
                 HashSet<UInt128> stringsLength16Plus,
                 HashSet<UInt128> arrays,
                 HashSet<UInt128> objects,
+                HashSet<UInt128> guids,
+                HashSet<UInt128> blobs,
                 SimpleValues simpleValues)
             {
                 this.numbers = numbers ?? throw new ArgumentNullException(nameof(numbers));
@@ -165,6 +181,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Distinct
                 this.stringsLength16Plus = stringsLength16Plus ?? throw new ArgumentNullException(nameof(stringsLength16Plus));
                 this.arrays = arrays ?? throw new ArgumentNullException(nameof(arrays));
                 this.objects = objects ?? throw new ArgumentNullException(nameof(objects));
+                this.guids = guids ?? throw new ArgumentNullException(nameof(guids));
+                this.blobs = blobs ?? throw new ArgumentNullException(nameof(blobs));
                 this.simpleValues = simpleValues;
             }
 
@@ -179,16 +197,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Distinct
                 // Unordered distinct does not need to return a valid hash.
                 // Since it doesn't need the last hash for a continuation.
                 hash = default;
-                return cosmosElement switch
-                {
-                    CosmosArray cosmosArray => this.AddArrayValue(cosmosArray),
-                    CosmosBoolean cosmosBoolean => this.AddSimpleValue(cosmosBoolean.Value ? SimpleValues.True : SimpleValues.False),
-                    CosmosNull _ => this.AddSimpleValue(SimpleValues.Null),
-                    CosmosNumber cosmosNumber => this.AddNumberValue(cosmosNumber.Value),
-                    CosmosObject cosmosObject => this.AddObjectValue(cosmosObject),
-                    CosmosString cosmosString => this.AddStringValue(cosmosString.Value),
-                    _ => throw new ArgumentOutOfRangeException($"Unexpected {nameof(CosmosElement)}: {cosmosElement}"),
-                };
+                CosmosElementVisitor visitor = new CosmosElementVisitor(this);
+                return cosmosElement.Accept(visitor);
             }
 
             public override string GetContinuationToken()
@@ -201,35 +211,43 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Distinct
                 Dictionary<string, CosmosElement> dictionary = new Dictionary<string, CosmosElement>()
                 {
                     {
-                        UnorderdDistinctMap.PropertyNames.Numbers,
+                        UnorderedDistinctMap.PropertyNames.Numbers,
                         CosmosArray.Create(this.numbers.Select(x => CosmosNumber64.Create(x)))
                     },
                     {
-                        UnorderdDistinctMap.PropertyNames.StringsLength4,
+                        UnorderedDistinctMap.PropertyNames.StringsLength4,
                         CosmosArray.Create(this.stringsLength4.Select(x => CosmosUInt32.Create(x)))
                     },
                     {
-                        UnorderdDistinctMap.PropertyNames.StringsLength8,
+                        UnorderedDistinctMap.PropertyNames.StringsLength8,
                         CosmosArray.Create(this.stringsLength8.Select(x => CosmosInt64.Create((long)x)))
                     },
                     {
-                        UnorderdDistinctMap.PropertyNames.StringsLength16,
+                        UnorderedDistinctMap.PropertyNames.StringsLength16,
                         CosmosArray.Create(this.stringsLength16.Select(x => CosmosBinary.Create(UInt128.ToByteArray(x))))
                     },
                     {
-                        UnorderdDistinctMap.PropertyNames.StringsLength16Plus,
+                        UnorderedDistinctMap.PropertyNames.StringsLength16Plus,
                         CosmosArray.Create(this.stringsLength16Plus.Select(x => CosmosBinary.Create(UInt128.ToByteArray(x))))
                     },
                     {
-                        UnorderdDistinctMap.PropertyNames.Arrays,
+                        UnorderedDistinctMap.PropertyNames.Arrays,
                         CosmosArray.Create(this.arrays.Select(x => CosmosBinary.Create(UInt128.ToByteArray(x))))
                     },
                     {
-                        UnorderdDistinctMap.PropertyNames.Object,
+                        UnorderedDistinctMap.PropertyNames.Object,
                         CosmosArray.Create(this.objects.Select(x => CosmosBinary.Create(UInt128.ToByteArray(x))))
                     },
                     {
-                        UnorderdDistinctMap.PropertyNames.SimpleValues,
+                        UnorderedDistinctMap.PropertyNames.Guids,
+                        CosmosArray.Create(this.guids.Select(x => CosmosBinary.Create(UInt128.ToByteArray(x))))
+                    },
+                    {
+                        UnorderedDistinctMap.PropertyNames.Blobs,
+                        CosmosArray.Create(this.blobs.Select(x => CosmosBinary.Create(UInt128.ToByteArray(x))))
+                    },
+                    {
+                        UnorderedDistinctMap.PropertyNames.SimpleValues,
                         CosmosString.Create(this.simpleValues.ToString())
                     }
                 };
@@ -274,7 +292,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Distinct
                 int utf8Length = Encoding.UTF8.GetByteCount(value);
 
                 // If you can fit the string with full fidelity in 16 bytes, then you might as well just hash the string itself.
-                if (utf8Length <= UnorderdDistinctMap.UInt128Length)
+                if (utf8Length <= UnorderedDistinctMap.UInt128Length)
                 {
                     Span<byte> utf8Buffer = stackalloc byte[UInt128Length];
                     Encoding.UTF8.GetBytes(value, utf8Buffer);
@@ -282,12 +300,12 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Distinct
                     {
                         added = this.AddSimpleValue(SimpleValues.EmptyString);
                     }
-                    else if (utf8Length <= UnorderdDistinctMap.UIntLength)
+                    else if (utf8Length <= UnorderedDistinctMap.UIntLength)
                     {
                         uint uintValue = MemoryMarshal.Read<uint>(utf8Buffer);
                         added = this.stringsLength4.Add(uintValue);
                     }
-                    else if (utf8Length <= UnorderdDistinctMap.ULongLength)
+                    else if (utf8Length <= UnorderedDistinctMap.ULongLength)
                     {
                         ulong uLongValue = MemoryMarshal.Read<ulong>(utf8Buffer);
                         added = this.stringsLength8.Add(uLongValue);
@@ -330,6 +348,28 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Distinct
                 return this.objects.Add(hash);
             }
 
+            /// <summary>
+            /// Adds a guid value to the distinct map.
+            /// </summary>
+            /// <param name="guid">The guid to add.</param>
+            /// <returns>Whether or not the value was successfully added.</returns>
+            private bool AddGuidValue(CosmosGuid guid)
+            {
+                UInt128 hash = DistinctHash.GetHash(guid);
+                return this.guids.Add(hash);
+            }
+
+            /// <summary>
+            /// Adds a binary value to the distinct map.
+            /// </summary>
+            /// <param name="binary">The array to add.</param>
+            /// <returns>Whether or not the value was successfully added.</returns>
+            private bool AddBinaryValue(CosmosBinary binary)
+            {
+                UInt128 hash = DistinctHash.GetHash(binary);
+                return this.blobs.Add(hash);
+            }
+
             public static TryCatch<DistinctMap> TryCreate(CosmosElement continuationToken)
             {
                 HashSet<Number64> numbers = new HashSet<Number64>();
@@ -339,6 +379,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Distinct
                 HashSet<UInt128> stringsLength16Plus = new HashSet<UInt128>();
                 HashSet<UInt128> arrays = new HashSet<UInt128>();
                 HashSet<UInt128> objects = new HashSet<UInt128>();
+                HashSet<UInt128> guids = new HashSet<UInt128>();
+                HashSet<UInt128> blobs = new HashSet<UInt128>();
                 SimpleValues simpleValues = SimpleValues.None;
 
                 if (continuationToken != null)
@@ -347,15 +389,15 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Distinct
                     {
                         return TryCatch<DistinctMap>.FromException(
                             new MalformedContinuationTokenException(
-                                $"{nameof(UnorderdDistinctMap)} continuation token was malformed."));
+                                $"{nameof(UnorderedDistinctMap)} continuation token was malformed."));
                     }
 
                     // Numbers
-                    if (!hashDictionary.TryGetValue(UnorderdDistinctMap.PropertyNames.Numbers, out CosmosArray numbersArray))
+                    if (!hashDictionary.TryGetValue(UnorderedDistinctMap.PropertyNames.Numbers, out CosmosArray numbersArray))
                     {
                         return TryCatch<DistinctMap>.FromException(
                             new MalformedContinuationTokenException(
-                                $"{nameof(UnorderdDistinctMap)} continuation token was malformed."));
+                                $"{nameof(UnorderedDistinctMap)} continuation token was malformed."));
                     }
 
                     foreach (CosmosElement rawNumber in numbersArray)
@@ -364,18 +406,18 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Distinct
                         {
                             return TryCatch<DistinctMap>.FromException(
                                 new MalformedContinuationTokenException(
-                                    $"{nameof(UnorderdDistinctMap)} continuation token was malformed."));
+                                    $"{nameof(UnorderedDistinctMap)} continuation token was malformed."));
                         }
 
                         numbers.Add(number.GetValue());
                     }
 
                     // Strings Length 4
-                    if (!hashDictionary.TryGetValue(UnorderdDistinctMap.PropertyNames.StringsLength4, out CosmosArray stringsLength4Array))
+                    if (!hashDictionary.TryGetValue(UnorderedDistinctMap.PropertyNames.StringsLength4, out CosmosArray stringsLength4Array))
                     {
                         return TryCatch<DistinctMap>.FromException(
                                 new MalformedContinuationTokenException(
-                                    $"{nameof(UnorderdDistinctMap)} continuation token was malformed."));
+                                    $"{nameof(UnorderedDistinctMap)} continuation token was malformed."));
                     }
 
                     foreach (CosmosElement rawStringLength4 in stringsLength4Array)
@@ -384,18 +426,18 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Distinct
                         {
                             return TryCatch<DistinctMap>.FromException(
                                 new MalformedContinuationTokenException(
-                                    $"{nameof(UnorderdDistinctMap)} continuation token was malformed."));
+                                    $"{nameof(UnorderedDistinctMap)} continuation token was malformed."));
                         }
 
                         stringsLength4.Add(stringlength4.GetValue());
                     }
 
                     // Strings Length 8
-                    if (!hashDictionary.TryGetValue(UnorderdDistinctMap.PropertyNames.StringsLength8, out CosmosArray stringsLength8Array))
+                    if (!hashDictionary.TryGetValue(UnorderedDistinctMap.PropertyNames.StringsLength8, out CosmosArray stringsLength8Array))
                     {
                         return TryCatch<DistinctMap>.FromException(
                             new MalformedContinuationTokenException(
-                                $"{nameof(UnorderdDistinctMap)} continuation token was malformed."));
+                                $"{nameof(UnorderedDistinctMap)} continuation token was malformed."));
                     }
 
                     foreach (CosmosElement rawStringLength8 in stringsLength8Array)
@@ -404,42 +446,42 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Distinct
                         {
                             return TryCatch<DistinctMap>.FromException(
                                 new MalformedContinuationTokenException(
-                                    $"{nameof(UnorderdDistinctMap)} continuation token was malformed."));
+                                    $"{nameof(UnorderedDistinctMap)} continuation token was malformed."));
                         }
 
                         stringsLength8.Add((ulong)stringlength8.GetValue());
                     }
 
-                    // Strings Length 16
-                    stringsLength16 = Parse128BitHashes(hashDictionary, UnorderdDistinctMap.PropertyNames.StringsLength16);
+                    stringsLength16 = Parse128BitHashes(hashDictionary, UnorderedDistinctMap.PropertyNames.StringsLength16);
 
-                    // Strings Length 24
-                    stringsLength16Plus = Parse128BitHashes(hashDictionary, UnorderdDistinctMap.PropertyNames.StringsLength16Plus);
+                    stringsLength16Plus = Parse128BitHashes(hashDictionary, UnorderedDistinctMap.PropertyNames.StringsLength16Plus);
 
-                    // Array
-                    arrays = Parse128BitHashes(hashDictionary, UnorderdDistinctMap.PropertyNames.Arrays);
+                    arrays = Parse128BitHashes(hashDictionary, UnorderedDistinctMap.PropertyNames.Arrays);
 
-                    // Object
-                    objects = Parse128BitHashes(hashDictionary, UnorderdDistinctMap.PropertyNames.Object);
+                    objects = Parse128BitHashes(hashDictionary, UnorderedDistinctMap.PropertyNames.Object);
+
+                    guids = Parse128BitHashes(hashDictionary, UnorderedDistinctMap.PropertyNames.Guids);
+
+                    blobs = Parse128BitHashes(hashDictionary, UnorderedDistinctMap.PropertyNames.Blobs);
 
                     // Simple Values
-                    CosmosElement rawSimpleValues = hashDictionary[UnorderdDistinctMap.PropertyNames.SimpleValues];
+                    CosmosElement rawSimpleValues = hashDictionary[UnorderedDistinctMap.PropertyNames.SimpleValues];
                     if (!(rawSimpleValues is CosmosString simpleValuesString))
                     {
                         return TryCatch<DistinctMap>.FromException(
                             new MalformedContinuationTokenException(
-                                $"{nameof(UnorderdDistinctMap)} continuation token was malformed."));
+                                $"{nameof(UnorderedDistinctMap)} continuation token was malformed."));
                     }
 
                     if (!Enum.TryParse<SimpleValues>(simpleValuesString.Value, out simpleValues))
                     {
                         return TryCatch<DistinctMap>.FromException(
                             new MalformedContinuationTokenException(
-                                $"{nameof(UnorderdDistinctMap)} continuation token was malformed."));
+                                $"{nameof(UnorderedDistinctMap)} continuation token was malformed."));
                     }
                 }
 
-                return TryCatch<DistinctMap>.FromResult(new UnorderdDistinctMap(
+                return TryCatch<DistinctMap>.FromResult(new UnorderedDistinctMap(
                     numbers,
                     stringsLength4,
                     stringsLength8,
@@ -447,6 +489,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Distinct
                     stringsLength16Plus,
                     arrays,
                     objects,
+                    guids,
+                    blobs,
                     simpleValues));
             }
 
@@ -456,7 +500,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Distinct
                 if (!hashDictionary.TryGetValue(propertyName, out CosmosArray array))
                 {
                     throw new MalformedContinuationTokenException(
-                        $"{nameof(UnorderdDistinctMap)} continuation token was malformed.");
+                        $"{nameof(UnorderedDistinctMap)} continuation token was malformed.");
                 }
 
                 foreach (CosmosElement item in array)
@@ -464,7 +508,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Distinct
                     if (!(item is CosmosBinary binary))
                     {
                         throw new MalformedContinuationTokenException(
-                            $"{nameof(UnorderdDistinctMap)} continuation token was malformed.");
+                            $"{nameof(UnorderedDistinctMap)} continuation token was malformed.");
                     }
 
                     UInt128 uint128 = UInt128.FromByteArray(binary.Value.Span);
@@ -472,6 +516,61 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Distinct
                 }
 
                 return hashSet;
+            }
+
+            private sealed class CosmosElementVisitor : ICosmosElementVisitor<bool>
+            {
+                private readonly UnorderedDistinctMap parent;
+
+                public CosmosElementVisitor(UnorderedDistinctMap parent)
+                {
+                    this.parent = parent ?? throw new ArgumentNullException(nameof(parent));
+                }
+
+                public bool Visit(CosmosArray cosmosArray)
+                {
+                    return this.parent.AddArrayValue(cosmosArray);
+                }
+
+                public bool Visit(CosmosBinary cosmosBinary)
+                {
+                    return this.parent.AddBinaryValue(cosmosBinary);
+                }
+
+                public bool Visit(CosmosBoolean cosmosBoolean)
+                {
+                    return this.parent.AddSimpleValue(cosmosBoolean.Value ? SimpleValues.True : SimpleValues.False);
+                }
+
+                public bool Visit(CosmosGuid cosmosGuid)
+                {
+                    return this.parent.AddGuidValue(cosmosGuid);
+                }
+
+                public bool Visit(CosmosNull cosmosNull)
+                {
+                    return this.parent.AddSimpleValue(SimpleValues.Null);
+                }
+
+                public bool Visit(CosmosNumber cosmosNumber)
+                {
+                    return this.parent.AddNumberValue(cosmosNumber.Value);
+                }
+
+                public bool Visit(CosmosObject cosmosObject)
+                {
+                    return this.parent.AddObjectValue(cosmosObject);
+                }
+
+                public bool Visit(CosmosString cosmosString)
+                {
+                    return this.parent.AddStringValue(cosmosString.Value);
+                }
+
+                public bool Visit(CosmosUndefined cosmosUndefined)
+                {
+                    return this.parent.AddSimpleValue(SimpleValues.Undefined);
+                }
             }
         }
     }

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Distinct/DistinctMap.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Distinct/DistinctMap.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Distinct
             CosmosElement distinctMapContinuationToken) => distinctQueryType switch
             {
                 DistinctQueryType.None => throw new ArgumentException("distinctQueryType can not be None. This part of code is not supposed to be reachable. Please contact support to resolve this issue."),
-                DistinctQueryType.Unordered => UnorderdDistinctMap.TryCreate(distinctMapContinuationToken),
+                DistinctQueryType.Unordered => UnorderedDistinctMap.TryCreate(distinctMapContinuationToken),
                 DistinctQueryType.Ordered => OrderedDistinctMap.TryCreate(distinctMapContinuationToken),
                 _ => throw new ArgumentException($"Unrecognized DistinctQueryType: {distinctQueryType}."),
             };

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/CosmosUndefinedQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/CosmosUndefinedQueryTests.cs
@@ -76,6 +76,9 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
                 MakeUndefinedProjectionTest(
                     query: $"SELECT VALUE AVG(c.{nameof(MixedTypeDocument.MixedTypeField)}) FROM c",
                     expectedCount: 0),
+                MakeUndefinedProjectionTest(
+                    query: $"SELECT DISTINCT VALUE SUM(c.{nameof(MixedTypeDocument.MixedTypeField)}) FROM c",
+                    expectedCount: 0)
             };
 
             foreach (UndefinedProjectionTestCase testCase in undefinedProjectionTestCases)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/DistinctQueryPipelineStageTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/DistinctQueryPipelineStageTests.cs
@@ -3,10 +3,11 @@
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.CosmosElements;
-    using Microsoft.Azure.Cosmos.Query.Core.ExecutionContext;
+    using Microsoft.Azure.Cosmos.CosmosElements.Numbers;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Distinct;
@@ -17,24 +18,201 @@
     [TestClass]
     public sealed class DistinctQueryPipelineStageTests
     {
+        private const int InputElementCount = 400;
+
+        private static readonly IReadOnlyList<CosmosElement> Literals = new List<CosmosElement>
+        {
+            CosmosUndefined.Create(),
+
+            CosmosNull.Create(),
+            
+            CosmosBoolean.Create(true),
+            CosmosBoolean.Create(false),
+            
+            CosmosNumber64.Create(0),
+            CosmosNumber64.Create(42),
+            CosmosNumber64.Create(-1),
+            CosmosNumber64.Create(100010),
+            CosmosNumber64.Create(3.141619),
+            CosmosNumber64.Create(Math.PI),
+            
+            CosmosString.Create(string.Empty),
+            CosmosString.Create("Hello World"),
+            CosmosString.Create(string.Join(',', Enumerable.Repeat("Hello World", 75))),
+            CosmosString.Create(string.Join(',', Enumerable.Repeat("Hello World", 100))),
+            CosmosString.Create("敏捷的棕色狐狸跳过了懒狗"),
+            CosmosString.Create(string.Join(',', Enumerable.Repeat("敏捷的棕色狐狸跳过了懒狗", 50))),
+            CosmosString.Create(string.Join(',', Enumerable.Repeat("敏捷的棕色狐狸跳过了懒狗", 60))),
+            
+            CosmosArray.Create(),
+            CosmosArray.Create(new CosmosElement[]
+            {
+                CosmosUndefined.Create(),
+                CosmosNull.Create(),
+                CosmosBoolean.Create(true),
+                CosmosBoolean.Create(false),
+                CosmosNumber64.Create(0),
+            }),
+            CosmosArray.Create(new CosmosElement[]
+            {
+                CosmosUndefined.Create(),
+                CosmosNull.Create(),
+                CosmosBoolean.Create(true),
+                CosmosBoolean.Create(false)
+            }),
+            CosmosArray.Create(new CosmosElement[]
+            {
+                CosmosUndefined.Create(),
+                CosmosNull.Create(),
+                CosmosBoolean.Create(true),
+                CosmosBoolean.Create(false),
+                CosmosNumber64.Create(0),
+                CosmosNumber64.Create(42),
+                CosmosNumber64.Create(-1),
+                CosmosNumber64.Create(100010),
+                CosmosNumber64.Create(3.141619),
+            }),
+            
+            CosmosObject.Create(new Dictionary<string, CosmosElement>()),
+            CosmosObject.Create(new Dictionary<string, CosmosElement>
+            {
+                ["敏"] = CosmosUndefined.Create(),
+                ["b"] = CosmosNull.Create(),
+                ["c"] = CosmosBoolean.Create(true),
+                ["d"] = CosmosBoolean.Create(false),
+                ["懒"] = CosmosNumber64.Create(0),
+            }),
+            CosmosObject.Create(new Dictionary<string, CosmosElement>
+            {
+                ["敏"] = CosmosUndefined.Create(),
+                ["b"] = CosmosNull.Create(),
+                ["c"] = CosmosBoolean.Create(true),
+                ["d"] = CosmosBoolean.Create(false),
+                ["懒"] = CosmosNumber64.Create(0),
+                ["e"] = CosmosNumber64.Create(42),
+                ["f"] = CosmosNumber64.Create(-1),
+                ["فوق"] = CosmosNumber64.Create(100010),
+                ["g"] = CosmosNumber64.Create(3.141619),
+            }),
+            
+            CosmosGuid.Create(Guid.Parse("D29F71E3-2D43-4573-A0E6-16D7E03FDEB5")),
+            CosmosGuid.Create(Guid.Parse("D29F71E3-2D43-4573-B0E6-16D7E03FDEB5")),
+            CosmosGuid.Create(Guid.Parse("D29F71E3-2D43-4573-C0E6-16D7E03FDEB5")),
+            CosmosGuid.Create(Guid.Parse("D29F71E3-2D43-4573-D0E6-16D7E03FDEB5")),
+            CosmosGuid.Create(Guid.Parse("D29F71E3-2D43-4573-E0E6-16D7E03FDEB5")),
+            
+            CosmosBinary.Create(Guid.Parse("D29F71E3-2D43-4573-A0E6-16D7E03FDEB5").ToByteArray()),
+            CosmosBinary.Create(Guid.Parse("D29F71E3-2D43-4573-B0E6-16D7E03FDEB5").ToByteArray()),
+            CosmosBinary.Create(Guid.Parse("D29F71E3-2D43-4573-C0E6-16D7E03FDEB5").ToByteArray()),
+            CosmosBinary.Create(Guid.Parse("D29F71E3-2D43-4573-D0E6-16D7E03FDEB5").ToByteArray()),
+            CosmosBinary.Create(Guid.Parse("D29F71E3-2D43-4573-E0E6-16D7E03FDEB5").ToByteArray()),
+            CosmosBinary.Create(Encoding.UTF8.GetBytes("Hello World")),
+            CosmosBinary.Create(Encoding.UTF8.GetBytes(string.Join(',', Enumerable.Repeat("Hello World", 75)))),
+            CosmosBinary.Create(Encoding.UTF8.GetBytes(string.Join(',', Enumerable.Repeat("Hello World", 100)))),
+            CosmosBinary.Create(Encoding.UTF8.GetBytes("敏捷的棕色狐狸跳过了懒狗")),
+            CosmosBinary.Create(Encoding.UTF8.GetBytes(string.Join(',', Enumerable.Repeat("敏捷的棕色狐狸跳过了懒狗", 50)))),
+            CosmosBinary.Create(Encoding.UTF8.GetBytes(string.Join(',', Enumerable.Repeat("敏捷的棕色狐狸跳过了懒狗", 60)))),
+        };
+
         [TestMethod]
         public async Task SanityTests()
         {
-            long[] values = new long[] { 42, 1337, 1337, 42 };
-            IReadOnlyList<IReadOnlyList<CosmosElement>> pages = values
-                .Select(value => new List<CosmosElement>()
+            long[] values = { 42, 1337, 1337, 42 };
+
+            IEnumerable<CosmosElement> input = values
+                .Select(value => CosmosObject.Create(new Dictionary<string, CosmosElement>
                 {
-                    CosmosElement.Parse($"{{\"item\": {value}}}")
-                })
-                .ToList();
+                    ["item"] = CosmosNumber64.Create(value)
+                }));
 
-            List<CosmosElement> elements = await DistinctQueryPipelineStageTests.CreateAndDrainAsync(
-                pages: pages,
-                executionEnvironment: ExecutionEnvironment.Compute,
-                continuationToken: null,
-                distinctQueryType: DistinctQueryType.Unordered);
+            IEnumerable<CosmosElement> expected = values
+                .Distinct()
+                .Select(value => CosmosObject.Create(new Dictionary<string, CosmosElement>
+                {
+                    ["item"] = CosmosNumber64.Create(value)
+                }));
 
-            Assert.AreEqual(values.Distinct().Count(), elements.Count);
+            DistinctQueryPipelineStageTestCase MakeTest(int pageSize)
+            {
+                return new DistinctQueryPipelineStageTestCase(input: input, pageSize: pageSize, expected: expected);
+            }
+
+            IEnumerable<DistinctQueryPipelineStageTestCase> testCases = new List<DistinctQueryPipelineStageTestCase>
+            {
+                MakeTest(pageSize: 1),
+                MakeTest(pageSize: 3),
+                MakeTest(pageSize : 10),
+            };
+
+            await RunTests(testCases);
+        }
+
+        [TestMethod]
+        public async Task MixedTypeTests()
+        {
+            List<CosmosElement> mixedTypeValues = new List<CosmosElement>();
+            mixedTypeValues.Capacity = InputElementCount;
+            for (int index = 0; index < InputElementCount; ++index)
+            {
+                mixedTypeValues.Add(Literals[index % Literals.Count]);
+            }
+
+            DistinctQueryPipelineStageTestCase MakeTest(int pageSize)
+            {
+                return new DistinctQueryPipelineStageTestCase(input: mixedTypeValues, pageSize: pageSize, expected: Literals);
+            }
+
+            IEnumerable<DistinctQueryPipelineStageTestCase> testCases = new List<DistinctQueryPipelineStageTestCase>
+            {
+                MakeTest(pageSize: 400),
+                MakeTest(pageSize: 100),
+                MakeTest(pageSize: 10),
+                MakeTest(pageSize: 1),
+            };
+
+            await RunTests(testCases);
+        }
+
+        private static async Task RunTests(IEnumerable<DistinctQueryPipelineStageTestCase> testCases)
+        {
+            foreach (DistinctQueryPipelineStageTestCase testCase in testCases)
+            {
+                IEnumerator<CosmosElement> enumerator = testCase.Input.GetEnumerator();
+                int pageSize = 0;
+                List<List<CosmosElement>> pages = new List<List<CosmosElement>>() { new List<CosmosElement>() };
+                while(enumerator.MoveNext())
+                {
+                    if(pageSize <= testCase.PageSize)
+                    {
+                        pages[pages.Count - 1].Add(enumerator.Current);
+                        ++pageSize;
+                    }
+                    else
+                    {
+                        pageSize = 0;
+                        pages.Add(new List<CosmosElement>());
+                    }
+                }
+    
+                foreach (ExecutionEnvironment env in new[] { ExecutionEnvironment.Compute, ExecutionEnvironment.Client })
+                {
+                    List<CosmosElement> elements = await DistinctQueryPipelineStageTests.CreateAndDrainAsync(
+                        pages: pages,
+                        executionEnvironment: env,
+                        continuationToken: null,
+                        distinctQueryType: DistinctQueryType.Unordered);
+
+                    List<string> actual = elements
+                        .Select(value => value.ToString())
+                        .ToList();
+
+                    List<string> expected = testCase.Expected
+                        .Select(value => value.ToString())
+                        .ToList();
+
+                    CollectionAssert.AreEquivalent(expected, actual);
+                }
+            }
         }
 
         private static async Task<List<CosmosElement>> CreateAndDrainAsync(
@@ -64,6 +242,22 @@
             }
 
             return elements;
+        }
+
+        private struct DistinctQueryPipelineStageTestCase
+        {
+            public IEnumerable<CosmosElement> Input { get; }
+
+            public int PageSize { get; }
+
+            public IEnumerable<CosmosElement> Expected { get; }
+
+            public DistinctQueryPipelineStageTestCase(IEnumerable<CosmosElement> input, int pageSize, IEnumerable<CosmosElement> expected)
+            {
+                this.Input = input ?? throw new ArgumentNullException(nameof(input));
+                this.PageSize = pageSize;
+                this.Expected = expected ?? throw new ArgumentNullException(nameof(expected));
+            }
         }
     }
 }


### PR DESCRIPTION
## Description

DistinctMap.UnorderedDistinctMap was missing code paths for handling some CosmosElement types like CosmosUndefined, CosmosGuid and CosmosBinary. This change adds the missing code paths to prevent `ArgumentOutOfRangeException`s on queries where these elements are encountered.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

