### PR TITLE
ReadMany: Fixes BadRequest when using Ids with single quotes

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ReadManyQueryHelper.cs
+++ b/Microsoft.Azure.Cosmos/src/ReadManyQueryHelper.cs
@@ -249,10 +249,13 @@ namespace Microsoft.Azure.Cosmos
         {
             int totalItemCount = Math.Min(items.Count, startIndex + this.maxItemsPerQuery);
             StringBuilder queryStringBuilder = new StringBuilder();
+            SqlParameterCollection sqlParameters = new SqlParameterCollection();
             queryStringBuilder.Append("SELECT * FROM c WHERE c.id IN ( ");
             for (int i = startIndex; i < totalItemCount; i++)
             {
-                queryStringBuilder.Append($"'{items[i].Item1}'");
+                string idParamName = "@param_id" + i;
+                sqlParameters.Add(new SqlParameter(idParamName, items[i].Item1));
+                queryStringBuilder.Append(idParamName);
                 if (i < totalItemCount - 1)
                 {
                     queryStringBuilder.Append(",");
@@ -260,7 +263,8 @@ namespace Microsoft.Azure.Cosmos
             }
             queryStringBuilder.Append(" )");
 
-            return new QueryDefinition(queryStringBuilder.ToString());
+            return QueryDefinition.CreateFromQuerySpec(new SqlQuerySpec(queryStringBuilder.ToString(),
+                                                        sqlParameters));
         }
 
         private QueryDefinition CreateReadManyQueryDefinitionForOther(List<(string, PartitionKey)> items,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosReadManyItemsTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosReadManyItemsTests.cs
@@ -5,16 +5,11 @@
 namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 {
     using System;
-    using System.Collections.Concurrent;
     using System.Collections.Generic;
-    using System.Collections.ObjectModel;
     using System.Net;
-    using System.Net.Http;
-    using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Fluent;
-    using Microsoft.Azure.Cosmos.Query.Core;
     using Microsoft.Azure.Cosmos.Tracing;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -22,16 +17,15 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
     public class CosmosReadManyItemsTests : BaseCosmosClientHelper
     {
         private Container Container = null;
-        private ContainerProperties containerSettings = null;
 
         [TestInitialize]
         public async Task TestInitialize()
         {
             await base.TestInit();
             string PartitionKey = "/pk";
-            this.containerSettings = new ContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey);
+            ContainerProperties containerSettings = new ContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey);
             ContainerResponse response = await this.database.CreateContainerAsync(
-                this.containerSettings,
+                containerSettings,
                 throughput: 20000,
                 cancellationToken: this.cancellationToken);
             Assert.IsNotNull(response);
@@ -122,23 +116,24 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         [TestMethod]
         public async Task ReadManyWithIdasPk()
         {
-            string PartitionKey = "/id";
-            ContainerProperties containerSettings = new ContainerProperties(id: Guid.NewGuid().ToString(), partitionKeyPath: PartitionKey);
-            Container container = await this.database.CreateContainerAsync(containerSettings);
+            Container container = await this.database.CreateContainerAsync(Guid.NewGuid().ToString(), "/id");
 
             List<(string, PartitionKey)> itemList = new List<(string, PartitionKey)>();
-            for (int i = 0; i < 5; i++)
-            {
-                itemList.Add((i.ToString(), new PartitionKey(i.ToString())));
-            }
 
             // Create items with different pk values
             for (int i = 0; i < 5; i++)
             {
                 ToDoActivity item = ToDoActivity.CreateRandomToDoActivity();
-                item.id = i.ToString();
                 ItemResponse<ToDoActivity> itemResponse = await container.CreateItemAsync(item);
                 Assert.AreEqual(HttpStatusCode.Created, itemResponse.StatusCode);
+                
+                itemList.Add((item.id, new PartitionKey(item.id)));
+
+                ToDoActivity itemWithSingleQuotes = ToDoActivity.CreateRandomToDoActivity(id: item.id + "'singlequote");
+                ItemResponse<ToDoActivity> itemResponseWithSingleQuotes = await container.CreateItemAsync(itemWithSingleQuotes);
+                Assert.AreEqual(HttpStatusCode.Created, itemResponseWithSingleQuotes.StatusCode);
+
+                itemList.Add((itemWithSingleQuotes.id, new PartitionKey(itemWithSingleQuotes.id)));
             }
 
             using (ResponseMessage responseMessage = await container.ReadManyItemsStreamAsync(itemList))
@@ -149,12 +144,12 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                 ToDoActivity[] items = this.GetClient().ClientContext.SerializerCore.FromFeedStream<ToDoActivity>(
                                         CosmosFeedResponseSerializer.GetStreamWithoutServiceEnvelope(responseMessage.Content));
-                Assert.AreEqual(items.Length, 5);
+                Assert.AreEqual(items.Length, 10);
             }
 
             FeedResponse<ToDoActivity> feedResponse = await container.ReadManyItemsAsync<ToDoActivity>(itemList);
             Assert.IsNotNull(feedResponse);
-            Assert.AreEqual(feedResponse.Count, 5);
+            Assert.AreEqual(feedResponse.Count, 10);
             Assert.IsTrue(feedResponse.Headers.RequestCharge > 0);
             Assert.IsNotNull(feedResponse.Diagnostics);
         }


### PR DESCRIPTION
# Pull Request Template

## Description

Using a **Container with /id as Partition Key Path**, when the input of ReadMany includes values with `'`, the query parsing fails with:

```
(Response status code does not indicate success: BadRequest (400); Substatus: 0; ActivityId: ; Reason: (Response status code does not indicate success: BadRequest (400); Substatus: 0; ActivityId: ; Reason: ({"errors":[{"severity":"Error","location":{"start":37,"end":41},"code":"SC1001","message":"Syntax error, incorrect syntax near 'user'."}]}););)
  ----> Microsoft.Azure.Cosmos.CosmosException : Response status code does not indicate success: BadRequest (400); Substatus: 0; ActivityId: ; Reason: (Response status code does not indicate success: BadRequest (400); Substatus: 0; ActivityId: ; Reason: ({"errors":[{"severity":"Error","location":{"start":37,"end":41},"code":"SC1001","message":"Syntax error, incorrect syntax near 'xxxx'."}]}););
  ----> Microsoft.Azure.Cosmos.Query.Core.Exceptions.ExpectedQueryPartitionProviderException : {"errors":[{"severity":"Error","location":{"start":37,"end":41},"code":"SC1001","message":"Syntax error, incorrect syntax near 'xxx'."}]}
```

The reason is that we are manually constructing a string concatenation of the query with `'` as separator:


```
private QueryDefinition CreateReadManyQueryDefinitionForId(List<(string, PartitionKey)> items,
                                                                    int startIndex)
        {
            int totalItemCount = Math.Min(items.Count, startIndex + this.maxItemsPerQuery);
            StringBuilder queryStringBuilder = new StringBuilder();
            queryStringBuilder.Append("SELECT * FROM c WHERE c.id IN ( ");
            for (int i = startIndex; i < totalItemCount; i++)
            {
                queryStringBuilder.Append($"'{items[i].Item1}'");
                if (i < totalItemCount - 1)
                {
                    queryStringBuilder.Append(",");
                }
            }
            queryStringBuilder.Append(" )");

            return new QueryDefinition(queryStringBuilder.ToString());
        }
```

The line with the problem is `queryStringBuilder.Append($"'{items[i].Item1}'");`

Using `SqlParameter` instead, provides guards against any escaping character and SQL injection.

## Closing issues

Closes https://github.com/Azure/azure-cosmos-dotnet-v3/issues/3731