### PR TITLE
Query: Fixes System.ArgumentException when using PartitionKey.None on x86, Linux or in Optimistic Direct Execution

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CosmosQueryExecutionContextFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CosmosQueryExecutionContextFactory.cs
@@ -214,7 +214,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
                                 List<Documents.PartitionKeyRange> targetRanges = await cosmosQueryContext.QueryClient.GetTargetPartitionKeyRangesByEpkStringAsync(
                                     cosmosQueryContext.ResourceLink,
                                     containerQueryProperties.ResourceId,
-                                    inputParameters.PartitionKey.Value.InternalKey.GetEffectivePartitionKeyString(partitionKeyDefinition),
+                                    containerQueryProperties.EffectivePartitionKeyString,
                                     forceRefresh: false,
                                     createQueryPipelineTrace);
 
@@ -779,7 +779,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
                     targetRanges = await cosmosQueryContext.QueryClient.GetTargetPartitionKeyRangesByEpkStringAsync(
                         cosmosQueryContext.ResourceLink,
                         containerQueryProperties.ResourceId,
-                        inputParameters.PartitionKey.Value.InternalKey.GetEffectivePartitionKeyString(partitionKeyDefinition),
+                        containerQueryProperties.EffectivePartitionKeyString,
                         forceRefresh: false,
                         trace);
                 }

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryIterator.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryIterator.cs
@@ -131,12 +131,6 @@ namespace Microsoft.Azure.Cosmos.Query
                     throw new ArgumentOutOfRangeException($"Unknown {nameof(ExecutionEnvironment)}: {queryRequestOptions.ExecutionEnvironment.Value}.");
             }
 
-            // Documents.PartitionKeyInternal has a broken contract for GetEffectivePartitionKeyString. It should return an optional instead of string
-            // Until this is fixed, we need to explicitly handle PartitionKey.None
-            PartitionKey? partitionKey = (queryRequestOptions.PartitionKey.HasValue && !queryRequestOptions.PartitionKey.Value.IsNone) ?
-                queryRequestOptions.PartitionKey.Value :
-                null;
-
             CosmosQueryExecutionContextFactory.InputParameters inputParameters = new CosmosQueryExecutionContextFactory.InputParameters(
                 sqlQuerySpec: sqlQuerySpec,
                 initialUserContinuationToken: requestContinuationToken,
@@ -144,7 +138,7 @@ namespace Microsoft.Azure.Cosmos.Query
                 maxConcurrency: queryRequestOptions.MaxConcurrency,
                 maxItemCount: queryRequestOptions.MaxItemCount,
                 maxBufferedItemCount: queryRequestOptions.MaxBufferedItemCount,
-                partitionKey: partitionKey,
+                partitionKey: queryRequestOptions.PartitionKey,
                 properties: queryRequestOptions.Properties,
                 partitionedQueryExecutionInfo: partitionedQueryExecutionInfo,
                 executionEnvironment: queryRequestOptions.ExecutionEnvironment,

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryIterator.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryIterator.cs
@@ -131,6 +131,12 @@ namespace Microsoft.Azure.Cosmos.Query
                     throw new ArgumentOutOfRangeException($"Unknown {nameof(ExecutionEnvironment)}: {queryRequestOptions.ExecutionEnvironment.Value}.");
             }
 
+            // Documents.PartitionKeyInternal has a broken contract for GetEffectivePartitionKeyString. It should return an optional instead of string
+            // Until this is fixed, we need to explicitly handle PartitionKey.None
+            PartitionKey? partitionKey = (queryRequestOptions.PartitionKey.HasValue && !queryRequestOptions.PartitionKey.Value.IsNone) ?
+                queryRequestOptions.PartitionKey.Value :
+                null;
+
             CosmosQueryExecutionContextFactory.InputParameters inputParameters = new CosmosQueryExecutionContextFactory.InputParameters(
                 sqlQuerySpec: sqlQuerySpec,
                 initialUserContinuationToken: requestContinuationToken,
@@ -138,7 +144,7 @@ namespace Microsoft.Azure.Cosmos.Query
                 maxConcurrency: queryRequestOptions.MaxConcurrency,
                 maxItemCount: queryRequestOptions.MaxItemCount,
                 maxBufferedItemCount: queryRequestOptions.MaxBufferedItemCount,
-                partitionKey: queryRequestOptions.PartitionKey,
+                partitionKey: partitionKey,
                 properties: queryRequestOptions.Properties,
                 partitionedQueryExecutionInfo: partitionedQueryExecutionInfo,
                 executionEnvironment: queryRequestOptions.ExecutionEnvironment,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/BypassQueryParsingTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/BypassQueryParsingTests.cs
@@ -10,8 +10,6 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
     [TestCategory("Query")]
     public sealed class BypassQueryParsingTests : QueryTestsBase
     {
-        private const string PartitionKeyField = "key";
-
         [TestMethod]
         public async Task TestBypassQueryParsingWithNonePartitionKey()
         {
@@ -41,22 +39,21 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
                 Assert.IsTrue(expected.SequenceEqual(actual));
             }
 
-            IReadOnlyList<string> documents = CreateSinglePartitionDocuments(documentCount);
+            IReadOnlyList<string> documents = CreateDocuments(documentCount);
 
             await this.CreateIngestQueryDeleteAsync(
                 ConnectionModes.Direct | ConnectionModes.Gateway,
-                CollectionTypes.SinglePartition | CollectionTypes.MultiPartition,
+                CollectionTypes.NonPartitioned,
                 documents,
-                ImplementationAsync,
-                "/" + PartitionKeyField);
+                ImplementationAsync);
         }
 
