### PR TITLE
Event Tracing: Adds Event Tracing support independent of distributed tracing

### DIFF
--- a/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Azure.Cosmos
     using System.Net.Security;
     using System.Security.Cryptography.X509Certificates;
     using Microsoft.Azure.Cosmos.Fluent;
+    using Microsoft.Azure.Cosmos.Telemetry.EventTracing;
     using Microsoft.Azure.Documents;
     using Microsoft.Azure.Documents.Client;
     using Newtonsoft.Json;
@@ -1001,6 +1002,12 @@ namespace Microsoft.Azure.Cosmos
                 return objectType == typeof(DateTime);
             }
         }
+
+        /// <summary>
+        /// Event Tracing Options. <see cref="Microsoft.Azure.Cosmos.EventTracingOptions"/>
+        /// </summary>
+        /// <remarks> There must be listener subscribed to "Azure-Cosmos-Operation-Request-Diagnostics" Event Source and filtering will happen based on this configuration</remarks>
+        internal EventTracingOptions EventTracingOptions { get; set; }
         
         /// <summary>
         /// Distributed Tracing Options. <see cref="Microsoft.Azure.Cosmos.DistributedTracingOptions"/>

--- a/Microsoft.Azure.Cosmos/src/Fluent/CosmosClientBuilder.cs
+++ b/Microsoft.Azure.Cosmos/src/Fluent/CosmosClientBuilder.cs
@@ -454,6 +454,19 @@ namespace Microsoft.Azure.Cosmos.Fluent
         }
 
         /// <summary>
+        /// Enables Event Tracing with a Configuration ref. <see cref="EventTracingOptions"/>
+        /// </summary>
+        /// <param name="options"><see cref="EventTracingOptions"/>.</param>
+        /// <returns>The current <see cref="CosmosClientBuilder"/>.</returns>]
+        /// <remarks>Refer https://opentelemetry.io/docs/instrumentation/net/exporters/ to know more about open telemetry exporters</remarks>
+        internal CosmosClientBuilder WithEventTracingOptions(EventTracingOptions options)
+        {
+            this.clientOptions.EventTracingOptions = options;
+
+            return this;
+        }
+
+        /// <summary>
         /// Sets the connection mode to Gateway. This is used by the client when connecting to the Azure Cosmos DB service.
         /// </summary>
         /// <param name="maxConnectionLimit">The number specifies the number of connections that may be opened simultaneously. Default is 50 connections</param>

--- a/Microsoft.Azure.Cosmos/src/RequestOptions/RequestOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/RequestOptions/RequestOptions.cs
@@ -46,7 +46,12 @@ namespace Microsoft.Azure.Cosmos
         /// Set Request Level Distributed Tracing Options.
         /// </summary>
         internal DistributedTracingOptions DistributedTracingOptions { get; set; }
-        
+
+        /// <summary>
+        /// Set Request Level Event Tracing Options.
+        /// </summary>
+        internal EventTracingOptions EventTracingOptions { get; set; }
+
         /// <summary>
         /// Gets or sets the boolean to use effective partition key routing in the cosmos db request.
         /// </summary>

--- a/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/CosmosException.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/CosmosException.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Azure.Cosmos
     using global::Azure.Core.Pipeline;
     using Microsoft.Azure.Cosmos.Diagnostics;
     using Microsoft.Azure.Cosmos.Telemetry;
+    using Microsoft.Azure.Cosmos.Telemetry.EventTracing;
     using Microsoft.Azure.Cosmos.Tracing;
     using Microsoft.Azure.Documents;
 
@@ -295,8 +296,6 @@ namespace Microsoft.Azure.Cosmos
             scope.AddAttribute(OpenTelemetryAttributeKeys.Region, 
                 ClientTelemetryHelper.GetContactedRegions(exception.Diagnostics?.GetContactedRegions()));
             scope.AddAttribute(OpenTelemetryAttributeKeys.ExceptionMessage, exception.Message);
-
-            CosmosDbEventSource.RecordDiagnosticsForExceptions(exception.Diagnostics);
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/CosmosNullReferenceException.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/CosmosNullReferenceException.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Azure.Cosmos
     using global::Azure.Core.Pipeline;
     using Microsoft.Azure.Cosmos.Diagnostics;
     using Microsoft.Azure.Cosmos.Telemetry;
+    using Microsoft.Azure.Cosmos.Telemetry.EventTracing;
     using Microsoft.Azure.Cosmos.Tracing;
 
     /// <summary>
