### PR TITLE
[Internal] Query: Adds OptimisticDirectExecution flag to SqlQuerySpec

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/OptimisticDirectExecution/OptimisticDirectExecutionQueryPipelineStage.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/OptimisticDirectExecution/OptimisticDirectExecutionQueryPipelineStage.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.OptimisticDirectExecutionQu
                 if (this.inner.Failed)
                 {
                     return false;
-                }  
+                }
 
                 success = await this.inner.Result.MoveNextAsync(trace);
             }

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/OptimisticDirectExecution/OptimisticDirectExecutionQueryPipelineStage.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/OptimisticDirectExecution/OptimisticDirectExecutionQueryPipelineStage.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.OptimisticDirectExecutionQu
         }
 
         public static TryCatch<IQueryPipelineStage> MonadicCreate(
-            DocumentContainer documentContainer,
+            IDocumentContainer documentContainer,
             CosmosQueryExecutionContextFactory.InputParameters inputParameters,
             FeedRangeEpk targetRange,
             QueryPaginationOptions queryPaginationOptions,
@@ -226,7 +226,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.OptimisticDirectExecutionQu
                 }
 
                 FeedRangeState<QueryState> feedRangeState = monadicExtractState.Result;
-                SqlQuerySpec updatedSqlQuerySpec = new SqlQuerySpec(sqlQuerySpec.QueryText, sqlQuerySpec.Parameters, true);
+                SqlQuerySpec updatedSqlQuerySpec = new SqlQuerySpec(sqlQuerySpec.QueryText, sqlQuerySpec.Parameters, optimisticDirectExecute: true);
 
                 QueryPartitionRangePageAsyncEnumerator partitionPageEnumerator = new QueryPartitionRangePageAsyncEnumerator(
                     documentContainer,

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/OptimisticDirectExecution/OptimisticDirectExecutionQueryPipelineStage.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/OptimisticDirectExecution/OptimisticDirectExecutionQueryPipelineStage.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.OptimisticDirectExecutionQu
                 if (this.inner.Failed)
                 {
                     return false;
-                }
+                }  
 
                 success = await this.inner.Result.MoveNextAsync(trace);
             }
@@ -226,10 +226,11 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.OptimisticDirectExecutionQu
                 }
 
                 FeedRangeState<QueryState> feedRangeState = monadicExtractState.Result;
