### PR TITLE
[Internal] Pipelines: Add nightly build to produce packages

### DIFF
--- a/azure-pipelines-nightly.yml
+++ b/azure-pipelines-nightly.yml
@@ -28,5 +28,5 @@ stages:
         VmImage: $(VmImage)
         ReleasePackage: true
         OutputPath: '$(Build.ArtifactStagingDirectory)/bin/AnyCPU/$(BuildConfiguration)/Microsoft.Azure.Cosmos'
-        BlobVersion: ''
+        BlobVersion: 'nightly'
         DeletePreviousContent: false

--- a/azure-pipelines-nightly.yml
+++ b/azure-pipelines-nightly.yml
@@ -29,4 +29,4 @@ stages:
         ReleasePackage: true
         OutputPath: '$(Build.ArtifactStagingDirectory)/bin/AnyCPU/$(BuildConfiguration)/Microsoft.Azure.Cosmos'
         BlobVersion: 'nightly'
-        DeletePreviousContent: false
+        DeletePreviousContent: true

--- a/azure-pipelines-nightly.yml
+++ b/azure-pipelines-nightly.yml
@@ -27,5 +27,5 @@ stages:
         VmImage: $(VmImage)
         ReleasePackage: true
         OutputPath: '$(Build.ArtifactStagingDirectory)/bin/AnyCPU/$(BuildConfiguration)/Microsoft.Azure.Cosmos'
-        BlobVersion: nightly
+        BlobVersion: 'nightly'
         DeletePreviousContent: true

--- a/azure-pipelines-nightly.yml
+++ b/azure-pipelines-nightly.yml
@@ -14,7 +14,9 @@ schedules:
 
 variables:
   VmImage: windows-latest # https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops 
-  BuildConfiguration: Release 
+  BuildConfiguration: Release
+  Packaging.EnableSBOMSigning: true
+  BlobVersion: nightly
 
 stages:
 - stage:
@@ -27,5 +29,5 @@ stages:
         VmImage: $(VmImage)
         ReleasePackage: true
         OutputPath: '$(Build.ArtifactStagingDirectory)/bin/AnyCPU/$(BuildConfiguration)/Microsoft.Azure.Cosmos'
-        BlobVersion: 'nightly'
+        BlobVersion: $(BlobVersion)
         DeletePreviousContent: true

--- a/azure-pipelines-nightly.yml
+++ b/azure-pipelines-nightly.yml
@@ -13,64 +13,19 @@ schedules:
 
 
 variables:
-  ReleaseArguments: ' --filter "TestCategory!=Quarantine" --verbosity normal ' 
   VmImage: windows-latest # https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops 
   BuildConfiguration: Release 
-  IsNightly: true 
-
 
 stages:
 - stage:
-  displayName: Gate 
-  jobs:
-    - template:  templates/static-tools.yml
-      parameters:
-        BuildConfiguration: $(BuildConfiguration)
-        VmImage: $(VmImage)
-
-    
-    - template:  templates/build-test.yml
-      parameters:
-        BuildConfiguration: $(BuildConfiguration)
-        Arguments: $(ReleaseArguments) /p:IsNightly=true /p:GeneratePackageOnBuild=true 
-        VmImage: $(VmImage)
-          
-
-- stage:
   displayName: Publish 
   jobs:
-    - job:
-      pool:
-        vmImage: $(VmImage)
-    
-      steps:
-      - task: DotNetCoreCLI@2
-        displayName: Build Microsoft.Azure.Cosmos
-        inputs: 
-          command: build  
-          configuration: $(BuildConfiguration)
-          nugetConfigPath: NuGet.config
-          projects: Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj 
-          arguments: --configuration $(BuildConfiguration) 
-          versioningScheme: OFF
-          
-      - task: DotNetCoreCLI@2
-        displayName: Pack Microsoft.Azure.Cosmos
-        inputs: 
-          command: pack 
-          configuration: $(BuildConfiguration)
-          searchPatternPack: Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
-          arguments: --configuration $(BuildConfiguration) 
-          versioningScheme: OFF
-          
-      - task: DotNetCoreCLI@2
-        displayName: Push Microsoft.Azure.Cosmos
-        inputs: 
-          command: push 
-          configuration: $(BuildConfiguration)
-          searchPatternPack: Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
-          arguments: --configuration $(BuildConfiguration) 
-          packagesToPush: '$(Build.ArtifactStagingDirectory)/*.nupkg'
-          nuGetFeedType: 'internal'
-          publishVstsFeed: '4000bd49-81c3-47f2-94d8-d1392b95c228/04efb628-f46d-4b48-ac4d-5af5b1c75043' #azure-cosmos-dotnet
-          versioningScheme: OFF
+    - template:  templates/nuget-pack.yml
+      parameters:
+        BuildConfiguration: Release
+        Arguments: /p:IsNightly=true
+        VmImage: $(VmImage)
+        ReleasePackage: true
+        OutputPath: '$(Build.ArtifactStagingDirectory)/bin/AnyCPU/$(BuildConfiguration)/Microsoft.Azure.Cosmos'
+        BlobVersion: nightly
+        DeletePreviousContent: true