@@ -83,8 +84,6 @@ namespace Microsoft.Azure.Cosmos
             scope.AddAttribute(OpenTelemetryAttributeKeys.Region, 
                 ClientTelemetryHelper.GetContactedRegions(exception.Diagnostics?.GetContactedRegions()));
             scope.AddAttribute(OpenTelemetryAttributeKeys.ExceptionMessage, exception.GetBaseException().Message);
-
-            CosmosDbEventSource.RecordDiagnosticsForExceptions(exception.Diagnostics);
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/CosmosObjectDisposedException.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/CosmosObjectDisposedException.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Azure.Cosmos
     using global::Azure.Core.Pipeline;
     using Microsoft.Azure.Cosmos.Diagnostics;
     using Microsoft.Azure.Cosmos.Telemetry;
+    using Microsoft.Azure.Cosmos.Telemetry.EventTracing;
     using Microsoft.Azure.Cosmos.Tracing;
 
     /// <summary>
@@ -99,8 +100,6 @@ namespace Microsoft.Azure.Cosmos
             scope.AddAttribute(OpenTelemetryAttributeKeys.Region, 
                 ClientTelemetryHelper.GetContactedRegions(exception.Diagnostics?.GetContactedRegions()));
             scope.AddAttribute(OpenTelemetryAttributeKeys.ExceptionMessage, exception.Message);
-
-            CosmosDbEventSource.RecordDiagnosticsForExceptions(exception.Diagnostics);
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/CosmosOperationCanceledException.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/CosmosOperationCanceledException.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Azure.Cosmos
     using global::Azure.Core.Pipeline;
     using Microsoft.Azure.Cosmos.Diagnostics;
     using Microsoft.Azure.Cosmos.Telemetry;
+    using Microsoft.Azure.Cosmos.Telemetry.EventTracing;
     using Microsoft.Azure.Cosmos.Tracing;
 
     /// <summary>
@@ -139,8 +140,6 @@ namespace Microsoft.Azure.Cosmos
                 ClientTelemetryHelper.GetContactedRegions(exception.Diagnostics?.GetContactedRegions()));
             scope.AddAttribute(OpenTelemetryAttributeKeys.ExceptionMessage, 
                 exception.GetBaseException().Message);
-
-            CosmosDbEventSource.RecordDiagnosticsForExceptions(exception.Diagnostics);
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Telemetry/EventTracing/CosmosDbEventSource.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/EventTracing/CosmosDbEventSource.cs
@@ -2,10 +2,12 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // ------------------------------------------------------------
 
-namespace Microsoft.Azure.Cosmos.Telemetry
+namespace Microsoft.Azure.Cosmos
 {
+    using System;
     using System.Diagnostics.Tracing;
     using global::Azure.Core.Diagnostics;
+    using Microsoft.Azure.Cosmos.Telemetry;
     using Microsoft.Azure.Cosmos.Telemetry.Diagnostics;
 
     /// <summary>
@@ -15,7 +17,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
     internal sealed class CosmosDbEventSource : AzureEventSource
     {
         internal const string EventSourceName = "Azure-Cosmos-Operation-Request-Diagnostics";
-        
+
         private static CosmosDbEventSource Singleton { get; } = new CosmosDbEventSource();
 
         private CosmosDbEventSource()
@@ -26,30 +28,39 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         [NonEvent]
         public static bool IsEnabled(EventLevel level)
         {
-            return CosmosDbEventSource.Singleton.IsEnabled(level, EventKeywords.None);
+            return Singleton.IsEnabled(level, EventKeywords.None);
         }
 
         [NonEvent]
         public static void RecordDiagnosticsForRequests(
-            DistributedTracingOptions config,
+            EventTracingOptions config,
             Documents.OperationType operationType,
             OpenTelemetryAttributes response)
         {
             if (DiagnosticsFilterHelper.IsTracingNeeded(
                     config: config,
                     operationType: operationType,
-                    response: response) && CosmosDbEventSource.IsEnabled(EventLevel.Warning))
+                    response: response) && IsEnabled(EventLevel.Warning))
             {
-                CosmosDbEventSource.Singleton.LatencyOverThreshold(response.Diagnostics.ToString());
+                Singleton.LatencyOverThreshold(response.Diagnostics.ToString());
             }
         }
 
         [NonEvent]
         public static void RecordDiagnosticsForExceptions(CosmosDiagnostics diagnostics)
         {
-            if (CosmosDbEventSource.IsEnabled(EventLevel.Error))
+            if (IsEnabled(EventLevel.Error))
             {
-                CosmosDbEventSource.Singleton.Exception(diagnostics.ToString());
+                Singleton.Exception(diagnostics.ToString());
+            }
+        }
+        
+        [NonEvent]
+        public static void RecordDiagnosticsForExceptions(Exception exception)
+        {
+            if (IsEnabled(EventLevel.Error))
+            {
+                Singleton.Exception(exception.ToString());
             }
         }
 

