### PR TITLE
[Internal] Tests: Removes Direct/HTTPS emulator tests

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTests.cs
@@ -385,12 +385,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        public async Task TestEtagOnUpsertOperationForHttpsClient()
-        {
-            await this.TestEtagOnUpsertOperation(false, Protocol.Https);
-        }
-
-        [TestMethod]
         public async Task TestEtagOnUpsertOperationForGatewayClient()
         {
             await this.TestEtagOnUpsertOperation(true);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/GatewayTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/GatewayTests.cs
@@ -285,13 +285,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 new ConnectionPolicy { ConnectionMode = ConnectionMode.Direct, ConnectionProtocol = Protocol.Tcp });
         }
 
-        [TestMethod]
-        public async Task ValidateStoredProcedureCrud_SessionDirectHttps()
-        {
-            await this.ValidateStoredProcedureCrudAsync(ConsistencyLevel.Session,
-                new ConnectionPolicy { ConnectionMode = ConnectionMode.Direct, ConnectionProtocol = Protocol.Https });
-        }
-
         internal async Task ValidateStoredProcedureCrudAsync(ConsistencyLevel consistencyLevel, ConnectionPolicy connectionPolicy)
         {
             DocumentClient client = TestCommon.CreateClient(connectionPolicy.ConnectionMode == ConnectionMode.Gateway,
@@ -432,13 +425,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 new ConnectionPolicy { ConnectionMode = ConnectionMode.Direct, ConnectionProtocol = Protocol.Tcp });
         }
 
-        [TestMethod]
-        public void ValidateTriggerCrud_SessionDirectHttps()
-        {
-            this.ValidateTriggerCrud(ConsistencyLevel.Session,
-                new ConnectionPolicy { ConnectionMode = ConnectionMode.Direct, ConnectionProtocol = Protocol.Https });
-        }
-
         internal void ValidateTriggerCrud(ConsistencyLevel consistencyLevel, ConnectionPolicy connectionPolicy)
         {
             DocumentClient client = TestCommon.CreateClient(connectionPolicy.ConnectionMode == ConnectionMode.Gateway,
@@ -564,14 +550,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         {
             this.ValidateUserDefinedFunctionCrud(ConsistencyLevel.Session,
                 new ConnectionPolicy { ConnectionMode = ConnectionMode.Direct, ConnectionProtocol = Protocol.Tcp });
-        }
-
-        [TestMethod]
-
-        public void ValidateUserDefinedFunctionCrud_SessionDirectHttps()
-        {
-            this.ValidateUserDefinedFunctionCrud(ConsistencyLevel.Session,
-                new ConnectionPolicy { ConnectionMode = ConnectionMode.Direct, ConnectionProtocol = Protocol.Https });
         }
 
         [TestMethod]
@@ -1501,7 +1479,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             await this.ValidateSystemSprocInternal(true);
 #if DIRECT_MODE
             // DIRECT MODE has ReadFeed issues in the Public emulator
-            ValidateSystemSprocInternal(false, Protocol.Https);
             ValidateSystemSprocInternal(false, Protocol.Tcp);
 #endif
         }
@@ -2183,7 +2160,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 #if DIRECT_MODE
             // DIRECT MODE has ReadFeed issues in the Public emulator
             await ValidateReadOnlyStoredProcedureExecutionInternal(false, Protocol.Tcp);
-            await ValidateReadOnlyStoredProcedureExecutionInternal(false, Protocol.Https);
 #endif
         }
 
@@ -2559,7 +2535,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             await this.ValidateChangeFeedIfNoneMatchHelper(true);
 #if DIRECT_MODE
             // DIRECT MODE has ReadFeed issues in the Public emulator
-            await ValidateChangeFeedIfNoneMatchHelper(false, Protocol.Https);
             await ValidateChangeFeedIfNoneMatchHelper(false, Protocol.Tcp);
 #endif
         }
@@ -2709,7 +2684,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             await this.ValidateChangeFeedIfModifiedSinceHelper(true);
 #if DIRECT_MODE
             // DIRECT MODE has ReadFeed issues in the Public emulator
-            await ValidateChangeFeedIfModifiedSinceHelper(false, Protocol.Https);
             await ValidateChangeFeedIfModifiedSinceHelper(false, Protocol.Tcp);
 #endif
         }
