### PR TITLE
[Internal] PriorityRequests: Fixes header value

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
 		<ClientOfficialVersion>3.32.0</ClientOfficialVersion>
 		<ClientPreviewVersion>3.32.0</ClientPreviewVersion>
 		<ClientPreviewSuffixVersion>preview</ClientPreviewSuffixVersion>
-		<DirectVersion>3.30.1</DirectVersion>
+		<DirectVersion>3.30.2</DirectVersion>
 		<EncryptionOfficialVersion>2.0.1</EncryptionOfficialVersion>
 		<EncryptionPreviewVersion>2.0.1</EncryptionPreviewVersion>
 		<EncryptionPreviewSuffixVersion>preview</EncryptionPreviewSuffixVersion>


### PR DESCRIPTION
## Description

Bumped the DirectVersion from 3.30.1 to 3.30.2. 
This update changes the value of "Low" PriorityLevel parsed in the backend from 0 to 2. This is just a convention change and the PriorityLevel header is currently not being used by anyone.