+                SqlQuerySpec updatedSqlQuerySpec = new SqlQuerySpec(sqlQuerySpec.QueryText, sqlQuerySpec.Parameters, true);
 
                 QueryPartitionRangePageAsyncEnumerator partitionPageEnumerator = new QueryPartitionRangePageAsyncEnumerator(
                     documentContainer,
-                    sqlQuerySpec,
+                    updatedSqlQuerySpec,
                     feedRangeState,
                     partitionKey,
                     queryPaginationOptions,

--- a/Microsoft.Azure.Cosmos/src/Query/Core/SqlQuerySpec.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/SqlQuerySpec.cs
@@ -39,8 +39,18 @@ namespace Microsoft.Azure.Cosmos.Query.Core
         /// </summary>
         /// <param name="queryText">The text of the database query.</param>
         /// <param name="parameters">The <see cref="T:Microsoft.Azure.Documents.SqlParameterCollection"/> instance, which represents the collection of query parameters.</param>
+        public SqlQuerySpec(string queryText, SqlParameterCollection parameters)
+            : this(queryText, parameters, false)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="T:Microsoft.Azure.Documents.SqlQuerySpec"/> class for the Azure Cosmos DB service.
+        /// </summary>
+        /// <param name="queryText">The text of the database query.</param>
+        /// <param name="parameters">The <see cref="T:Microsoft.Azure.Documents.SqlParameterCollection"/> instance, which represents the collection of query parameters.</param>
         /// /// <param name="optimisticDirectExecute">Boolean indicating whether query is direct (optimistic) execution.</param>
-        public SqlQuerySpec(string queryText, SqlParameterCollection parameters, bool optimisticDirectExecute = false)
+        public SqlQuerySpec(string queryText, SqlParameterCollection parameters, bool optimisticDirectExecute)
         {
             this.QueryText = queryText;
             this.parameters = parameters ?? throw new ArgumentNullException("parameters");

--- a/Microsoft.Azure.Cosmos/src/Query/Core/SqlQuerySpec.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/SqlQuerySpec.cs
@@ -39,12 +39,12 @@ namespace Microsoft.Azure.Cosmos.Query.Core
         /// </summary>
         /// <param name="queryText">The text of the database query.</param>
         /// <param name="parameters">The <see cref="T:Microsoft.Azure.Documents.SqlParameterCollection"/> instance, which represents the collection of query parameters.</param>
-        /// /// <param name="optimisticDirectExecution">Boolean indicating whether query is direct (optimistic) execution.</param>
-        public SqlQuerySpec(string queryText, SqlParameterCollection parameters, bool optimisticDirectExecution = false)
+        /// /// <param name="optimisticDirectExecute">Boolean indicating whether query is direct (optimistic) execution.</param>
+        public SqlQuerySpec(string queryText, SqlParameterCollection parameters, bool optimisticDirectExecute = false)
         {
             this.QueryText = queryText;
             this.parameters = parameters ?? throw new ArgumentNullException("parameters");
-            this.OptimisticDirectExecution = optimisticDirectExecution;
+            this.OptimisticDirectExecute = optimisticDirectExecute;
         }
         
         /// <summary>
@@ -58,8 +58,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core
         /// Gets or sets whether Optimistic Direct execution is desired for this query.
         /// </summary>
         /// <value>Boolean indicating whether query is direct (optimistic) execution.</value>
-        [DataMember(Name = "optimisticDirectExecution")]
-        public bool OptimisticDirectExecution { get; set; }
+        [DataMember(Name = "optimisticDirectExecute")]
+        public bool OptimisticDirectExecute { get; set; }
 
         /// <summary>
         /// Gets or sets the <see cref="T:Microsoft.Azure.Documents.SqlParameterCollection"/> instance, which represents the collection of Azure Cosmos DB query parameters.

--- a/Microsoft.Azure.Cosmos/src/Query/Core/SqlQuerySpec.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/SqlQuerySpec.cs
@@ -39,10 +39,12 @@ namespace Microsoft.Azure.Cosmos.Query.Core
         /// </summary>
         /// <param name="queryText">The text of the database query.</param>
         /// <param name="parameters">The <see cref="T:Microsoft.Azure.Documents.SqlParameterCollection"/> instance, which represents the collection of query parameters.</param>
-        public SqlQuerySpec(string queryText, SqlParameterCollection parameters)
+        /// /// <param name="optimisticDirectExecution">Boolean indicating whether query is direct (optimistic) execution.</param>
+        public SqlQuerySpec(string queryText, SqlParameterCollection parameters, bool optimisticDirectExecution = false)
         {
             this.QueryText = queryText;
             this.parameters = parameters ?? throw new ArgumentNullException("parameters");
+            this.OptimisticDirectExecution = optimisticDirectExecution;
         }
         
         /// <summary>
@@ -51,6 +53,13 @@ namespace Microsoft.Azure.Cosmos.Query.Core
         /// <value>The text of the database query.</value>
         [DataMember(Name = "query")]
         public string QueryText { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether Optimistic Direct execution is desired for this query.
+        /// </summary>
+        /// <value>Boolean indicating whether query is direct (optimistic) execution.</value>
+        [DataMember(Name = "optimisticDirectExecution")]
+        public bool OptimisticDirectExecution { get; set; }
 
         /// <summary>
         /// Gets or sets the <see cref="T:Microsoft.Azure.Documents.SqlParameterCollection"/> instance, which represents the collection of Azure Cosmos DB query parameters.

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/InMemoryContainer.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/InMemoryContainer.cs
@@ -37,6 +37,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
     {
         private readonly PartitionKeyDefinition partitionKeyDefinition;
         private readonly Dictionary<int, (int, int)> parentToChildMapping;
+        public readonly Action<SqlQuerySpec> SqlQuerySpecCallback;
 
         private PartitionKeyHashRangeDictionary<Records> partitionedRecords;
         private PartitionKeyHashRangeDictionary<List<Change>> partitionedChanges;
@@ -44,7 +45,8 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
         private Dictionary<int, PartitionKeyHashRange> cachedPartitionKeyRangeIdToHashRange;
 
         public InMemoryContainer(
-            PartitionKeyDefinition partitionKeyDefinition)
+            PartitionKeyDefinition partitionKeyDefinition, 
+            Action<SqlQuerySpec> sqlQuerySpecCallback = null)
         {
             this.partitionKeyDefinition = partitionKeyDefinition ?? throw new ArgumentNullException(nameof(partitionKeyDefinition));
             PartitionKeyHashRange fullRange = new PartitionKeyHashRange(startInclusive: null, endExclusive: new PartitionKeyHash(Cosmos.UInt128.MaxValue));
@@ -62,6 +64,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
                 { 0, fullRange }
             };
             this.parentToChildMapping = new Dictionary<int, (int, int)>();
+            this.SqlQuerySpecCallback = sqlQuerySpecCallback;
         }
 
         public Task<TryCatch<List<FeedRangeEpk>>> MonadicGetFeedRangesAsync(
@@ -464,6 +467,8 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
             {
                 throw new ArgumentNullException(nameof(sqlQuerySpec));
             }
+
+            this.SqlQuerySpecCallback?.Invoke(sqlQuerySpec);
 
             using (ITrace childTrace = trace.StartChild("Query Transport", TraceComponent.Transport, TraceLevel.Info))
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/InMemoryContainer.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/InMemoryContainer.cs
@@ -37,7 +37,6 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
     {
         private readonly PartitionKeyDefinition partitionKeyDefinition;
         private readonly Dictionary<int, (int, int)> parentToChildMapping;
-        public readonly Action<SqlQuerySpec> SqlQuerySpecCallback;
 
         private PartitionKeyHashRangeDictionary<Records> partitionedRecords;
         private PartitionKeyHashRangeDictionary<List<Change>> partitionedChanges;
@@ -45,8 +44,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
         private Dictionary<int, PartitionKeyHashRange> cachedPartitionKeyRangeIdToHashRange;
 
         public InMemoryContainer(
-            PartitionKeyDefinition partitionKeyDefinition, 
-            Action<SqlQuerySpec> sqlQuerySpecCallback = null)
+            PartitionKeyDefinition partitionKeyDefinition)
         {
             this.partitionKeyDefinition = partitionKeyDefinition ?? throw new ArgumentNullException(nameof(partitionKeyDefinition));
             PartitionKeyHashRange fullRange = new PartitionKeyHashRange(startInclusive: null, endExclusive: new PartitionKeyHash(Cosmos.UInt128.MaxValue));
@@ -64,7 +62,6 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
                 { 0, fullRange }
             };
             this.parentToChildMapping = new Dictionary<int, (int, int)>();
-            this.SqlQuerySpecCallback = sqlQuerySpecCallback;
         }
 
         public Task<TryCatch<List<FeedRangeEpk>>> MonadicGetFeedRangesAsync(
@@ -467,8 +464,6 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
             {
                 throw new ArgumentNullException(nameof(sqlQuerySpec));
             }
-
-            this.SqlQuerySpecCallback?.Invoke(sqlQuerySpec);
 
             using (ITrace childTrace = trace.StartChild("Query Transport", TraceComponent.Transport, TraceLevel.Info))
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OptimisticDirectExecutionQueryBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OptimisticDirectExecutionQueryBaselineTests.cs
@@ -214,7 +214,6 @@
             bool result = await queryPipelineStage.Result.MoveNextAsync(NoOpTrace.Singleton);
         }
 
-
         // test checks that the pipeline can take a query to the backend and returns its associated document(s).
         [TestMethod]
         public async Task TestPipelineForBackendDocumentsOnSinglePartitionAsync()
@@ -406,7 +405,6 @@
         private async Task<int> GetPipelineAndDrainAsync(OptimisticDirectExecutionTestInput input, int numItems, bool isMultiPartition, int expectedContinuationTokenCount)
         {
             QueryRequestOptions queryRequestOptions = GetQueryRequestOptions(enableOptimisticDirectExecution: true);
-           
             DocumentContainer inMemoryCollection = await CreateDocumentContainerAsync(numItems, multiPartition: isMultiPartition);
             IQueryPipelineStage queryPipelineStage = await GetOdePipelineAsync(input, inMemoryCollection, queryRequestOptions);
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OptimisticDirectExecutionQueryBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OptimisticDirectExecutionQueryBaselineTests.cs
@@ -188,7 +188,6 @@
                 Assert.IsTrue(querySpec.OptimisticDirectExecute);
 
                 ImmutableDictionary<string, string>.Builder additionalHeaders = ImmutableDictionary.CreateBuilder<string, string>();
-                additionalHeaders.Add("x-ms-documentdb-partitionkeyrangeid", "0");
                 additionalHeaders.Add("x-ms-test-header", "true");
 
                 return TryCatch<QueryPage>.FromResult(


### PR DESCRIPTION
# Pull Request Template

## Description

Adds a new boolean flag to SqlQuerySpec. This lets the backend know whether this query was executed with the OptimisticDirectExecution pipeline on the SDK.

## Type of change

Please delete options that are not relevant.

- [] New feature (non-breaking change which adds functionality)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber