### PR TITLE
[Internal] GitHub Template: Adds needs-investigation label

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: Create a report to help us improve
 title: ''
-labels: ''
+labels: needs-investigation
 assignees: ''
 
 ---


### PR DESCRIPTION
By default, all "Bug report" issues will have "needs-investigation"