### PR TITLE
[Internal] Client Telemetry: Adds Network Information in TraceSummary

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosDiagnostics.cs
+++ b/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosDiagnostics.cs
@@ -83,8 +83,8 @@ namespace Microsoft.Azure.Cosmos
         /// <returns>The list of tuples containing the Region name and the URI</returns>
         public abstract IReadOnlyList<(string regionName, Uri uri)> GetContactedRegions();
 
-        internal abstract IReadOnlyList<StoreResponseStatistics> StoreResponseStatistics { get; }
+        internal virtual IReadOnlyList<StoreResponseStatistics> StoreResponseStatistics { get; }
 
-        internal abstract IReadOnlyList<HttpResponseStatistics> HttpResponseStatistics { get; }
+        internal virtual IReadOnlyList<HttpResponseStatistics> HttpResponseStatistics { get; }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosDiagnostics.cs
+++ b/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosDiagnostics.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Azure.Cosmos
 {
     using System;
     using System.Collections.Generic;
+    using static Microsoft.Azure.Cosmos.Tracing.TraceData.ClientSideRequestStatisticsTraceDatum;
 
     /// <summary>
     ///  Contains the cosmos diagnostic information for the current request to Azure Cosmos DB service.
@@ -81,5 +82,9 @@ namespace Microsoft.Azure.Cosmos
         /// </summary>
         /// <returns>The list of tuples containing the Region name and the URI</returns>
         public abstract IReadOnlyList<(string regionName, Uri uri)> GetContactedRegions();
+
+        internal abstract IReadOnlyList<StoreResponseStatistics> StoreResponseStatistics { get; }
+
+        internal abstract IReadOnlyList<HttpResponseStatistics> HttpResponseStatistics { get; }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosTraceDiagnostics.cs
+++ b/Microsoft.Azure.Cosmos/src/Diagnostics/CosmosTraceDiagnostics.cs
@@ -6,7 +6,6 @@ namespace Microsoft.Azure.Cosmos.Diagnostics
 {
     using System;
     using System.Collections.Generic;
-    using System.Linq;
     using System.Text;
     using Microsoft.Azure.Cosmos.Json;
     using Microsoft.Azure.Cosmos.Tracing;
@@ -48,6 +47,10 @@ namespace Microsoft.Azure.Cosmos.Diagnostics
         {
             return this.Value?.Summary?.RegionsContacted;
         }
+
+        internal override IReadOnlyList<HttpResponseStatistics> HttpResponseStatistics => this.Value?.Summary?.HttpResponseStatistics;
+
+        internal override IReadOnlyList<StoreResponseStatistics> StoreResponseStatistics => this.Value?.Summary?.StoreResponseStatistics;
 
         internal bool IsGoneExceptionHit()
         {

--- a/Microsoft.Azure.Cosmos/src/Handler/TransportHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/TransportHandler.cs
@@ -134,7 +134,7 @@ namespace Microsoft.Azure.Cosmos.Handlers
                 }
                 finally
                 {
-                    processMessageAsyncTrace.Summary.UpdateRegionContacted(clientSideRequestStatisticsTraceDatum);
+                    processMessageAsyncTrace.Summary.UpdateSummary(clientSideRequestStatisticsTraceDatum);
                 }
                
                 ResponseMessage responseMessage = response.ToCosmosResponseMessage(

--- a/Microsoft.Azure.Cosmos/src/Tracing/Trace.cs
+++ b/Microsoft.Azure.Cosmos/src/Tracing/Trace.cs
@@ -6,9 +6,6 @@ namespace Microsoft.Azure.Cosmos.Tracing
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics;
-    using System.Linq;
-    using System.Runtime.CompilerServices;
     using Microsoft.Azure.Cosmos.Tracing.TraceData;
     using Microsoft.Azure.Documents;
 
@@ -121,11 +118,16 @@ namespace Microsoft.Azure.Cosmos.Tracing
                 parent: null,
                 summary: new TraceSummary());
         }
-
+        
         public void AddDatum(string key, TraceDatum traceDatum)
         {
             this.data.Value.Add(key, traceDatum);
-            this.Summary.UpdateRegionContacted(traceDatum);
+            
+            if (traceDatum is ClientSideRequestStatisticsTraceDatum clientSideRequestStatisticsTraceDatum)
+            {
+                this.Summary.UpdateSummary(clientSideRequestStatisticsTraceDatum);
+            }
+            
         }
 
         public void AddDatum(string key, object value)

--- a/Microsoft.Azure.Cosmos/src/Tracing/TraceData/ClientSideRequestStatisticsTraceDatum.cs
+++ b/Microsoft.Azure.Cosmos/src/Tracing/TraceData/ClientSideRequestStatisticsTraceDatum.cs
@@ -384,13 +384,14 @@ namespace Microsoft.Azure.Cosmos.Tracing.TraceData
                 }
 
                 this.shallowCopyOfHttpResponseStatistics = null;
