### PR TITLE
[Internal] Client Telemetry: Refactors code to use base useragent string 

### DIFF
--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -1036,7 +1036,7 @@ namespace Microsoft.Azure.Cosmos
                     this.clientTelemetry = ClientTelemetry.CreateAndStartBackgroundTelemetry(
                         clientId: this.clientId,
                         httpClient: this.httpClient,
-                        userAgent: this.ConnectionPolicy.UserAgentContainer.UserAgent,
+                        userAgent: this.ConnectionPolicy.UserAgentContainer.BaseUserAgent,
                         connectionMode: this.ConnectionPolicy.ConnectionMode,
                         authorizationTokenProvider: this.cosmosAuthorization,
                         diagnosticsHelper: DiagnosticsHandlerHelper.Instance,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
@@ -974,6 +974,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Assert.IsNotNull(telemetryInfo.ProcessId);
                 Assert.AreEqual(HashingExtension.ComputeHash(System.Diagnostics.Process.GetCurrentProcess().ProcessName), telemetryInfo.ProcessId);
                 Assert.IsNotNull(telemetryInfo.UserAgent);
+                Assert.IsFalse(telemetryInfo.UserAgent.Contains("userAgentSuffix"), "Useragent should not have suffix appended"); // Useragent should not contain useragentsuffix as it can have PII
                 Assert.IsNotNull(telemetryInfo.ConnectionMode);
 
                 if(!string.IsNullOrEmpty(telemetryInfo.MachineId))
@@ -1090,7 +1091,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
 
             this.cosmosClientBuilder = this.cosmosClientBuilder
-                .WithHttpClientFactory(() => new HttpClient(handlerHelper));
+                .WithHttpClientFactory(() => new HttpClient(handlerHelper))
+                .WithApplicationName("userAgentSuffix");
 
             this.cosmosClient = mode == ConnectionMode.Gateway
                 ? this.cosmosClientBuilder.WithConnectionModeGateway().Build()


### PR DESCRIPTION
## Description
 As discussed in security review meeting, we should not have custom suffix in user agent stored in client telemetry. So removing it as part of this PR.

## Type of change
- [] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #3650