### PR TITLE
PackageLicense: Removes PackageLicenseUrl and Adds PackageLicenseFile since PackageLicenseUrl is deprecated

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
+++ b/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
@@ -24,7 +24,6 @@
 		<PackageId>Microsoft.Azure.Cosmos</PackageId>
 		<PackageTags>microsoft;azure;cosmos;cosmosdb;documentdb;docdb;nosql;azureofficial;dotnetcore;netcore;netstandard</PackageTags>
 		<PackageReleaseNotes>The change log for this SDK is made available at https://github.com/Azure/azure-cosmos-dotnet-v3/blob/master/changelog.md at the time of release.</PackageReleaseNotes>
-		<PackageLicenseUrl>https://aka.ms/netcoregaeula</PackageLicenseUrl>
 		<PackageProjectUrl>https://github.com/Azure/azure-cosmos-dotnet-v3</PackageProjectUrl>
 		<PublishRepositoryUrl Condition=" '$(ProjectRef)' != 'True' ">true</PublishRepositoryUrl>
 		<PackageIconUrl>http://go.microsoft.com/fwlink/?LinkID=288890</PackageIconUrl>
@@ -43,8 +42,13 @@
 		<NoWarn>NU5125</NoWarn>
 		<Optimize Condition="'$(Configuration)'=='Release'">true</Optimize>
 		<LangVersion>$(LangVersion)</LangVersion>
+		<PackageLicenseFile>LICENSE</PackageLicenseFile>
 	</PropertyGroup>
 
+	<ItemGroup>
+		<None Include="..\..\LICENSE" Pack="true" PackagePath=""/>
+	</ItemGroup>
+	
 	<ItemGroup>
 		<AdditionalFiles Include="stylecop.json" />
 		<None Include="Icon.png" Pack="true" PackagePath="\" />

--- a/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
+++ b/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
@@ -46,7 +46,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<None Include="..\..\LICENSE" Pack="true" PackagePath=""/>
+		<None Include="..\..\LICENSE" Pack="true" PackagePath="" Visible="false"/>
 	</ItemGroup>
 	
 	<ItemGroup>


### PR DESCRIPTION
## Description

This originated from an [3582](https://github.com/Azure/azure-cosmos-dotnet-v3/issues/3582) issue where the license was using an Url and not showing up in _Nuget.org_ in the details of the package. **PackageLicenseUrl** was deprecated and it was recommended to use either **PackageLicenseFile** or **PackageLicenseExpression** for immutability reasons. I am providing link to the original issue and [discussion](https://github.com/NuGet/Home/issues/4628). 

There was an option to leave LICENSE without extension or rename with .TXT extension. I opted to use the original without the .TXT as I do not see either a PRO or a CON to one over the other, but I have no qualms with either option.

In regard to not using **PackageLicenseExpression**. I am not really seeing a PRO or a CON on the surface as to using this or not for this particular repo.

## Type of change

.NET project file to include **PackageLicenseFile** and exclude **PackageLicenseUrl**.

## Closing issues

To automatically close an issue: closes #IssueNumber