### PR TITLE
[Internal] MerlinBot: Fixes text used for auto-close

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -168,7 +168,7 @@
           {
             "name": "addReply",
             "parameters": {
-              "comment": "${issueAuthor} this issue requires more information for the team to be able to help. In case this information is available, please add it and re-open the Issue."
+              "comment": "@${issueAuthor} this issue requires more information for the team to be able to help. In case this information is available, please add it and re-open the Issue."
             }
           },
           {


### PR DESCRIPTION
When auto-closing Issues, the `${issueAuthor}` does not automatically add `@`, so the original author does not receive a notification that they are being mentioned on the message.

This PR fixes it by adding the `@`.