### PR TITLE
Upgrade Resiliency: Refactors GatewayAddressCache to Mark TransportAddresses to Unhealthy when Connection Reset Event Occurs

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
 		<ClientOfficialVersion>3.32.2</ClientOfficialVersion>
 		<ClientPreviewVersion>3.32.2</ClientPreviewVersion>
 		<ClientPreviewSuffixVersion>preview</ClientPreviewSuffixVersion>
-		<DirectVersion>3.30.2</DirectVersion>
+		<DirectVersion>3.30.4</DirectVersion>
 		<EncryptionOfficialVersion>2.0.1</EncryptionOfficialVersion>
 		<EncryptionPreviewVersion>2.0.1</EncryptionPreviewVersion>
 		<EncryptionPreviewSuffixVersion>preview</EncryptionPreviewSuffixVersion>

--- a/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
@@ -438,28 +438,6 @@ namespace Microsoft.Azure.Cosmos.Routing
             }
         }
 
-        public async Task<PartitionAddressInformation> UpdateAsync(
-            PartitionKeyRangeIdentity partitionKeyRangeIdentity,
-            CancellationToken cancellationToken)
-        {
-            if (partitionKeyRangeIdentity == null)
-            {
-                throw new ArgumentNullException(nameof(partitionKeyRangeIdentity));
-            }
-
-            cancellationToken.ThrowIfCancellationRequested();
-
-            return await this.serverPartitionAddressCache.GetAsync(
-                       key: partitionKeyRangeIdentity,
-                       singleValueInitFunc: (_) => this.GetAddressesForRangeIdAsync(
-                           null,
-                           cachedAddresses: null,
-                           partitionKeyRangeIdentity.CollectionRid,
-                           partitionKeyRangeIdentity.PartitionKeyRangeId,
-                           forceRefresh: true),
-                       forceRefresh: (_) => true);
-        }
-
         private async Task<Tuple<PartitionKeyRangeIdentity, PartitionAddressInformation>> ResolveMasterAsync(DocumentServiceRequest request, bool forceRefresh)
         {
             Tuple<PartitionKeyRangeIdentity, PartitionAddressInformation> masterAddressAndRange = this.masterPartitionAddressCache;

--- a/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
@@ -411,6 +411,10 @@ namespace Microsoft.Azure.Cosmos.Routing
 
                 foreach (PartitionKeyRangeIdentity pkRangeId in pkRangeIdsCopy)
                 {
+                    // The forceRefresh flag is set to true for the callback delegate is because, if the GetAsync() from the async
+                    // non-blocking cache fails to look up the pkRangeId, then there are some inconsistency present in the cache, and it is
+                    // more safe to do a force refresh to fetch the addresses from the gateway, instead of fetching it from the cache itself.
+                    // Please note that, the chances of encountering such scenario is highly unlikely.
                     PartitionAddressInformation addressInfo = await this.serverPartitionAddressCache.GetAsync(
                        key: pkRangeId,
                        singleValueInitFunc: (_) => this.GetAddressesForRangeIdAsync(
@@ -418,7 +422,7 @@ namespace Microsoft.Azure.Cosmos.Routing
                            cachedAddresses: null,
                            pkRangeId.CollectionRid,
                            pkRangeId.PartitionKeyRangeId,
-                           forceRefresh: false),
+                           forceRefresh: true),
                        forceRefresh: (_) => false);
 
                     IReadOnlyList<TransportAddressUri> transportAddresses = addressInfo.Get(Protocol.Tcp)?.ReplicaTransportAddressUris;

--- a/Microsoft.Azure.Cosmos/src/Routing/GlobalAddressResolver.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GlobalAddressResolver.cs
@@ -228,33 +228,16 @@ namespace Microsoft.Azure.Cosmos.Routing
         }
 
         public async Task UpdateAsync(
-            IReadOnlyList<AddressCacheToken> addressCacheTokens,
-            CancellationToken cancellationToken)
-        {
-            List<Task> tasks = new List<Task>();
-
-            foreach (AddressCacheToken cacheToken in addressCacheTokens)
-            {
-                if (this.addressCacheByEndpoint.TryGetValue(cacheToken.ServiceEndpoint, out EndpointCache endpointCache))
-                {
-                    tasks.Add(endpointCache.AddressCache.UpdateAsync(cacheToken.PartitionKeyRangeIdentity, cancellationToken));
-                }
-            }
-
-            await Task.WhenAll(tasks);
-        }
-
-        public Task UpdateAsync(
            ServerKey serverKey,
            CancellationToken cancellationToken)
         {
             foreach (KeyValuePair<Uri, EndpointCache> addressCache in this.addressCacheByEndpoint)
             {
-                // since we don't know which address cache contains the pkRanges mapped to this node, we do a tryRemove on all AddressCaches of all regions
-                addressCache.Value.AddressCache.TryRemoveAddresses(serverKey);
+                // since we don't know which address cache contains the pkRanges mapped to this node,
+                // we mark all transport uris that has the same server key to unhealthy status in the
+                // AddressCaches of all regions.
+                await addressCache.Value.AddressCache.MarkAddressesToUnhealthyAsync(serverKey);
             }
-
-            return Task.CompletedTask;
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Tracing/TraceTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Tracing/TraceTests.cs
@@ -125,6 +125,8 @@
             storeResultProperties.Remove(nameof(storeResult.Target.Exception));
             storeResultProperties.Add("transportRequestTimeline");
             storeResultProperties.Remove(nameof(storeResult.Target.TransportRequestStats));
+            storeResultProperties.Add("ReplicaHealthStatuses");
+            storeResultProperties.Remove(nameof(storeResult.Target.ReplicaHealthStatuses));
 
             foreach (string key in jsonPropertyNames)
             {


### PR DESCRIPTION
# Pull Request Template

## Description

- This PR refactors the code in `GatewayAddressCache` to mark a `TransportAddress` to `Unhealthy` when a connection reset event occurs through the `ConnectionStateListener`.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Closing issues

To automatically close an issue: closes #3738 