### PR TITLE
[Internal] Query: Adds OptimisticDirectExecution flag to SqlQuerySpec for Backend

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CosmosQueryExecutionContextFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CosmosQueryExecutionContextFactory.cs
@@ -355,7 +355,6 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
             if (tryCreatePipelineStage.Failed && tryCreatePipelineStage.InnerMostException is MalformedContinuationTokenException)
             {
                 SetTestInjectionPipelineType(inputParameters, Specialized);
-                inputParameters.SqlQuerySpec.OptimisticDirectExecution = false;
 
                 if (partitionedQueryExecutionInfo != null)
                 {

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CosmosQueryExecutionContextFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CosmosQueryExecutionContextFactory.cs
@@ -355,6 +355,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
             if (tryCreatePipelineStage.Failed && tryCreatePipelineStage.InnerMostException is MalformedContinuationTokenException)
             {
                 SetTestInjectionPipelineType(inputParameters, Specialized);
+                inputParameters.SqlQuerySpec.OptimisticDirectExecution = false;
 
                 if (partitionedQueryExecutionInfo != null)
                 {
@@ -479,6 +480,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
                 queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: inputParameters.MaxItemCount),
                 fallbackQueryPipelineStageFactory: (continuationToken) =>
                 {
+                    inputParameters.SqlQuerySpec.OptimisticDirectExecution = false;
+
                     // In fallback scenario, the Specialized pipeline is always invoked
                     Task<TryCatch<IQueryPipelineStage>> tryCreateContext =
                         CosmosQueryExecutionContextFactory.TryCreateSpecializedDocumentQueryExecutionContextAsync(

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CosmosQueryExecutionContextFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CosmosQueryExecutionContextFactory.cs
@@ -479,8 +479,6 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
                 queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: inputParameters.MaxItemCount),
                 fallbackQueryPipelineStageFactory: (continuationToken) =>
                 {
-                    inputParameters.SqlQuerySpec.OptimisticDirectExecution = false;
-
                     // In fallback scenario, the Specialized pipeline is always invoked
                     Task<TryCatch<IQueryPipelineStage>> tryCreateContext =
                         CosmosQueryExecutionContextFactory.TryCreateSpecializedDocumentQueryExecutionContextAsync(

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/OptimisticDirectExecution/OptimisticDirectExecutionQueryPipelineStage.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/OptimisticDirectExecution/OptimisticDirectExecutionQueryPipelineStage.cs
@@ -226,6 +226,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.OptimisticDirectExecutionQu
                 }
 
                 FeedRangeState<QueryState> feedRangeState = monadicExtractState.Result;
+                sqlQuerySpec.OptimisticDirectExecution = true;
 
                 QueryPartitionRangePageAsyncEnumerator partitionPageEnumerator = new QueryPartitionRangePageAsyncEnumerator(
                     documentContainer,

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/OptimisticDirectExecution/OptimisticDirectExecutionQueryPipelineStage.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/OptimisticDirectExecution/OptimisticDirectExecutionQueryPipelineStage.cs
@@ -226,11 +226,11 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.OptimisticDirectExecutionQu
                 }
 
                 FeedRangeState<QueryState> feedRangeState = monadicExtractState.Result;
-                sqlQuerySpec.OptimisticDirectExecution = true;
+                SqlQuerySpec newSqlQuerySpec = new SqlQuerySpec(sqlQuerySpec.QueryText, sqlQuerySpec.Parameters, true);
 
                 QueryPartitionRangePageAsyncEnumerator partitionPageEnumerator = new QueryPartitionRangePageAsyncEnumerator(
                     documentContainer,
-                    sqlQuerySpec,
+                    newSqlQuerySpec,
                     feedRangeState,
                     partitionKey,
                     queryPaginationOptions,

--- a/Microsoft.Azure.Cosmos/src/Query/Core/SqlQuerySpec.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/SqlQuerySpec.cs
@@ -53,6 +53,13 @@ namespace Microsoft.Azure.Cosmos.Query.Core
         public string QueryText { get; set; }
 
         /// <summary>
+        /// Gets or sets whether the OpimisticDirectExecution pipeline was utilized or not.
+        /// </summary>
+        /// <value>A boolean value indicating whether the OptimisticDirextExecution pipeline was used or not.</value>
+        [DataMember(Name = "optimisticDirectExecution")]
+        public bool OptimisticDirectExecution { get; set; } = false;
+
+        /// <summary>
         /// Gets or sets the <see cref="T:Microsoft.Azure.Documents.SqlParameterCollection"/> instance, which represents the collection of Azure Cosmos DB query parameters.
         /// </summary>
         /// <value>The <see cref="T:Microsoft.Azure.Documents.SqlParameterCollection"/> instance.</value>

--- a/Microsoft.Azure.Cosmos/src/Query/Core/SqlQuerySpec.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/SqlQuerySpec.cs
@@ -39,10 +39,12 @@ namespace Microsoft.Azure.Cosmos.Query.Core
         /// </summary>
         /// <param name="queryText">The text of the database query.</param>
         /// <param name="parameters">The <see cref="T:Microsoft.Azure.Documents.SqlParameterCollection"/> instance, which represents the collection of query parameters.</param>
-        public SqlQuerySpec(string queryText, SqlParameterCollection parameters)
+        /// <param name="optimisticDirectExecution">Boolean indicating whether query is direct (optimistic) execution.</param>
+        public SqlQuerySpec(string queryText, SqlParameterCollection parameters, bool optimisticDirectExecution = false)
         {
             this.QueryText = queryText;
             this.parameters = parameters ?? throw new ArgumentNullException("parameters");
+            this.OptimisticDirectExecution = optimisticDirectExecution;
         }
         
         /// <summary>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/settings.json
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/settings.json
@@ -1,6 +1,6 @@
 ﻿{
   "AppSettings": {
-    "GatewayEndpoint": "https://127.0.0.1:8081/",
+    "GatewayEndpoint": "https://127.0.0.1:443/",
     "ComputeGatewayEndpoint": "https://localhost:8903/",
     "ComputeGatewayPort": "8903",
     "Location": "South Central US",

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OptimisticDirectExecutionQueryBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OptimisticDirectExecutionQueryBaselineTests.cs
@@ -526,10 +526,12 @@
             if (input.ExpectedOptimisticDirectExecution)
             {
                 Assert.AreEqual(TestInjections.PipelineType.OptimisticDirectExecution, queryRequestOptions.TestSettings.Stats.PipelineType.Value);
+                Assert.IsTrue(inputParameters.SqlQuerySpec.OptimisticDirectExecution);
             }
             else
             {
                 Assert.AreNotEqual(TestInjections.PipelineType.OptimisticDirectExecution, queryRequestOptions.TestSettings.Stats.PipelineType.Value);
+                Assert.IsFalse(inputParameters.SqlQuerySpec.OptimisticDirectExecution);
             }
 
             Assert.IsNotNull(queryPipelineStage);


### PR DESCRIPTION
# Pull Request Template

## Description

Adds a new boolean flag to SqlQuerySpec. This lets the backend know that this query was executed with the OptimisticDirectExecution pipeline on the SDK.  

## Type of change

Please delete options that are not relevant.

- [] New feature (non-breaking change which adds functionality)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber