### PR TITLE
[Internal] Upgrade Resiliency: Adds Aggressive Replica Validation Logic.

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
@@ -857,17 +857,8 @@ namespace Microsoft.Azure.Cosmos.Routing
                 throw new ArgumentNullException(nameof(addresses));
             }
 
-            IEnumerable<TransportAddressUri> addressesNeedToValidateStatus = addresses
-                .Where(address => this.isFirstPreferredReadRegion ?
-                    address
-                    .GetCurrentHealthState()
-                    .GetHealthStatus() is
-                    TransportAddressHealthState.HealthStatus.Unknown or
-                    TransportAddressHealthState.HealthStatus.UnhealthyPending :
-                    address
-                    .GetCurrentHealthState()
-                    .GetHealthStatus() is
-                    TransportAddressHealthState.HealthStatus.UnhealthyPending);
+            IEnumerable<TransportAddressUri> addressesNeedToValidateStatus = this.GetAddressesNeededToValidateStatus(
+                    transportAddresses: addresses);
 
             if (addressesNeedToValidateStatus.Any())
             {
@@ -928,6 +919,31 @@ namespace Microsoft.Azure.Cosmos.Routing
             }
 
             return newAddresses;
+        }
+
+        /// <summary>
+        /// Returns a list of <see cref="TransportAddressUri"/> needed to validate their health status. Validating
+        /// a uri is done by opening Rntbd connection to that replica, which is a costly operation by nature. Therefore
+        /// vaidating both Unhealthy and Unknown replicas at the same time could impose a high CPU utilization. To avoid
+        /// this situation, validating both Unknown and Unhealthy replicas at the same time is restricted only for the
+        /// first preferred read region at the moment.
+        /// </summary>
+        /// <param name="transportAddresses">A read only list of <see cref="TransportAddressUri"/>s.</param>
+        /// <returns>A list of <see cref="TransportAddressUri"/> that needs to validate their status.</returns>
+        private IEnumerable<TransportAddressUri> GetAddressesNeededToValidateStatus(
+            IReadOnlyList<TransportAddressUri> transportAddresses)
+        {
+            return transportAddresses
+                .Where(address => this.isFirstPreferredReadRegion ?
+                    address
+                        .GetCurrentHealthState()
+                        .GetHealthStatus() is
+                            TransportAddressHealthState.HealthStatus.Unknown or
+                            TransportAddressHealthState.HealthStatus.UnhealthyPending :
+                    address
+                        .GetCurrentHealthState()
+                        .GetHealthStatus() is
+                            TransportAddressHealthState.HealthStatus.UnhealthyPending);
         }
 
         protected virtual void Dispose(bool disposing)

--- a/Microsoft.Azure.Cosmos/src/Routing/GlobalAddressResolver.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GlobalAddressResolver.cs
@@ -216,9 +216,9 @@ namespace Microsoft.Azure.Cosmos.Routing
             CancellationToken cancellationToken)
         {
             request.RequestContext.FirstPreferredReadRegion = this.endpointManager
-                .ReadEndpoints
-                .First()?
-                .ToString();
+                .GetLocation(endpoint: this.endpointManager
+                    .ReadEndpoints
+                    .First());
 
             IAddressResolver resolver = this.GetAddressResolver(request);
             PartitionAddressInformation partitionAddressInformation = await resolver.ResolveAsync(request, forceRefresh, cancellationToken);

--- a/Microsoft.Azure.Cosmos/src/Routing/GlobalAddressResolver.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GlobalAddressResolver.cs
@@ -215,6 +215,11 @@ namespace Microsoft.Azure.Cosmos.Routing
             bool forceRefresh,
             CancellationToken cancellationToken)
         {
+            request.RequestContext.FirstPreferredReadRegion = this.endpointManager
+                .ReadEndpoints
+                .First()?
+                .ToString();
+
             IAddressResolver resolver = this.GetAddressResolver(request);
             PartitionAddressInformation partitionAddressInformation = await resolver.ResolveAsync(request, forceRefresh, cancellationToken);
 
@@ -281,7 +286,8 @@ namespace Microsoft.Azure.Cosmos.Routing
                         this.serviceConfigReader,
                         this.httpClient,
                         this.openConnectionsHandler,
-                        enableTcpConnectionEndpointRediscovery: this.enableTcpConnectionEndpointRediscovery);
+                        enableTcpConnectionEndpointRediscovery: this.enableTcpConnectionEndpointRediscovery,
+                        isFirstPreferredReadRegion: endpoint.Equals(this.endpointManager.ReadEndpoints.First()));
 
                     string location = this.endpointManager.GetLocation(endpoint);
                     AddressResolver addressResolver = new AddressResolver(null, new NullRequestSigner(), location);

