### PR TITLE
Change Feed Processor: Fixes LeaseLostException leaks on notification APIs for Renew scenarios

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseManagerCosmos.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseManagerCosmos.cs
@@ -190,7 +190,17 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
                     if (serverLease.Owner != lease.Owner)
                     {
                         DefaultTrace.TraceInformation("Lease with token {0} no need to release lease. The lease was already taken by another host '{1}'.", lease.CurrentLeaseToken, serverLease.Owner);
-                        throw new LeaseLostException(lease);
+                        throw new LeaseLostException(
+                            lease,
+                            CosmosExceptionFactory.Create(
+                                statusCode: HttpStatusCode.PreconditionFailed,
+                                message: $"{lease.CurrentLeaseToken} lease token was taken over by owner '{serverLease.Owner}'",
+                                headers: new Headers(),
+                                stackTrace: default,
+                                trace: NoOpTrace.Singleton,
+                                error: default,
+                                innerException: default),
+                            isGone: false);
                     }
                     serverLease.Owner = null;
                     return serverLease;
@@ -232,7 +242,17 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
                     if (serverLease.Owner != lease.Owner)
                     {
                         DefaultTrace.TraceInformation("Lease with token {0} was taken over by owner '{1}'", lease.CurrentLeaseToken, serverLease.Owner);
-                        throw new LeaseLostException(lease);
+                        throw new LeaseLostException(
+                            lease,
+                            CosmosExceptionFactory.Create(
+                                statusCode: HttpStatusCode.PreconditionFailed,
+                                message: $"{lease.CurrentLeaseToken} lease token was taken over by owner '{serverLease.Owner}'",
+                                headers: new Headers(),
+                                stackTrace: default,
+                                trace: NoOpTrace.Singleton,
+                                error: default,
+                                innerException: default),
+                            isGone: false);
                     }
                     return serverLease;
                 }).ConfigureAwait(false);
@@ -257,7 +277,17 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
                     if (serverLease.Owner != lease.Owner)
                     {
                         DefaultTrace.TraceInformation("Lease with token '{0}' was taken over by owner '{1}'", lease.CurrentLeaseToken, serverLease.Owner);
-                        throw new LeaseLostException(lease);
+                        throw new LeaseLostException(
+                            lease,
+                            CosmosExceptionFactory.Create(
+                                statusCode: HttpStatusCode.PreconditionFailed,
+                                message: $"{lease.CurrentLeaseToken} lease token was taken over by owner '{serverLease.Owner}'",
+                                headers: new Headers(),
+                                stackTrace: default,
+                                trace: NoOpTrace.Singleton,
+                                error: default,
+                                innerException: default),
+                            isGone: false);
                     }
                     serverLease.Properties = lease.Properties;
                     return serverLease;

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseManagerCosmos.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseManagerCosmos.cs
@@ -265,7 +265,17 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
             if (lease.Owner != this.options.HostName)
             {
                 DefaultTrace.TraceInformation("Lease with token '{0}' was taken over by owner '{1}' before lease properties update", lease.CurrentLeaseToken, lease.Owner);
-                throw new LeaseLostException(lease);
+                throw new LeaseLostException(
+                    lease,
+                    CosmosExceptionFactory.Create(
+                        statusCode: HttpStatusCode.PreconditionFailed,
+                        message: $"{lease.CurrentLeaseToken} lease token was taken over by owner '{lease.Owner}'",
+                        headers: new Headers(),
+                        stackTrace: default,
+                        trace: NoOpTrace.Singleton,
+                        error: default,
+                        innerException: default),
+                    isGone: false);
             }
 
             return await this.leaseUpdater.UpdateLeaseAsync(

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseManagerCosmosTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseManagerCosmosTests.cs
@@ -357,6 +357,201 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         }
 
         /// <summary>
