### PR TITLE
[Internal] CTL: Fixes docker image pipeline

### DIFF
--- a/azure-pipelines-ctl-publishing.yml
+++ b/azure-pipelines-ctl-publishing.yml
@@ -1,5 +1,5 @@
 variables:
-  VmImage: 'ubuntu-18.04'
+  VmImage: 'ubuntu-latest'
 
 jobs:
   - job: BuildDockerImage


### PR DESCRIPTION
Docker image pipeline is failing due to deprecated VM image:

```
The ubuntu-18.04 environment is deprecated, consider switching to ubuntu-20.04 or ubuntu-22.04 (ubuntu-latest). For more details, see https://github.com/actions/runner-images/issues/6002
```

In order to be future-proof, we should be using `ubuntu-latest`