### PR TITLE
SummaryDiagnostics: Refactors Code to Remove Dependency of HttpResponseHeadersWrapper to fetch Sub Status Codes

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Tracing/TraceData/SummaryDiagnostics.cs
+++ b/Microsoft.Azure.Cosmos/src/Tracing/TraceData/SummaryDiagnostics.cs
@@ -166,7 +166,7 @@ namespace Microsoft.Azure.Cosmos.Tracing.TraceData
                     .TryGetValues(
                         name: Documents.WFConstants.BackendHeaders.SubStatus,
                         values: out IEnumerable<string> httpResponseHeaderValues) ?
-                        httpResponseHeaderValues.First() :
+                        httpResponseHeaderValues.FirstOrDefault() :
                         null;
         }
     }

--- a/Microsoft.Azure.Cosmos/src/Tracing/TraceData/SummaryDiagnostics.cs
+++ b/Microsoft.Azure.Cosmos/src/Tracing/TraceData/SummaryDiagnostics.cs
@@ -166,7 +166,7 @@ namespace Microsoft.Azure.Cosmos.Tracing.TraceData
                     .TryGetValues(
                         name: Documents.WFConstants.BackendHeaders.SubStatus,
                         values: out IEnumerable<string> httpResponseHeaderValues) ?
-                        string.Join(",", httpResponseHeaderValues) :
+                        httpResponseHeaderValues.First() :
                         null;
         }
     }

--- a/Microsoft.Azure.Cosmos/src/Tracing/TraceData/SummaryDiagnostics.cs
+++ b/Microsoft.Azure.Cosmos/src/Tracing/TraceData/SummaryDiagnostics.cs
@@ -152,55 +152,22 @@ namespace Microsoft.Azure.Cosmos.Tracing.TraceData
         }
 
         /// <summary>
-        /// Gets the sub status code as a comma separated value from the http response message headers or
-        /// from the http response content headers. If the sub status code header is not found in either
-        /// of the two, then returns a null.
+        /// Gets the sub status code as a comma separated value from the http response message headers.
+        /// If the sub status code header is not found, then returns null.
         /// </summary>
         /// <param name="httpResponseStatistics">An instance of <see cref="HttpResponseStatistics"/>.</param>
         /// <returns>A string containing the sub status code.</returns>
         private static string GetSubStatusCodes(
             HttpResponseStatistics httpResponseStatistics)
         {
-            if (httpResponseStatistics
-                .HttpResponseMessage
-                .Headers
-                .Contains(Documents.WFConstants.BackendHeaders.SubStatus))
-            {
-                httpResponseStatistics
+            return httpResponseStatistics
                     .HttpResponseMessage
                     .Headers
                     .TryGetValues(
                         name: Documents.WFConstants.BackendHeaders.SubStatus,
-                        values: out IEnumerable<string> httpResponseHeaderValues);
-
-                if (httpResponseHeaderValues != null && httpResponseHeaderValues.Any())
-                {
-                    return string.Join(",", httpResponseHeaderValues);
-                }
-            }
-
-            if ((httpResponseStatistics
-                .HttpResponseMessage
-                .Content?
-                .Headers
-                .Contains(Documents.WFConstants.BackendHeaders.SubStatus))
-                .Value)
-            {
-                httpResponseStatistics
-                    .HttpResponseMessage
-                    .Content
-                    .Headers
-                    .TryGetValues(
-                        name: Documents.WFConstants.BackendHeaders.SubStatus,
-                        values: out IEnumerable<string> httpContentHeaderValues);
-
-                if (httpContentHeaderValues != null && httpContentHeaderValues.Any())
-                {
-                    return string.Join(",", httpContentHeaderValues);
-                }
-            }
-
-            return null;
+                        values: out IEnumerable<string> httpResponseHeaderValues) ?
+                        string.Join(",", httpResponseHeaderValues) :
+                        null;
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/SummaryDiagnosticsTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/SummaryDiagnosticsTests.cs
@@ -139,15 +139,18 @@
         public async Task SummaryDiagnostics_WhenContainerDoesNotExists_ShouldRecordSubStatusCode()
         {
             string partitionKey = "/pk";
-            string databaseName = "testdb";
-            string containerName = "testcontainer";
             int notFoundStatusCode = 404, notFoundSubStatusCode = 1003;
-            CosmosClient cosmosClient = TestCommon.CreateCosmosClient(useGateway: false);
+            using CosmosClient cosmosClient = TestCommon.CreateCosmosClient(useGateway: false);
 
             try
             {
-                Container container = cosmosClient.GetContainer(databaseName, containerName);
-                ItemResponse<dynamic> readResponse = await container.ReadItemAsync<dynamic>(partitionKey, new Cosmos.PartitionKey(partitionKey));
+                Container container = cosmosClient.GetContainer(
+                    databaseId: Guid.NewGuid().ToString(),
+                    containerId: Guid.NewGuid().ToString());
+
+                ItemResponse<dynamic> readResponse = await container.ReadItemAsync<dynamic>(
+                    partitionKey,
+                    new Cosmos.PartitionKey(partitionKey));
             }
             catch (CosmosException ex)
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/SummaryDiagnosticsTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/SummaryDiagnosticsTests.cs
@@ -128,5 +128,35 @@
             Assert.AreEqual(summaryDiagnostics.DirectRequestsSummary.Value[(410, (int)SubStatusCodes.TransportGenerated410)], 3);
             Assert.AreEqual(summaryDiagnostics.DirectRequestsSummary.Value[(201, 0)], 1);
         }
+
+        /// <summary>
+        /// Test to validate that when a read operation is done on a database and a container that
+        /// does not exists, then the <see cref="SummaryDiagnostics"/> should capture the sub status
+        /// codes successfully.
+        /// </summary>
+        [TestMethod]
+        [Owner("dkunda")]
+        public async Task SummaryDiagnostics_WhenContainerDoesNotExists_ShouldRecordSubStatusCode()
+        {
+            string partitionKey = "/pk";
+            string databaseName = "testdb";
+            string containerName = "testcontainer";
+            int notFoundStatusCode = 404, notFoundSubStatusCode = 1003;
+            CosmosClient cosmosClient = TestCommon.CreateCosmosClient(useGateway: false);
+
+            try
+            {
+                Container container = cosmosClient.GetContainer(databaseName, containerName);
+                ItemResponse<dynamic> readResponse = await container.ReadItemAsync<dynamic>(partitionKey, new Cosmos.PartitionKey(partitionKey));
+            }
+            catch (CosmosException ex)
+            {
+                ITrace trace = ((CosmosTraceDiagnostics)ex.Diagnostics).Value;
+                SummaryDiagnostics summaryDiagnostics = new(trace);
+
+                Assert.IsNotNull(value: summaryDiagnostics);
+                Assert.IsTrue(condition: summaryDiagnostics.GatewayRequestsSummary.Value.ContainsKey((notFoundStatusCode, notFoundSubStatusCode)));
+            }
+        }
     }
 }


### PR DESCRIPTION
# Pull Request Template

## Description

When trying to log cosmos exception, by doing `cosmosException.ToString()` is causing `IndexOutOfRangeException` and the stack trace points out to `HttpResponseHeadersWrapper` constructor. This PR fixes the bug by removing the dependency of `HttpResponseHeadersWrapper` and fetching the required headers from http response/ content message headers.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #3765