### PR TITLE
Client Encryption: Adds raw key value to MDE Encryption

### DIFF
--- a/Microsoft.Azure.Cosmos.Encryption.Custom/src/MdeServices/MdeEncryptionAlgorithm.cs
+++ b/Microsoft.Azure.Cosmos.Encryption.Custom/src/MdeServices/MdeEncryptionAlgorithm.cs
@@ -14,8 +14,10 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom
     {
         private readonly AeadAes256CbcHmac256EncryptionAlgorithm mdeAeadAes256CbcHmac256EncryptionAlgorithm;
 
+        private readonly byte[] unwrapKey;
+
         // unused for MDE Algorithm.
-        public override byte[] RawKey => null;
+        public override byte[] RawKey => this.unwrapKey;
 
         public override string EncryptionAlgorithm => CosmosEncryptionAlgorithm.MdeAeadAes256CbcHmac256Randomized;
 
@@ -90,9 +92,11 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom
         /// <param name="dataEncryptionKey"> Data Encryption Key </param>
         /// <param name="encryptionType"> Encryption type </param>
         public MdeEncryptionAlgorithm(
+            byte[] unwrapKey,
             Data.Encryption.Cryptography.DataEncryptionKey dataEncryptionKey,
             Data.Encryption.Cryptography.EncryptionType encryptionType)
         {
+            this.unwrapKey = unwrapKey;
             this.mdeAeadAes256CbcHmac256EncryptionAlgorithm = AeadAes256CbcHmac256EncryptionAlgorithm.GetOrCreate(
                 dataEncryptionKey,
                 encryptionType);


### PR DESCRIPTION
## Description

Update is to add raw key to MDE algorithm. Clients using legacy algorithm use the same key storage and API not only for Cosmos DB encryption, but also for others (Azure Storage, generic encryptor...). For this, we leverage the DataEncryptionKeyProvider.FetchDataEncryptionKeyAsync method to load the unwrapped key from the container.
But in current MdeEncryptionAlgorithm, the RawKey property is null by design. 

## Type of change

- [] New feature (non-breaking change which adds functionality)
- [] This change requires a documentation update