-        private static IReadOnlyList<string> CreateSinglePartitionDocuments(int documentCount)
+        private static IReadOnlyList<string> CreateDocuments(int documentCount)
         {
             List<string> documents = new List<string>(documentCount);
             for (int i = 0; i < documentCount; ++i)
             {
-                string document = $@"{{ {PartitionKeyField}: ""/value"", ""numberField"": {i}, ""nullField"": null }}";
+                string document = $@"{{ ""numberField"": {i}, ""nullField"": null }}";
                 documents.Add(document);
             }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/BypassQueryParsingTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/BypassQueryParsingTests.cs
@@ -1,0 +1,66 @@
+namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.CosmosElements;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    [TestCategory("Query")]
+    public sealed class BypassQueryParsingTests : QueryTestsBase
+    {
+        private const string PartitionKeyField = "key";
+
+        [TestMethod]
+        public async Task TestBypassQueryParsingWithNonePartitionKey()
+        {
+            int documentCount = 400;
+            QueryRequestOptions feedOptions = new QueryRequestOptions { PartitionKey = PartitionKey.None };
+            string query = "SELECT VALUE r.numberField FROM r";
+            IReadOnlyList<int> expected = Enumerable.Range(0, documentCount).ToList();
+
+            async Task ImplementationAsync(Container container, IReadOnlyList<CosmosObject> documents)
+            {
+                ContainerInternal containerCore = container as ContainerInlineCore;
+
+                MockCosmosQueryClient cosmosQueryClientCore = new MockCosmosQueryClient(
+                    containerCore.ClientContext,
+                    containerCore,
+                    forceQueryPlanGatewayElseServiceInterop: true);
+
+                ContainerInternal containerWithBypassParsing = new ContainerInlineCore(
+                    containerCore.ClientContext,
+                    (DatabaseCore)containerCore.Database,
+                    containerCore.Id,
+                    cosmosQueryClientCore);
+
+                List<CosmosElement> items = await RunQueryAsync(containerWithBypassParsing, query, feedOptions);
+                int[] actual = items.Cast<CosmosNumber>().Select(x => (int)Number64.ToLong(x.Value)).ToArray();
+
+                Assert.IsTrue(expected.SequenceEqual(actual));
+            }
+
+            IReadOnlyList<string> documents = CreateSinglePartitionDocuments(documentCount);
+
+            await this.CreateIngestQueryDeleteAsync(
+                ConnectionModes.Direct | ConnectionModes.Gateway,
+                CollectionTypes.SinglePartition | CollectionTypes.MultiPartition,
+                documents,
+                ImplementationAsync,
+                "/" + PartitionKeyField);
+        }
+
+        private static IReadOnlyList<string> CreateSinglePartitionDocuments(int documentCount)
+        {
+            List<string> documents = new List<string>(documentCount);
+            for (int i = 0; i < documentCount; ++i)
+            {
+                string document = $@"{{ {PartitionKeyField}: ""/value"", ""numberField"": {i}, ""nullField"": null }}";
+                documents.Add(document);
+            }
+
+            return documents;
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/BypassQueryParsingTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/BypassQueryParsingTests.cs
@@ -43,9 +43,10 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
 
             await this.CreateIngestQueryDeleteAsync(
                 ConnectionModes.Direct | ConnectionModes.Gateway,
-                CollectionTypes.NonPartitioned,
+                CollectionTypes.NonPartitioned | CollectionTypes.SinglePartition | CollectionTypes.MultiPartition,
                 documents,
-                ImplementationAsync);
+                ImplementationAsync,
+                "/undefinedPartitionKey");
         }
 
         private static IReadOnlyList<string> CreateDocuments(int documentCount)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/OptimisticDirectExecutionQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/OptimisticDirectExecutionQueryTests.cs
@@ -202,7 +202,7 @@
                     expectedPipelineType: TestInjections.PipelineType.Specialized)
             };
 
-            List<string> documents = CreateDocuments(NumberOfDocuments, PartitionKeyField, NumberField, NullField);
+            IReadOnlyList<string> documents = CreateDocuments(NumberOfDocuments, PartitionKeyField, NumberField, NullField);
 
             await this.CreateIngestQueryDeleteAsync(
                 ConnectionModes.Direct | ConnectionModes.Gateway,
@@ -286,7 +286,7 @@
                     expectedPipelineType: TestInjections.PipelineType.Specialized),
             };
 
-            List<string> documents = CreateDocuments(documentCount, PartitionKeyField, NumberField, NullField);
+            IReadOnlyList<string> documents = CreateDocuments(documentCount, PartitionKeyField, NumberField, NullField);
 
             await this.CreateIngestQueryDeleteAsync(
                 ConnectionModes.Direct | ConnectionModes.Gateway,
@@ -299,7 +299,7 @@
         [TestMethod]
         public async Task TestFailingOptimisticDirectExecutionOutput()
         {
-            List<string> documents = CreateDocuments(NumberOfDocuments, PartitionKeyField, NumberField, NullField);
+            IReadOnlyList<string> documents = CreateDocuments(NumberOfDocuments, PartitionKeyField, NumberField, NullField);
 
             // check if bad continuation queries and syntax error queries are handled by pipeline
             IDictionary<string, string> invalidQueries = new Dictionary<string, string>
@@ -375,7 +375,7 @@
             }
         }
 