@@ -2822,7 +2796,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         public async Task ValidateChangeFeedWithPartitionKey()
         {
             await this.ValidateChangeFeedWithPartitionKeyHelper(true);
-            await this.ValidateChangeFeedWithPartitionKeyHelper(false, Protocol.Https);
             await this.ValidateChangeFeedWithPartitionKeyHelper(false, Protocol.Tcp);
         }
 
@@ -2999,7 +2972,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             await this.ValidateReadPartitionKeyRangeHelper(true);
 #if DIRECT_MODE
             // DIRECT MODE has ReadFeed issues in the Public emulator
-            await ValidateReadPartitionKeyRangeHelper(false, Protocol.Https);
             await ValidateReadPartitionKeyRangeHelper(false, Protocol.Tcp);
 #endif
         }
@@ -3106,13 +3078,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         public void ValidateGenericReadDocumentDirectTcp()
         {
             this.ValidateGenericReadDocument(false, Protocol.Tcp).Wait();
-            this.ValidateGenericReadDocumentFromResource(false, Protocol.Tcp).Wait();
-        }
-
-        [TestMethod]
-        public void ValidateGenericReadDocumentDirectHttps()
-        {
-            this.ValidateGenericReadDocument(false, Protocol.Https).Wait();
             this.ValidateGenericReadDocumentFromResource(false, Protocol.Tcp).Wait();
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/HeadersValidationTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/HeadersValidationTests.cs
@@ -58,14 +58,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        public void ValidatePageSizeHttps()
-        {
-            var client = TestCommon.CreateClient(false, Protocol.Https);
-            ValidatePageSize(client);
-            ValidatePageSize(client);
-        }
-
-        [TestMethod]
         public void ValidatePageSizeRntbd()
         {
             var client = TestCommon.CreateClient(false, Protocol.Tcp);
@@ -182,13 +174,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             await ValidateCosistencyLevel(client);
         }
 
-        [TestMethod]
-        public async Task ValidateConsistencyLevelHttps()
-        {
-            DocumentClient client = TestCommon.CreateClient(false, Protocol.Https);
-            await ValidateCosistencyLevel(client);
-        }
-
         private async Task ValidateCosistencyLevel(DocumentClient client)
         {
             DocumentCollection collection = TestCommon.CreateOrGetDocumentCollection(client);
@@ -229,13 +214,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         public void ValidateJsonSerializationFormatRntbd()
         {
             var client = TestCommon.CreateClient(false, Protocol.Tcp);
-            ValidateJsonSerializationFormat(client);
-        }
-
-        [TestMethod]
-        public void ValidateJsonSerializationFormatHttps()
-        {
-            var client = TestCommon.CreateClient(false, Protocol.Https);
             ValidateJsonSerializationFormat(client);
         }
 
@@ -342,14 +320,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             ValidateIndexingDirective(client);
         }
 
-        [TestMethod]
-        public void ValidateIndexingDirectiveHttps()
-        {
-            //var client = TestCommon.CreateClient(false, Protocol.Https);
-            var client = TestCommon.CreateClient(true, Protocol.Https);
-            ValidateIndexingDirective(client);
-        }
-
         private void ValidateIndexingDirective(DocumentClient client)
         {
             // Number out of range.
@@ -407,13 +377,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             ValidateEnableScanInQuery(client);
         }
 
-        [TestMethod]
-        public void ValidateEnableScanInQueryHttps()
-        {
-            var client = TestCommon.CreateClient(false, Protocol.Https);
-            ValidateEnableScanInQuery(client);
-        }
-
         private void ValidateEnableScanInQuery(DocumentClient client, bool isHttps = false)
         {
             // Value not boolean
@@ -458,14 +421,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         {
             var client = TestCommon.CreateClient(false, Protocol.Tcp);
             ValidateEnableLowPrecisionOrderBy(client);
-        }
-
-        [TestMethod]
-
-        public void ValidateEnableLowPrecisionOrderByHttps()
-        {
-            var client = TestCommon.CreateClient(false, Protocol.Https);
-            ValidateEnableLowPrecisionOrderBy(client, true);
         }
 
         private void ValidateEnableLowPrecisionOrderBy(DocumentClient client, bool isHttps = false)
@@ -516,13 +471,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             ValidateEmitVerboseTracesInQuery(client);
         }
 
-        [TestMethod]
-        public void ValidateEmitVerboseTracesInQueryHttps()
-        {
-            var client = TestCommon.CreateClient(false, Protocol.Https);
-            ValidateEmitVerboseTracesInQuery(client, true);
-        }
-
         private void ValidateEmitVerboseTracesInQuery(DocumentClient client, bool isHttps = false)
         {
             // Value not boolean
@@ -561,12 +509,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             var client = TestCommon.CreateClient(true);
             ValidateIfNonMatch(client);
 
-        }
-        [TestMethod]
-        public void ValidateIfNonMatchHttps()
-        {
-            var client = TestCommon.CreateClient(false, Protocol.Https);
-            ValidateIfNonMatch(client);
         }
 
         [TestMethod]
@@ -715,11 +657,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         public async Task ValidateCollectionIndexProgressHeaders()
         {
             using (var client = TestCommon.CreateClient(true))
-            {
-                await ValidateCollectionIndexProgressHeadersAsync(client, isElasticCollection: true);
-            }
-
-            using (var client = TestCommon.CreateClient(false, Protocol.Https))
             {
                 await ValidateCollectionIndexProgressHeadersAsync(client, isElasticCollection: true);
             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/NameRoutingTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/NameRoutingTests.cs
@@ -41,15 +41,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
     // DIRECT MODE has ReadFeed issues in the Public emulator
 
         [TestMethod]
-        public void NameRoutingSmokeDirectHttpsTest()
-        {
-            DocumentClient client;
-            client = TestCommon.CreateClient(false, Protocol.Https, 10, ConsistencyLevel.Session);
-
-            this.NameRoutingSmokeTestPrivateAsync(client).Wait();
-        }
-
-        [TestMethod]
         public void NameRoutingSmokeDirectTcpTest()
         {
             DocumentClient client;
@@ -436,8 +427,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             this.ReplaceDocumentWithUriPrivateAsync(client).Wait();
 #if DIRECT_MODE
             // DIRECT MODE has ReadFeed issues in the Public emulator
-            client = TestCommon.CreateClient(false, Protocol.Https);
-            this.ReplaceDocumentWithUriPrivateAsync(client).Wait();            
 
             client = TestCommon.CreateClient(false, Protocol.Tcp);
             this.ReplaceDocumentWithUriPrivateAsync(client).Wait();
@@ -501,10 +490,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
 #if DIRECT_MODE
             // DIRECT MODE has ReadFeed issues in the Public emulator
-            client = TestCommon.CreateClient(false, Protocol.Https);
-            await this.CollectionDeleteAndCreateWithSameNameTestPrivateAsync(client);
-            
-
             client = TestCommon.CreateClient(false, Protocol.Tcp);
             await this.CollectionDeleteAndCreateWithSameNameTestPrivateAsync(client);
 #endif
@@ -606,14 +591,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         // 11. Now it succeed.
 #if DIRECT_MODE
             // DIRECT MODE has ReadFeed issues in the Public emulator
-
-        [TestMethod]
-        public void VerifyGatewayNameIdCacheRefreshDirectHttp()
-        {
-            DocumentClient client = TestCommon.CreateClient(false, Protocol.Https);
-            this.VerifyGatewayNameIdCacheRefreshPrivateAsync(client).Wait();
-        }
-
         [TestMethod]
         public void VerifyGatewayNameIdCacheRefreshDirectTcp()
         {
@@ -760,9 +737,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             this.VerifyInvalidPartitionExceptionPrivateAsync(client).Wait();
 #if DIRECT_MODE
             // DIRECT MODE has ReadFeed issues in the Public emulator
-            client = TestCommon.CreateClient(false, Protocol.Https);
-            this.VerifyInvalidPartitionExceptionPrivateAsync(client).Wait();
-
             client = TestCommon.CreateClient(false, Protocol.Tcp);
             this.VerifyInvalidPartitionExceptionPrivateAsync(client).Wait();
 #endif
@@ -797,9 +771,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             await this.VerifyInvalidPartitionExceptionWithPopulateQuotaInfo(client);
 #if DIRECT_MODE
             // DIRECT MODE has ReadFeed issues in the Public emulator
-            client = TestCommon.CreateClient(false, Protocol.Https);
-            await this.VerifyInvalidPartitionExceptionWithPopulateQuotaInfo(client);
-
             client = TestCommon.CreateClient(false, Protocol.Tcp);
             await this.VerifyInvalidPartitionExceptionWithPopulateQuotaInfo(client);
 #endif
@@ -850,9 +821,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             this.VerifyNameIdCacheTaskReusePrivateAsync(client).Wait();
 #if DIRECT_MODE
             // DIRECT MODE has ReadFeed issues in the Public emulator
-            client = TestCommon.CreateClient(false, Protocol.Https);
-            this.VerifyNameIdCacheTaskReusePrivateAsync(client).Wait();
-
             client = TestCommon.CreateClient(false, Protocol.Tcp);
             this.VerifyNameIdCacheTaskReusePrivateAsync(client).Wait();
 #endif
@@ -903,10 +871,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
 #if DIRECT_MODE
             // DIRECT MODE has ReadFeed issues in the Public emulator
-
-            client = TestCommon.CreateClient(false, Protocol.Https);
-            this.CrazyNameTestPrivateAsync(client, false).Wait();
-
             client = TestCommon.CreateClient(false, Protocol.Tcp);
             this.CrazyNameTestPrivateAsync(client, false, true).Wait(); 
 #endif
@@ -1019,9 +983,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             this.NameRoutingBadUrlTestPrivateAsync(client, false).Wait();
 #if DIRECT_MODE
             // DIRECT MODE has ReadFeed issues in the Public emulator
-            client = TestCommon.CreateClient(false, Protocol.Https);
-            this.NameRoutingBadUrlTestPrivateAsync(client, false).Wait();
-
             client = TestCommon.CreateClient(false, Protocol.Tcp);
             this.NameRoutingBadUrlTestPrivateAsync(client, false, true).Wait();
 #endif
@@ -1106,8 +1067,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             this.VerifyInvalidNameTestPrivateAsync(client).Wait();
 #if DIRECT_MODE
             // DIRECT MODE has ReadFeed issues in the Public emulator
-            client = TestCommon.CreateClient(false, Protocol.Https);
-            this.VerifyInvalidNameTestPrivateAsync(client).Wait();
 
             client = TestCommon.CreateClient(false, Protocol.Tcp);
             this.VerifyInvalidNameTestPrivateAsync(client).Wait();
@@ -1250,14 +1209,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 #if DIRECT_MODE
             // DIRECT MODE has ReadFeed issues in the Public emulator
         [TestMethod]
-        [TestCategory("Ignore")]
-        public void VerifyMasterNodeThrottlingDirectHttp()
-        {
-            DocumentClient client = TestCommon.CreateClient(false, Protocol.Https);
-            this.VerifyMasterNodeThrottlingPrivateAsync(client).Wait();
-        }        
-
-        [TestMethod]
         public void VerifyMasterNodeThrottlingDirectTcp()
         {
             DocumentClient client = TestCommon.CreateClient(false, Protocol.Tcp);
@@ -1271,9 +1222,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             await this.VerifyNameBasedCollectionCRUDOperationsAsync(client);
 #if DIRECT_MODE
             // DIRECT MODE has ReadFeed issues in the Public emulator
-            client = TestCommon.CreateClient(false, Protocol.Https);
-            await this.VerifyNameBasedCollectionCRUDOperationsAsync(client);
-
             client = TestCommon.CreateClient(false, Protocol.Tcp);
             await this.VerifyNameBasedCollectionCRUDOperationsAsync(client);
 #endif
@@ -1291,7 +1239,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 #if DIRECT_MODE
             // DIRECT MODE has ReadFeed issues in the Public emulator
             await this.TestPartitionKeyDefinitionOnCollectionRecreate(TestCommon.CreateClient(false, protocol: Protocol.Tcp));
-            await this.TestPartitionKeyDefinitionOnCollectionRecreate(TestCommon.CreateClient(false, protocol: Protocol.Https));
 #endif
         }
 
@@ -1328,7 +1275,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 #if DIRECT_MODE
             // DIRECT MODE has ReadFeed issues in the Public emulator
             await this.TestPartitionKeyDefinitionOnContainerRecreateFromDifferentPartitionKeyPath(TestCommon.CreateClient(false, protocol: Protocol.Tcp));
-            await this.TestPartitionKeyDefinitionOnContainerRecreateFromDifferentPartitionKeyPath(TestCommon.CreateClient(false, protocol: Protocol.Https));
 #endif
         }
 
@@ -1426,7 +1372,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 #if DIRECT_MODE
             // DIRECT MODE has ReadFeed issues in the Public emulator
             await this.TestPartitionKeyDefinitionOnCollectionRecreateFromNonPartitionedToPartitionedForQuery(TestCommon.CreateClient(false, protocol: Protocol.Tcp));
-            await this.TestPartitionKeyDefinitionOnCollectionRecreateFromNonPartitionedToPartitionedForQuery(TestCommon.CreateClient(false, protocol: Protocol.Https));
 #endif
         }
 
@@ -1484,7 +1429,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 #if DIRECT_MODE
             // DIRECT MODE has ReadFeed issues in the Public emulator
             await this.TestPartitionKeyDefinitionOnCollectionRecreateFromNonPartitionedToPartitionedForParallelQuery(TestCommon.CreateClient(false, protocol: Protocol.Tcp));
-            await this.TestPartitionKeyDefinitionOnCollectionRecreateFromNonPartitionedToPartitionedForParallelQuery(TestCommon.CreateClient(false, protocol: Protocol.Https));
 #endif
         }
 
@@ -1537,7 +1481,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         {
             await this.TestCollectionRecreateFromMultipartitionToSinglePartitionedForQuery(TestCommon.CreateClient(true));
             await this.TestCollectionRecreateFromMultipartitionToSinglePartitionedForQuery(TestCommon.CreateClient(false, protocol: Protocol.Tcp));
-            await this.TestCollectionRecreateFromMultipartitionToSinglePartitionedForQuery(TestCommon.CreateClient(false, protocol: Protocol.Https));
         }
 
         internal async Task TestCollectionRecreateFromMultipartitionToSinglePartitionedForQuery(DocumentClient client)
@@ -1584,7 +1527,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 #if DIRECT_MODE
             // DIRECT MODE has ReadFeed issues in the Public emulator
             await this.TestRouteToNonExistentRangeAfterCollectionRecreate(TestCommon.CreateClient(false, protocol: Protocol.Tcp));
-            await this.TestRouteToNonExistentRangeAfterCollectionRecreate(TestCommon.CreateClient(false, protocol: Protocol.Https));
 #endif
         }
 
@@ -1657,7 +1599,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 #if DIRECT_MODE
             // DIRECT MODE has ReadFeed issues in the Public emulator
             await this.TestRouteToExistentRangeAfterCollectionRecreate(TestCommon.CreateClient(false, protocol: Protocol.Tcp));
-            await this.TestRouteToExistentRangeAfterCollectionRecreate(TestCommon.CreateClient(false, protocol: Protocol.Https));
 #endif
         }
 
