### PR TITLE
[Internal] Client Telemetry: Adds network information in the payload

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Handler/TelemetryHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/TelemetryHandler.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Azure.Cosmos.Handlers
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Core.Trace;
     using Microsoft.Azure.Cosmos.Telemetry;
+    using Microsoft.Azure.Cosmos.Tracing.TraceData;
 
     internal class TelemetryHandler : RequestHandler
     {
@@ -40,7 +41,8 @@ namespace Microsoft.Azure.Cosmos.Handlers
                                 resourceType: request.ResourceType,
                                 consistencyLevel: request.Headers?[Documents.HttpConstants.HttpHeaders.ConsistencyLevel],
                                 requestCharge: response.Headers.RequestCharge,
-                                subStatusCode: response.Headers.SubStatusCode);
+                                subStatusCode: response.Headers.SubStatusCode,
+                                trace: response.Trace);
                 }
                 catch (Exception ex)
                 {

--- a/Microsoft.Azure.Cosmos/src/Handler/TelemetryHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/TelemetryHandler.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.Cosmos.Handlers
                 }
                 catch (Exception ex)
                 {
-                    DefaultTrace.TraceError("Error while collecting telemetry information : " + ex.StackTrace);
+                    DefaultTrace.TraceError($"Error while collecting telemetry information : {ex}");
                 }
             }
             return response;

--- a/Microsoft.Azure.Cosmos/src/Handler/TelemetryHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/TelemetryHandler.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.Cosmos.Handlers
                 }
                 catch (Exception ex)
                 {
-                    DefaultTrace.TraceError("Error while collecting telemetry information : " + ex.Message);
+                    DefaultTrace.TraceError("Error while collecting telemetry information : " + ex.StackTrace);
                 }
             }
             return response;

--- a/Microsoft.Azure.Cosmos/src/Handler/TelemetryHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/TelemetryHandler.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.Cosmos.Handlers
                 }
                 catch (Exception ex)
                 {
-                    DefaultTrace.TraceError($"Error while collecting telemetry information : {ex}");
+                    DefaultTrace.TraceError("Error while collecting telemetry information : {0}", ex);
                 }
             }
             return response;

--- a/Microsoft.Azure.Cosmos/src/Handler/TelemetryHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/TelemetryHandler.cs
@@ -10,7 +10,6 @@ namespace Microsoft.Azure.Cosmos.Handlers
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Core.Trace;
     using Microsoft.Azure.Cosmos.Telemetry;
-    using Microsoft.Azure.Cosmos.Tracing.TraceData;
 
     internal class TelemetryHandler : RequestHandler
     {

--- a/Microsoft.Azure.Cosmos/src/Routing/ClientCollectionCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/ClientCollectionCache.cs
@@ -227,8 +227,7 @@ namespace Microsoft.Azure.Cosmos.Routing
                                                     operationType: request.OperationType,
                                                     resourceType: request.ResourceType,
                                                     subStatusCode: response.SubStatusCode,
-                                                    databaseId: databaseName,
-                                                    trace: childTrace);
+                                                    databaseId: databaseName);
                                 }
 
                                 return containerProperties;

--- a/Microsoft.Azure.Cosmos/src/Routing/ClientCollectionCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/ClientCollectionCache.cs
@@ -227,7 +227,8 @@ namespace Microsoft.Azure.Cosmos.Routing
                                                     operationType: request.OperationType,
                                                     resourceType: request.ResourceType,
                                                     subStatusCode: response.SubStatusCode,
-                                                    databaseId: databaseName);
+                                                    databaseId: databaseName,
+                                                    trace: childTrace);
                                 }
 
                                 return containerProperties;

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
@@ -209,7 +209,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             }
             catch (Exception ex)
             {
-                DefaultTrace.TraceError("Exception in EnrichAndSendAsync() : {0}", ex.Message);
+                DefaultTrace.TraceError($"Exception in EnrichAndSendAsync() : {ex}");
             }
 
             DefaultTrace.TraceInformation("Telemetry Job Stopped.");
@@ -266,7 +266,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             }
             catch (Exception ex)
             {
-                DefaultTrace.TraceError("Latency Recording Failed by Telemetry. Exception : {0}", ex.Message);
+                DefaultTrace.TraceError($"Latency Recording Failed by Telemetry. Exception : {ex}");
             }
         }
 
@@ -334,7 +334,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             }
             catch (Exception ex)
             {
-                DefaultTrace.TraceError("Latency Recording Failed by Telemetry. Exception : {0}", ex.Message);
+                DefaultTrace.TraceError($"Latency Recording Failed by Telemetry. Exception : {ex}");
             }
 
             long requestChargeToRecord = (long)(requestCharge * ClientTelemetryOptions.HistogramPrecisionFactor);
