### PR TITLE
[Internal] CTL: Fixes Reservoir Sampling Logic

### DIFF
--- a/Microsoft.Azure.Cosmos.Samples/Tools/CTL/CTLConfig.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/CTL/CTLConfig.cs
@@ -11,6 +11,7 @@ namespace CosmosCTL
     using CommandLine.Text;
     using Microsoft.Azure.Cosmos;
     using Newtonsoft.Json;
+    using static CosmosCTL.ReservoirProvider;
 
     public class CTLConfig
     {
@@ -76,7 +77,7 @@ namespace CosmosCTL
         }
 
         [Option("ctl_content_response_on_write", Required = false, HelpText = "Should return content response on writes")]
-        public bool IsContentResponseOnWriteEnabled { get; set; } = true;
+        public bool? IsContentResponseOnWriteEnabled { get; set; } = true;
 
         [Option("ctl_output_event_traces", Required = false, HelpText = "Outputs TraceSource to console")]
         public bool OutputEventTraces { get; set; } = false;
@@ -101,6 +102,12 @@ namespace CosmosCTL
 
         [Option("ctl_telemetry_schedule_in_sec", Required = false, HelpText = "telemetry task schedule time in sec")]
         public string TelemetryScheduleInSeconds { get; set; }
+
+        [Option("ctl_reservoir_type", Required = false, HelpText = "Defines the reservoir type.")]
+        public ReservoirTypes ReservoirType { get; set; } = ReservoirTypes.SlidingWindow;
+
+        [Option("ctl_reservoir_sample_size", Required = false, HelpText = "The reservoir sample size.")]
+        public int ReservoirSampleSize { get; set; } = 1028;
 
         internal TimeSpan RunningTimeDurationAsTimespan { get; private set; } = TimeSpan.FromHours(10);
         internal TimeSpan DiagnosticsThresholdDurationAsTimespan { get; private set; } = TimeSpan.FromSeconds(60);

--- a/Microsoft.Azure.Cosmos.Samples/Tools/CTL/CTLConfig.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/CTL/CTLConfig.cs
@@ -103,7 +103,7 @@ namespace CosmosCTL
         [Option("ctl_telemetry_schedule_in_sec", Required = false, HelpText = "telemetry task schedule time in sec")]
         public string TelemetryScheduleInSeconds { get; set; }
 
-        [Option("ctl_reservoir_type", Required = false, HelpText = "Defines the reservoir type.")]
+        [Option("ctl_reservoir_type", Required = false, HelpText = "Defines the reservoir type. Valid values are: Uniform, SlidingWindow and ExponentialDecay. The default value is SlidingWindow.")]
         public ReservoirTypes ReservoirType { get; set; } = ReservoirTypes.SlidingWindow;
 
         [Option("ctl_reservoir_sample_size", Required = false, HelpText = "The reservoir sample size.")]

