### PR TITLE
Connection: Adds code to sneak peek rntbd health check improvements

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Azure.Cosmos.Routing
                 GatewayAddressCache.ProtocolString(this.protocol));
 
             this.openConnectionsHandler = openConnectionsHandler;
-            this.isReplicaAddressValidationEnabled = Helpers.GetEnvironmentVariableAsBool(
+            this.isReplicaAddressValidationEnabled = Helpers.GetEnvironmentVariable(
                 name: Constants.EnvironmentVariables.ReplicaConnectivityValidationEnabled,
                 defaultValue: false);
         }

--- a/Microsoft.Azure.Cosmos/src/direct/Channel.cs
+++ b/Microsoft.Azure.Cosmos/src/direct/Channel.cs
@@ -221,6 +221,7 @@ namespace Microsoft.Azure.Documents.Rntbd
                 Debug.Assert(object.ReferenceEquals(completedTask, tasks[1]));
                 timer.CancelTimer();
 
+                this.dispatcher.CompleteCall(request.IsReadOnlyRequest);
                 if (completedTask.IsFaulted)
                 {
                     await completedTask;

--- a/Microsoft.Azure.Cosmos/src/direct/Channel.cs
+++ b/Microsoft.Azure.Cosmos/src/direct/Channel.cs
@@ -205,7 +205,7 @@ namespace Microsoft.Azure.Documents.Rntbd
                 callArguments.CommonArguments.SnapshotCallState(
                     out timeoutCode, out payloadSent);
                 Debug.Assert(TransportException.IsTimeout(timeoutCode));
-                this.dispatcher.CancelCall(callArguments.PreparedCall);
+                this.dispatcher.CancelCall(callArguments.PreparedCall, request.IsReadOnlyRequest);
                 Channel.HandleTaskTimeout(tasks[1], activityId);
                 Exception ex = completedTask.Exception?.InnerException;
                 DefaultTrace.TraceWarning("RNTBD call timed out on channel {0}. Error: {1}",

--- a/Microsoft.Azure.Cosmos/src/direct/Channel.cs
+++ b/Microsoft.Azure.Cosmos/src/direct/Channel.cs
@@ -221,7 +221,7 @@ namespace Microsoft.Azure.Documents.Rntbd
                 Debug.Assert(object.ReferenceEquals(completedTask, tasks[1]));
                 timer.CancelTimer();
 
-                this.dispatcher.CompleteCall(request.IsReadOnlyRequest);
+                this.dispatcher.CompleteCall();
                 if (completedTask.IsFaulted)
                 {
                     await completedTask;

--- a/Microsoft.Azure.Cosmos/src/direct/Connection.cs
+++ b/Microsoft.Azure.Cosmos/src/direct/Connection.cs
@@ -175,7 +175,7 @@ namespace Microsoft.Azure.Documents.Rntbd
                 }
 
                 DateTime currentTime = DateTime.UtcNow;
-                int transitTimeoutCounter = -1, transitTimeoutWriteCounter = -1;
+                int transitTimeoutCounter = 0, transitTimeoutWriteCounter = 0;
 
                 this.SnapshotConnectionTimestamps(
                     out DateTime lastSendAttempt,

--- a/Microsoft.Azure.Cosmos/src/direct/ConnectionHealthChecker.cs
+++ b/Microsoft.Azure.Cosmos/src/direct/ConnectionHealthChecker.cs
@@ -186,7 +186,7 @@ namespace Microsoft.Azure.Documents
                 currentTime: currentTime,
                 lastReceive: lastReceive))
             {
-                return true;
+                return false;
             }
 
             // See https://aka.ms/zero-byte-send.
@@ -196,7 +196,7 @@ namespace Microsoft.Azure.Documents
         }
 
         /// <summary>
-        /// blabla,
+        /// Detects transit timeouts.
         /// </summary>
         /// <param name="transitTimeoutCounter"></param>
         /// <param name="transitTimeoutWriteCounter"></param>