@@ -344,7 +344,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             }
             catch (Exception ex)
             {
-                DefaultTrace.TraceError("Request Charge Recording Failed by Telemetry. Request Charge Value : {0}  Exception : {1} ", requestChargeToRecord, ex.Message);
+                DefaultTrace.TraceError($"Request Charge Recording Failed by Telemetry. Request Charge Value : {requestChargeToRecord}  Exception : {ex} ");
             }
         }
 
@@ -427,7 +427,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             }
             catch (Exception ex)
             {
-                DefaultTrace.TraceError("System Usage Recording Error : {0}", ex.Message);
+                DefaultTrace.TraceError($"System Usage Recording Error : {ex}");
             }
         }
 
@@ -505,7 +505,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             {
                 this.numberOfFailures++;
 
-                DefaultTrace.TraceError("Exception while sending telemetry data : {0}", ex.StackTrace);
+                DefaultTrace.TraceError($"Exception while sending telemetry data : {ex}");
             }
             finally
             {

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
@@ -373,23 +373,24 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             {
                 if (ClientTelemetryOptions.IsEligible((int)httpstatistics.HttpResponseMessage.StatusCode, httpstatistics.Duration))
                 {
-                    string subStatusCode = httpstatistics.HttpResponseMessage.Headers?.GetValues(WFConstants.BackendHeaders.SubStatus)?.First();
+                    IEnumerable<string> substatuscodes = null;
+                    httpstatistics.HttpResponseMessage.Headers?.TryGetValues(WFConstants.BackendHeaders.SubStatus, out substatuscodes);
 
                     string operationTypeValue = string.Empty;
                     if (httpstatistics.ResourceType == ResourceType.Document)
                     {
                         operationTypeValue = operationType.ToOperationTypeString();
                     }
-                    
+
                     RequestInfo requestInfo = new RequestInfo()
                     {
                         DatabaseName = databaseId,
                         ContainerName = containerId,
                         Uri = httpstatistics.RequestUri.ToString(),
                         StatusCode = (int)httpstatistics.HttpResponseMessage.StatusCode,
-                        SubStatusCode = Convert.ToInt32(subStatusCode),
+                        SubStatusCode = Convert.ToInt32(substatuscodes?.First()),
                         Resource = httpstatistics.ResourceType.ToResourceTypeString(),
-                        Operation = operationTypeValue,
+                        Operation = operationTypeValue
                     };
 
                     LongConcurrentHistogram latencyHist = this.requestInfoMap.GetOrAdd(requestInfo, x => new LongConcurrentHistogram(ClientTelemetryOptions.RequestLatencyMin,

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
@@ -207,7 +207,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             }
             catch (Exception ex)
             {
-                DefaultTrace.TraceError($"Exception in EnrichAndSendAsync() : {ex}");
+                DefaultTrace.TraceError("Exception in EnrichAndSendAsync() : {0}", ex);
             }
 
             DefaultTrace.TraceInformation("Telemetry Job Stopped.");
@@ -259,7 +259,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             }
             catch (Exception ex)
             {
-                DefaultTrace.TraceError($"Latency Recording Failed by Telemetry. Exception : {ex}");
+                DefaultTrace.TraceError("Latency Recording Failed by Telemetry. Exception : {0}", ex);
             }
         }
 
@@ -326,7 +326,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             }
             catch (Exception ex)
             {
-                DefaultTrace.TraceError($"Latency Recording Failed by Telemetry. Exception : {ex}");
+                DefaultTrace.TraceError("Latency Recording Failed by Telemetry. Exception : {0}", ex);
             }
 
             long requestChargeToRecord = (long)(requestCharge * ClientTelemetryOptions.HistogramPrecisionFactor);
@@ -336,7 +336,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             }
             catch (Exception ex)
             {
-                DefaultTrace.TraceError($"Request Charge Recording Failed by Telemetry. Request Charge Value : {requestChargeToRecord}  Exception : {ex} ");
+                DefaultTrace.TraceError("Request Charge Recording Failed by Telemetry. Request Charge Value : {0}  Exception : {1} ", requestChargeToRecord, ex);
             }
         }
 
@@ -396,7 +396,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             }
             catch (Exception ex)
             {
-                DefaultTrace.TraceError($"System Usage Recording Error : {ex}");
+                DefaultTrace.TraceError("System Usage Recording Error : {0} ", ex);
             }
         }
 
