### PR TITLE
[Internal] Benchmark : Fixes issue with dependency on Cosmos Project

### DIFF
--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/BenchmarkConfig.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/BenchmarkConfig.cs
@@ -224,7 +224,7 @@ namespace CosmosBenchmark
                 clientOptions.ConsistencyLevel = (Microsoft.Azure.Cosmos.ConsistencyLevel)Enum.Parse(typeof(Microsoft.Azure.Cosmos.ConsistencyLevel), this.ConsistencyLevel, ignoreCase: true);
             }
 
-            clientOptions.EnableDistributedTracing = this.EnableDistributedTracing;
+            clientOptions.IsDistributedTracingEnabled = this.EnableDistributedTracing;
 
             return new Microsoft.Azure.Cosmos.CosmosClient(
                         this.EndPoint,

--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/BenchmarkConfig.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/BenchmarkConfig.cs
@@ -224,7 +224,7 @@ namespace CosmosBenchmark
                 clientOptions.ConsistencyLevel = (Microsoft.Azure.Cosmos.ConsistencyLevel)Enum.Parse(typeof(Microsoft.Azure.Cosmos.ConsistencyLevel), this.ConsistencyLevel, ignoreCase: true);
             }
 
-            clientOptions.IsDistributedTracingEnabled = this.EnableDistributedTracing;
+            clientOptions.EnableDistributedTracing = this.EnableDistributedTracing;
 
             return new Microsoft.Azure.Cosmos.CosmosClient(
                         this.EndPoint,

--- a/templates/build-benchmark.yml
+++ b/templates/build-benchmark.yml
@@ -30,5 +30,5 @@ jobs:
       configuration: $(parameters.BuildConfiguration)
       nugetConfigPath: NuGet.config
       projects:  'Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/CosmosBenchmark.sln' 
-      arguments: -p:Optimize=true
+      arguments: -p:Optimize=true -p:OSSProjectRef=true
       versioningScheme: OFF

--- a/templates/build-preview.yml
+++ b/templates/build-preview.yml
@@ -167,5 +167,5 @@ jobs:
       configuration: $(parameters.BuildConfiguration)
       nugetConfigPath: NuGet.config
       projects:  'Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/CosmosBenchmark.sln' 
-      arguments: -p:Optimize=true -p:IsPreview=true
+      arguments: -p:Optimize=true -p:IsPreview=true -p:OSSProjectRef=true
       versioningScheme: OFF


### PR DESCRIPTION
## Description
Benchmark project was not referencing master cosmos db code in build pipeline. Hence, even if there is compilation error in Benchmark project due to a latest change in cosmosdb repo, it was not failing the pipeline.

As part of this PR fixing this.
## Type of change

- [] Bug fix (non-breaking change which fixes an issue)