--- a/Microsoft.Azure.Cosmos.Samples/Tools/CTL/ReservoirProvider.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/CTL/ReservoirProvider.cs
@@ -1,0 +1,49 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace CosmosCTL
+{
+    using System;
+    using App.Metrics.ReservoirSampling;
+
+    /// <summary>
+    /// Returns the <see cref="IReservoir"/> based on the CTL configuration.
+    /// </summary>
+    public class ReservoirProvider
+    {
+        /// <summary>
+        /// Create and returns a new instance of the <see cref="IReservoir"/> based on the CTL configuration.
+        /// </summary>
+        /// <param name="ctlConfig">An instance of <see cref="CTLConfig"/> containing the CTL config params.</param>
+        /// <returns>An implementation of <see cref="IReservoir"/>.</returns>
+        public static IReservoir GetReservoir(CTLConfig ctlConfig)
+        {
+            return ctlConfig.ReservoirType switch
+            {
+                ReservoirTypes.Uniform => new App.Metrics.ReservoirSampling.Uniform.DefaultAlgorithmRReservoir(
+                    sampleSize: ctlConfig.ReservoirSampleSize),
+
+                ReservoirTypes.SlidingWindow => new App.Metrics.ReservoirSampling.SlidingWindow.DefaultSlidingWindowReservoir(
+                    sampleSize: ctlConfig.ReservoirSampleSize),
+
+                ReservoirTypes.ExponentialDecay => new App.Metrics.ReservoirSampling.ExponentialDecay.DefaultForwardDecayingReservoir(
+                    sampleSize: ctlConfig.ReservoirSampleSize,
+                    alpha: 0.015),
+
+                _ => throw new ArgumentException(
+                    message: "Invalid ReservoirType Specified."),
+            };
+        }
+
+        /// <summary>
+        /// An enum containing different reservoir types.
+        /// </summary>
+        public enum ReservoirTypes
+        {
+            Uniform,
+            SlidingWindow,
+            ExponentialDecay
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Scenarios/ChangeFeedPullScenario.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Scenarios/ChangeFeedPullScenario.cs
@@ -64,7 +64,7 @@ namespace CosmosCTL
                 DurationUnit = TimeUnit.Milliseconds,
                 RateUnit = TimeUnit.Seconds,
                 Context = loggingContextIdentifier,
-                Reservoir = () => new App.Metrics.ReservoirSampling.Uniform.DefaultAlgorithmRReservoir()
+                Reservoir = () => ReservoirProvider.GetReservoir(config)
             };
 
             Container container = cosmosClient.GetContainer(config.Database, config.Collection);

--- a/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Scenarios/ReadManyScenario.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Scenarios/ReadManyScenario.cs
@@ -76,7 +76,7 @@ namespace CosmosCTL
                     DurationUnit = TimeUnit.Milliseconds,
                     RateUnit = TimeUnit.Seconds,
                     Context = loggingContextIdentifier,
-                    Reservoir = () => new App.Metrics.ReservoirSampling.Uniform.DefaultAlgorithmRReservoir()
+                    Reservoir = () => ReservoirProvider.GetReservoir(config)
                 };
 
                 Container container = cosmosClient.GetContainer(config.Database, config.Collection);

--- a/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Scenarios/ReadWriteQueryScenario.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Scenarios/ReadWriteQueryScenario.cs
@@ -105,34 +105,34 @@ namespace CosmosCTL
             CounterOptions querySuccessMeter = new CounterOptions { Name = "#Query Successful Operations", Context = loggingContextIdentifier };
             CounterOptions queryFailureMeter = new CounterOptions { Name = "#Query Unsuccessful Operations", Context = loggingContextIdentifier };
 
-            TimerOptions readLatencyTimer = new TimerOptions
+            TimerOptions readLatencyTimer = new()
             {
                 Name = "Read latency",
                 MeasurementUnit = Unit.Requests,
                 DurationUnit = TimeUnit.Milliseconds,
                 RateUnit = TimeUnit.Seconds,
                 Context = loggingContextIdentifier,
-                Reservoir = () => new App.Metrics.ReservoirSampling.Uniform.DefaultAlgorithmRReservoir()
+                Reservoir = () => ReservoirProvider.GetReservoir(config)
             };
 
-            TimerOptions writeLatencyTimer = new TimerOptions
+            TimerOptions writeLatencyTimer = new ()
             {
                 Name = "Write latency",
                 MeasurementUnit = Unit.Requests,
                 DurationUnit = TimeUnit.Milliseconds,
                 RateUnit = TimeUnit.Seconds,
                 Context = loggingContextIdentifier,
-                Reservoir = () => new App.Metrics.ReservoirSampling.Uniform.DefaultAlgorithmRReservoir()
+                Reservoir = () => ReservoirProvider.GetReservoir(config)
             };
 
-            TimerOptions queryLatencyTimer = new TimerOptions
+            TimerOptions queryLatencyTimer = new ()
             {
                 Name = "Query latency",
                 MeasurementUnit = Unit.Requests,
                 DurationUnit = TimeUnit.Milliseconds,
                 RateUnit = TimeUnit.Seconds,
                 Context = loggingContextIdentifier,
-                Reservoir = () => new App.Metrics.ReservoirSampling.Uniform.DefaultAlgorithmRReservoir()
+                Reservoir = () => ReservoirProvider.GetReservoir(config)
             };
 
             SemaphoreSlim concurrencyControlSemaphore = new SemaphoreSlim(config.Concurrency);
@@ -178,7 +178,7 @@ namespace CosmosCTL
                             operation: i,
                             partitionKeyAttributeName: config.CollectionPartitionKey,
                             containers: initializationResult.Containers,
-                            isContentResponseOnWriteEnabled: config.IsContentResponseOnWriteEnabled)),
+                            isContentResponseOnWriteEnabled: (bool)config.IsContentResponseOnWriteEnabled)),
                         onSuccess: () =>
                         {
                             concurrencyControlSemaphore.Release();

--- a/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Scenarios/ReadWriteQueryScenario.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Scenarios/ReadWriteQueryScenario.cs
@@ -178,7 +178,7 @@ namespace CosmosCTL
                             operation: i,
                             partitionKeyAttributeName: config.CollectionPartitionKey,
                             containers: initializationResult.Containers,
-                            isContentResponseOnWriteEnabled: (bool)config.IsContentResponseOnWriteEnabled)),
+                            isContentResponseOnWriteEnabled: config.IsContentResponseOnWriteEnabled.Value)),
                         onSuccess: () =>
                         {
                             concurrencyControlSemaphore.Release();


### PR DESCRIPTION
# Pull Request Template

## Description

Fixes the reservoir sampling logic in CTL. This will help to fix the percentiles measurement reported to CTL graphana dashboards.

To better understand the problem, please take a look at the Graphana dashboards snapshots during two runs. The first one was triggered with a reservoir type `Sliding Window` where as the second one was triggered with `Uniform`. The p999 fluctuations are clearly visible in the first one, compared to the later one.

**Sliding Window Reservoir:**

![image](https://user-images.githubusercontent.com/87335885/219528633-843e8de6-a174-408e-8435-df8546133369.png)

**Uniform Reservoir:**

![image](https://user-images.githubusercontent.com/87335885/219528642-3679374c-6dde-42b8-95b5-4083ef4546e2.png)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #3647 