--- a/Microsoft.Azure.Cosmos/src/Telemetry/EventTracing/EventTracingOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/EventTracing/EventTracingOptions.cs
@@ -1,0 +1,30 @@
+﻿// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos
+{
+    using System;
+
+    /// <summary>
+    /// Options for configuring the event tracing
+    /// </summary>
+    internal class EventTracingOptions
+    {
+        /// <summary>
+        /// Default Latency threshold for other than query Operation
+        /// </summary>
+        internal static readonly TimeSpan DefaultCrudLatencyThreshold = TimeSpan.FromMilliseconds(100);
+
+        /// <summary>
+        /// Default Latency threshold for QUERY operation
+        /// </summary>
+        internal static readonly TimeSpan DefaultQueryTimeoutThreshold = TimeSpan.FromMilliseconds(500);
+
+        /// <summary>
+        /// SDK generates <see cref="System.Diagnostics.Tracing.EventSource"/> (Event Source Name is "Azure-Cosmos-Operation-Request-Diagnostics") with Request Diagnostics String, If Operation level distributed tracing is not disabled i.e. <see cref="CosmosClientOptions.IsDistributedTracingEnabled"/>
+        /// </summary>
+        /// <remarks>If it is not set then, by default, it will generate <see cref="System.Diagnostics.Tracing.EventSource"/> for query operation which are taking more than 500 ms and non-query operations taking more than 100 ms.</remarks>
+        public TimeSpan? LatencyThresholdForDiagnosticEvent { get; set; }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Telemetry/OpenTelemetry/DistributedTracingOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/OpenTelemetry/DistributedTracingOptions.cs
@@ -7,24 +7,10 @@ namespace Microsoft.Azure.Cosmos
     using System;
 
     /// <summary>
-    /// Options for configuring the distributed tracing and event tracing
+    /// Options for configuring the distributed tracing
     /// </summary>
     internal sealed class DistributedTracingOptions
     {
-        /// <summary>
-        /// Default Latency threshold for other than query Operation
-        /// </summary>
-        internal static readonly TimeSpan DefaultCrudLatencyThreshold = TimeSpan.FromMilliseconds(100);
-
-        /// <summary>
-        /// Default Latency threshold for QUERY operation
-        /// </summary>
-        internal static readonly TimeSpan DefaultQueryTimeoutThreshold = TimeSpan.FromMilliseconds(500);
-
-        /// <summary>
-        /// SDK generates <see cref="System.Diagnostics.Tracing.EventSource"/> (Event Source Name is "Azure-Cosmos-Operation-Request-Diagnostics") with Request Diagnostics String, If Operation level distributed tracing is not disabled i.e. <see cref="Microsoft.Azure.Cosmos.CosmosClientOptions.IsDistributedTracingEnabled"/>
-        /// </summary>
-        /// <remarks>If it is not set then, by default, it will generate <see cref="System.Diagnostics.Tracing.EventSource"/> for query operation which are taking more than 500 ms and non-query operations taking more than 100 ms.</remarks>
-        public TimeSpan? LatencyThresholdForDiagnosticEvent { get; set; }
+       // No options as of now.
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Telemetry/OpenTelemetry/Filters/DiagnosticsFilterHelper.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/OpenTelemetry/Filters/DiagnosticsFilterHelper.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry.Diagnostics
 {
     using System;
     using Documents;
+    using Microsoft.Azure.Cosmos.Telemetry.EventTracing;
 
     internal static class DiagnosticsFilterHelper
     {
@@ -16,7 +17,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry.Diagnostics
         /// </summary>
         /// <returns>true or false</returns>
         public static bool IsTracingNeeded(
-            DistributedTracingOptions config,
+            EventTracingOptions config,
             OperationType operationType,
             OpenTelemetryAttributes response)
         {
@@ -28,7 +29,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry.Diagnostics
             }
             else
             {
-                latencyThreshold = operationType == OperationType.Query ? DistributedTracingOptions.DefaultQueryTimeoutThreshold : DistributedTracingOptions.DefaultCrudLatencyThreshold;
+                latencyThreshold = operationType == OperationType.Query ? EventTracingOptions.DefaultQueryTimeoutThreshold : EventTracingOptions.DefaultCrudLatencyThreshold;
             }
 
             return response.Diagnostics.GetClientElapsedTime() > latencyThreshold || !response.StatusCode.IsSuccess();

--- a/Microsoft.Azure.Cosmos/src/Telemetry/OpenTelemetry/OpenTelemetryCoreRecorder.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/OpenTelemetry/OpenTelemetryCoreRecorder.cs
@@ -152,11 +152,11 @@ namespace Microsoft.Azure.Cosmos.Telemetry
 
         public void Dispose()
         {
+            Documents.OperationType operationType
+                  = (this.response == null || this.response?.OperationType == Documents.OperationType.Invalid) ? this.operationType : this.response.OperationType;
+
             if (this.scope.IsEnabled)
             {
-                Documents.OperationType operationType 
-                    = (this.response == null || this.response?.OperationType == Documents.OperationType.Invalid) ? this.operationType : this.response.OperationType;
-
                 this.scope.AddAttribute(OpenTelemetryAttributeKeys.OperationType, operationType);
 
                 if (this.response != null)
@@ -173,7 +173,6 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                     if (this.response.Diagnostics != null)
                     {
                         this.scope.AddAttribute(OpenTelemetryAttributeKeys.Region, ClientTelemetryHelper.GetContactedRegions(this.response.Diagnostics.GetContactedRegions()));
-                        CosmosDbEventSource.RecordDiagnosticsForRequests(this.config, operationType, this.response);
                     }
                 }
 

--- a/Microsoft.Azure.Cosmos/src/Telemetry/OpenTelemetry/OpenTelemetryRecorderFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/OpenTelemetry/OpenTelemetryRecorderFactory.cs
@@ -4,7 +4,6 @@
 
 namespace Microsoft.Azure.Cosmos.Telemetry
 {
-    using System;
     using global::Azure.Core.Pipeline;
 
     /// <summary>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Tracing/EndToEndTraceWriterBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Tracing/EndToEndTraceWriterBaselineTests.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Tracing
                 enableDistributingTracing: true);
             bulkClient = TestCommon.CreateCosmosClient(builder => builder
                 .WithBulkExecution(true)
-                .WithDistributedTracingOptions(new DistributedTracingOptions()
+                .WithEventTracingOptions(new EventTracingOptions()
                 {
                     LatencyThresholdForDiagnosticEvent = TimeSpan.FromMilliseconds(0)
                 }));
@@ -60,7 +60,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Tracing
             miscCosmosClient = TestCommon.CreateCosmosClient(builder =>
                 builder
                     .AddCustomHandlers(requestHandler)
-                    .WithDistributedTracingOptions(new DistributedTracingOptions()
+                    .WithEventTracingOptions(new EventTracingOptions()
                     {
                         LatencyThresholdForDiagnosticEvent = TimeSpan.FromMilliseconds(0)
                     }));
@@ -979,7 +979,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Tracing
                 Guid exceptionActivityId = Guid.NewGuid();
                 using CosmosClient throttleClient = TestCommon.CreateCosmosClient(builder =>
                     builder
-                     .WithDistributedTracingOptions(new DistributedTracingOptions()
+                     .WithEventTracingOptions(new EventTracingOptions()
                      {
                          LatencyThresholdForDiagnosticEvent = TimeSpan.FromMilliseconds(0)
                      })
@@ -1267,7 +1267,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Tracing
                         maxRetryWaitTimeOnThrottledRequests: TimeSpan.FromSeconds(1),
                         maxRetryAttemptsOnThrottledRequests: 3)
                         .WithBulkExecution(true)
-                        .WithDistributedTracingOptions(new DistributedTracingOptions()
+                        .WithEventTracingOptions(new EventTracingOptions()
                          {
                              LatencyThresholdForDiagnosticEvent = TimeSpan.FromMilliseconds(0)
                          })


### PR DESCRIPTION
## Description

Right now, Event generation with request diagnostics is dependent on distributed tracing feature flag and configuration. As part of this PR, segregating distributed tracing and event generation logic, so that it can be used separately.

After this PR, if customer can use event source listener subscribed to "Azure-Cosmos-Operation-Request-Diagnostics" event source to capture diagnostics for high latency and errored operation calls.

## Type of change
- [] New feature (non-breaking change which adds functionality)

## Closing issues

To automatically close an issue: closes #IssueNumber