-                this.httpResponseStatistics.Add(new HttpResponseStatistics(requestStartTimeUtc,
+
+                new HttpResponseStatistics(requestStartTimeUtc,
                                                                            requestEndTimeUtc,
                                                                            request.RequestUri,
                                                                            request.Method,
                                                                            resourceType,
                                                                            responseMessage: null,
-                                                                           exception: exception));
+                                                                           exception: exception);
             }
         }
 

--- a/Microsoft.Azure.Cosmos/src/Tracing/TraceSummary.cs
+++ b/Microsoft.Azure.Cosmos/src/Tracing/TraceSummary.cs
@@ -7,13 +7,12 @@ namespace Microsoft.Azure.Cosmos.Tracing
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Text;
     using System.Threading;
     using Microsoft.Azure.Cosmos.Tracing.TraceData;
     using static Microsoft.Azure.Cosmos.Tracing.TraceData.ClientSideRequestStatisticsTraceDatum;
 
     /// <summary>
-    /// The total count of failed requests for an <see cref="ITrace"/>.
+    /// Aggregated data from Trace tree
     /// </summary>
 #if INTERNAL
     public

--- a/Microsoft.Azure.Cosmos/src/Tracing/TraceSummary.cs
+++ b/Microsoft.Azure.Cosmos/src/Tracing/TraceSummary.cs
@@ -47,12 +47,12 @@ namespace Microsoft.Azure.Cosmos.Tracing
         /// <summary>
         /// List of all HTTP requests and its statistics
         /// </summary>
-        public IReadOnlyList<HttpResponseStatistics> HttpResponseStatistics => this.httpResponseStatisticsInternal;
+        internal IReadOnlyList<HttpResponseStatistics> HttpResponseStatistics => this.httpResponseStatisticsInternal;
 
         /// <summary>
         /// List of all TCP requests and its statistics
         /// </summary>
-        public IReadOnlyList<StoreResponseStatistics> StoreResponseStatistics => this.storeResponseStatisticsInternal;
+        internal IReadOnlyList<StoreResponseStatistics> StoreResponseStatistics => this.storeResponseStatisticsInternal;
 
         private readonly List<HttpResponseStatistics> httpResponseStatisticsInternal = new List<HttpResponseStatistics>();
         private readonly List<StoreResponseStatistics> storeResponseStatisticsInternal = new List<StoreResponseStatistics>();

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -3002,6 +3002,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Assert.IsTrue(diagnosticString.Contains("ForceAddressRefresh"));
                 Assert.IsTrue(diagnosticString.Contains("No change to cache"));
                 Assert.AreNotEqual(0, diagnostics.GetFailedRequestCount());
+
+                Assert.IsNotNull(diagnostics.HttpResponseStatistics);
+                Assert.IsTrue(diagnostics.HttpResponseStatistics.Count > 0);
+                Assert.IsNotNull(diagnostics.StoreResponseStatistics);
+                Assert.IsTrue(diagnostics.StoreResponseStatistics.Count > 0);
             }
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -2986,8 +2986,15 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             CosmosClient cosmosClient = TestCommon.CreateCosmosClient(clientOptions);
             Container container = cosmosClient.GetContainer(this.database.Id, this.Container.Id);
             ToDoActivity testItem = ToDoActivity.CreateRandomToDoActivity();
-            await container.CreateItemAsync<ToDoActivity>(testItem);
+            
+            ItemResponse<ToDoActivity> response = await container.CreateItemAsync<ToDoActivity>(testItem);
 