@@ -474,7 +474,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             {
                 this.numberOfFailures++;
 
-                DefaultTrace.TraceError($"Exception while sending telemetry data : {ex}");
+                DefaultTrace.TraceError("Exception while sending telemetry data : {0}", ex);
             }
             finally
             {

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
@@ -9,7 +9,6 @@ namespace Microsoft.Azure.Cosmos.Telemetry
     using System.Collections.Generic;
     using System.Net;
     using System.Net.Http;
-    using System.Net.NetworkInformation;
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
@@ -238,11 +238,10 @@ namespace Microsoft.Azure.Cosmos.Telemetry
 
             DefaultTrace.TraceVerbose($"Collecting cacheRefreshSource {cacheRefreshSource} data for Telemetry.");
 
-            // Record Network/Replica Information
+            // Record Network Information
             SummaryDiagnostics summaryDiagnostics = new SummaryDiagnostics(trace);
             this.RecordHttpResponses(containerId, databaseId, operationType, resourceType, summaryDiagnostics.HttpResponseStatistics.Value);
-            this.RecordRntbdResponses(containerId, databaseId, summaryDiagnostics.StoreResponseStatistics.Value);
-
+           
             string regionsContacted = ClientTelemetryHelper.GetContactedRegions(regionsContactedList);
 
             // Recording Request Latency

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
@@ -506,7 +506,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             {
                 this.numberOfFailures++;
 
-                DefaultTrace.TraceError("Exception while sending telemetry data : {0}", ex.Message);
+                DefaultTrace.TraceError("Exception while sending telemetry data : {0}", ex.StackTrace);
             }
             finally
             {

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
@@ -237,11 +237,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             }
 
             DefaultTrace.TraceVerbose($"Collecting cacheRefreshSource {cacheRefreshSource} data for Telemetry.");
-
-            // Record Network Information
-            SummaryDiagnostics summaryDiagnostics = new SummaryDiagnostics(trace);
-            this.RecordHttpResponses(containerId, databaseId, operationType, resourceType, summaryDiagnostics.HttpResponseStatistics.Value);
-           
+            
             string regionsContacted = ClientTelemetryHelper.GetContactedRegions(regionsContactedList);
 
             // Recording Request Latency
@@ -305,7 +301,6 @@ namespace Microsoft.Azure.Cosmos.Telemetry
 
             // Record Network/Replica Information
             SummaryDiagnostics summaryDiagnostics = new SummaryDiagnostics(trace);
-            this.RecordHttpResponses(containerId, databaseId, operationType, resourceType, summaryDiagnostics.HttpResponseStatistics.Value);
             this.RecordRntbdResponses(containerId, databaseId, summaryDiagnostics.StoreResponseStatistics.Value);
 
             string regionsContacted = ClientTelemetryHelper.GetContactedRegions(cosmosDiagnostics.GetContactedRegions());

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryHelper.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryHelper.cs
@@ -93,7 +93,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                 OperationInfo payloadForLatency = entry.Key;
                 payloadForLatency.MetricInfo = new MetricInfo(ClientTelemetryOptions.RequestLatencyName, ClientTelemetryOptions.RequestLatencyUnit);
                 payloadForLatency.SetAggregators(entry.Value.latency, ClientTelemetryOptions.TicksToMsFactor);
-
+                
                 payloadWithMetricInformation.Add(payloadForLatency);
 
                 OperationInfo payloadForRequestCharge = payloadForLatency.Copy();
@@ -104,6 +104,34 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             }
 
             DefaultTrace.TraceInformation("Aggregating operation information to list done");
+
+            return payloadWithMetricInformation;
+        }
+
+        /// <summary>
+        /// Convert map with request information to list of operations along with request latency and request charge metrics
+        /// </summary>
+        /// <param name="metrics"></param>
+        /// <returns>Collection of ReportPayload</returns>
+        internal static List<RequestInfo> ToListWithMetricsInfo(
+                IDictionary<RequestInfo,
+                LongConcurrentHistogram> metrics)
+        {
+            DefaultTrace.TraceVerbose("Aggregating RequestInfo information to list started");
+
+            List<RequestInfo> payloadWithMetricInformation = new List<RequestInfo>();
+            foreach (KeyValuePair<RequestInfo, LongConcurrentHistogram> entry in metrics)
+            {
+                MetricInfo metricInfo = new MetricInfo(ClientTelemetryOptions.RequestLatencyName, ClientTelemetryOptions.RequestLatencyUnit);
+                metricInfo.SetAggregators(entry.Value, ClientTelemetryOptions.TicksToMsFactor);
+                
+                RequestInfo payloadForLatency = entry.Key;
+                payloadForLatency.Metrics.Add(metricInfo);
+              
+                payloadWithMetricInformation.Add(payloadForLatency);
+            }
+
+            DefaultTrace.TraceInformation("Aggregating RequestInfo information to list done");
 
             return payloadWithMetricInformation;
         }

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryHelper.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryHelper.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                 payloadWithMetricInformation.Add(payloadForRequestCharge);
             }
 
-            DefaultTrace.TraceInformation("Aggregating operation information to list done");
+            DefaultTrace.TraceVerbose("Aggregating operation information to list done");
 
             return payloadWithMetricInformation;
         }
@@ -128,7 +128,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                 payloadWithMetricInformation.Add(payloadForLatency);
             }
 
-            DefaultTrace.TraceInformation("Aggregating RequestInfo information to list done");
+            DefaultTrace.TraceVerbose("Aggregating RequestInfo information to list done");
 
             return payloadWithMetricInformation;
         }

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryHelper.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryHelper.cs
@@ -6,15 +6,12 @@ namespace Microsoft.Azure.Cosmos.Telemetry
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Net.Http;
     using System.Text;