--- a/azure-pipelines-nightly.yml
+++ b/azure-pipelines-nightly.yml
@@ -29,4 +29,4 @@ stages:
         ReleasePackage: true
         OutputPath: '$(Build.ArtifactStagingDirectory)/bin/AnyCPU/$(BuildConfiguration)/Microsoft.Azure.Cosmos'
         BlobVersion: 'nightly'
-        DeletePreviousContent: true
+        DeletePreviousContent: false

--- a/azure-pipelines-nightly.yml
+++ b/azure-pipelines-nightly.yml
@@ -16,7 +16,6 @@ variables:
   VmImage: windows-latest # https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops 
   BuildConfiguration: Release
   Packaging.EnableSBOMSigning: true
-  BlobVersion: nightly
 
 stages:
 - stage:
@@ -29,5 +28,5 @@ stages:
         VmImage: $(VmImage)
         ReleasePackage: true
         OutputPath: '$(Build.ArtifactStagingDirectory)/bin/AnyCPU/$(BuildConfiguration)/Microsoft.Azure.Cosmos'
-        BlobVersion: '$(BlobVersion)'
+        BlobVersion: 'nightly'
         DeletePreviousContent: true

--- a/azure-pipelines-nightly.yml
+++ b/azure-pipelines-nightly.yml
@@ -28,5 +28,5 @@ stages:
         VmImage: $(VmImage)
         ReleasePackage: true
         OutputPath: '$(Build.ArtifactStagingDirectory)/bin/AnyCPU/$(BuildConfiguration)/Microsoft.Azure.Cosmos'
-        BlobVersion: nightly
+        BlobVersion: ''
         DeletePreviousContent: false

--- a/azure-pipelines-nightly.yml
+++ b/azure-pipelines-nightly.yml
@@ -29,5 +29,5 @@ stages:
         VmImage: $(VmImage)
         ReleasePackage: true
         OutputPath: '$(Build.ArtifactStagingDirectory)/bin/AnyCPU/$(BuildConfiguration)/Microsoft.Azure.Cosmos'
-        BlobVersion: $(BlobVersion)
+        BlobVersion: '$(BlobVersion)'
         DeletePreviousContent: true

--- a/azure-pipelines-nightly.yml
+++ b/azure-pipelines-nightly.yml
@@ -28,5 +28,5 @@ stages:
         VmImage: $(VmImage)
         ReleasePackage: true
         OutputPath: '$(Build.ArtifactStagingDirectory)/bin/AnyCPU/$(BuildConfiguration)/Microsoft.Azure.Cosmos'
-        BlobVersion: 'nightly'
+        BlobVersion: nightly
         DeletePreviousContent: false

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -32,4 +32,4 @@ stages:
         VmImage: $(VmImage)
         ReleasePackage: true
         OutputPath: '$(Build.ArtifactStagingDirectory)/bin/AnyCPU/$(BuildConfiguration)/Microsoft.Azure.Cosmos'
-        BlobVersion: variables['BlobVersion']
+        BlobVersion: $(BlobVersion)

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -29,7 +29,6 @@ stages:
     - template:  templates/nuget-pack.yml
       parameters:
         BuildConfiguration: Release
-        Arguments: $(ReleaseArguments)
         VmImage: $(VmImage)
         ReleasePackage: true
         OutputPath: '$(Build.ArtifactStagingDirectory)/bin/AnyCPU/$(BuildConfiguration)/Microsoft.Azure.Cosmos'