-        private static List<string> CreateDocuments(int documentCount, string partitionKey, string numberField, string nullField)
+        private static IReadOnlyList<string> CreateDocuments(int documentCount, string partitionKey, string numberField, string nullField)
         {
             List<string> documents = new List<string>(documentCount);
             for (int i = 0; i < documentCount; ++i)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/OptimisticDirectExecutionQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/OptimisticDirectExecutionQueryTests.cs
@@ -7,91 +7,299 @@
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Query.Core;
-    using Microsoft.Azure.Documents;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     [TestClass]
     [TestCategory("Query")]
     public sealed class OptimisticDirectExecutionQueryTests : QueryTestsBase
     {
+        private const int NumberOfDocuments = 8;
+        private const string PartitionKeyField = "key";
+        private const string NumberField = "numberField";
+        private const string NullField = "nullField";
+
         private static class PageSizeOptions
         {
             public static readonly int[] NonGroupByPageSizeOptions = { -1, 1, 2, 10, 100 };
             public static readonly int[] GroupByPageSizeOptions = { -1 };
+            public static readonly int[] PageSize100 = { 100 };
         }
 
         [TestMethod]
         public async Task TestPassingOptimisticDirectExecutionQueries()
         {
-            int numberOfDocuments = 8;
-            string partitionKey = "key";
-            string numberField = "numberField";
-            string nullField = "nullField";
+            IReadOnlyList<int> first5Integers = Enumerable.Range(0, 5).ToList();
+            IReadOnlyList<int> first7Integers = Enumerable.Range(0, NumberOfDocuments).ToList();
+            IReadOnlyList<int> first7IntegersReversed = Enumerable.Range(0, NumberOfDocuments).Reverse().ToList();
 
-            List<string> documents = CreateDocuments(numberOfDocuments, partitionKey, numberField, nullField);
-
+            PartitionKey partitionKeyValue = new PartitionKey("/value");
             List<DirectExecutionTestCase> singlePartitionContainerTestCases = new List<DirectExecutionTestCase>()
             {
                 // Tests for bool enableOptimisticDirectExecution
-                CreateInput( query: $"SELECT TOP 5 VALUE r.numberField FROM r ORDER BY r.{partitionKey}", expectedResult: new List<long> { 0, 1, 2, 3, 4 }, partitionKey: "/value", partition: CollectionTypes.SinglePartition, enableOptimisticDirectExecution: true, pageSizeOptions: PageSizeOptions.NonGroupByPageSizeOptions, expectedPipelineType: TestInjections.PipelineType.OptimisticDirectExecution),
-                CreateInput( query: $"SELECT TOP 5 VALUE r.numberField FROM r ORDER BY r.{partitionKey}", expectedResult: new List<long> { 0, 1, 2, 3, 4 }, partitionKey: "/value", partition: CollectionTypes.SinglePartition, enableOptimisticDirectExecution: false, pageSizeOptions: PageSizeOptions.NonGroupByPageSizeOptions, expectedPipelineType: TestInjections.PipelineType.Passthrough),
+                CreateInput(
+                    query: $"SELECT TOP 5 VALUE r.numberField FROM r ORDER BY r.{PartitionKeyField}",
+                    expectedResult: first5Integers,
+                    partitionKey: partitionKeyValue,
+                    enableOptimisticDirectExecution: true,
+                    pageSizeOptions: PageSizeOptions.NonGroupByPageSizeOptions,
+                    expectedPipelineType: TestInjections.PipelineType.OptimisticDirectExecution),
+                CreateInput(
+                    query: $"SELECT TOP 5 VALUE r.numberField FROM r ORDER BY r.{PartitionKeyField}",
+                    expectedResult: first5Integers,
+                    partitionKey: PartitionKey.None,
+                    enableOptimisticDirectExecution: true,
+                    pageSizeOptions: PageSizeOptions.NonGroupByPageSizeOptions,
+                    expectedPipelineType: TestInjections.PipelineType.OptimisticDirectExecution),
+                CreateInput(
+                    query: $"SELECT TOP 5 VALUE r.numberField FROM r ORDER BY r.{PartitionKeyField}",
+                    expectedResult: first5Integers,
+                    partitionKey: partitionKeyValue,
+                    enableOptimisticDirectExecution: false,
+                    pageSizeOptions: PageSizeOptions.NonGroupByPageSizeOptions,
+                    expectedPipelineType: TestInjections.PipelineType.Passthrough),
                 
                 // Simple query
-                CreateInput( query: $"SELECT VALUE r.numberField FROM r", expectedResult: new List<long> { 0, 1, 2, 3, 4, 5, 6, 7 }, partitionKey: "/value", partition: CollectionTypes.SinglePartition, enableOptimisticDirectExecution: true, pageSizeOptions: PageSizeOptions.NonGroupByPageSizeOptions, expectedPipelineType: TestInjections.PipelineType.OptimisticDirectExecution),
-                CreateInput( query: $"SELECT VALUE r.numberField FROM r", expectedResult: new List<long> { 0, 1, 2, 3, 4, 5, 6, 7 }, partitionKey: null, partition: CollectionTypes.SinglePartition, enableOptimisticDirectExecution: true, pageSizeOptions: PageSizeOptions.NonGroupByPageSizeOptions, expectedPipelineType: TestInjections.PipelineType.OptimisticDirectExecution),
+                CreateInput(
+                    query: $"SELECT VALUE r.numberField FROM r",
+                    expectedResult: first7Integers,
+                    partitionKey: partitionKeyValue,
+                    enableOptimisticDirectExecution: true,
+                    pageSizeOptions: PageSizeOptions.NonGroupByPageSizeOptions,
+                    expectedPipelineType: TestInjections.PipelineType.OptimisticDirectExecution),
+                CreateInput(
+                    query: $"SELECT VALUE r.numberField FROM r",
+                    expectedResult: first7Integers,
+                    partitionKey: PartitionKey.None,
+                    enableOptimisticDirectExecution: true,
+                    pageSizeOptions: PageSizeOptions.NonGroupByPageSizeOptions,
+                    expectedPipelineType: TestInjections.PipelineType.OptimisticDirectExecution),
+                CreateInput(
+                    query: $"SELECT VALUE r.numberField FROM r",
+                    expectedResult: first7Integers,
+                    partitionKey: null,
+                    enableOptimisticDirectExecution: true,
+                    pageSizeOptions: PageSizeOptions.NonGroupByPageSizeOptions,
+                    expectedPipelineType: TestInjections.PipelineType.OptimisticDirectExecution),
                
                 // DISTINCT with ORDER BY
-                CreateInput( query: $"SELECT DISTINCT VALUE r.{numberField} FROM r ORDER BY r.{numberField} DESC", expectedResult: new List<long> { 7, 6, 5, 4, 3, 2, 1, 0 }, partitionKey: "/value", partition: CollectionTypes.SinglePartition, enableOptimisticDirectExecution: true, pageSizeOptions: PageSizeOptions.NonGroupByPageSizeOptions, expectedPipelineType: TestInjections.PipelineType.OptimisticDirectExecution),
-                CreateInput( query: $"SELECT DISTINCT VALUE r.{numberField} FROM r ORDER BY r.{numberField} DESC", expectedResult: new List<long> { 7, 6, 5, 4, 3, 2, 1, 0 }, partitionKey: null, partition: CollectionTypes.SinglePartition, enableOptimisticDirectExecution: true, pageSizeOptions: PageSizeOptions.NonGroupByPageSizeOptions, expectedPipelineType: TestInjections.PipelineType.OptimisticDirectExecution),
+                CreateInput(
+                    query: $"SELECT DISTINCT VALUE r.{NumberField} FROM r ORDER BY r.{NumberField} DESC",
+                    expectedResult: first7IntegersReversed,
+                    partitionKey: partitionKeyValue,
+                    enableOptimisticDirectExecution: true,
+                    pageSizeOptions: PageSizeOptions.NonGroupByPageSizeOptions,
+                    expectedPipelineType: TestInjections.PipelineType.OptimisticDirectExecution),
+                CreateInput(
+                    query: $"SELECT DISTINCT VALUE r.{NumberField} FROM r ORDER BY r.{NumberField} DESC",
+                    expectedResult: first7IntegersReversed,
+                    partitionKey: PartitionKey.None,
+                    enableOptimisticDirectExecution: true,
+                    pageSizeOptions: PageSizeOptions.NonGroupByPageSizeOptions,
+                    expectedPipelineType: TestInjections.PipelineType.OptimisticDirectExecution),
+                CreateInput(
+                    query: $"SELECT DISTINCT VALUE r.{NumberField} FROM r ORDER BY r.{NumberField} DESC",
+                    expectedResult: first7IntegersReversed,
+                    partitionKey: null,
+                    enableOptimisticDirectExecution: true,
+                    pageSizeOptions: PageSizeOptions.NonGroupByPageSizeOptions,
+                    expectedPipelineType: TestInjections.PipelineType.OptimisticDirectExecution),
              
                 // TOP with GROUP BY
-                CreateInput( query: $"SELECT TOP 5 VALUE r.{numberField} FROM r GROUP BY r.{numberField}", expectedResult: new List<long> { 0, 1, 2, 3, 4 }, partitionKey: "/value", partition: CollectionTypes.SinglePartition, enableOptimisticDirectExecution: true, pageSizeOptions: PageSizeOptions.GroupByPageSizeOptions, expectedPipelineType: TestInjections.PipelineType.OptimisticDirectExecution),
-                CreateInput( query: $"SELECT TOP 5 VALUE r.{numberField} FROM r GROUP BY r.{numberField}", expectedResult: new List<long> { 0, 1, 2, 3, 4 }, partitionKey: null, partition: CollectionTypes.SinglePartition, enableOptimisticDirectExecution: true, pageSizeOptions: PageSizeOptions.GroupByPageSizeOptions, expectedPipelineType: TestInjections.PipelineType.OptimisticDirectExecution),
+                CreateInput(
+                    query: $"SELECT TOP 5 VALUE r.{NumberField} FROM r GROUP BY r.{NumberField}",
+                    expectedResult: first5Integers,
+                    partitionKey: partitionKeyValue,
+                    enableOptimisticDirectExecution: true,
+                    pageSizeOptions: PageSizeOptions.GroupByPageSizeOptions,
+                    expectedPipelineType: TestInjections.PipelineType.OptimisticDirectExecution),
+                CreateInput(
+                    query: $"SELECT TOP 5 VALUE r.{NumberField} FROM r GROUP BY r.{NumberField}",
+                    expectedResult: first5Integers,
+                    partitionKey: PartitionKey.None,
+                    enableOptimisticDirectExecution: true,
+                    pageSizeOptions: PageSizeOptions.GroupByPageSizeOptions,
+                    expectedPipelineType: TestInjections.PipelineType.OptimisticDirectExecution),
+                CreateInput(
+                    query: $"SELECT TOP 5 VALUE r.{NumberField} FROM r GROUP BY r.{NumberField}",
+                    expectedResult: first5Integers,
+                    partitionKey: null,
+                    enableOptimisticDirectExecution: true,
+                    pageSizeOptions: PageSizeOptions.GroupByPageSizeOptions,
+                    expectedPipelineType: TestInjections.PipelineType.OptimisticDirectExecution),
               
                 // OFFSET LIMIT with WHERE and BETWEEN
-                CreateInput( query: $"SELECT VALUE r.numberField FROM r WHERE r.{numberField} BETWEEN 0 AND {numberOfDocuments} OFFSET 1 LIMIT 1", expectedResult: new List<long> { 1 }, partitionKey: "/value", partition: CollectionTypes.SinglePartition, pageSizeOptions: PageSizeOptions.NonGroupByPageSizeOptions, enableOptimisticDirectExecution: true, expectedPipelineType: TestInjections.PipelineType.OptimisticDirectExecution),
-                CreateInput( query: $"SELECT VALUE r.numberField FROM r WHERE r.{numberField} BETWEEN 0 AND {numberOfDocuments} OFFSET 1 LIMIT 1", expectedResult: new List<long> { 1 }, partitionKey: null, partition: CollectionTypes.SinglePartition, pageSizeOptions: PageSizeOptions.NonGroupByPageSizeOptions, enableOptimisticDirectExecution: true, expectedPipelineType: TestInjections.PipelineType.OptimisticDirectExecution)
+                CreateInput(
+                    query: $"SELECT VALUE r.numberField FROM r WHERE r.{NumberField} BETWEEN 0 AND {NumberOfDocuments} OFFSET 1 LIMIT 1",
+                    expectedResult: new List<int> { 1 },
+                    partitionKey: partitionKeyValue,
+                    pageSizeOptions: PageSizeOptions.NonGroupByPageSizeOptions,
+                    enableOptimisticDirectExecution: true,
+                    expectedPipelineType: TestInjections.PipelineType.OptimisticDirectExecution),
+                CreateInput(
+                    query: $"SELECT VALUE r.numberField FROM r WHERE r.{NumberField} BETWEEN 0 AND {NumberOfDocuments} OFFSET 1 LIMIT 1",
+                    expectedResult: new List<int> { 1 },
+                    partitionKey: PartitionKey.None,
+                    pageSizeOptions: PageSizeOptions.NonGroupByPageSizeOptions,
+                    enableOptimisticDirectExecution: true,
+                    expectedPipelineType: TestInjections.PipelineType.OptimisticDirectExecution),
+                CreateInput(
+                    query: $"SELECT VALUE r.numberField FROM r WHERE r.{NumberField} BETWEEN 0 AND {NumberOfDocuments} OFFSET 1 LIMIT 1",
+                    expectedResult: new List<int> { 1 },
+                    partitionKey: null,
+                    pageSizeOptions: PageSizeOptions.NonGroupByPageSizeOptions,
+                    enableOptimisticDirectExecution: true,
+                    expectedPipelineType: TestInjections.PipelineType.OptimisticDirectExecution)
             };
 
             List<DirectExecutionTestCase> multiPartitionContainerTestCases = new List<DirectExecutionTestCase>()
             {
                 // Simple query
-                CreateInput( query: $"SELECT VALUE r.numberField FROM r", expectedResult: new List<long> { 0, 1, 2, 3, 4, 5, 6, 7 }, partitionKey: "/value", partition: CollectionTypes.MultiPartition, enableOptimisticDirectExecution: true, pageSizeOptions: PageSizeOptions.NonGroupByPageSizeOptions, expectedPipelineType: TestInjections.PipelineType.OptimisticDirectExecution),
-                CreateInput( query: $"SELECT VALUE r.numberField FROM r", expectedResult: new List<long> { 0, 1, 2, 3, 4, 5, 6, 7 }, partitionKey: null, partition: CollectionTypes.MultiPartition, enableOptimisticDirectExecution: true, pageSizeOptions: PageSizeOptions.NonGroupByPageSizeOptions, expectedPipelineType: TestInjections.PipelineType.Passthrough),
+                CreateInput(
+                    query: $"SELECT VALUE r.numberField FROM r",
+                    expectedResult: first7Integers,
+                    partitionKey: partitionKeyValue,
+                    enableOptimisticDirectExecution: true,
+                    pageSizeOptions: PageSizeOptions.NonGroupByPageSizeOptions,
+                    expectedPipelineType: TestInjections.PipelineType.OptimisticDirectExecution),
+                CreateInput(
+                    query: $"SELECT VALUE r.numberField FROM r",
+                    expectedResult: first7Integers,
+                    partitionKey: null,
+                    enableOptimisticDirectExecution: true,
+                    pageSizeOptions: PageSizeOptions.NonGroupByPageSizeOptions,
+                    expectedPipelineType: TestInjections.PipelineType.Passthrough),
 
                 // DISTINCT with ORDER BY
-                CreateInput( query: $"SELECT DISTINCT VALUE r.{numberField} FROM r ORDER BY r.{numberField} DESC", expectedResult: new List<long> { 7, 6, 5, 4, 3, 2, 1, 0 }, partitionKey: "/value", partition: CollectionTypes.MultiPartition, enableOptimisticDirectExecution: true, pageSizeOptions: PageSizeOptions.NonGroupByPageSizeOptions, expectedPipelineType: TestInjections.PipelineType.OptimisticDirectExecution),
-                CreateInput( query: $"SELECT DISTINCT VALUE r.{numberField} FROM r ORDER BY r.{numberField} DESC", expectedResult: new List<long> { 7, 6, 5, 4, 3, 2, 1, 0 }, partitionKey: null, partition: CollectionTypes.MultiPartition, enableOptimisticDirectExecution: true, pageSizeOptions: PageSizeOptions.NonGroupByPageSizeOptions, expectedPipelineType: TestInjections.PipelineType.Specialized),
+                CreateInput(
+                    query: $"SELECT DISTINCT VALUE r.{NumberField} FROM r ORDER BY r.{NumberField} DESC",
+                    expectedResult: first7IntegersReversed,
+                    partitionKey: partitionKeyValue,
+                    enableOptimisticDirectExecution: true,
+                    pageSizeOptions: PageSizeOptions.NonGroupByPageSizeOptions,
+                    expectedPipelineType: TestInjections.PipelineType.OptimisticDirectExecution),
+                CreateInput(
+                    query: $"SELECT DISTINCT VALUE r.{NumberField} FROM r ORDER BY r.{NumberField} DESC",
+                    expectedResult: first7IntegersReversed,
+                    partitionKey: null,
+                    enableOptimisticDirectExecution: true,
+                    pageSizeOptions: PageSizeOptions.NonGroupByPageSizeOptions,
+                    expectedPipelineType: TestInjections.PipelineType.Specialized),
 
                 // OFFSET LIMIT with WHERE and BETWEEN
-                CreateInput( query: $"SELECT VALUE r.numberField FROM r WHERE r.{numberField} BETWEEN 0 AND {numberOfDocuments} OFFSET 1 LIMIT 1", expectedResult: new List<long> { 1 }, partitionKey: "/value", partition: CollectionTypes.MultiPartition, enableOptimisticDirectExecution: true, pageSizeOptions: PageSizeOptions.NonGroupByPageSizeOptions, expectedPipelineType: TestInjections.PipelineType.OptimisticDirectExecution),
-                CreateInput( query: $"SELECT VALUE r.numberField FROM r WHERE r.{numberField} BETWEEN 0 AND {numberOfDocuments} OFFSET 1 LIMIT 1", expectedResult: new List<long> { 1 }, partitionKey: null, partition: CollectionTypes.MultiPartition, enableOptimisticDirectExecution: true, pageSizeOptions: PageSizeOptions.NonGroupByPageSizeOptions, expectedPipelineType: TestInjections.PipelineType.Specialized)
+                CreateInput(
+                    query: $"SELECT VALUE r.numberField FROM r WHERE r.{NumberField} BETWEEN 0 AND {NumberOfDocuments} OFFSET 1 LIMIT 1",
+                    expectedResult: new List<int> { 1 },
+                    partitionKey: partitionKeyValue,
+                    enableOptimisticDirectExecution: true,
+                    pageSizeOptions: PageSizeOptions.NonGroupByPageSizeOptions,
+                    expectedPipelineType: TestInjections.PipelineType.OptimisticDirectExecution),
+                CreateInput(
+                    query: $"SELECT VALUE r.numberField FROM r WHERE r.{NumberField} BETWEEN 0 AND {NumberOfDocuments} OFFSET 1 LIMIT 1",
+                    expectedResult: new List<int> { 1 },
+                    partitionKey: null,
+                    enableOptimisticDirectExecution: true,
+                    pageSizeOptions: PageSizeOptions.NonGroupByPageSizeOptions,
+                    expectedPipelineType: TestInjections.PipelineType.Specialized)
             };
+
+            List<string> documents = CreateDocuments(NumberOfDocuments, PartitionKeyField, NumberField, NullField);
 
             await this.CreateIngestQueryDeleteAsync(
                 ConnectionModes.Direct | ConnectionModes.Gateway,
                 CollectionTypes.SinglePartition,
                 documents,
-                (container, documents) => RunPassingTests(singlePartitionContainerTestCases, container),
-                "/" + partitionKey);
+                (container, documents) => RunTests(singlePartitionContainerTestCases, container),
+                "/" + PartitionKeyField);
 
             await this.CreateIngestQueryDeleteAsync(
                 ConnectionModes.Direct | ConnectionModes.Gateway,
                 CollectionTypes.MultiPartition,
                 documents,
-                (container, documents) => RunPassingTests(multiPartitionContainerTestCases, container),
-                "/" + partitionKey);
+                (container, documents) => RunTests(multiPartitionContainerTestCases, container),
+                "/" + PartitionKeyField);
+        }
+
+        [TestMethod]
+        public async Task TestMultiPartitionQueriesWithNonePartitionKey()
+        {
+            int documentCount = 400;
+            IReadOnlyList<int> first400Integers = Enumerable.Range(0, documentCount).ToList();
+            IReadOnlyList<int> first400IntegersReversed = Enumerable.Range(0, documentCount).Reverse().ToList();
+
+            IReadOnlyList<DirectExecutionTestCase> testCases = new List<DirectExecutionTestCase>
+            {
+                CreateInput(
+                    query: $"SELECT VALUE r.numberField FROM r",
+                    expectedResult: first400Integers,
+                    partitionKey: PartitionKey.None,
+                    enableOptimisticDirectExecution: false,
+                    pageSizeOptions: PageSizeOptions.PageSize100,
+                    expectedPipelineType: TestInjections.PipelineType.Passthrough),
+                CreateInput(
+                    query: $"SELECT VALUE r.{NumberField} FROM r ORDER BY r.{NumberField} ASC",
+                    expectedResult: first400Integers,
+                    partitionKey: PartitionKey.None,
+                    enableOptimisticDirectExecution: false,
+                    pageSizeOptions: PageSizeOptions.PageSize100,
+                    expectedPipelineType: TestInjections.PipelineType.Specialized),
+                CreateInput(
+                    query: $"SELECT VALUE r.{NumberField} FROM r ORDER BY r.{NumberField} DESC",
+                    expectedResult: first400IntegersReversed,
+                    partitionKey: PartitionKey.None,
+                    enableOptimisticDirectExecution: false,
+                    pageSizeOptions: PageSizeOptions.PageSize100,
+                    expectedPipelineType: TestInjections.PipelineType.Specialized),
+                CreateInput(
+                    query: $"SELECT VALUE r.numberField FROM r WHERE r.{NumberField} BETWEEN 0 AND {NumberOfDocuments} OFFSET 1 LIMIT 1",
+                    expectedResult: new List<int> { 1 },
+                    partitionKey: PartitionKey.None,
+                    enableOptimisticDirectExecution: false,
+                    pageSizeOptions: PageSizeOptions.PageSize100,
+                    expectedPipelineType: TestInjections.PipelineType.Specialized),
+                CreateInput(
+                    query: $"SELECT VALUE r.numberField FROM r",
+                    expectedResult: first400Integers,
+                    partitionKey: PartitionKey.None,
+                    enableOptimisticDirectExecution: true,
+                    pageSizeOptions: PageSizeOptions.PageSize100,
+                    expectedPipelineType: TestInjections.PipelineType.Passthrough),
+                CreateInput(
+                    query: $"SELECT VALUE r.{NumberField} FROM r ORDER BY r.{NumberField} ASC",
+                    expectedResult: first400Integers,
+                    partitionKey: PartitionKey.None,
+                    enableOptimisticDirectExecution: true,
+                    pageSizeOptions: PageSizeOptions.PageSize100,
+                    expectedPipelineType: TestInjections.PipelineType.Specialized),
+                CreateInput(
+                    query: $"SELECT VALUE r.{NumberField} FROM r ORDER BY r.{NumberField} DESC",
+                    expectedResult: first400IntegersReversed,
+                    partitionKey: PartitionKey.None,
+                    enableOptimisticDirectExecution: true,
+                    pageSizeOptions: PageSizeOptions.PageSize100,
+                    expectedPipelineType: TestInjections.PipelineType.Specialized),
+                CreateInput(
+                    query: $"SELECT VALUE r.numberField FROM r WHERE r.{NumberField} BETWEEN 0 AND {NumberOfDocuments} OFFSET 1 LIMIT 1",
+                    expectedResult: new List<int> { 1 },
+                    partitionKey: PartitionKey.None,
+                    enableOptimisticDirectExecution: true,
+                    pageSizeOptions: PageSizeOptions.PageSize100,
+                    expectedPipelineType: TestInjections.PipelineType.Specialized),
+            };
+
+            List<string> documents = CreateDocuments(documentCount, PartitionKeyField, NumberField, NullField);
+
+            await this.CreateIngestQueryDeleteAsync(
+                ConnectionModes.Direct | ConnectionModes.Gateway,
+                CollectionTypes.MultiPartition,
+                documents,
+                (container, documents) => RunTests(testCases, container),
+                "/" + PartitionKeyField);
         }
 
         [TestMethod]
         public async Task TestFailingOptimisticDirectExecutionOutput()
         {
-            int numberOfDocuments = 8;
-            string partitionKey = "key";
-            string numberField = "numberField";
-            string nullField = "nullField";
-
-            List<string> documents = CreateDocuments(numberOfDocuments, partitionKey, numberField, nullField);
+            List<string> documents = CreateDocuments(NumberOfDocuments, PartitionKeyField, NumberField, NullField);
 
             // check if bad continuation queries and syntax error queries are handled by pipeline
             IDictionary<string, string> invalidQueries = new Dictionary<string, string>
@@ -106,10 +314,10 @@
                 CollectionTypes.SinglePartition | CollectionTypes.MultiPartition,
                 documents,
                 (container, documents) => RunFailingTests(container, invalidQueries),
-                "/" + partitionKey);
+                "/" + PartitionKeyField);
         }
 