-    using System.Threading;
     using System.Threading.Tasks;
     using HdrHistogram;
     using Microsoft.Azure.Cosmos.Core.Trace;
     using Microsoft.Azure.Cosmos.Routing;
     using Microsoft.Azure.Cosmos.Telemetry.Models;
-    using Microsoft.Azure.Documents;
     using Microsoft.Azure.Documents.Rntbd;
 
     internal static class ClientTelemetryHelper

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryOptions.cs
@@ -190,10 +190,9 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         /// <returns>true/false</returns>
         internal static bool IsEligible(int statusCode, int subStatusCode, TimeSpan latencyInMs)
         {
-            return 
-                (ClientTelemetryOptions.IsUserOrServerError(statusCode) && 
-                    ClientTelemetryOptions.IsStatusCodeNotExcluded(statusCode, subStatusCode)) ||
-                        latencyInMs >= ClientTelemetryOptions.NetworkLatencyThreshold;
+            return
+                ClientTelemetryOptions.IsStatusCodeNotExcluded(statusCode, subStatusCode) && 
+                    (ClientTelemetryOptions.IsUserOrServerError(statusCode) || latencyInMs >= ClientTelemetryOptions.NetworkLatencyThreshold);
         }
 
         private static bool IsUserOrServerError(int statusCode)

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryOptions.cs
@@ -179,15 +179,31 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             return environmentName;
         }
 
+        /// <summary>
+        /// This method will return true if the request is failed with User or Server Exception and not excluded from telemetry.
+        /// This method will return true if the request latency is more than the threshold.
+        /// otherwise return false
+        /// </summary>
+        /// <param name="statusCode"></param>
+        /// <param name="subStatusCode"></param>
+        /// <param name="latencyInMs"></param>
+        /// <returns>true/false</returns>
         internal static bool IsEligible(int statusCode, int subStatusCode, TimeSpan latencyInMs)
         {
-            if ((statusCode >= 400 && statusCode <= 599 &&
-                !(ClientTelemetryOptions.ExcludedStatusCodes.Contains(statusCode) && subStatusCode == 0)) ||
-                    latencyInMs >= ClientTelemetryOptions.NetworkLatencyThreshold)
-            {
-                return true;
-            }
-            return false;
+            return 
+                (ClientTelemetryOptions.IsUserOrServerError(statusCode) && 
+                    ClientTelemetryOptions.IsStatusCodeNotExcluded(statusCode, subStatusCode)) ||
+                        latencyInMs >= ClientTelemetryOptions.NetworkLatencyThreshold;
+        }
+
+        private static bool IsUserOrServerError(int statusCode)
+        {
+            return statusCode >= 400 && statusCode <= 599;
+        }
+
+        private static bool IsStatusCodeNotExcluded(int statusCode, int subStatusCode)
+        {
+            return !(ClientTelemetryOptions.ExcludedStatusCodes.Contains(statusCode) && subStatusCode == 0);
         }
 
     }

--- a/Microsoft.Azure.Cosmos/src/Telemetry/Models/ClientTelemetryProperties.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/Models/ClientTelemetryProperties.cs
@@ -60,6 +60,9 @@ namespace Microsoft.Azure.Cosmos.Telemetry.Models
         [JsonProperty(PropertyName = "operationInfo")]
         internal List<OperationInfo> OperationInfo { get; set; }
 
+        [JsonProperty(PropertyName = "requestInfo")]
+        internal List<RequestInfo> RequestInfo { get; set; }
+
         [JsonIgnore]
         internal bool IsDirectConnectionMode { get; }
 
@@ -97,6 +100,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry.Models
             List<SystemInfo> systemInfo,
             List<CacheRefreshInfo> cacheRefreshInfo,
             List<OperationInfo> operationInfo,
+            List<RequestInfo> requestInfo,
             string machineId)
         {
             this.DateTimeUtc = dateTimeUtc;
@@ -111,6 +115,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry.Models
             this.SystemInfo = systemInfo;
             this.CacheRefreshInfo = cacheRefreshInfo;
             this.OperationInfo = operationInfo;
+            this.RequestInfo = requestInfo;
             this.PreferredRegions = preferredRegions;
             this.MachineId = machineId;
         }