--- a/templates/nuget-pack.yml
+++ b/templates/nuget-pack.yml
@@ -1,14 +1,27 @@
 # File: templates/nuget-pack.yml
 
 parameters:
-  BuildConfiguration: ''
-  Arguments: ''
-  VmImage: '' # https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops
-  OS: 'Windows'
-  OutputPath: ''
-  ReleasePackage: false
-  BlobVersion: ''
-  DeletePreviousContent: false
+  - name: BuildConfiguration
+    type: string
+    default: ''
+  - name: Arguments
+    type: string
+    default: ''
+  - name: VmImage
+    type: string
+    default: ''
+  - name: OutputPath
+    type: string
+    default: ''
+  - name: BlobVersion
+    type: string
+    default: ''
+  - name: DeletePreviousContent
+    type: boolean
+    default: false
+  - name: ReleasePackage
+    type: boolean
+    default: false
 
 jobs:
 - job: GenerateNugetPackages

--- a/templates/nuget-pack.yml
+++ b/templates/nuget-pack.yml
@@ -37,7 +37,7 @@ jobs:
       configuration: $(BuildConfiguration)
       nugetConfigPath: NuGet.config
       projects: Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj 
-      arguments: --configuration ${{ parameters.BuildConfiguration }} -p:Optimize=true 
+      arguments: --configuration ${{ parameters.BuildConfiguration }} -p:Optimize=true ${{ parameters.Arguments }}
       versioningScheme: OFF
 
   - task: DotNetCoreCLI@2
@@ -60,22 +60,23 @@ jobs:
       inputs:
         BuildDropPath: '$(Build.ArtifactStagingDirectory)/bin/AnyCPU/$(BuildConfiguration)/Microsoft.Azure.Cosmos'
 
-    - task: AzureFileCopy@2
-      displayName: 'Copy Artifacts to Azure SDK Release blob storage'
-      condition: and(succeeded(),ne('${{ parameters.BlobVersion }}', ''))
-      inputs:
-        SourcePath: '$(Build.ArtifactStagingDirectory)/bin/AnyCPU/$(BuildConfiguration)/Microsoft.Azure.Cosmos'
-        azureSubscription: azuresdkpartnerdrops
-        Destination: AzureBlob
-        storage: azuresdkpartnerdrops
-        ContainerName: 'drops'
-        BlobPrefix: 'cosmosdb/csharp/$(BlobVersion)'
-        CleanTargetBeforeCopy: DeletePreviousContent
+    - ${{ if ne(parameters.BlobVersion, '') }}:
+      - task: AzureFileCopy@2
+        displayName: 'Copy Artifacts to Azure SDK Release blob storage'
+        condition: succeeded()
+        inputs:
+          SourcePath: '$(Build.ArtifactStagingDirectory)/bin/AnyCPU/$(BuildConfiguration)/Microsoft.Azure.Cosmos'
+          azureSubscription: azuresdkpartnerdrops
+          Destination: AzureBlob
+          storage: azuresdkpartnerdrops
+          ContainerName: 'drops'
+          BlobPrefix: 'cosmosdb/csharp/$(BlobVersion)'
+          CleanTargetBeforeCopy: DeletePreviousContent
 
-    - task: PublishBuildArtifacts@1
-      displayName: 'Publish Artifacts: Microsoft.Azure.Cosmos'
-      inputs:
-        artifactName: Microsoft.Azure.Cosmos
+      - task: PublishBuildArtifacts@1
+        displayName: 'Publish Artifacts: Microsoft.Azure.Cosmos'
+        inputs:
+          artifactName: Microsoft.Azure.Cosmos
 
-    - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
-      displayName: 'Component Detection'
+      - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+        displayName: 'Component Detection'

--- a/templates/nuget-pack.yml
+++ b/templates/nuget-pack.yml
@@ -62,7 +62,7 @@ jobs:
 
     - task: AzureFileCopy@2
       displayName: 'Copy Artifacts to Azure SDK Release blob storage'
-      condition: and(succeeded(),ne(${{ parameters.BlobVersion }}, ''))
+      condition: and(succeeded(),ne('${{ parameters.BlobVersion }}', ''))
       inputs:
         SourcePath: '$(Build.ArtifactStagingDirectory)/bin/AnyCPU/$(BuildConfiguration)/Microsoft.Azure.Cosmos'
         azureSubscription: azuresdkpartnerdrops

