### PR TITLE
Connectivity: Fixes ConnectionBroken and adds support for Burst Capacity

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
 		<ClientOfficialVersion>3.32.2</ClientOfficialVersion>
 		<ClientPreviewVersion>3.32.2</ClientPreviewVersion>
 		<ClientPreviewSuffixVersion>preview</ClientPreviewSuffixVersion>
-		<DirectVersion>3.30.2</DirectVersion>
+		<DirectVersion>3.30.20</DirectVersion>
 		<EncryptionOfficialVersion>2.0.1</EncryptionOfficialVersion>
 		<EncryptionPreviewVersion>2.0.1</EncryptionPreviewVersion>
 		<EncryptionPreviewSuffixVersion>preview</EncryptionPreviewSuffixVersion>


### PR DESCRIPTION
When enabling Burst Capacity on an account, a client running on Direct mode can encounter:

```
Microsoft.Azure.Documents.TransportException: A client transport error occurred: The connection failed. (Time: 2023-03-28T05:20:21.3266713Z, activity ID: 814c6f9a-6413-4152-bbbe-29cdd33ef362, error code: ConnectionBroken [0x0012], base error: HRESULT 0x80131508, URI: rntbd://10.0.2.32:14300/apps/f9e22fdc-bc10-4c67-a092-e0e3791b7ab3/services/df313d2f-cdf3-4ebf-a5ff-e58ff1e6596c/partitions/f4ef0a42-650c-4ef2-9aff-081c993080cd/replicas/133045491009455711p, connection: 10.0.1.5:59554 -> 10.0.2.32:14300, payload sent: True) --->
System.IndexOutOfRangeException: Index was outside the bounds of the array.

   at Microsoft.Azure.Documents.RntbdTokenStream`1.ParseFrom(BytesDeserializer& reader)
   at Microsoft.Azure.Documents.Rntbd.Dispatcher.<ReceiveLoopAsync>d__41.MoveNext()
```