@@ -258,7 +258,7 @@ namespace Microsoft.Azure.Documents
         }
 
         /// <summary>
-        /// blabla.
+        /// Detects black hole.
         /// </summary>
         /// <param name="currentTime"></param>
         /// <param name="lastSendAttempt"></param>
@@ -316,7 +316,7 @@ namespace Microsoft.Azure.Documents
         }
 
         /// <summary>
-        /// blabla.
+        /// Detects frequent data retrival.
         /// </summary>
         /// <param name="currentTime"></param>
         /// <param name="lastReceiveTime"></param>
@@ -329,7 +329,7 @@ namespace Microsoft.Azure.Documents
         }
 
         /// <summary>
-        /// blabla.
+        /// Detects Idle Timeout.
         /// </summary>
         /// <param name="currentTime"></param>
         /// <param name="lastReceive"></param>
@@ -351,7 +351,7 @@ namespace Microsoft.Azure.Documents
         }
 
         /// <summary>
-        /// blabla.
+        /// Detects socket connectivity.
         /// </summary>
         /// <param name="socket"></param>
         /// <returns>A bool.</returns>

--- a/Microsoft.Azure.Cosmos/src/direct/ConnectionHealthChecker.cs
+++ b/Microsoft.Azure.Cosmos/src/direct/ConnectionHealthChecker.cs
@@ -1,0 +1,320 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Documents
+{
+    using System;
+    using System.Diagnostics;
+    using System.Globalization;
+    using System.Net.Sockets;
+    using Microsoft.Azure.Cosmos.Core.Trace;
+    using Microsoft.Azure.Documents.Rntbd;
+
+    /// <summary>
+    /// ConnectionHealthChecker listens to the connection reset event notification fired by the transport client
+    /// and refreshes the Document client's address cache
+    /// </summary>
+    internal sealed class ConnectionHealthChecker
+    {
+        private const int MinNumberOfSendsSinceLastReceiveForUnhealthyConnection = 3;
+
+        // The connection will declare itself unhealthy if the
+        // (lastSendTime - lastReceiveTime) gap grows beyond this value.
+        // receiveDelayLimit must be greater than receiveHangGracePeriod.
+        private readonly TimeSpan receiveDelayLimit;
+
+        // The connection will declare itself unhealthy if the
+        // (lastSendAttemptTime - lastSendTime) gap grows beyond this value.
+        // sendDelayLimit must be greater than sendHangGracePeriod.
+        private readonly TimeSpan sendDelayLimit;
+
+        private readonly TimeSpan idleConnectionTimeout;
+        private readonly bool timeoutDetectionEnabled;
+        private readonly TimeSpan timeoutDetectionTimeLimit;
+        private readonly int timeoutDetectionOnWriteThreshold;
+        private readonly TimeSpan timeoutDetectionOnWriteTimeLimit;
+        private readonly int timeoutDetectionHighFrequencyThreshold;
+        private readonly TimeSpan timeoutDetectionHighFrequencyTimeLimit;
+        private readonly double timeoutDetectionDisableCPUThreshold;
+        private readonly SystemUtilizationReaderBase systemUtilizationReader = SystemUtilizationReaderBase.SingletonInstance;
+
+        // The connection should not declare itself unhealthy if a send was
+        // attempted very recently. As such, ignore
+        // (lastSendAttemptTime - lastSendTime) gaps lower than sendHangGracePeriod.
+        // The grace period should be large enough to accommodate slow sends.
+        // In effect, a setting of 2s requires the client to be able to send
+        // data at least at 1 MB/s for 2 MB documents.
+        private static readonly TimeSpan sendHangGracePeriod = TimeSpan.FromSeconds(2.0);
+
+        // The connection should not declare itself unhealthy if a send
+        // succeeded very recently. As such, ignore
+        // (lastSendTime - lastReceiveTime) gaps lower than receiveHangGracePeriod.
+        // The grace period should be large enough to accommodate the round trip
+        // time of the slowest server request. Assuming 1s of network RTT,
+        // a 2 MB request, a 2 MB response, a connection that can sustain
+        // 1 MB/s both ways, and a 5-second deadline at the server, 10 seconds
+        // should be enough.
+        private static readonly TimeSpan receiveHangGracePeriod = TimeSpan.FromSeconds(10.0);
+
+        private static readonly TimeSpan recentReceiveWindow = TimeSpan.FromSeconds(1.0);
+
+        private static readonly byte[] healthCheckBuffer = new byte[1];
+
+        /// <summary>
+        /// Ctor.
+        /// </summary>
+        /// <param name="sendDelayLimit"></param>
+        /// <param name="receiveDelayLimit"></param>
+        /// <param name="timeoutDetectionEnabled"></param>
+        /// <param name="idleConnectionTimeout"></param>
+        /// <param name="timeoutDetectionTimeLimit"></param>
+        /// <param name="timeoutDetectionOnWriteThreshold"></param>
+        /// <param name="timeoutDetectionOnWriteTimeLimit"></param>
+        /// <param name="timeoutDetectionHighFrequencyThreshold"></param>
+        /// <param name="timeoutDetectionHighFrequencyTimeLimit"></param>
+        /// <param name="timeoutDetectionDisableCPUThreshold"></param>
+        public ConnectionHealthChecker(
+            TimeSpan sendDelayLimit,
+            TimeSpan receiveDelayLimit,
+            bool timeoutDetectionEnabled,
+            TimeSpan idleConnectionTimeout,
+            TimeSpan timeoutDetectionTimeLimit,
+            int timeoutDetectionOnWriteThreshold,
+            TimeSpan timeoutDetectionOnWriteTimeLimit,
+            int timeoutDetectionHighFrequencyThreshold,
+            TimeSpan timeoutDetectionHighFrequencyTimeLimit,
+            double timeoutDetectionDisableCPUThreshold)
+        {
+            if (receiveDelayLimit <= ConnectionHealthChecker.receiveHangGracePeriod)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(receiveDelayLimit),
+                    receiveDelayLimit,
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        "{0} must be greater than {1} ({2})",
+                        nameof(receiveDelayLimit),
+                        nameof(ConnectionHealthChecker.receiveHangGracePeriod),
+                        ConnectionHealthChecker.receiveHangGracePeriod));
+            }
+            if (sendDelayLimit <= ConnectionHealthChecker.sendHangGracePeriod)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(sendDelayLimit),
+                    sendDelayLimit,
+                    string.Format(
+                        CultureInfo.InvariantCulture,
+                        "{0} must be greater than {1} ({2})",
+                        nameof(sendDelayLimit),
+                        nameof(ConnectionHealthChecker.sendHangGracePeriod),
+                        ConnectionHealthChecker.sendHangGracePeriod));
+            }
+
+            // TODO" To be read from the configs.
+            this.sendDelayLimit = sendDelayLimit;
+            this.receiveDelayLimit = receiveDelayLimit;
+            this.idleConnectionTimeout = idleConnectionTimeout;
+            this.timeoutDetectionEnabled = timeoutDetectionEnabled;
+            this.timeoutDetectionTimeLimit = timeoutDetectionTimeLimit;
+            this.timeoutDetectionOnWriteThreshold = timeoutDetectionOnWriteThreshold;
+            this.timeoutDetectionOnWriteTimeLimit = timeoutDetectionOnWriteTimeLimit;
+            this.timeoutDetectionHighFrequencyThreshold = timeoutDetectionHighFrequencyThreshold;
+            this.timeoutDetectionHighFrequencyTimeLimit = timeoutDetectionHighFrequencyTimeLimit;
+            this.timeoutDetectionDisableCPUThreshold = timeoutDetectionDisableCPUThreshold;
+        }
+
+        /// <summary>
+        /// blabla,
+        /// </summary>
+        /// <param name="transitTimeoutCounter"></param>
+        /// <param name="transitTimeoutWriteCounter"></param>
+        /// <param name="lastReadTime"></param>
+        /// <returns>Bool.</returns>
+        public bool ValidateTransitTimeouts(
+            int transitTimeoutCounter,
+            int transitTimeoutWriteCounter,
+            DateTime lastReadTime)
+        {
+            DateTime now = DateTime.UtcNow;
+            if (this.timeoutDetectionEnabled &&
+                transitTimeoutCounter > 0)
+            {
+                // Transit timeout can be a normal symptom under high CPU load.
+                // When request timeout due to high CPU,
+                // close the existing the connection and re-establish a new one will not help the issue but rather make it worse, return fast
+                if (this.systemUtilizationReader.GetSystemWideCpuUsage() > this.timeoutDetectionDisableCPUThreshold)
+                {
+                    DefaultTrace.TraceWarning(
+                        "Unhealthy RNTBD connection: Health check failed due to transit timeout detection time limit: {0}. " +
+                        "Last send attempt: {1:o}. Last send: {2:o}. " +
+                        "Tolerance {3:c}");
+                    return true;
+                }
+
+                TimeSpan readDelay = now - lastReadTime;
+
+                // The channel will be closed if all requests are failed due to transit timeout within the time limit.
+                // This helps to close channel faster for sparse workload.
+                if (readDelay >= this.timeoutDetectionTimeLimit)
+                {
+                    DefaultTrace.TraceWarning(
+                        "Unhealthy RNTBD connection: Health check failed due to transit timeout detection time limit: {0}. " +
+                        "Last send attempt: {1:o}. Last send: {2:o}. " +
+                        "Tolerance {3:c}");
+                    return false;
+                }
+
+                // Timeout detection in high frequency.
+                if (transitTimeoutCounter >= this.timeoutDetectionHighFrequencyThreshold &&
+                    readDelay >= this.timeoutDetectionHighFrequencyTimeLimit)
+                {
+                    DefaultTrace.TraceWarning(
+                        "Unhealthy RNTBD connection: Transit timeout high frequency threshold hit: {0}. " +
+                        "Last send attempt: {1:o}. Last send: {2:o}. " +
+                        "Tolerance {3:c}");
+                    return false;
+                }
+
+                // Timeout detection in write operation.
+                if (transitTimeoutWriteCounter >= this.timeoutDetectionOnWriteThreshold &&
+                    readDelay >= this.timeoutDetectionOnWriteTimeLimit)
+                {
+                    DefaultTrace.TraceWarning(
+                        "Unhealthy RNTBD connection: Transit timeout on write threshold hit: {0}. " +
+                        "Last send attempt: {1:o}. Last send: {2:o}. " +
+                        "Tolerance {3:c}");
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// blabla.
+        /// </summary>
+        /// <param name="lastSendAttempt"></param>
+        /// <param name="lastSend"></param>
+        /// <param name="lastReceive"></param>
+        /// <param name="firstSendSinceLastReceive"></param>
+        /// <param name="numberOfSendsSinceLastReceive"></param>
+        /// <returns>bool.</returns>
+        public bool ValidateBlackhole(
+            DateTime lastSendAttempt,
+            DateTime lastSend,
+            DateTime lastReceive,
+            DateTime? firstSendSinceLastReceive,
+            long numberOfSendsSinceLastReceive)
+        {
+            DateTime now = DateTime.UtcNow;
+            // Black hole detection, part 1:
+            // Treat the connection as unhealthy if the gap between the last
+            // attempted send and the last successful send grew beyond
+            // acceptable limits, unless a send was attempted very recently.
+            // This is a sign of a hung send().
+            if ((lastSendAttempt - lastSend > this.sendDelayLimit) &&
+                (now - lastSendAttempt > ConnectionHealthChecker.sendHangGracePeriod))
+            {
+                DefaultTrace.TraceWarning(
+                    "Unhealthy RNTBD connection: Hung send: {0}. " +
+                    "Last send attempt: {1:o}. Last send: {2:o}. " +
+                    "Tolerance {3:c}");
+                return false;
+            }
+
+            // Black hole detection, part 2:
+            // Treat the connection as unhealthy if the gap between the last
+            // successful send and the last successful receive grew beyond
+            // acceptable limits, unless a send succeeded very recently and the number of
+            // outstanding receives is within reasonable limits.
+            if ((lastSend - lastReceive > this.receiveDelayLimit) &&
+                (
+                    now - lastSend > ConnectionHealthChecker.receiveHangGracePeriod ||
+                    (
+                        numberOfSendsSinceLastReceive >= ConnectionHealthChecker.MinNumberOfSendsSinceLastReceiveForUnhealthyConnection &&
+                        firstSendSinceLastReceive != null &&
+                        now - firstSendSinceLastReceive > ConnectionHealthChecker.receiveHangGracePeriod
+                    )
+                ))
+            {
+                DefaultTrace.TraceWarning(
+                    "Unhealthy RNTBD connection: Replies not getting back: {0}. " +
+                    "Last send: {1:o}. Last receive: {2:o}. Tolerance: {3:c}. " +
+                    "First send since last receieve: {4:o}. # of sends since last receive: {5}");
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// blabla.
+        /// </summary>
+        /// <param name="currentTime"></param>
+        /// <param name="lastReceiveTime"></param>
+        /// <returns>A bool.</returns>
+        public bool IsDataReceivedRecently(
+            DateTime currentTime,
+            DateTime lastReceiveTime)
+        {
+            return currentTime - lastReceiveTime < ConnectionHealthChecker.recentReceiveWindow;
+        }
+
+        /// <summary>
+        /// blabla.
+        /// </summary>
+        /// <param name="lastReceive"></param>
+        /// <returns>A bool.</returns>
+        public bool ValidateIdleTimeouts(
+            DateTime lastReceive)
+        {
+            DateTime now = DateTime.UtcNow;
+            if (this.idleConnectionTimeout > TimeSpan.Zero)
+            {
+                // idle timeout is enabled
+                if (now - lastReceive > this.idleConnectionTimeout)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// blabla.
+        /// </summary>
+        /// <param name="socket"></param>
+        /// <returns>A bool.</returns>
+        public bool ValidateSocketConnection(
+            Socket socket)
+        {
+            try
+            {
+                if (socket == null || !socket.Connected)
+                {
+                    return false;
+                }
+                Debug.Assert(!socket.Blocking);
+                socket.Send(ConnectionHealthChecker.healthCheckBuffer, 0, 0);
+                return true;
+            }
+            catch (SocketException e)
+            {
+                bool healthy = e.SocketErrorCode == SocketError.WouldBlock;
+                if (!healthy)
+                {
+                    DefaultTrace.TraceWarning(
+                        "Unhealthy RNTBD connection. Socket error code: {0}",
+                        e.SocketErrorCode.ToString());
+                }
+                return healthy;
+            }
+            catch (ObjectDisposedException)
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/direct/Constants.cs
+++ b/Microsoft.Azure.Cosmos/src/direct/Constants.cs
@@ -2116,7 +2116,17 @@ namespace Microsoft.Azure.Documents
 
         public static class EnvironmentVariables
         {
+            public const string SocketOptionTcpKeepAliveIntervalName = "AZURE_COSMOS_TCP_KEEPALIVE_INTERVAL_SECONDS";
+            public const string SocketOptionTcpKeepAliveTimeName = "AZURE_COSMOS_TCP_KEEPALIVE_TIME_SECONDS";
             public const string ReplicaConnectivityValidationEnabled = "AZURE_COSMOS_REPLICA_VALIDATION_ENABLED";
+            public const string TimeoutDetectionEnabled = "AZURE_COSMOS_TIMEOUT_DETECTION_ENABLED";
+            public const string TimeoutDetectionTimeLimit = "AZURE_COSMOS_TIMEOUT_DETECTION_TIME_LIMIT";
+            public const string TimeoutDetectionOnWriteThreshold = "AZURE_COSMOS_TIMEOUT_DETECTION_ON_WRITE_THRESHOLD";
+            public const string TimeoutDetectionOnWriteTimeLimit = "AZURE_COSMOS_TIMEOUT_DETECTION_ON_WRITE_TIME_LIMIT";
+            public const string TimeoutDetectionOnHighFrequencyThreshold = "AZURE_COSMOS_TIMEOUT_DETECTION_ON_HIGH_FREQUENCY_THRESHOLD";
+            public const string TimeoutDetectionOnHighFrequencyTimeLimit = "AZURE_COSMOS_TIMEOUT_DETECTION_ON_HIGH_FREQUENCY_TIME_LIMIT";
+            public const string TimeoutDetectionDisabledOnCPUThreshold = "AZURE_COSMOS_TIMEOUT_DETECTION_DISABLED_ON_CPU_THRESHOLD";
+
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/direct/Dispatcher.cs
+++ b/Microsoft.Azure.Cosmos/src/direct/Dispatcher.cs
@@ -361,7 +361,9 @@ namespace Microsoft.Azure.Documents.Rntbd
             bool isReadOnly)
         {
             this.ThrowIfDisposed();
-            this.connection.IncrementTransitTimeoutCounter(isReadOnly);
+            this.connection.IncrementTransitTimeoutCounter(
+                isReadOnly: isReadOnly);
+
             CallInfo call = this.RemoveCall(preparedCall.RequestId);
             if (call != null)
             {
@@ -372,21 +374,10 @@ namespace Microsoft.Azure.Documents.Rntbd
         /// <summary>
         /// Cancels call.
         /// </summary>
-        /// <param name="isReadOnly">A boolean flag indicating if the request is read only.</param>
-        public void CompleteCall(
-            bool isReadOnly)
+        public void CompleteCall()
         {
             this.ThrowIfDisposed();
-
-            if (isReadOnly)
-            {
-                this.connection.UpdateLastReadTime();
-                this.connection.ResetTransitTimeout();
-            }
-            else
-            {
-                this.connection.UpdateLastWriteTime();
-            }
+            this.connection.ResetTransitTimeout();
         }
 
         public override string ToString()
@@ -634,6 +625,7 @@ namespace Microsoft.Azure.Documents.Rntbd
             }
         }
 
+        // Something to take a look to update the last read time.
         private async Task NegotiateRntbdContextAsync(ChannelOpenArguments args)
         {
             byte[] contextMessage = TransportSerialization.BuildContextRequest(

--- a/Microsoft.Azure.Cosmos/src/direct/Dispatcher.cs
+++ b/Microsoft.Azure.Cosmos/src/direct/Dispatcher.cs
@@ -372,7 +372,7 @@ namespace Microsoft.Azure.Documents.Rntbd
         }
 
         /// <summary>
-        /// Cancels call.
+        /// Completes a call.
         /// </summary>
         public void CompleteCall()
         {

--- a/Microsoft.Azure.Cosmos/src/direct/Dispatcher.cs
+++ b/Microsoft.Azure.Cosmos/src/direct/Dispatcher.cs
@@ -351,9 +351,17 @@ namespace Microsoft.Azure.Documents.Rntbd
             }
         }
 
-        public void CancelCall(PrepareCallResult preparedCall)
+        /// <summary>
+        /// Cancels call.
+        /// </summary>
+        /// <param name="preparedCall">Prepared call result.</param>
+        /// <param name="isReadOnly">A boolean flag indicating if the request is read only.</param>
+        public void CancelCall(
+            PrepareCallResult preparedCall,
+            bool isReadOnly)
         {
             this.ThrowIfDisposed();
+            this.connection.IncrementTransitTimeoutCounter(isReadOnly);
             CallInfo call = this.RemoveCall(preparedCall.RequestId);
             if (call != null)
             {

--- a/Microsoft.Azure.Cosmos/src/direct/Dispatcher.cs
+++ b/Microsoft.Azure.Cosmos/src/direct/Dispatcher.cs
@@ -625,7 +625,6 @@ namespace Microsoft.Azure.Documents.Rntbd
             }
         }
 
-        // Something to take a look to update the last read time.
         private async Task NegotiateRntbdContextAsync(ChannelOpenArguments args)
         {
             byte[] contextMessage = TransportSerialization.BuildContextRequest(
@@ -706,6 +705,7 @@ namespace Microsoft.Azure.Documents.Rntbd
                 }
             }
 
+            this.CompleteCall();
             args.OpenTimeline.RecordRntbdHandshakeFinishTime();
         }
 

--- a/Microsoft.Azure.Cosmos/src/direct/Dispatcher.cs
+++ b/Microsoft.Azure.Cosmos/src/direct/Dispatcher.cs
@@ -369,6 +369,26 @@ namespace Microsoft.Azure.Documents.Rntbd
             }
         }
 
+        /// <summary>
+        /// Cancels call.
+        /// </summary>
+        /// <param name="isReadOnly">A boolean flag indicating if the request is read only.</param>
+        public void CompleteCall(
+            bool isReadOnly)
+        {
+            this.ThrowIfDisposed();
+
+            if (isReadOnly)
+            {
+                this.connection.UpdateLastReadTime();
+                this.connection.ResetTransitTimeout();
+            }
+            else
+            {
+                this.connection.UpdateLastWriteTime();
+            }
+        }
+
         public override string ToString()
         {
             return this.connection.ToString();

--- a/Microsoft.Azure.Cosmos/src/direct/Helpers.cs
+++ b/Microsoft.Azure.Cosmos/src/direct/Helpers.cs
@@ -239,11 +239,11 @@ namespace Microsoft.Azure.Documents
         /// Gets the environment variable value using the user provided key.
         /// </summary>
         /// <param name="name">A string containing the environment variable name.</param>
-        /// <param name="defaultValue">A boolean field containing the default value of the variable.</param>
-        /// <returns>The environment variable value as a boolean field.</returns>
-        internal static bool GetEnvironmentVariableAsBool(
+        /// <param name="defaultValue">A generic field containing the default value of the variable.</param>
+        /// <returns>The environment variable value as a generic field.</returns>
+        internal static T GetEnvironmentVariable<T>(
             string name,
-            bool defaultValue)
+            T defaultValue)
         {
             string environmentVariableValue = Environment.GetEnvironmentVariable(name);
 
@@ -252,13 +252,31 @@ namespace Microsoft.Azure.Documents
                 return defaultValue;
             }
 
-            if (bool.TryParse(environmentVariableValue, out bool environmentVariableBool))
+            switch (typeof(T))
             {
-                return environmentVariableBool;
+                case Type intType when intType == typeof(int):
+
+                    if (int.TryParse(environmentVariableValue, out int environmentVariableInteger))
+                    {
+                        return (T)(object)environmentVariableInteger;
+                    }
+
+                    // Value is not valid.
+                    throw new ArgumentException(message: $"{name} has an invalid integer value of: {environmentVariableValue}.");
+
+                case Type boolType when boolType == typeof(bool):
+
+                    if (bool.TryParse(environmentVariableValue, out bool environmentVariableBool))
+                    {
+                        return (T)(object)environmentVariableBool;
+                    }
+
+                    // Value is not valid.
+                    throw new ArgumentException(message: $"{name} has an invalid boolean value of: {environmentVariableValue}.");
             }
 
-            // Value is not valid.
-            throw new ArgumentException(message: $"{name} has an invalid boolean value of: {environmentVariableValue}.");
+            // Generic is not valid.
+            throw new ArgumentException(message: $"{typeof(T)} is not a valid generic.");
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/direct/StoreReader.cs
+++ b/Microsoft.Azure.Cosmos/src/direct/StoreReader.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.Documents
             this.addressEnumerator = addressEnumerator ?? throw new ArgumentNullException(nameof(addressEnumerator));
             this.sessionContainer = sessionContainer;
             this.canUseLocalLSNBasedHeaders = VersionUtility.IsLaterThan(HttpConstants.Versions.CurrentVersion, HttpConstants.Versions.v2018_06_18);
-            this.isReplicaAddressValidationEnabled = Helpers.GetEnvironmentVariableAsBool(
+            this.isReplicaAddressValidationEnabled = Helpers.GetEnvironmentVariable(
                 name: Constants.EnvironmentVariables.ReplicaConnectivityValidationEnabled,
                 defaultValue: false);
         }


### PR DESCRIPTION
# Pull Request Template

## Description

Sneak peek rntbd health check improvements. The goals of this PR are defined below -

- Achieving separation of concern, by slicing out the entire connection health logic into a new class `ConnectionHealthChecker` so that all the health check logic can stay together.

- Implementing the aggressive connection health check logic to close the connection aggressively, based on some pre-defined thresholds and timeouts. Note that this is being introduced based on few learning from the on-call investigations. Below are the new feature flags introduced to achieve the aggressive timeout detection feature.

  * `AZURE_COSMOS_TIMEOUT_DETECTION_ENABLED`: Default `true`
  * `AZURE_COSMOS_TIMEOUT_DETECTION_TIME_LIMIT`: Default `60` seconds.
  * `AZURE_COSMOS_TIMEOUT_DETECTION_ON_HIGH_FREQUENCY_THRESHOLD`: Default `3`
  * `AZURE_COSMOS_TIMEOUT_DETECTION_ON_HIGH_FREQUENCY_TIME_LIMIT`: Default `10` seconds.
  * `AZURE_COSMOS_TIMEOUT_DETECTION_ON_WRITE_THRESHOLD`: Default `1`
  * `AZURE_COSMOS_TIMEOUT_DETECTION_ON_WRITE_TIME_LIMIT`: Default `6` seconds.
  * `AZURE_COSMOS_TIMEOUT_DETECTION_DISABLED_ON_CPU_THRESHOLD`: Default `90.0`


Few timeout scenarios would trigger a connection to be closed aggressively:

- Within the `AZURE_COSMOS_TIMEOUT_DETECTION_TIME_LIMIT`: A Timeout has been observed beyond the defined limit, it does not matter how many. This will help to detect a broken connection for sparse workloads.

- Within `AZURE_COSMOS_TIMEOUT_DETECTION_ON_HIGH_FREQUENCY_THRESHOLD` + `AZURE_COSMOS_TIMEOUT_DETECTION_ON_HIGH_FREQUENCY_TIME_LIMIT`: Timeout has happened very frequently, in this case, we would want to close the channel more frequently.

- Within `AZURE_COSMOS_TIMEOUT_DETECTION_ON_WRITE_THRESHOLD` + `AZURE_COSMOS_TIMEOUT_DETECTION_ON_WRITE_TIME_LIMIT`: Timeout happened on write related operation. Since for write operation, only primary replica will be used, so we want to close the channel more aggressively as well.

- Beyond `AZURE_COSMOS_TIMEOUT_DETECTION_DISABLED_ON_CPU_THRESHOLD`: High CPU can cause high number of request timeout, and when this happens, closing existing channels and re-establishing new ones will not help the situation but rather make it worse. When the cpu threshold being hit, timeout detection shoule be disabled and then it will automatically resumed when the CPU usage back below the configured threshold.  

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Closing issues

To automatically close an issue: closes #IssueNumber