--- a/templates/nuget-pack.yml
+++ b/templates/nuget-pack.yml
@@ -73,10 +73,10 @@ jobs:
           BlobPrefix: 'cosmosdb/csharp/$(BlobVersion)'
           CleanTargetBeforeCopy: DeletePreviousContent
 
-      - task: PublishBuildArtifacts@1
-        displayName: 'Publish Artifacts: Microsoft.Azure.Cosmos'
-        inputs:
-          artifactName: Microsoft.Azure.Cosmos
+    - task: PublishBuildArtifacts@1
+      displayName: 'Publish Artifacts: Microsoft.Azure.Cosmos'
+      inputs:
+        artifactName: Microsoft.Azure.Cosmos
 
-      - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
-        displayName: 'Component Detection'
+    - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+      displayName: 'Component Detection'

--- a/templates/nuget-pack.yml
+++ b/templates/nuget-pack.yml
@@ -8,6 +8,7 @@ parameters:
   OutputPath: ''
   ReleasePackage: false
   BlobVersion: ''
+  DeletePreviousContent: false
 
 jobs:
 - job: GenerateNugetPackages
@@ -47,7 +48,7 @@ jobs:
         BuildDropPath: '$(Build.ArtifactStagingDirectory)/bin/AnyCPU/$(BuildConfiguration)/Microsoft.Azure.Cosmos'
 
     - task: AzureFileCopy@2
-      displayName: ' Copy Artifacts to Azure SDK Release blob storage'
+      displayName: 'Copy Artifacts to Azure SDK Release blob storage'
       condition: and(succeeded(),ne(${{ parameters.BlobVersion }}, ''))
       inputs:
         SourcePath: '$(Build.ArtifactStagingDirectory)/bin/AnyCPU/$(BuildConfiguration)/Microsoft.Azure.Cosmos'
@@ -56,6 +57,7 @@ jobs:
         storage: azuresdkpartnerdrops
         ContainerName: 'drops'
         BlobPrefix: 'cosmosdb/csharp/$(BlobVersion)'
+        CleanTargetBeforeCopy: DeletePreviousContent
 
     - task: PublishBuildArtifacts@1
       displayName: 'Publish Artifacts: Microsoft.Azure.Cosmos'

--- a/templates/nuget-pack.yml
+++ b/templates/nuget-pack.yml
@@ -70,7 +70,7 @@ jobs:
           Destination: AzureBlob
           storage: azuresdkpartnerdrops
           ContainerName: 'drops'
-          BlobPrefix: 'cosmosdb/csharp/$(BlobVersion)'
+          BlobPrefix: 'cosmosdb/csharp/${{ parameters.BlobVersion }}'
           CleanTargetBeforeCopy: DeletePreviousContent
 
     - task: PublishBuildArtifacts@1

--- a/templates/nuget-pack.yml
+++ b/templates/nuget-pack.yml
@@ -62,7 +62,7 @@ jobs:
 
     - task: AzureFileCopy@2
       displayName: 'Copy Artifacts to Azure SDK Release blob storage'
-      condition: and(succeeded(),ne('${{ parameters.BlobVersion }}', ''))
+      condition: and(succeeded(),ne(${{ parameters.BlobVersion }}, ''))
       inputs:
         SourcePath: '$(Build.ArtifactStagingDirectory)/bin/AnyCPU/$(BuildConfiguration)/Microsoft.Azure.Cosmos'
         azureSubscription: azuresdkpartnerdrops


### PR DESCRIPTION
Nightly will create a nupkg with the format: `Microsoft.Azure.Cosmos.{current version}-nightly-{date}.nupkg` (example `Microsoft.Azure.Cosmos.3.32.3-nightly-20230405.nupkg`) then copy it to a `nightly` folder while clearing the folder for any previous nightly build.

This PR:

* Re-enables the old nightly yml, refactoring to produce a package and copy it to target at 0 UTC.
* Add the capability of nuget-pack template to cleanup the publish folder.
* Adjust the official release pipeline to pass parameters correctly to the nuget-pack template for official releases to keep working.
