### PR TITLE
LocalQuorum: Adds Quorum reads on Consistent Prefix Accounts

### DIFF
--- a/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
@@ -600,7 +600,7 @@ namespace Microsoft.Azure.Cosmos
         internal bool EnablePartitionLevelFailover { get; set; } = false;
 
         /// <summary>
-        /// Quorum Read allowed with eventual consistency account
+        /// Quorum Read allowed with eventual consistency account or consistent prefix account.
         /// </summary>
         internal bool EnableUpgradeConsistencyToLocalQuorum { get; set; } = false;
         

--- a/Microsoft.Azure.Cosmos/src/Fluent/CosmosClientBuilder.cs
+++ b/Microsoft.Azure.Cosmos/src/Fluent/CosmosClientBuilder.cs
@@ -698,7 +698,7 @@ namespace Microsoft.Azure.Cosmos.Fluent
         }
 
         /// <summary>
-        /// To enable LocalQuorum Consistency, i.e. Allow Quorum read with Eventual Consistency Account
+        /// To enable LocalQuorum Consistency, i.e. Allows Quorum read with Eventual Consistency Account or with Consistent Prefix Account.
         /// Use By Compute Only
         /// </summary>
         internal CosmosClientBuilder AllowUpgradeConsistencyToLocalQuorum()

--- a/Microsoft.Azure.Cosmos/src/ValidationHelpers.cs
+++ b/Microsoft.Azure.Cosmos/src/ValidationHelpers.cs
@@ -10,12 +10,12 @@ namespace Microsoft.Azure.Cosmos
     internal static class ValidationHelpers
     {
         /// <summary>
-        /// If isLocalQuorumConsistency flag is true, it allows only "Quorum Read with Eventual Consistency Account". 
+        /// If isLocalQuorumConsistency flag is true, it allows only "Quorum Read with either an Eventual Consistency Account or a Consistent Prefix Account". 
         /// It goes through a validation where it doesn't allow strong consistency over weaker consistency.
         /// </summary>
         /// <param name="backendConsistency"> Account Level Consistency </param>
         /// <param name="desiredConsistency"> Request/Client Level Consistency</param>
-        /// <param name="isLocalQuorumConsistency"> Allows Quorum Read with Eventual Account</param>
+        /// <param name="isLocalQuorumConsistency"> Allows Quorum Read with Eventual or Consistent Prefix Account</param>
         /// <param name="operationType"> <see cref="OperationType"/> </param>
         /// <param name="resourceType"> <see cref="ResourceType"/> </param>
         /// <returns>true/false</returns>
@@ -36,12 +36,12 @@ namespace Microsoft.Azure.Cosmos
         }
 
         /// <summary>
-        /// If isLocalQuorumConsistency flag is true, it allows only "Quorum Read with Eventual Consistency Account". 
+        /// If isLocalQuorumConsistency flag is true, it allows only "Quorum Read with either an Eventual Consistency Account or a Consistent Prefix Account". 
         /// It goes through a validation where it doesn't allow strong consistency over weaker consistency.
         /// </summary>
         /// <param name="backendConsistency"> Account Level Consistency </param>
         /// <param name="desiredConsistency"> Request/Client Level Consistency</param>
-        /// <param name="isLocalQuorumConsistency"> Allows Quorum Read with Eventual Account</param>
+        /// <param name="isLocalQuorumConsistency"> Allows Quorum Read with Eventual or Consistent Prefix Account</param>
         /// <param name="operationType">  <see cref="OperationType"/> </param>
         /// <param name="resourceType"> <see cref="ResourceType"/> </param>
         /// <returns>true/false</returns>
@@ -107,7 +107,7 @@ namespace Microsoft.Azure.Cosmos
         }
 
         /// <summary>
-        /// Condition to check Quorum(i.e. Strong) read with eventual account
+        /// Condition to check Quorum(i.e. Strong) read with either an eventual consistency account or a consistent prefix account.
         /// </summary>
         /// <param name="backendConsistency"></param>
         /// <param name="desiredConsistency"></param>