--- a/Microsoft.Azure.Cosmos/src/Telemetry/Models/RequestInfo.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/Models/RequestInfo.cs
@@ -1,0 +1,72 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Telemetry.Models
+{
+    using System;
+    using System.Collections.Generic;
+    using System.ComponentModel;
+    using Newtonsoft.Json;
+
+    [Serializable]
+    internal sealed class RequestInfo
+    {
+        [JsonProperty("uri")]
+        public string Uri { get; set; }
+
+        [JsonProperty("databaseName")]
+        public string DatabaseName { get; set; }
+
+        [JsonProperty("containerName")]
+        public string ContainerName { get; set; }
+
+        [JsonProperty("operation")]
+        public string Operation { get; set; }
+
+        [JsonProperty("resource")]
+        public string Resource { get; set; }
+
+        [JsonProperty("statusCode")]
+        public int? StatusCode { get; set; }
+
+        [JsonProperty("subStatusCode")]
+        public int SubStatusCode { get; set; }
+
+        [JsonProperty("cacheRefreshSource")]
+        public string CacheRefreshSource { get; set; }
+
+        [JsonProperty("metricInfo")]
+        public List<MetricInfo> Metrics { get; set; } = new List<MetricInfo>();
+
+        public override int GetHashCode()
+        {
+            int hash = 3;
+            hash = (hash * 7) ^ (this.Uri == null ? 0 : this.Uri.GetHashCode());
+            hash = (hash * 7) ^ (this.DatabaseName == null ? 0 : this.DatabaseName.GetHashCode());
+            hash = (hash * 7) ^ (this.ContainerName == null ? 0 : this.ContainerName.GetHashCode());
+            hash = (hash * 7) ^ (this.Operation == null ? 0 : this.Operation.GetHashCode());
+            hash = (hash * 7) ^ (this.Resource == null ? 0 : this.Resource.GetHashCode());
+            hash = (hash * 7) ^ (this.StatusCode == null ? 0 : this.StatusCode.GetHashCode());
+            hash = (hash * 7) ^ (this.SubStatusCode.GetHashCode());
+            hash = (hash * 7) ^ (this.CacheRefreshSource == null ? 0 : this.CacheRefreshSource.GetHashCode());
+            return hash;
+        }
+        
+        public override bool Equals(object obj)
+        {
+            bool isequal = obj is RequestInfo payload &&
+                   ((this.Uri == null && payload.Uri == null) || (this.Uri != null && payload.Uri != null && this.Uri.Equals(payload.Uri))) &&
+                   ((this.DatabaseName == null && payload.DatabaseName == null) || (this.DatabaseName != null && payload.DatabaseName != null && this.DatabaseName.Equals(payload.DatabaseName))) &&
+                   ((this.ContainerName == null && payload.ContainerName == null) || (this.ContainerName != null && payload.ContainerName != null && this.ContainerName.Equals(payload.ContainerName))) &&
+                   ((this.Operation == null && payload.Operation == null) || (this.Operation != null && payload.Operation != null && this.Operation.Equals(payload.Operation))) &&
+                   ((this.Resource == null && payload.Resource == null) || (this.Resource != null && payload.Resource != null && this.Resource.Equals(payload.Resource))) &&
+                   ((this.StatusCode == null && payload.StatusCode == null) || (this.StatusCode != null && payload.StatusCode != null && this.StatusCode.Equals(payload.StatusCode))) &&
+                   this.SubStatusCode.Equals(payload.SubStatusCode) &&
+                   String.CompareOrdinal(this.CacheRefreshSource, payload.CacheRefreshSource) == 0;
+
+            return isequal;
+        }
+
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Telemetry/Models/RequestInfo.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/Models/RequestInfo.cs
@@ -6,7 +6,6 @@ namespace Microsoft.Azure.Cosmos.Telemetry.Models
 {
     using System;
     using System.Collections.Generic;
-    using System.ComponentModel;
     using Newtonsoft.Json;
 
     [Serializable]
@@ -33,9 +32,6 @@ namespace Microsoft.Azure.Cosmos.Telemetry.Models
         [JsonProperty("subStatusCode")]
         public int SubStatusCode { get; set; }
 
-        [JsonProperty("cacheRefreshSource")]
-        public string CacheRefreshSource { get; set; }
-
         [JsonProperty("metricInfo")]
         public List<MetricInfo> Metrics { get; set; } = new List<MetricInfo>();
 
@@ -49,7 +45,6 @@ namespace Microsoft.Azure.Cosmos.Telemetry.Models
             hash = (hash * 7) ^ (this.Resource == null ? 0 : this.Resource.GetHashCode());
             hash = (hash * 7) ^ (this.StatusCode == null ? 0 : this.StatusCode.GetHashCode());
             hash = (hash * 7) ^ (this.SubStatusCode.GetHashCode());
-            hash = (hash * 7) ^ (this.CacheRefreshSource == null ? 0 : this.CacheRefreshSource.GetHashCode());
             return hash;
         }
         
@@ -62,8 +57,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry.Models
                    ((this.Operation == null && payload.Operation == null) || (this.Operation != null && payload.Operation != null && this.Operation.Equals(payload.Operation))) &&
                    ((this.Resource == null && payload.Resource == null) || (this.Resource != null && payload.Resource != null && this.Resource.Equals(payload.Resource))) &&
                    ((this.StatusCode == null && payload.StatusCode == null) || (this.StatusCode != null && payload.StatusCode != null && this.StatusCode.Equals(payload.StatusCode))) &&
-                   this.SubStatusCode.Equals(payload.SubStatusCode) &&
-                   String.CompareOrdinal(this.CacheRefreshSource, payload.CacheRefreshSource) == 0;
+                   this.SubStatusCode.Equals(payload.SubStatusCode);
 
             return isequal;
         }

--- a/Microsoft.Azure.Cosmos/src/Tracing/TraceData/ClientSideRequestStatisticsTraceDatum.cs
+++ b/Microsoft.Azure.Cosmos/src/Tracing/TraceData/ClientSideRequestStatisticsTraceDatum.cs
@@ -477,6 +477,7 @@ namespace Microsoft.Azure.Cosmos.Tracing.TraceData
             public string RequestSessionToken { get; }
             public Uri LocationEndpoint { get; }
             public bool IsSupplementalResponse { get; }
+            public TimeSpan RequestLatency => this.RequestResponseTime - this.RequestStartTime.GetValueOrDefault();
         }
 
         public readonly struct HttpResponseStatistics

