### PR TITLE
Fixed CosmosClientBuilder.WithConnectionModeGateway documentation

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Fluent/CosmosClientBuilder.cs
+++ b/Microsoft.Azure.Cosmos/src/Fluent/CosmosClientBuilder.cs
@@ -438,7 +438,7 @@ namespace Microsoft.Azure.Cosmos.Fluent
         /// <summary>
         /// Sets the connection mode to Gateway. This is used by the client when connecting to the Azure Cosmos DB service.
         /// </summary>
-        /// <param name="maxConnectionLimit">The number specifies the time to wait for response to come back from network peer. Default is 60 connections</param>
+        /// <param name="maxConnectionLimit">The number specifies the number of connections which may be executed simultaneously. Default is 50 connections</param>
         /// <param name="webProxy">Get or set the proxy information used for web requests.</param>
         /// <remarks>
         /// For more information, see <see href="https://docs.microsoft.com/azure/documentdb/documentdb-performance-tips#direct-connection">Connection policy: Use direct connection mode</see>.

--- a/Microsoft.Azure.Cosmos/src/Fluent/CosmosClientBuilder.cs
+++ b/Microsoft.Azure.Cosmos/src/Fluent/CosmosClientBuilder.cs
@@ -438,7 +438,7 @@ namespace Microsoft.Azure.Cosmos.Fluent
         /// <summary>
         /// Sets the connection mode to Gateway. This is used by the client when connecting to the Azure Cosmos DB service.
         /// </summary>
-        /// <param name="maxConnectionLimit">The number specifies the number of connections which may be executed simultaneously. Default is 50 connections</param>
+        /// <param name="maxConnectionLimit">The number specifies the number of connections that may be opened simultaneously. Default is 50 connections</param>
         /// <param name="webProxy">Get or set the proxy information used for web requests.</param>
         /// <remarks>
         /// For more information, see <see href="https://docs.microsoft.com/azure/documentdb/documentdb-performance-tips#direct-connection">Connection policy: Use direct connection mode</see>.


### PR DESCRIPTION
# Pull Request Template

## Description

The documentation for `CosmosClientBuilder.WithConnectionModeGateway` is a bit confuse. This one is saying that the parameter `maxConnectionLimit` is the time that the client will wait, however, in the end, it is saying about number of connections. I've analyzed and this value is used on `HttpMessageHandler.MaxConnectionsPerServer`.

By the way, it's saying that the default value is 60, but, analyzing the code, this value is 50. 

## Type of change

Please delete options that are not relevant.

- [x] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #3641