@@ -119,7 +119,7 @@ namespace Microsoft.Azure.Cosmos
                                 OperationType? operationType,
                                 ResourceType? resourceType)
         {
-            if (backendConsistency != Documents.ConsistencyLevel.Eventual)
+            if (backendConsistency != Documents.ConsistencyLevel.Eventual && backendConsistency != Documents.ConsistencyLevel.ConsistentPrefix)
             {
                 return false;
             }
@@ -136,7 +136,8 @@ namespace Microsoft.Azure.Cosmos
             }
 
             if (!operationType.HasValue || 
-                    (operationType.HasValue && !(operationType == OperationType.Read || operationType == OperationType.ReadFeed)))
+                    (operationType.HasValue && 
+                    !(operationType == OperationType.Read || operationType == OperationType.ReadFeed || operationType == OperationType.SqlQuery || operationType == OperationType.Query)))
             {
                 return false;
             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ValidationHelpersTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ValidationHelpersTests.cs
@@ -1,0 +1,72 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Tests
+{
+    using System.Data;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class ValidationHelpersTest
+    {
+        [TestMethod]
+        [DataRow(true, ConsistencyLevel.Eventual, ConsistencyLevel.Strong)]
+        [DataRow(true, ConsistencyLevel.ConsistentPrefix, ConsistencyLevel.Strong)]
+        [DataRow(false, ConsistencyLevel.Eventual, ConsistencyLevel.BoundedStaleness)]
+        [DataRow(false, ConsistencyLevel.ConsistentPrefix, ConsistencyLevel.BoundedStaleness)]
+        [DataRow(false, ConsistencyLevel.Session, ConsistencyLevel.Strong)]
+        [DataRow(false, ConsistencyLevel.BoundedStaleness, ConsistencyLevel.Strong)]
+        public void TestIsValidConsistencyLevelOverwrite(bool isValidConsistencyLevelOverwrite,
+            ConsistencyLevel backendConsistencyLevel,
+            ConsistencyLevel desiredConsistencyLevel)
+        {
+            bool result = ValidationHelpers.IsValidConsistencyLevelOverwrite(backendConsistencyLevel,
+                desiredConsistencyLevel,
+                true,
+                Documents.OperationType.Read,
+                Documents.ResourceType.Document);
+
+            Assert.AreEqual(isValidConsistencyLevelOverwrite, result);
+        }
+
+        [TestMethod]
+        [DataRow(false, ConsistencyLevel.Eventual, ConsistencyLevel.Strong)]
+        [DataRow(false, ConsistencyLevel.ConsistentPrefix, ConsistencyLevel.Strong)]
+        public void TestIsValidConsistencyLevelOverwrite_OnlyWhenSpecifyingExplicitOverwrite(bool isValidConsistencyLevelOverwrite,
+            ConsistencyLevel backendConsistencyLevel,
+            ConsistencyLevel desiredConsistencyLevel)
+        {
+            bool result = ValidationHelpers.IsValidConsistencyLevelOverwrite(backendConsistencyLevel,
+                desiredConsistencyLevel,
+                false,
+                Documents.OperationType.Read,
+                Documents.ResourceType.Document);
+
+            Assert.AreEqual(isValidConsistencyLevelOverwrite, result);
+        }
+
+        [TestMethod]
+        [DataRow(true, ConsistencyLevel.Eventual, ConsistencyLevel.Strong, Documents.OperationType.Read)]
+        [DataRow(true, ConsistencyLevel.Eventual, ConsistencyLevel.Strong, Documents.OperationType.ReadFeed)]
+        [DataRow(true, ConsistencyLevel.ConsistentPrefix, ConsistencyLevel.Strong, Documents.OperationType.Query)]
+        [DataRow(true, ConsistencyLevel.ConsistentPrefix, ConsistencyLevel.Strong, Documents.OperationType.SqlQuery)]
+        [DataRow(false, ConsistencyLevel.Eventual, ConsistencyLevel.Strong, Documents.OperationType.QueryPlan)]
+        [DataRow(false, ConsistencyLevel.ConsistentPrefix, ConsistencyLevel.Strong, Documents.OperationType.Create)]
+        [DataRow(false, ConsistencyLevel.ConsistentPrefix, ConsistencyLevel.Strong, Documents.OperationType.Batch)]
+        public void TestIsValidConsistencyLevelOverwrite_OnlyAllowedForCertainOperationTypes(
+            bool isValidConsistencyLevelOverwrite,
+            ConsistencyLevel backendConsistencyLevel,
+            ConsistencyLevel desiredConsistencyLevel,
+            dynamic operationType)
+        {
+            bool result = ValidationHelpers.IsValidConsistencyLevelOverwrite(backendConsistencyLevel,
+                desiredConsistencyLevel,
+                true,
+                (Documents.OperationType) operationType,
+                Documents.ResourceType.Document);
+
+            Assert.AreEqual(isValidConsistencyLevelOverwrite, result);
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request Template

## Description

New Feature: Allow Strong Consistency reads (local minority reads, quorum reads from 2 replicas) for Consistent Prefix accounts. This feature can only be enabled when explicitly opting in for the consistency upgrade during the client initialization.

## Type of change

- [] New feature (non-breaking change which adds functionality)
