### PR TITLE
[Internal] ConnectionStateListener: Refactors GatewayAddressCache to mark replica addresses to Unhealthy

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Routing/GlobalAddressResolver.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GlobalAddressResolver.cs
@@ -235,7 +235,7 @@ namespace Microsoft.Azure.Cosmos.Routing
             foreach (KeyValuePair<Uri, EndpointCache> addressCache in this.addressCacheByEndpoint)
             {
                 // since we don't know which address cache contains the pkRanges mapped to this node, we mark all transport uris to unhealthy status in the AddressCaches of all regions
-                await addressCache.Value.AddressCache.MarkAddressesUnhealthyAsync(serverKey);
+                await addressCache.Value.AddressCache.MarkAddressesToUnhealthyAsync(serverKey);
             }
         }
 

--- a/Microsoft.Azure.Cosmos/src/direct/IAddressResolver.cs
+++ b/Microsoft.Azure.Cosmos/src/direct/IAddressResolver.cs
@@ -17,10 +17,6 @@ namespace Microsoft.Azure.Documents
             CancellationToken cancellationToken);
 
         Task UpdateAsync(
-           IReadOnlyList<AddressCacheToken> addressCacheTokens,
-           CancellationToken cancellationToken = default(CancellationToken));
-
-        Task UpdateAsync(
            ServerKey serverKey,
            CancellationToken cancellationToken = default(CancellationToken));
     }

--- a/Microsoft.Azure.Cosmos/src/direct/TransportAddressUri.cs
+++ b/Microsoft.Azure.Cosmos/src/direct/TransportAddressUri.cs
@@ -48,6 +48,7 @@ namespace Microsoft.Azure.Documents
         public TransportAddressUri(Uri addressUri)
         {
             this.Uri = addressUri ?? throw new ArgumentNullException(paramName: nameof(addressUri));
+            this.serverKey = new (uri: addressUri);
             this.uriToString = addressUri.ToString();
             this.PathAndQuery = addressUri.PathAndQuery.TrimEnd(TransportSerialization.UrlTrim);
             this.healthState = new (
@@ -68,6 +69,11 @@ namespace Microsoft.Azure.Documents
         /// Gets the current path and query as string.
         /// </summary>
         public string PathAndQuery { get; }
+
+        /// <summary>
+        /// An instance of <see cref="ServerKey"/> containing the host and port details.
+        /// </summary>
+        public ServerKey serverKey;
 
         /// <summary>
         /// Is a flag to determine if the replica the URI is pointing to is unhealthy.

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GatewayAddressCacheTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GatewayAddressCacheTests.cs
@@ -134,7 +134,7 @@ namespace Microsoft.Azure.Cosmos
             Assert.IsNotNull(addresses.AllAddresses.Select(address => address.PhysicalUri == "https://blabla.com"));
 
             // call updateAddress
-            await cache.MarkAddressesUnhealthyAsync(new Documents.Rntbd.ServerKey(new Uri("https://blabla.com")));
+            await cache.MarkAddressesToUnhealthyAsync(new Documents.Rntbd.ServerKey(new Uri("https://blabla.com")));
 
             // check if the addresss is updated
             addresses = await cache.TryGetAddressesAsync(


### PR DESCRIPTION
# Pull Request Template

## Description

Connection State Listener Changes.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)


## Closing issues

To automatically close an issue: closes #IssueNumber