+        /// Verifies that if the renewed read a different Owner from the captured in memory, throws a LeaseLost
+        /// </summary>
+        [TestMethod]
+        public async Task IfOwnerChangedThrowOnRenew()
+        {
+            DocumentServiceLeaseStoreManagerOptions options = new DocumentServiceLeaseStoreManagerOptions
+            {
+                HostName = Guid.NewGuid().ToString()
+            };
+
+            DocumentServiceLeaseCore lease = new DocumentServiceLeaseCore()
+            {
+                LeaseToken = "0",
+                Owner = Guid.NewGuid().ToString(),
+                FeedRange = new FeedRangePartitionKeyRange("0")
+            };
+
+            Mock<DocumentServiceLeaseUpdater> mockUpdater = new Mock<DocumentServiceLeaseUpdater>();
+
+            Func<Func<DocumentServiceLease, DocumentServiceLease>, bool> validateUpdater = (Func<DocumentServiceLease, DocumentServiceLease> updater) =>
+            {
+                // Simulate dirty read from db
+                DocumentServiceLeaseCore serverLease = new DocumentServiceLeaseCore()
+                {
+                    LeaseToken = "0",
+                    Owner = Guid.NewGuid().ToString(),
+                    FeedRange = new FeedRangePartitionKeyRange("0")
+                };
+                DocumentServiceLease afterUpdateLease = updater(serverLease);
+                return true;
+            };
+
+            mockUpdater.Setup(c => c.UpdateLeaseAsync(
+                It.IsAny<DocumentServiceLease>(),
+                It.IsAny<string>(),
+                It.IsAny<PartitionKey>(),
+                It.Is<Func<DocumentServiceLease, DocumentServiceLease>>(f => validateUpdater(f))))
+                .ReturnsAsync(lease);
+
+            ResponseMessage leaseResponse = new ResponseMessage(System.Net.HttpStatusCode.OK)
+            {
+                Content = new CosmosJsonDotNetSerializer().ToStream(lease)
+            };
+
+            Mock<ContainerInternal> leaseContainer = new Mock<ContainerInternal>();
+            leaseContainer.Setup(c => c.ReadItemStreamAsync(
+                It.IsAny<string>(),
+                It.IsAny<PartitionKey>(),
+                It.IsAny<ItemRequestOptions>(),
+                It.IsAny<CancellationToken>())).ReturnsAsync(leaseResponse);
+
+            DocumentServiceLeaseManagerCosmos documentServiceLeaseManagerCosmos = new DocumentServiceLeaseManagerCosmos(
+                Mock.Of<ContainerInternal>(),
+                leaseContainer.Object,
+                mockUpdater.Object,
+                options,
+                Mock.Of<RequestOptionsFactory>());
+
+            LeaseLostException leaseLost = await Assert.ThrowsExceptionAsync<LeaseLostException>(() => documentServiceLeaseManagerCosmos.RenewAsync(lease));
+
+            Assert.IsTrue(leaseLost.InnerException is CosmosException innerCosmosException
+                && innerCosmosException.StatusCode == HttpStatusCode.PreconditionFailed);
+        }
+
+        /// <summary>
+        /// Verifies that if the update properties read a different Owner from the captured in memory, throws a LeaseLost
+        /// </summary>
+        [TestMethod]
+        public async Task IfOwnerChangedThrowOnUpdateProperties()
+        {
+            DocumentServiceLeaseCore lease = new DocumentServiceLeaseCore()
+            {
+                LeaseToken = "0",
+                Owner = Guid.NewGuid().ToString(),
+                FeedRange = new FeedRangePartitionKeyRange("0")
+            };
+
+            DocumentServiceLeaseStoreManagerOptions options = new DocumentServiceLeaseStoreManagerOptions
+            {
+                HostName = lease.Owner
+            };
+
+            Mock<DocumentServiceLeaseUpdater> mockUpdater = new Mock<DocumentServiceLeaseUpdater>();
+
+            Func<Func<DocumentServiceLease, DocumentServiceLease>, bool> validateUpdater = (Func<DocumentServiceLease, DocumentServiceLease> updater) =>
+            {
+                // Simulate dirty read from db
+                DocumentServiceLeaseCore serverLease = new DocumentServiceLeaseCore()
+                {
+                    LeaseToken = "0",
+                    Owner = Guid.NewGuid().ToString(),
+                    FeedRange = new FeedRangePartitionKeyRange("0")
+                };
+                DocumentServiceLease afterUpdateLease = updater(serverLease);
+                return true;
+            };
+
+            mockUpdater.Setup(c => c.UpdateLeaseAsync(
+                It.IsAny<DocumentServiceLease>(),
+                It.IsAny<string>(),
+                It.IsAny<PartitionKey>(),
+                It.Is<Func<DocumentServiceLease, DocumentServiceLease>>(f => validateUpdater(f))))
+                .ReturnsAsync(lease);
+
+            ResponseMessage leaseResponse = new ResponseMessage(System.Net.HttpStatusCode.OK)
+            {
+                Content = new CosmosJsonDotNetSerializer().ToStream(lease)
+            };
+
+            Mock<ContainerInternal> leaseContainer = new Mock<ContainerInternal>();
+            leaseContainer.Setup(c => c.ReadItemStreamAsync(
+                It.IsAny<string>(),
+                It.IsAny<PartitionKey>(),
+                It.IsAny<ItemRequestOptions>(),
+                It.IsAny<CancellationToken>())).ReturnsAsync(leaseResponse);
+
+            DocumentServiceLeaseManagerCosmos documentServiceLeaseManagerCosmos = new DocumentServiceLeaseManagerCosmos(
+                Mock.Of<ContainerInternal>(),
+                leaseContainer.Object,
+                mockUpdater.Object,
+                options,
+                Mock.Of<RequestOptionsFactory>());
+
+            LeaseLostException leaseLost = await Assert.ThrowsExceptionAsync<LeaseLostException>(() => documentServiceLeaseManagerCosmos.UpdatePropertiesAsync(lease));
+
+            Assert.IsTrue(leaseLost.InnerException is CosmosException innerCosmosException
+                && innerCosmosException.StatusCode == HttpStatusCode.PreconditionFailed);
+        }
+
+        /// <summary>
+        /// Verifies that if the update properties read a different Owner from the captured in memory, throws a LeaseLost
+        /// </summary>
+        [TestMethod]
+        public async Task IfOwnerChangedThrowOnRelease()
+        {
+            DocumentServiceLeaseStoreManagerOptions options = new DocumentServiceLeaseStoreManagerOptions
+            {
+                HostName = Guid.NewGuid().ToString()
+            };
+
+            DocumentServiceLeaseCore lease = new DocumentServiceLeaseCore()
+            {
+                LeaseToken = "0",
+                Owner = Guid.NewGuid().ToString(),
+                FeedRange = new FeedRangePartitionKeyRange("0")
+            };
+
+            Mock<DocumentServiceLeaseUpdater> mockUpdater = new Mock<DocumentServiceLeaseUpdater>();
+
+            Func<Func<DocumentServiceLease, DocumentServiceLease>, bool> validateUpdater = (Func<DocumentServiceLease, DocumentServiceLease> updater) =>
+            {
+                // Simulate dirty read from db
+                DocumentServiceLeaseCore serverLease = new DocumentServiceLeaseCore()
+                {
+                    LeaseToken = "0",
+                    Owner = Guid.NewGuid().ToString(),
+                    FeedRange = new FeedRangePartitionKeyRange("0")
+                };
+                DocumentServiceLease afterUpdateLease = updater(serverLease);
+                return true;
+            };
+
+            mockUpdater.Setup(c => c.UpdateLeaseAsync(
+                It.IsAny<DocumentServiceLease>(),
+                It.IsAny<string>(),
+                It.IsAny<PartitionKey>(),
+                It.Is<Func<DocumentServiceLease, DocumentServiceLease>>(f => validateUpdater(f))))
+                .ReturnsAsync(lease);
+
+            ResponseMessage leaseResponse = new ResponseMessage(System.Net.HttpStatusCode.OK)
+            {
+                Content = new CosmosJsonDotNetSerializer().ToStream(lease)
+            };
+
+            Mock<ContainerInternal> leaseContainer = new Mock<ContainerInternal>();
+            leaseContainer.Setup(c => c.ReadItemStreamAsync(
+                It.IsAny<string>(),
+                It.IsAny<PartitionKey>(),
+                It.IsAny<ItemRequestOptions>(),
+                It.IsAny<CancellationToken>())).ReturnsAsync(leaseResponse);
+
+            DocumentServiceLeaseManagerCosmos documentServiceLeaseManagerCosmos = new DocumentServiceLeaseManagerCosmos(
+                Mock.Of<ContainerInternal>(),
+                leaseContainer.Object,
+                mockUpdater.Object,
+                options,
+                Mock.Of<RequestOptionsFactory>());
+
+            LeaseLostException leaseLost = await Assert.ThrowsExceptionAsync<LeaseLostException>(() => documentServiceLeaseManagerCosmos.ReleaseAsync(lease));
+
+            Assert.IsTrue(leaseLost.InnerException is CosmosException innerCosmosException
+                && innerCosmosException.StatusCode == HttpStatusCode.PreconditionFailed);
+        }
+
+        /// <summary>
         /// When a lease is missing the range information, check that we are adding it
         /// </summary>
         [TestMethod]


### PR DESCRIPTION
## Description

https://github.com/Azure/azure-cosmos-dotnet-v3/pull/3401 covered the most common cases reported for LeaseLostException leaks, including the case where `AcquireAsync` would fail because of lease rebalancing.

From personal testing, there was another case that was discovered: When a lease is Renewed on the background on scenarios where there is **no activity**, and during the no activity period, the lease is rebalanced, the exception that gets sent to the Notification APIs is a LeaseLostException (internal).

Because the Notification APIs will inspect the LeaseLostException.InnerException to log that if present, this PR covers all the other cases in `DocumentServiceLeaseManagerCosmos` where there is lease rebalancing (Renew, UpdateProperties, Release) to avoid throwing the LeaseLostException.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update