### PR TITLE
Add more tests to ExpressionToSQL.cs which demonstrate regression

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Linq/CosmosLinqJsonConverterTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Linq/CosmosLinqJsonConverterTests.cs
@@ -33,9 +33,8 @@ namespace Microsoft.Azure.Cosmos.Linq
             Assert.AreEqual("(a[\"StartDate\"] <= \"2022-05-26\")", sql);
         }
 
-
         [TestMethod]
-        public void EnumIsPreservedAsStringTest()
+        public void EnumIsPreservedAsINTest()
         {
             // Arrange
             CosmosLinqSerializerOptions options = new()
@@ -51,6 +50,25 @@ namespace Microsoft.Azure.Cosmos.Linq
 
             // Assert
             Assert.AreEqual("(a[\"Value\"] IN (\"One\", \"Two\"))", sql);
+        }
+
+        [TestMethod]
+        public void EnumIsPreservedAsEQUALSTest()
+        {
+            // Arrange
+            CosmosLinqSerializerOptions options = new()
+            {
+                CustomCosmosSerializer = new CustomJsonSerializer()
+            };
+
+            // Act
+            TestEnum statusValue = TestEnum.One;
+            Expression<Func<EnumContainerDocument, bool>> expr = a => a.Value == statusValue;
+
+            string sql = SqlTranslator.TranslateExpression(expr.Body, options);
+
+            // Assert
+            Assert.AreEqual("(a[\"Value\"] = \"One\")", sql);
         }
 
         enum TestEnum


### PR DESCRIPTION
# Pull Request Template

## Description

This change adds failing unit tests that highlight a regression to ExpressionToSQL.cs between 3.31.2 and 3.32.0

## Type of change
- [x] Adds failing unit test to reproduce #3697 

## Closing issues
None