--- a/Microsoft.Azure.Cosmos/src/direct/AddressEnumerator.cs
+++ b/Microsoft.Azure.Cosmos/src/direct/AddressEnumerator.cs
@@ -33,7 +33,8 @@ namespace Microsoft.Azure.Documents
         /// </summary>
         public IEnumerable<TransportAddressUri> GetTransportAddresses(IReadOnlyList<TransportAddressUri> transportAddressUris,
                                                                       Lazy<HashSet<TransportAddressUri>> failedEndpoints,
-                                                                      bool replicaAddressValidationEnabled)
+                                                                      bool replicaAddressValidationEnabled,
+                                                                      bool validateUnknownReplicasAggressively)
         {
             if (failedEndpoints == null)
             {
@@ -51,7 +52,8 @@ namespace Microsoft.Azure.Documents
             return AddressEnumerator.ReorderReplicasByHealthStatus(
                 randomPermutation: randomPermutation,
                 lazyFailedReplicasPerRequest: failedEndpoints,
-                replicaAddressValidationEnabled: replicaAddressValidationEnabled);
+                replicaAddressValidationEnabled: replicaAddressValidationEnabled,
+                validateUnknownReplicasAggressively: validateUnknownReplicasAggressively);
         }
 
         /// <summary>
@@ -202,11 +204,13 @@ namespace Microsoft.Azure.Documents
         /// <param name="randomPermutation">A list containing the permutation of the replicas.</param>
         /// <param name="lazyFailedReplicasPerRequest">A lazy set containing the unhealthy replicas.</param>
         /// <param name="replicaAddressValidationEnabled">A boolean flag indicating if the replica validation is enabled.</param>
+        /// <param name="validateUnknownReplicasAggressively">A boolean flag indicating if aggressive validation of unknown replicas are enabled.</param>
         /// <returns>A list of <see cref="TransportAddressUri"/> ordered by the replica health statuses.</returns>
         private static IEnumerable<TransportAddressUri> ReorderReplicasByHealthStatus(
             IEnumerable<TransportAddressUri> randomPermutation,
             Lazy<HashSet<TransportAddressUri>> lazyFailedReplicasPerRequest,
-            bool replicaAddressValidationEnabled)
+            bool replicaAddressValidationEnabled,
+            bool validateUnknownReplicasAggressively)
         {
             HashSet<TransportAddressUri> failedReplicasPerRequest = null;
             if (lazyFailedReplicasPerRequest != null &&
@@ -226,7 +230,8 @@ namespace Microsoft.Azure.Documents
             {
                 return AddressEnumerator.ReorderAddressesWhenReplicaValidationEnabled(
                     addresses: randomPermutation,
-                    failedReplicasPerRequest: failedReplicasPerRequest);
+                    failedReplicasPerRequest: failedReplicasPerRequest,
+                    validateUnknownReplicasAggressively: validateUnknownReplicasAggressively);
             }
         }
 
@@ -238,24 +243,42 @@ namespace Microsoft.Azure.Documents
         /// </summary>
         /// <param name="addresses">A random list containing all of the replica <see cref="TransportAddressUri"/> addresses.</param>
         /// <param name="failedReplicasPerRequest">A hash set containing the failed replica addresses.</param>