@@ -1736,7 +1677,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 #if DIRECT_MODE
             // DIRECT MODE has ReadFeed issues in the Public emulator
             await this.TestPartitionKeyDefinitionOnCollectionRecreateFromPartitionedToNonPartitionedForQuery(TestCommon.CreateClient(false, protocol: Protocol.Tcp));
-            await this.TestPartitionKeyDefinitionOnCollectionRecreateFromPartitionedToNonPartitionedForQuery(TestCommon.CreateClient(false, protocol: Protocol.Https));
 #endif
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/QueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/QueryTests.cs
@@ -777,12 +777,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             this.TestQueryUnicodeDocument(useGateway: true, protocol: Protocol.Https);
         }
 
-        [TestMethod]
-        public void TestQueryUnicodeDocumentHttpsDirect()
-        {
-            this.TestQueryUnicodeDocument(useGateway: false, protocol: Protocol.Https);
-        }
-
         private void TestQueryUnicodeDocument(bool useGateway, Protocol protocol)
         {
             try

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/SmokeTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/SmokeTests.cs
@@ -68,13 +68,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        public async Task DocumentInsertsTest_DirectHttps()
-        {
-            this.client = this.GetDocumentClient(ConnectionMode.Direct, Documents.Client.Protocol.Https);
-            await this.DocumentInsertsTest();
-        }
-
-        [TestMethod]
         public async Task DocumentInsertsTest_DirectTcp()
         {
             this.client = this.GetDocumentClient(ConnectionMode.Direct, Documents.Client.Protocol.Tcp);
@@ -104,13 +97,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         public async Task QueryWithPaginationTest_GatewayHttps()
         {
             this.client = this.GetDocumentClient(ConnectionMode.Gateway, Documents.Client.Protocol.Https);
-            await this.QueryWithPagination();
-        }
-
-        [TestMethod]
-        public async Task QueryWithPaginationTest_DirectHttps()
-        {
-            this.client = this.GetDocumentClient(ConnectionMode.Direct, Documents.Client.Protocol.Https);
             await this.QueryWithPagination();
         }
 
@@ -174,13 +160,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        public async Task CrossPartitionQueries_DirectHttps()
-        {
-            this.client = this.GetDocumentClient(ConnectionMode.Direct, Documents.Client.Protocol.Https);
-            await this.CrossPartitionQueries();
-        }
-
-        [TestMethod]
         public async Task CrossPartitionQueries_DirectTcp()
         {
             this.client = this.GetDocumentClient(ConnectionMode.Direct, Documents.Client.Protocol.Tcp);
@@ -221,13 +200,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        public async Task CreateDatabaseIfNotExists_DirectHttps()
-        {
-            this.client = this.GetDocumentClient(ConnectionMode.Direct, Documents.Client.Protocol.Https);
-            await this.CreateDatabaseIfNotExists(this.client);
-        }
-
-        [TestMethod]
         public async Task CreateDatabaseIfNotExists_DirectTcp()
         {
             this.client = this.GetDocumentClient(ConnectionMode.Direct, Documents.Client.Protocol.Tcp);
@@ -263,13 +235,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         public async Task CreateDocumentCollectionIfNotExists_GatewayHttps()
         {
             this.client = this.GetDocumentClient(ConnectionMode.Gateway, Documents.Client.Protocol.Https);
-            await this.CreateDocumentCollectionIfNotExists();
-        }
-
-        [TestMethod]
-        public async Task CreateDocumentCollectionIfNotExists_DirectHttps()
-        {
-            this.client = this.GetDocumentClient(ConnectionMode.Direct, Documents.Client.Protocol.Https);
             await this.CreateDocumentCollectionIfNotExists();
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/Util.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/Util.cs
@@ -112,8 +112,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 new Dictionary<DocumentClientType, DocumentClient>
             {
                 {DocumentClientType.Gateway, TestCommon.CreateClient(true, tokenType: authTokenType, defaultConsistencyLevel: consistencyLevel)},
-                {DocumentClientType.DirectTcp, TestCommon.CreateClient(false, Protocol.Tcp, tokenType: authTokenType, defaultConsistencyLevel: consistencyLevel)},
-                {DocumentClientType.DirectHttps, TestCommon.CreateClient(false, Protocol.Https, tokenType: authTokenType, defaultConsistencyLevel: consistencyLevel)}
+                {DocumentClientType.DirectTcp, TestCommon.CreateClient(false, Protocol.Tcp, tokenType: authTokenType, defaultConsistencyLevel: consistencyLevel)}
             };
 
             foreach (KeyValuePair<DocumentClientType, DocumentClient> clientEntry in clients)
@@ -149,8 +148,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 new Dictionary<DocumentClientType, DocumentClient>
             {
                 {DocumentClientType.Gateway, TestCommon.CreateClient(true, tokenType: authTokenType, defaultConsistencyLevel: consistencyLevel)},
-                {DocumentClientType.DirectTcp, TestCommon.CreateClient(false, Protocol.Tcp, tokenType: authTokenType, defaultConsistencyLevel: consistencyLevel)},
-                {DocumentClientType.DirectHttps, TestCommon.CreateClient(false, Protocol.Https, tokenType: authTokenType, defaultConsistencyLevel: consistencyLevel)}
+                {DocumentClientType.DirectTcp, TestCommon.CreateClient(false, Protocol.Tcp, tokenType: authTokenType, defaultConsistencyLevel: consistencyLevel)}
             };
 
             int seed = (int)DateTime.Now.Ticks;

--- a/templates/emulator-setup.yml
+++ b/templates/emulator-setup.yml
@@ -11,6 +11,7 @@ steps:
         mkdir "$env:temp\Azure Cosmos DB Emulator"
         lessmsi x "$env:temp\azure-cosmosdb-emulator.msi" "$env:temp\Azure Cosmos DB Emulator\"
         Write-Host "Starting Comsos DB Emulator" -ForegroundColor green 
+        Add-MpPreference -ExclusionPath "$env:temp\Azure Cosmos DB Emulator\SourceDir\Azure Cosmos DB Emulator"
         Start-Process "$env:temp\Azure Cosmos DB Emulator\SourceDir\Azure Cosmos DB Emulator\CosmosDB.Emulator.exe" "/NoExplorer /NoUI /DisableRateLimiting /PartitionCount=100 /Consistency=Strong /enableRio /EnablePreview /EnableAadAuthentication /EnableSqlComputeEndpoint" -Verb RunAs
         Import-Module "$env:temp\Azure Cosmos DB Emulator\SourceDir\Azure Cosmos DB Emulator\PSModules\Microsoft.Azure.CosmosDB.Emulator"
         Get-Item env:* | Sort-Object -Property Name


### PR DESCRIPTION
Direct/HTTPS is not a mode that users can set on the V3 SDK, these tests are just adding execution time on the CI without adding any value.

Also disabling Windows Defender on the Emulator folder.