### PR TITLE
Honor JsonObjectPropertyAttribute naming strategy

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Linq/TypeSystem.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/TypeSystem.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Azure.Cosmos.Linq
     using Microsoft.Azure.Cosmos.Serializer;
     using Microsoft.Azure.Documents;
     using Newtonsoft.Json;
+    using Newtonsoft.Json.Serialization;
 
     internal static class TypeSystem
     {
@@ -41,6 +42,20 @@ namespace Microsoft.Azure.Cosmos.Linq
                     if (dataMemberAttribute != null && !string.IsNullOrEmpty(dataMemberAttribute.Name))
                     {
                         memberName = dataMemberAttribute.Name;
+                    }
+                }
+                
+                if (memberName == null)
+                {
+                    // If there are neither DataContractAttribute nor JsonPropertyAttribute,
+                    // we need to check the naming strategy of the declaring type.
+                    JsonObjectAttribute jsonObjectAttribute = memberInfo.DeclaringType.GetCustomAttribute<JsonObjectAttribute>(true);
+                    if (jsonObjectAttribute != null && jsonObjectAttribute.NamingStrategyType != null)
+                    {
+                        if (Activator.CreateInstance(jsonObjectAttribute.NamingStrategyType) is NamingStrategy namingStrategy)
+                        {
+                            memberName = namingStrategy.GetPropertyName(memberInfo.Name, false);
+                        }
                     }
                 }
             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqAttributeContractBaselineTests.TestClassAndMemberAssignmentAttributeContract.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqAttributeContractBaselineTests.TestClassAndMemberAssignmentAttributeContract.xml
@@ -1,0 +1,13 @@
+﻿<Results>
+  <Result>
+    <Input>
+      <Description><![CDATA[ClassAndMemberAssignment]]></Description>
+      <Expression><![CDATA[query.Select(doc => new Datum3() {DataMember = doc.DataMember, Default = doc.Default, JsonProperty = doc.JsonProperty, JsonPropertyAndDataMember = doc.JsonPropertyAndDataMember})]]></Expression>
+    </Input>
+    <Output>
+      <SqlQuery><![CDATA[
+SELECT VALUE {"dataMember": root["dataMember"], "default": root["Default"], "jsonProperty": root["jsonProperty"], "jsonPropertyHasHigherPriority": root["jsonPropertyHasHigherPriority"]} 
+FROM root]]></SqlQuery>
+    </Output>
+  </Result>
+</Results>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Microsoft.Azure.Cosmos.EmulatorTests.csproj
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Microsoft.Azure.Cosmos.EmulatorTests.csproj
@@ -116,6 +116,9 @@
     <Content Include="BaselineTest\TestBaseline\LinqAggregateFunctionBaselineTests.TestAggregateSum.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="BaselineTest\TestBaseline\LinqAttributeContractBaselineTests.TestClassAndMemberAssignmentAttributeContract.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="BaselineTest\TestBaseline\LinqAttributeContractBaselineTests.TestMemberAssignmentAttributeContract.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>


### PR DESCRIPTION
# Pull Request Template

## Description

There's an open issue in the old v2 repo that is still applicable to the v3 SDK, namely the case where declaring types used in LINQ translations holds the naming strategy of members: https://github.com/Azure/azure-cosmos-dotnet-v2/issues/638

This PR adds a small change to check for the presence of that attribute AFTER JsonPropertyAttribute and any DataContract attributes.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: https://github.com/Azure/azure-cosmos-dotnet-v2/issues/638