### PR TITLE
HttpClient: Adds Properties to the Http messages if available

### DIFF
--- a/Microsoft.Azure.Cosmos/src/GatewayStoreClient.cs
+++ b/Microsoft.Azure.Cosmos/src/GatewayStoreClient.cs
@@ -320,6 +320,14 @@ namespace Microsoft.Azure.Cosmos
                 }
             }
 
+            if (request.Properties != null)
+            {
+                foreach (KeyValuePair<string, object> property in request.Properties)
+                {
+                    requestMessage.Properties.Add(property);
+                }
+            }
+
             // add activityId
             Guid activityId = System.Diagnostics.Trace.CorrelationManager.ActivityId;
             Debug.Assert(activityId != Guid.Empty);


### PR DESCRIPTION
An operation is mapped to a DocumentServiceRequest. When the DocumentServiceRequest is sent through Gateway mode, it is converted to an HttpRequestMessage.

The DocumentServiceRequest contains a list of Headers and Properties. 

Today we are just copying the Headers but not the Properties on the HttpRequestMessage. 