-        private static async Task RunPassingTests(IEnumerable<DirectExecutionTestCase> testCases, Container container)
+        private static async Task RunTests(IEnumerable<DirectExecutionTestCase> testCases, Container container)
         {
             foreach (DirectExecutionTestCase testCase in testCases)
             {
@@ -118,9 +326,7 @@
                     QueryRequestOptions feedOptions = new QueryRequestOptions
                     {
                         MaxItemCount = pageSize,
-                        PartitionKey = testCase.PartitionKey == null
-                            ? null
-                            : new Cosmos.PartitionKey(testCase.PartitionKey),
+                        PartitionKey = testCase.PartitionKey,
                         EnableOptimisticDirectExecution = testCase.EnableOptimisticDirectExecution,
                         TestSettings = new TestInjections(simulate429s: false, simulateEmptyPages: false, new TestInjections.ResponseStats())
                     };
@@ -130,7 +336,7 @@
                             testCase.Query,
                             feedOptions);
 
-                    long[] actual = items.Cast<CosmosNumber>().Select(x => Number64.ToLong(x.Value)).ToArray();
+                    int[] actual = items.Cast<CosmosNumber>().Select(x => (int)Number64.ToLong(x.Value)).ToArray();
 
                     Assert.IsTrue(testCase.ExpectedResult.SequenceEqual(actual));
                     Assert.AreEqual(testCase.ExpectedPipelineType, feedOptions.TestSettings.Stats.PipelineType.Value);
@@ -151,7 +357,7 @@
             {
                 try
                 {
-                    await container.GetItemQueryIterator<Document>(
+                    await container.GetItemQueryIterator<string>(
                         queryDefinition: new QueryDefinition(queryAndResult.Key),
                         continuationToken: queryAndResult.Value,
                         requestOptions: feedOptions).ReadNextAsync();
@@ -174,11 +380,8 @@
             List<string> documents = new List<string>(documentCount);
             for (int i = 0; i < documentCount; ++i)
             {
-                Document doc = new Document();
-                doc.SetPropertyValue(partitionKey, "/value");
-                doc.SetPropertyValue(numberField, i % documentCount);
-                doc.SetPropertyValue(nullField, null);
-                documents.Add(doc.ToString());
+                string document = $@"{{ {partitionKey}: ""/value"", {numberField}: {i}, {nullField}: null }}";
+                documents.Add(document);
             }
 
             return documents;
@@ -186,31 +389,28 @@
 
         private static DirectExecutionTestCase CreateInput(
             string query,
-            List<long> expectedResult,
-            string partitionKey,
-            CollectionTypes partition,
+            IReadOnlyList<int> expectedResult,
+            PartitionKey? partitionKey,
             bool enableOptimisticDirectExecution,
             int[] pageSizeOptions,
             TestInjections.PipelineType expectedPipelineType)
         {
-            return new DirectExecutionTestCase(query, expectedResult, partitionKey, partition, enableOptimisticDirectExecution, pageSizeOptions, expectedPipelineType);
+            return new DirectExecutionTestCase(query, expectedResult, partitionKey, enableOptimisticDirectExecution, pageSizeOptions, expectedPipelineType);
         }
 
-        internal readonly struct DirectExecutionTestCase
+        private readonly struct DirectExecutionTestCase
         {
             public string Query { get; }
-            public List<long> ExpectedResult { get; }
-            public string PartitionKey { get; }
-            public CollectionTypes Partition { get; }
+            public IReadOnlyList<int> ExpectedResult { get; }
+            public PartitionKey? PartitionKey { get; }
             public bool EnableOptimisticDirectExecution { get; }
             public int[] PageSizeOptions { get; }
             public TestInjections.PipelineType ExpectedPipelineType { get; }
 
             public DirectExecutionTestCase(
                 string query,
-                List<long> expectedResult,
-                string partitionKey,
-                CollectionTypes partition,
+                IReadOnlyList<int> expectedResult,
+                PartitionKey? partitionKey,
                 bool enableOptimisticDirectExecution,
                 int[] pageSizeOptions,
                 TestInjections.PipelineType expectedPipelineType)
@@ -218,7 +418,6 @@
                 this.Query = query;
                 this.ExpectedResult = expectedResult;
                 this.PartitionKey = partitionKey;
-                this.Partition = partition;
                 this.EnableOptimisticDirectExecution = enableOptimisticDirectExecution;
                 this.PageSizeOptions = pageSizeOptions;
                 this.ExpectedPipelineType = expectedPipelineType;


### PR DESCRIPTION
## Description

Microsoft.Azure.Documents.PartitionKeyInternal has the following method:
`public string GetEffectivePartitionKeyString(PartitionKeyDefinition partitionKeyDefinition, bool strict = true)`
Unfortunately, this is a broken contract, since it also has members:
```
        private static readonly PartitionKeyInternal NonePartitionKey = new PartitionKeyInternal();
        public static PartitionKeyInternal None
        {
            get
            {
                return PartitionKeyInternal.NonePartitionKey;
            }
        }
```

This implies that  `GetEffectivePartitionKeyString` throws an `System.ArgumentException` when `this` evaluates to `PartitionKeyInternal.None`.

The higher layer at `Microsoft.Azure.Cosmos.PartitionKey` is also broken since it exposes a `PartitionKey.None` member that maps to `PartitionKeyInternal.None`, instead of mapping to one of `PartitionKeyInternal.Empty` or `PartitionKeyInternal.Undefined` depending on the whether the collection is a legacy fixed collection that was migrated to be system partitioned or if it is regular multi partitioned collection.

This change uses a workaround called `CachedContainerQueryProperties` which currently has the behavior mentioned above.

Also, did some housekeeping in `OptimisticDirectExecutionQueryTests`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Closing issues

closes #2030