--- a/Microsoft.Azure.Cosmos/src/Tracing/TraceData/SummaryDiagnostics.cs
+++ b/Microsoft.Azure.Cosmos/src/Tracing/TraceData/SummaryDiagnostics.cs
@@ -8,25 +8,31 @@ namespace Microsoft.Azure.Cosmos.Tracing.TraceData
     using System.Collections.Generic;
     using System.Globalization;
     using Microsoft.Azure.Cosmos.Json;
+    using static Microsoft.Azure.Cosmos.Tracing.TraceData.ClientSideRequestStatisticsTraceDatum;
 
     internal struct SummaryDiagnostics
     {
         public SummaryDiagnostics(ITrace trace)
             : this()
         {
-            this.DirectRequestsSummary = new Lazy<Dictionary<(int, int), int>>(() =>
-                                                new Dictionary<(int, int), int>());
-            this.GatewayRequestsSummary = new Lazy<Dictionary<(int, int), int>>(() =>
-                                                new Dictionary<(int, int), int>());
-            this.AllRegionsContacted = new Lazy<HashSet<Uri>>(() => new HashSet<Uri>());
+            this.DirectRequestsSummary 
+                = new Lazy<Dictionary<(int, int), int>>(() => new Dictionary<(int, int), int>());
+            this.GatewayRequestsSummary 
+                = new Lazy<Dictionary<(int, int), int>>(() => new Dictionary<(int, int), int>());
+            this.AllRegionsContacted 
+                = new Lazy<HashSet<Uri>>(() => new HashSet<Uri>());
+            
             this.CollectSummaryFromTraceTree(trace);
         }
 
+        public Lazy<HashSet<string>> AllRegionsNameContacted { get; private set; } = new Lazy<HashSet<string>>(() => new HashSet<string>());
         public Lazy<HashSet<Uri>> AllRegionsContacted { get; private set; }
 
+        public Lazy<List<StoreResponseStatistics>> StoreResponseStatistics { get; private set; } = new Lazy<List<StoreResponseStatistics>>(() => new List<StoreResponseStatistics>());
         // Count of (StatusCode, SubStatusCode) tuples
         public Lazy<Dictionary<(int statusCode, int subStatusCode), int>> DirectRequestsSummary { get; private set; }
 
+        public Lazy<List<HttpResponseStatistics>> HttpResponseStatistics { get; private set; } = new Lazy<List<HttpResponseStatistics>>(() => new List<HttpResponseStatistics>());
         public Lazy<Dictionary<(int statusCode, int subStatusCode), int>> GatewayRequestsSummary { get; private set; }
 
         private void CollectSummaryFromTraceTree(ITrace currentTrace)
@@ -49,9 +55,10 @@ namespace Microsoft.Azure.Cosmos.Tracing.TraceData
 
         private void AggregateRegionsContacted(HashSet<(string, Uri)> regionsContacted)
         {
-            foreach ((string _, Uri uri) in regionsContacted)
+            foreach ((string name, Uri uri) in regionsContacted)
             {
                 this.AllRegionsContacted.Value.Add(uri);
+                this.AllRegionsNameContacted.Value.Add(name);
             }
         }
 
@@ -59,6 +66,8 @@ namespace Microsoft.Azure.Cosmos.Tracing.TraceData
         {
             foreach (ClientSideRequestStatisticsTraceDatum.HttpResponseStatistics httpResponseStatistics in httpResponseStatisticsList)
             {
+                this.HttpResponseStatistics.Value.Add(httpResponseStatistics);
+                
                 int statusCode = 0;
                 int substatusCode = 0;
                 if (httpResponseStatistics.HttpResponseMessage != null)
@@ -91,8 +100,11 @@ namespace Microsoft.Azure.Cosmos.Tracing.TraceData
         {
             foreach (ClientSideRequestStatisticsTraceDatum.StoreResponseStatistics storeResponseStatistics in storeResponseStatisticsList)
             {
+                this.StoreResponseStatistics.Value.Add(storeResponseStatistics);
+                
                 int statusCode = (int)storeResponseStatistics.StoreResult.StatusCode;
                 int subStatusCode = (int)storeResponseStatistics.StoreResult.SubStatusCode;
+                
                 if (!this.DirectRequestsSummary.Value.ContainsKey((statusCode, subStatusCode)))
                 {
                     this.DirectRequestsSummary.Value[(statusCode, subStatusCode)] = 1;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
     using Microsoft.Azure.Cosmos.Telemetry.Models;
     using Microsoft.Azure.Cosmos.Routing;
     using Microsoft.Azure.Cosmos.Common;
+    using System.Diagnostics;
 
     [TestClass]
     public class ClientTelemetryTests : BaseCosmosClientHelper
@@ -71,6 +72,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                         string jsonObject = request.Content.ReadAsStringAsync().GetAwaiter().GetResult();
 
+                        Console.WriteLine("1 ==> " + jsonObject);
+                        
                         lock (this.actualInfo)
                         {
                             this.actualInfo.Add(JsonConvert.DeserializeObject<ClientTelemetryProperties>(jsonObject));
@@ -100,7 +103,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                         HttpResponseMessage result = new HttpResponseMessage(HttpStatusCode.OK);
 
                         string jsonObject = request.Content.ReadAsStringAsync().GetAwaiter().GetResult();
-
+                        Console.WriteLine("2 ==> " + jsonObject);
+                        
                         lock (this.actualInfo)
                         {
                             this.actualInfo.Add(JsonConvert.DeserializeObject<ClientTelemetryProperties>(jsonObject));
@@ -361,6 +365,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         [DataRow(ConnectionMode.Gateway)]
         public async Task BatchOperationsTest(ConnectionMode mode)
         {
+            Stopwatch watch = new Stopwatch();
+            watch.Start();
             Container container = await this.CreateClientAndContainer(mode, Microsoft.Azure.Cosmos.ConsistencyLevel.Eventual); // Client level consistency
             using (BatchAsyncContainerExecutor executor =
                 new BatchAsyncContainerExecutor(
@@ -384,6 +390,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 { Documents.OperationType.Batch.ToString(), 1}
             };
 
+            watch.Stop();
+
+            Console.WriteLine($"Time taken: {watch.ElapsedMilliseconds} ms");
+            
             await this.WaitAndAssert(expectedOperationCount: 2,
                 expectedConsistencyLevel: Microsoft.Azure.Cosmos.ConsistencyLevel.Eventual,
                 expectedOperationRecordCountMap: expectedRecordCountInOperation);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
@@ -266,7 +266,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             await this.WaitAndAssert(expectedOperationCount: 2,
                 expectedConsistencyLevel: Microsoft.Azure.Cosmos.ConsistencyLevel.Eventual,
                 expectedOperationRecordCountMap: expectedRecordCountInOperation, 
-                expectedCacheSource: null);
+                expectedCacheSource: null,
+                isExpectedNetworkTelemetry: false);
         }
 
         [TestMethod]
@@ -301,7 +302,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             await this.WaitAndAssert(expectedOperationCount: 2,
                 expectedConsistencyLevel: Microsoft.Azure.Cosmos.ConsistencyLevel.ConsistentPrefix,
                 expectedOperationRecordCountMap: expectedRecordCountInOperation,
-                expectedCacheSource: null);
+                expectedCacheSource: null,
+                isExpectedNetworkTelemetry: false);
         }
 
         [TestMethod]
@@ -756,10 +758,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             {
                 { Documents.OperationType.Create.ToString(), 1}
             };
-
+            
             await this.WaitAndAssert(expectedOperationCount: 2,
                 expectedOperationRecordCountMap: expectedRecordCountInOperation,
-                expectedSubstatuscode: 999999);
+                expectedSubstatuscode: 999999,
+                isExpectedNetworkTelemetry: false);
 
         }
 
@@ -776,7 +779,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             IDictionary<string, long> expectedOperationRecordCountMap = null,
             int expectedSubstatuscode = 0,
             bool? isAzureInstance = null,
-            string expectedCacheSource = "ClientCollectionCache")
+            string expectedCacheSource = "ClientCollectionCache",
+            bool isExpectedNetworkTelemetry = true)
         {
             Assert.IsNotNull(this.actualInfo, "Telemetry Information not available");
 
@@ -861,13 +865,14 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
            
             ClientTelemetryTests.AssertSystemLevelInformation(actualSystemInformation, this.expectedMetricNameUnitMap);
-            if (localCopyOfActualInfo.First().ConnectionMode == ConnectionMode.Direct.ToString().ToUpperInvariant() && expectedSubstatuscode != 999999)
+            if (localCopyOfActualInfo.First().ConnectionMode == ConnectionMode.Direct.ToString().ToUpperInvariant() 
+                && isExpectedNetworkTelemetry)
             {
                 ClientTelemetryTests.AssertNetworkLevelInformation(actualRequestInformation);
             }
             else
             {
-                Assert.IsTrue(actualRequestInformation.Count == 0, "Request Information is not expected in Gateway mode");
+                Assert.IsTrue(actualRequestInformation == null || actualRequestInformation.Count == 0, "Request Information is not expected in Gateway mode");
             }
         }
         

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
@@ -24,8 +24,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
     using System.Linq;
     using Cosmos.Util;
     using Microsoft.Azure.Cosmos.Telemetry.Models;
-    using Microsoft.Azure.Cosmos.Routing;
-    using Microsoft.Azure.Cosmos.Common;
     using System.Diagnostics;
 
     [TestClass]
@@ -71,9 +69,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                         HttpResponseMessage result = new HttpResponseMessage(HttpStatusCode.OK);
 
                         string jsonObject = request.Content.ReadAsStringAsync().GetAwaiter().GetResult();
-
-                        Console.WriteLine("1 ==> " + jsonObject);
-                        
                         lock (this.actualInfo)
                         {
                             this.actualInfo.Add(JsonConvert.DeserializeObject<ClientTelemetryProperties>(jsonObject));
@@ -103,8 +98,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                         HttpResponseMessage result = new HttpResponseMessage(HttpStatusCode.OK);
 
                         string jsonObject = request.Content.ReadAsStringAsync().GetAwaiter().GetResult();
-                        Console.WriteLine("2 ==> " + jsonObject);
-                        
                         lock (this.actualInfo)
                         {
                             this.actualInfo.Add(JsonConvert.DeserializeObject<ClientTelemetryProperties>(jsonObject));
@@ -365,8 +358,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         [DataRow(ConnectionMode.Gateway)]
         public async Task BatchOperationsTest(ConnectionMode mode)
         {
-            Stopwatch watch = new Stopwatch();
-            watch.Start();
             Container container = await this.CreateClientAndContainer(mode, Microsoft.Azure.Cosmos.ConsistencyLevel.Eventual); // Client level consistency
             using (BatchAsyncContainerExecutor executor =
                 new BatchAsyncContainerExecutor(
@@ -389,11 +380,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             {
                 { Documents.OperationType.Batch.ToString(), 1}
             };
-
-            watch.Stop();
-
-            Console.WriteLine($"Time taken: {watch.ElapsedMilliseconds} ms");
-            
             await this.WaitAndAssert(expectedOperationCount: 2,
                 expectedConsistencyLevel: Microsoft.Azure.Cosmos.ConsistencyLevel.Eventual,
                 expectedOperationRecordCountMap: expectedRecordCountInOperation);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
@@ -865,9 +865,12 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             ClientTelemetryTests.AssertSystemLevelInformation(actualSystemInformation, this.expectedMetricNameUnitMap);
             ClientTelemetryTests.AssertNetworkLevelInformation(actualRequestInformation);
         }
-
+        
         private static void AssertNetworkLevelInformation(List<RequestInfo> actualRequestInformation)
         {
+            Assert.IsNotNull(actualRequestInformation);
+            Assert.IsTrue(actualRequestInformation.Count > 0);
+            
             foreach(RequestInfo requestInfo in actualRequestInformation)
             {
                 Assert.IsNotNull(requestInfo.Uri);
@@ -876,6 +879,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Assert.IsNotNull(requestInfo.Operation);
                 Assert.IsNotNull(requestInfo.Resource);
                 Assert.IsNotNull(requestInfo.StatusCode);
+                Assert.AreNotEqual(0, requestInfo.StatusCode);
                 Assert.IsNotNull(requestInfo.SubStatusCode);
 
                 Assert.IsNotNull(requestInfo.Metrics, "MetricInfo is null");


### PR DESCRIPTION
## Description

As part of this PR, Network Information is also included into the client telemetry payload.

```
"RequestInfo": [ 
    { 
      "url": "<rntbd>/<http regional> url, it will contain information till replica", 
      "operation": "Create", 
      "resource": "Document", 
      "statusCode": 201, 
      “subStatusCode”: 0 <applicable only on rntbd calls>, 
      “databaseName”: databaseName, 
      “containerName”: containerName, 
      "metricInfo": [count P90, P99]Notice: this is an array of metrics 
     } 
  ] 
```
Collects only for request failed request and high latency request. Right now, covering only RNTBD requests

### Client Telemetry Performance Impact
0-3% of performance impact is there.

## Design Doc

https://microsoftapc-my.sharepoint.com/:w:/g/personal/sourabhjain_microsoft_com/EfdDbQm27gZDpRGWMli0tO0Be4B_VS_A_GzIXf3ovabvjQ?e=LkmlfP

Updated this design doc with the approach taken as part of this PR.

## Type of change
- [] New feature (non-breaking change which adds functionality)

## Closing issues

To automatically close an issue: closes #3471 #3130