### PR TITLE
[Internal] ContainerProperties: Fixes version reset when setting PartitionKeyPath

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/ContainerProperties.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/ContainerProperties.cs
@@ -362,10 +362,17 @@ namespace Microsoft.Azure.Cosmos
                     throw new ArgumentNullException(nameof(this.PartitionKeyPath));
                 }
 
+                PartitionKeyDefinitionVersion? currentDefinitionVersion = this.PartitionKeyDefinitionVersion;
+
                 this.PartitionKey = new PartitionKeyDefinition
                 {
                     Paths = new Collection<string>() { value }
                 };
+                
+                if (currentDefinitionVersion.HasValue)
+                {
+                    this.PartitionKeyDefinitionVersion = currentDefinitionVersion.Value;
+                }
             }
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosContainerSettingsTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosContainerSettingsTests.cs
@@ -165,6 +165,17 @@ namespace Microsoft.Azure.Cosmos.Tests
             }
         }
 
+        [TestMethod]
+        public void SettingPKShouldNotResetVersion()
+        {
+            ContainerProperties containerProperties = new();
+            containerProperties.Id = "test";
+            containerProperties.PartitionKeyDefinitionVersion = Cosmos.PartitionKeyDefinitionVersion.V2;
+            containerProperties.PartitionKeyPath = "/id";
+
+            Assert.AreEqual(Cosmos.PartitionKeyDefinitionVersion.V2, containerProperties.PartitionKeyDefinitionVersion);
+        }
+
         private static string SerializeDocumentCollection(DocumentCollection collection)
         {
             using (MemoryStream ms = new MemoryStream())


### PR DESCRIPTION
When setting `ContainerProperties.PartitionKeyPath` upon creating a `ContainerProperties` object, the setter creates a new `PartitionKey` object to replace the previous one.

Example:

```
ContainerProperties containerProperties = new();
containerProperties.Id = testContext.TestName;
containerProperties.PartitionKeyDefinitionVersion = PartitionKeyDefinitionVersion.V2;
containerProperties.PartitionKeyPath = "/id";
```

Setting the `PartitionKeyPath` on line 4 resets the `PartitionKeyDefinitionVersion` value. 