### PR TITLE
[Internal] Build: Fixes static tool analysis versions

### DIFF
--- a/templates/static-tools.yml
+++ b/templates/static-tools.yml
@@ -48,21 +48,17 @@ jobs:
       verboseOutput: false
 
   # Scan text elements including code, code comments, and content/web pages, for sensitive terms based on legal, cultural, or geopolitical reasons
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@1
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@2
     displayName: 'PoliCheck'
     inputs:
       targetType: F
 
   # AntiMalware scan
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-antimalware.AntiMalware@3
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-antimalware.AntiMalware@4
     displayName: 'AntiMalware'
     continueOnError: true # signature refresh failing resulting in tasks failures
     inputs:
       EnableServices: true
-
-  # Run checks for recently discovered vulnerabilities which are not yet incorporated to another tool
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-vulnerabilityassessment.VulnerabilityAssessment@0
-    displayName: 'Vulnerability Assessment'
 
   - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
     displayName: 'Component Governance Detection' #https://docs.opensource.microsoft.com/tools/cg.html
@@ -71,11 +67,11 @@ jobs:
       failOnAlert: true
 
   # Publish Analysis Results (position after all tools ran)
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@2
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-publishsecurityanalysislogs.PublishSecurityAnalysisLogs@3
     displayName: 'Publish Security Analysis Logs'
 
   # The Post-Analysis build task will analyze the log files produced by the tools, and introduce a build break
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@1
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@2
     displayName: 'Post Analysis'
     inputs:
       AllTools: true

--- a/templates/static-tools.yml
+++ b/templates/static-tools.yml
@@ -26,10 +26,7 @@ jobs:
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-binskim.BinSkim@4
     displayName: 'BinSkim'
     inputs:
-        toolVersion:        Latest
-        InputType:          Basic
-        Function:           analyze
-        AnalyzeTarget:      $(Build.SourcesDirectory)\Microsoft.Azure.Cosmos\src\bin\Release\netstandard2.0\Microsoft.Azure.Cosmos.Client.dll
+        AnalyzeTargetGlob:      $(Build.SourcesDirectory)\Microsoft.Azure.Cosmos\src\bin\Release\netstandard2.0\Microsoft.Azure.Cosmos.Client.dll
         AnalyzeConfigPath:  default
         AnalyzeRecurse:     true
         AnalyzeVerbose:     true

--- a/templates/static-tools.yml
+++ b/templates/static-tools.yml
@@ -72,5 +72,8 @@ jobs:
     displayName: 'Post Analysis'
     inputs:
       GdnBreakFast: true
-      GdnBreakPolicyMinSev: Default
-      GdnBreakAllTools: true
+      GdnBreakAllTools: false
+      GdnBreakGdnToolCredScan: true
+      GdnBreakGdnToolBinSkim: true
+      GdnBreakGdnToolPoliCheck: true
+      GdnBreakGdnToolPoliCheckSeverity: Error

--- a/templates/static-tools.yml
+++ b/templates/static-tools.yml
@@ -48,6 +48,7 @@ jobs:
     displayName: 'PoliCheck'
     inputs:
       targetType: F
+      optionsFC: 0
 
   # AntiMalware scan
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-antimalware.AntiMalware@4

--- a/templates/static-tools.yml
+++ b/templates/static-tools.yml
@@ -71,4 +71,6 @@ jobs:
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@2
     displayName: 'Post Analysis'
     inputs:
-      AllTools: true
+      GdnBreakFast: true
+      GdnBreakPolicyMinSev: Default
+      GdnBreakAllTools: true

--- a/templates/static-tools.yml
+++ b/templates/static-tools.yml
@@ -26,8 +26,7 @@ jobs:
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-binskim.BinSkim@4
     displayName: 'BinSkim'
     inputs:
-        AnalyzeTargetGlob:      $(Build.SourcesDirectory)\Microsoft.Azure.Cosmos\src\bin\Release\netstandard2.0\Microsoft.Azure.Cosmos.Client.dll
-        AnalyzeConfigPath:  default
+        AnalyzeTargetGlob:  $(Build.SourcesDirectory)\Microsoft.Azure.Cosmos\src\bin\Release\netstandard2.0\Microsoft.Azure.Cosmos.Client.dll
         AnalyzeRecurse:     true
         AnalyzeVerbose:     true
         AnalyzeHashes:      false

--- a/templates/static-tools.yml
+++ b/templates/static-tools.yml
@@ -37,18 +37,8 @@ jobs:
         AnalyzeStatistics:  false
         AnalyzeEnvironment: false
 
-  #Analyze source code for type of content and target types to help determine which tools to run
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-autoapplicability.AutoApplicability@1
-    displayName: 'AutoApplicability'
-    inputs:
-      VerboseWriter: true
-      ExternalRelease: true
-      InternalRelease: true
-      IsService: true
-      IsSoftware: true
-
   # Analyze source and build output text files for credentials
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@3
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@4
     displayName: 'CredScan'
     inputs:
       toolMajorVersion: V2

--- a/templates/static-tools.yml
+++ b/templates/static-tools.yml
@@ -23,7 +23,7 @@ jobs:
       arguments: '-p:Optimize=true -p:IsPreview=true --configuration Release'
       versioningScheme: OFF
 
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-binskim.BinSkim@3
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-binskim.BinSkim@4
     displayName: 'BinSkim'
     inputs:
         toolVersion:        Latest
@@ -38,7 +38,7 @@ jobs:
         AnalyzeEnvironment: false
 
   # Analyze source and build output text files for credentials
-  - task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@4
+  - task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@3
     displayName: 'CredScan'
     inputs:
       toolMajorVersion: V2


### PR DESCRIPTION
Builds are issuing this warning:

For BinSkim:
```
##[warning]* Please upgrade the version of this build task in your build to major version: 4. For more information, please see: https://aka.ms/gdn-v1-deprecation
* Secure Development Tools (Guardian v1) is on the path to deprecation.
* Based on usage telemetry, this message will increase in build severity in the near future.
```

For AutoApplicability:
```
##[warning]* This tool is no longer supported. Please remove this build task from your build definition. For more information, please see: https://aka.ms/gdn-v1-deprecation
* Secure Development Tools (Guardian v1) is on the path to deprecation.
* Based on usage telemetry, this message will increase in build severity in the near future.
*
```

Following https://aka.ms/gdn-v1-deprecation, BinSkim is moving to version 4, others have also major version bumps, and AutoApplicability and others are no longer supported.