+        /// <param name="validateUnknownReplicasAggressively">A boolean flag indicating if aggressive validation of unknown replicas are enabled.</param>
         /// <returns>The reordered list of <see cref="TransportAddressUri"/>.</returns>
         private static IEnumerable<TransportAddressUri> ReorderAddressesWhenReplicaValidationEnabled(
             IEnumerable<TransportAddressUri> addresses,
-            HashSet<TransportAddressUri> failedReplicasPerRequest)
+            HashSet<TransportAddressUri> failedReplicasPerRequest,
+            bool validateUnknownReplicasAggressively)
         {
-            List<TransportAddressUri> failedReplicas = null, pendingReplicas = null;
-            foreach(TransportAddressUri transportAddressUri in addresses)
+            List<TransportAddressUri> unknownReplicas = null, failedReplicas = null, pendingReplicas = null;
+            foreach (TransportAddressUri transportAddressUri in addresses)
             {
                 TransportAddressHealthState.HealthStatus status = AddressEnumerator.GetEffectiveStatus(
                     addressUri: transportAddressUri,
                     failedEndpoints: failedReplicasPerRequest);
 
-                if (status == TransportAddressHealthState.HealthStatus.Connected ||
-                    status == TransportAddressHealthState.HealthStatus.Unknown)
+                if (validateUnknownReplicasAggressively)
                 {
-                    yield return transportAddressUri;
+                    if (status == TransportAddressHealthState.HealthStatus.Connected)
+                    {
+                        yield return transportAddressUri;
+                    }
+                    else if (status == TransportAddressHealthState.HealthStatus.Unknown)
+                    {
+                        unknownReplicas ??= new ();
+                        unknownReplicas.Add(transportAddressUri);
+                    }
                 }
-                else if (status == TransportAddressHealthState.HealthStatus.UnhealthyPending)
+                else
+                {
+                    if (status == TransportAddressHealthState.HealthStatus.Connected
+                        || status == TransportAddressHealthState.HealthStatus.Unknown)
+                    {
+                        yield return transportAddressUri;
+                    }
+                }
+
+                if (status == TransportAddressHealthState.HealthStatus.UnhealthyPending)
                 {
                     pendingReplicas ??= new ();
                     pendingReplicas.Add(transportAddressUri);
@@ -267,6 +290,14 @@ namespace Microsoft.Azure.Documents
                 }
             }
 
+            if (unknownReplicas != null)
+            {
+                foreach (TransportAddressUri transportAddressUri in unknownReplicas)
+                {
+                    yield return transportAddressUri;
+                }
+            }
+
             if (pendingReplicas != null)
             {
                 foreach (TransportAddressUri transportAddressUri in pendingReplicas)
@@ -275,7 +306,7 @@ namespace Microsoft.Azure.Documents
                 }
             }
 
-            if(failedReplicas != null)
+            if (failedReplicas != null)
             {
                 foreach (TransportAddressUri transportAddressUri in failedReplicas)
                 {

--- a/Microsoft.Azure.Cosmos/src/direct/AddressEnumerator.cs
+++ b/Microsoft.Azure.Cosmos/src/direct/AddressEnumerator.cs
@@ -283,7 +283,7 @@ namespace Microsoft.Azure.Documents
                     pendingReplicas ??= new ();
                     pendingReplicas.Add(transportAddressUri);
                 }
-                else
+                else if (status == TransportAddressHealthState.HealthStatus.Unhealthy)
                 {
                     failedReplicas ??= new ();
                     failedReplicas.Add(transportAddressUri);

--- a/Microsoft.Azure.Cosmos/src/direct/DocumentServiceRequestContext.cs
+++ b/Microsoft.Azure.Cosmos/src/direct/DocumentServiceRequestContext.cs
@@ -97,6 +97,11 @@ namespace Microsoft.Azure.Documents
         public string RegionName { get; set; }
 
         /// <summary>
+        /// The first preferred read region.
+        /// </summary>
+        public string FirstPreferredReadRegion { get; set; }
+
+        /// <summary>
         /// Indicates if the request is orginating from  the same Azure region as the Cosmos DB account
         /// </summary>
         public bool LocalRegionRequest { get; set; }

--- a/Microsoft.Azure.Cosmos/src/direct/IAddressEnumerator.cs
+++ b/Microsoft.Azure.Cosmos/src/direct/IAddressEnumerator.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Azure.Documents
     {
         IEnumerable<TransportAddressUri> GetTransportAddresses(IReadOnlyList<TransportAddressUri> transportAddressUris,
                                                                Lazy<HashSet<TransportAddressUri>> failedEndpoints,
-                                                               bool replicaAddressValidationEnabled);
+                                                               bool replicaAddressValidationEnabled,
+                                                               bool validateUnknownReplicasAggressively);
     }
 }

