### PR TITLE
[Internal] LocalQuorum: Refactors override (i.e. strong) to allow from any account consistency

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ValidationHelpers.cs
+++ b/Microsoft.Azure.Cosmos/src/ValidationHelpers.cs
@@ -55,7 +55,6 @@ namespace Microsoft.Azure.Cosmos
         {
             if (isLocalQuorumConsistency && 
                     ValidationHelpers.IsLocalQuorumConsistency(
-                            backendConsistency: backendConsistency,
                             desiredConsistency: desiredConsistency,
                             operationType: operationType,
                             resourceType: resourceType))
@@ -109,21 +108,15 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Condition to check Quorum(i.e. Strong) read with either an eventual consistency account or a consistent prefix account.
         /// </summary>
-        /// <param name="backendConsistency"></param>
         /// <param name="desiredConsistency"></param>
         /// <param name="operationType"></param>
         /// <param name="resourceType"></param>
         /// <returns>true/false</returns>
-        private static bool IsLocalQuorumConsistency(Documents.ConsistencyLevel backendConsistency,
+        private static bool IsLocalQuorumConsistency(
                                 Documents.ConsistencyLevel desiredConsistency,
                                 OperationType? operationType,
                                 ResourceType? resourceType)
         {
-            if (backendConsistency != Documents.ConsistencyLevel.Eventual && backendConsistency != Documents.ConsistencyLevel.ConsistentPrefix)
-            {
-                return false;
-            }
-
             if (desiredConsistency != Documents.ConsistencyLevel.Strong)
             {
                 return false;


### PR DESCRIPTION
## Description
- Localquorum override (i.e. strong) to allow from any account consistency
- Facilitates no-downtime downgrade of existing accounts (i.e. existing Strong/bounded accounts migration to Eventual)

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update