+            // Network information on successful request
+            Assert.IsNotNull(response.Diagnostics.HttpResponseStatistics);
+            Assert.IsTrue(response.Diagnostics.HttpResponseStatistics.Count > 0);
+            Assert.IsNotNull(response.Diagnostics.StoreResponseStatistics);
+            Assert.IsTrue(response.Diagnostics.StoreResponseStatistics.Count > 0);
+            
             try
             {
                 await container.ReadItemAsync<ToDoActivity>(testItem.id, new Cosmos.PartitionKey(testItem.pk));
@@ -3003,6 +3010,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Assert.IsTrue(diagnosticString.Contains("No change to cache"));
                 Assert.AreNotEqual(0, diagnostics.GetFailedRequestCount());
 
+                // Network information on failed request
                 Assert.IsNotNull(diagnostics.HttpResponseStatistics);
                 Assert.IsTrue(diagnostics.HttpResponseStatistics.Count > 0);
                 Assert.IsNotNull(diagnostics.StoreResponseStatistics);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/SummaryDiagnosticsTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/SummaryDiagnosticsTests.cs
@@ -50,9 +50,9 @@
             trace = ((CosmosTraceDiagnostics)response.Diagnostics).Value;
             summaryDiagnostics = new SummaryDiagnostics(trace);
 
-            Assert.AreEqual(summaryDiagnostics.DirectRequestsSummary.Value[(200, 0)], 1);
+            Assert.AreEqual(1, summaryDiagnostics.DirectRequestsSummary.Value[(200, 0)]);
             Assert.IsFalse(summaryDiagnostics.GatewayRequestsSummary.IsValueCreated);
-            Assert.AreEqual(trace.Summary.RegionsContacted.Count, 1);
+            Assert.AreEqual(1, trace.Summary.RegionsContacted.Count);
         }
 
         [TestMethod]
@@ -60,7 +60,7 @@
         {
             CosmosClient gwCosmosClient = TestCommon.CreateCosmosClient(useGateway: true);
             Container container = gwCosmosClient.GetContainer(this.Database.Id, this.Container.Id);
-
+            
             ToDoActivity testItem = ToDoActivity.CreateRandomToDoActivity();
             ItemResponse<ToDoActivity> response = await container.CreateItemAsync(testItem, new Cosmos.PartitionKey(testItem.pk));
             Assert.IsNotNull(response.Diagnostics);
@@ -91,6 +91,7 @@
                 FeedResponse<ToDoActivity> response = await feedIterator.ReadNextAsync();
                 traces.Add(((CosmosTraceDiagnostics)response.Diagnostics).Value);
             }
+            
             HashSet<(string, Uri)> headers = new HashSet<(string, Uri)>();
             foreach (Trace item in traces)
             {
@@ -98,9 +99,9 @@
             }
 
             SummaryDiagnostics summaryDiagnostics = new SummaryDiagnostics(TraceJoiner.JoinTraces(traces));
-            Assert.AreEqual(summaryDiagnostics.DirectRequestsSummary.Value.Keys.Count, 1);
+            Assert.AreEqual(1, summaryDiagnostics.DirectRequestsSummary.Value.Keys.Count);
             Assert.IsTrue(summaryDiagnostics.DirectRequestsSummary.Value[(200, 0)] > 1);
-            Assert.AreEqual(headers.Count, 1);
+            Assert.AreEqual(1, headers.Count);
         }
 
         [TestMethod]
@@ -123,9 +124,9 @@
             ItemResponse<ToDoActivity> response = await withTransportErrors.CreateItemAsync(testItem, new Cosmos.PartitionKey(testItem.pk));
             ITrace trace = ((CosmosTraceDiagnostics)response.Diagnostics).Value;
             SummaryDiagnostics summaryDiagnostics = new SummaryDiagnostics(trace);
-            Assert.AreEqual(summaryDiagnostics.DirectRequestsSummary.Value.Keys.Count, 2);
-            Assert.AreEqual(summaryDiagnostics.DirectRequestsSummary.Value[(410, (int)SubStatusCodes.TransportGenerated410)], 3);
-            Assert.AreEqual(summaryDiagnostics.DirectRequestsSummary.Value[(201, 0)], 1);
+            Assert.AreEqual(2, summaryDiagnostics.DirectRequestsSummary.Value.Keys.Count);
+            Assert.AreEqual(3, summaryDiagnostics.DirectRequestsSummary.Value[(410, (int)SubStatusCodes.TransportGenerated410)]);
+            Assert.AreEqual(1, summaryDiagnostics.DirectRequestsSummary.Value[(201, 0)]);
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Tracing/TraceJoiner.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Tracing/TraceJoiner.cs
@@ -7,8 +7,6 @@ namespace Microsoft.Azure.Cosmos.Tracing
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Runtime.CompilerServices;
-    using System.Text;
 
     internal static class TraceJoiner
     {


### PR DESCRIPTION
## Description

In Client telemetry, we decided to include network (i.e replica/gateway) information. As part of this PR, exposing an internal API in `CosmosDiagnostics `which will return consolidated HTTP and TCP request statistics.

_**Note:** In separate PR, this information will be aggregated and included in client telemetry request

## Type of change
- [] New feature (non-breaking change which adds functionality)