--- a/Microsoft.Azure.Cosmos/src/direct/StoreReader.cs
+++ b/Microsoft.Azure.Cosmos/src/direct/StoreReader.cs
@@ -218,18 +218,18 @@ namespace Microsoft.Azure.Documents
             Exception cancellationException = null;
             Exception exceptionToThrow = null;
             SubStatusCodes subStatusCodeForException = SubStatusCodes.Unknown;
-            IEnumerator<TransportAddressUri> uriEnumerator = this.addressEnumerator
+            IEnumerable<TransportAddressUri> transportAddresses = this.addressEnumerator
                                                             .GetTransportAddresses(transportAddressUris: resolveApiResults,
                                                                                    failedEndpoints: entity.RequestContext.FailedEndpoints,
                                                                                    replicaAddressValidationEnabled: this.isReplicaAddressValidationEnabled,
-                                                                                   validateUnknownReplicasAggressively: aggressiveValidationEnabled)
-                                                            .GetEnumerator();
+                                                                                   validateUnknownReplicasAggressively: aggressiveValidationEnabled);
 
             // The replica health status of the transport address uri will change eventually with the motonically increasing time.
             // However, the purpose of this list is to capture the health status snapshot at this moment.
-            IReadOnlyList<string> replicaHealthStatuses = resolveApiResults
-                .Select(x => x.GetCurrentHealthState().GetHealthStatusDiagnosticString())
-                .ToList();
+            IEnumerable<string> replicaHealthStatuses = transportAddresses
+                .Select(x => x.GetCurrentHealthState().GetHealthStatusDiagnosticString());
+
+            IEnumerator<TransportAddressUri> uriEnumerator = transportAddresses.GetEnumerator();
 
             // Loop until we have the read quorum number of valid responses or if we have read all the replicas
             while (replicasToRead > 0 && uriEnumerator.MoveNext())

--- a/Microsoft.Azure.Cosmos/src/direct/StoreReader.cs
+++ b/Microsoft.Azure.Cosmos/src/direct/StoreReader.cs
@@ -214,7 +214,10 @@ namespace Microsoft.Azure.Documents
 
             bool hasGoneException = false;
             bool hasCancellationException = false;
-            bool aggressiveValidationEnabled = entity.RequestContext.RegionName?.Equals(entity.RequestContext.FirstPreferredReadRegion) ?? false;
+            bool aggressiveValidationEnabled = entity.RequestContext.RegionName?.Equals(
+                value: entity.RequestContext.FirstPreferredReadRegion,
+                comparisonType: StringComparison.OrdinalIgnoreCase) ?? false;
+
             Exception cancellationException = null;
             Exception exceptionToThrow = null;
             SubStatusCodes subStatusCodeForException = SubStatusCodes.Unknown;

--- a/Microsoft.Azure.Cosmos/src/direct/StoreReader.cs
+++ b/Microsoft.Azure.Cosmos/src/direct/StoreReader.cs
@@ -214,7 +214,7 @@ namespace Microsoft.Azure.Documents
 
             bool hasGoneException = false;
             bool hasCancellationException = false;
-            bool aggressiveValidationEnabled = entity.RequestContext.RegionName.Equals(entity.RequestContext.FirstPreferredReadRegion);
+            bool aggressiveValidationEnabled = entity.RequestContext.RegionName?.Equals(entity.RequestContext.FirstPreferredReadRegion) ?? false;
             Exception cancellationException = null;
             Exception exceptionToThrow = null;
             SubStatusCodes subStatusCodeForException = SubStatusCodes.Unknown;


### PR DESCRIPTION
# Pull Request Template

## Description

The purpose of this PR is to validate the Unknown replicas aggressively, only for the first preferred read region and modify the AddressEnumerator sorting logic as Connected > Unknown > UnhealthyPending > Unhealthy. Because validating the Unknown replicas are aggressive in nature, our concurrency logic in RntbdOpenConnectionHandler should handle it gracefully.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Closing issues

To automatically close an issue: closes #IssueNumber