### PR TITLE
Client Telemetry: Refactors code to create client telemetry config

### DIFF
--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Azure.Cosmos
     using Microsoft.Azure.Cosmos.Query.Core.QueryPlan;
     using Microsoft.Azure.Cosmos.Routing;
     using Microsoft.Azure.Cosmos.Telemetry;
+    using Microsoft.Azure.Cosmos.Telemetry.Models;
     using Microsoft.Azure.Cosmos.Tracing;
     using Microsoft.Azure.Cosmos.Tracing.TraceData;
     using Microsoft.Azure.Documents;
@@ -1058,7 +1059,8 @@ namespace Microsoft.Azure.Cosmos
                         authorizationTokenProvider: this.cosmosAuthorization,
                         diagnosticsHelper: DiagnosticsHandlerHelper.Instance,
                         preferredRegions: this.ConnectionPolicy.PreferredLocations,
-                        globalEndpointManager: this.GlobalEndpointManager);
+                        globalEndpointManager: this.GlobalEndpointManager,
+                        configuration: new ClientTelemetryConfig());
 
                     DefaultTrace.TraceInformation("Client Telemetry Enabled.");
                 }

--- a/Microsoft.Azure.Cosmos/src/Handler/TelemetryHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/TelemetryHandler.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.Cosmos.Handlers
 
         private bool IsAllowed(RequestMessage request)
         { 
-            return ClientTelemetryOptions.AllowedResourceTypes.Equals(request.ResourceType);
+            return this.telemetry.Configuration.AllowedResourceTypes.Equals(request.ResourceType);
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
+++ b/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
@@ -46,7 +46,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<None Include="..\..\LICENSE" Pack="true" PackagePath="" Visible="false"/>
+		<None Include="..\..\LICENSE" Pack="true" PackagePath="" Visible="false" />
 	</ItemGroup>
 	
 	<ItemGroup>

--- a/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
+++ b/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
@@ -46,7 +46,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<None Include="..\..\LICENSE" Pack="true" PackagePath="" Visible="false" />
+		<None Include="..\..\LICENSE" Pack="true" PackagePath="" Visible="false"/>
 	</ItemGroup>
 	
 	<ItemGroup>

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryHelper.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryHelper.cs
@@ -47,9 +47,11 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         /// </summary>
         /// <param name="systemUsageHistory"></param>
         /// <param name="isDirectConnectionMode"></param>
+        /// <param name="config"></param>
         private static List<SystemInfo> RecordSystemUsage(
                 SystemUsageHistory systemUsageHistory, 
-                bool isDirectConnectionMode)
+                bool isDirectConnectionMode,
+                ClientTelemetryConfig config)
         {
             if (systemUsageHistory.Values == null)
             {
@@ -60,16 +62,16 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             
             List<SystemInfo> systemInfoCollection = new List<SystemInfo>(6)
             {
-                TelemetrySystemUsage.GetCpuInfo(systemUsageHistory.Values),
-                TelemetrySystemUsage.GetMemoryRemainingInfo(systemUsageHistory.Values),
-                TelemetrySystemUsage.GetAvailableThreadsInfo(systemUsageHistory.Values),
-                TelemetrySystemUsage.GetThreadWaitIntervalInMs(systemUsageHistory.Values),
+                TelemetrySystemUsage.GetCpuInfo(systemUsageHistory.Values, config),
+                TelemetrySystemUsage.GetMemoryRemainingInfo(systemUsageHistory.Values, config),
+                TelemetrySystemUsage.GetAvailableThreadsInfo(systemUsageHistory.Values, config),
+                TelemetrySystemUsage.GetThreadWaitIntervalInMs(systemUsageHistory.Values, config),
                 TelemetrySystemUsage.GetThreadStarvationSignalCount(systemUsageHistory.Values)
             }; // Reset System Information
 
             if (isDirectConnectionMode)
             {
-                systemInfoCollection.Add(TelemetrySystemUsage.GetTcpConnectionCount(systemUsageHistory.Values));
+                systemInfoCollection.Add(TelemetrySystemUsage.GetTcpConnectionCount(systemUsageHistory.Values, config));
             }
 
             return systemInfoCollection;
@@ -78,7 +80,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         /// <summary>
         /// Record CPU and memory usage which will be sent as part of telemetry information
         /// </summary>
-        internal static List<SystemInfo> RecordSystemUtilization(DiagnosticsHandlerHelper helper, bool isDirectMode)
+        internal static List<SystemInfo> RecordSystemUtilization(DiagnosticsHandlerHelper helper, bool isDirectMode, ClientTelemetryConfig config)
         {
             try
             {
@@ -90,7 +92,8 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                 {
                     return ClientTelemetryHelper.RecordSystemUsage(
                         systemUsageHistory: systemUsageHistory,
-                        isDirectConnectionMode: isDirectMode);
+                        isDirectConnectionMode: isDirectMode,
+                        config: config);
                 }
                 else
                 {

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryOptions.cs
@@ -86,7 +86,6 @@ namespace Microsoft.Azure.Cosmos.Telemetry
 
         private static string environmentName;
         private static TimeSpan scheduledTimeSpan = TimeSpan.Zero;
-        internal const double DefaultTimeStampInSeconds = 600;
         private static Uri clientTelemetryEndpoint;
         
         internal static bool IsClientTelemetryEnabled()
@@ -100,7 +99,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             return isTelemetryEnabled;
         }
 
-        internal static TimeSpan GetScheduledTimeSpan()
+        internal static TimeSpan GetScheduledTimeSpan(ClientTelemetryConfig config)
         {
             if (scheduledTimeSpan.Equals(TimeSpan.Zero))
             {
@@ -110,7 +109,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                     scheduledTimeInSeconds = ConfigurationManager
                                                     .GetEnvironmentVariable<double>(
                                                            ClientTelemetryOptions.EnvPropsClientTelemetrySchedulingInSeconds,
-                                                           ClientTelemetryOptions.DefaultTimeStampInSeconds);
+                                                           config.AggregationIntervalInSeconds);
 
                     if (scheduledTimeInSeconds <= 0)
                     {

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryOptions.cs
@@ -14,15 +14,27 @@ namespace Microsoft.Azure.Cosmos.Telemetry
     {
         // ConversionFactor used in Histogram calculation to maintain precision or to collect data in desired unit
         internal const int HistogramPrecisionFactor = 100;
+        
         internal const double TicksToMsFactor = TimeSpan.TicksPerMillisecond;
         internal const int KbToMbFactor = 1024;
-
         internal const int OneKbToBytes = 1024;
             
+        internal const string DateFormat = "yyyy-MM-ddTHH:mm:ssZ";
+        internal const string EnvPropsClientTelemetrySchedulingInSeconds = "COSMOS.CLIENT_TELEMETRY_SCHEDULING_IN_SECONDS";
+        internal const string EnvPropsClientTelemetryEnabled = "COSMOS.CLIENT_TELEMETRY_ENABLED";
+        internal const string EnvPropsClientTelemetryVmMetadataUrl = "COSMOS.VM_METADATA_URL";
+        internal const string EnvPropsClientTelemetryEndpoint = "COSMOS.CLIENT_TELEMETRY_ENDPOINT";
+        internal const string EnvPropsClientTelemetryEnvironmentName = "COSMOS.ENVIRONMENT_NAME";
+
+        internal const double Percentile50 = 50.0;
+        internal const double Percentile90 = 90.0;
+        internal const double Percentile95 = 95.0;
+        internal const double Percentile99 = 99.0;
+        internal const double Percentile999 = 99.9;
+        
         // Expecting histogram to have Minimum Latency of 1 and Maximum Latency of 1 hour (which is never going to happen)
         internal const long RequestLatencyMax = TimeSpan.TicksPerHour;
         internal const long RequestLatencyMin = 1;
-        internal const int RequestLatencyPrecision = 4;
         internal const string RequestLatencyName = "RequestLatency";
         internal const string RequestLatencyUnit = "MilliSecond";
 
@@ -30,81 +42,52 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         // For all the Document ReadWriteQuery Operations there will be at least 1 request charge.
         internal const long RequestChargeMax = 9999900;
         internal const long RequestChargeMin = 1;
-        internal const int RequestChargePrecision = 2;
         internal const string RequestChargeName = "RequestCharge";
         internal const string RequestChargeUnit = "RU";
-
+        
         // Expecting histogram to have Minimum CPU Usage of .001% and Maximum CPU Usage of 999.99%
         internal const long CpuMax = 99999;
         internal const long CpuMin = 1;
-        internal const int CpuPrecision = 2;
         internal const String CpuName = "CPU";
         internal const String CpuUnit = "Percentage";
 
         // Expecting histogram to have Minimum Memory Remaining of 1 MB and Maximum Memory Remaining of Long Max Value
         internal const long MemoryMax = Int64.MaxValue;
         internal const long MemoryMin = 1;
-        internal const int MemoryPrecision = 2;
         internal const String MemoryName = "MemoryRemaining";
         internal const String MemoryUnit = "MB";
 
         // Expecting histogram to have Minimum Available Threads = 0 and Maximum Available Threads = it can be any anything depends on the machine
         internal const long AvailableThreadsMax = Int64.MaxValue;
         internal const long AvailableThreadsMin = 1;
-        internal const int AvailableThreadsPrecision = 2;
         internal const String AvailableThreadsName = "SystemPool_AvailableThreads";
         internal const String AvailableThreadsUnit = "ThreadCount";
 
         // Expecting histogram to have Minimum ThreadWaitIntervalInMs of 1 and Maximum ThreadWaitIntervalInMs of 1 second
         internal const long ThreadWaitIntervalInMsMax = TimeSpan.TicksPerSecond;
         internal const long ThreadWaitIntervalInMsMin = 1;
-        internal const int ThreadWaitIntervalInMsPrecision = 2;
         internal const string ThreadWaitIntervalInMsName = "SystemPool_ThreadWaitInterval";
         internal const string ThreadWaitIntervalInMsUnit = "MilliSecond";
-
+        
         // Expecting histogram to have Minimum Number of TCP connections as 1 and Maximum Number Of TCP connection as 70000
         internal const long NumberOfTcpConnectionMax = 70000;
         internal const long NumberOfTcpConnectionMin = 1;
-        internal const int NumberOfTcpConnectionPrecision = 2;
         internal const string NumberOfTcpConnectionName = "RntbdOpenConnections";
         internal const string NumberOfTcpConnectionUnit = "Count";
 
         internal const string IsThreadStarvingName = "SystemPool_IsThreadStarving_True";
         internal const string IsThreadStarvingUnit = "Count";
-
-        internal const double DefaultTimeStampInSeconds = 600;
-        internal const double Percentile50 = 50.0;
-        internal const double Percentile90 = 90.0;
-        internal const double Percentile95 = 95.0;
-        internal const double Percentile99 = 99.0;
-        internal const double Percentile999 = 99.9;
-        internal const string DateFormat = "yyyy-MM-ddTHH:mm:ssZ";
-        internal const string EnvPropsClientTelemetrySchedulingInSeconds = "COSMOS.CLIENT_TELEMETRY_SCHEDULING_IN_SECONDS";
-        internal const string EnvPropsClientTelemetryEnabled = "COSMOS.CLIENT_TELEMETRY_ENABLED";
-        internal const string EnvPropsClientTelemetryVmMetadataUrl = "COSMOS.VM_METADATA_URL";
-        internal const string EnvPropsClientTelemetryEndpoint = "COSMOS.CLIENT_TELEMETRY_ENDPOINT";
-        internal const string EnvPropsClientTelemetryEnvironmentName = "COSMOS.ENVIRONMENT_NAME";
-        
-        internal static readonly ResourceType AllowedResourceTypes = ResourceType.Document;
-        // Why 5 sec? As of now, if any network request is taking more than 5 millisecond sec, we will consider it slow request this value can be revisited in future
-        internal static readonly TimeSpan NetworkLatencyThreshold = TimeSpan.FromMilliseconds(5);
-        internal static readonly int NetworkRequestsSampleSizeThreshold = 10;
         
         internal static readonly JsonSerializerSettings JsonSerializerSettings = new JsonSerializerSettings 
         { 
             NullValueHandling = NullValueHandling.Ignore,
             MaxDepth = 64, // https://github.com/advisories/GHSA-5crp-9r3c-p9vr
         };
-        
-        internal static readonly List<int> ExcludedStatusCodes = new List<int> { 404, 409, 412 };
 
-        internal static readonly int NetworkTelemetrySampleSize = 200;
-        internal static int PayloadSizeThreshold = 1024 * 1024 * 2; // 2MB
-        internal static TimeSpan ClientTelemetryProcessorTimeOut = TimeSpan.FromMinutes(5);
-        
-        private static Uri clientTelemetryEndpoint;
         private static string environmentName;
         private static TimeSpan scheduledTimeSpan = TimeSpan.Zero;
+        internal const double DefaultTimeStampInSeconds = 600;
+        private static Uri clientTelemetryEndpoint;
         
         internal static bool IsClientTelemetryEnabled()
         {

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryOptions.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         {
             if (scheduledTimeSpan.Equals(TimeSpan.Zero))
             {
-                double scheduledTimeInSeconds = ClientTelemetryOptions.DefaultTimeStampInSeconds;
+                double scheduledTimeInSeconds = config.AggregationIntervalInSeconds;
                 try
                 {
                     scheduledTimeInSeconds = ConfigurationManager

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryPayloadWriter.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryPayloadWriter.cs
@@ -22,14 +22,15 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             ConcurrentDictionary<OperationInfo, (LongConcurrentHistogram latency, LongConcurrentHistogram requestcharge)> operationInfoSnapshot,
             ConcurrentDictionary<CacheRefreshInfo, LongConcurrentHistogram> cacheRefreshInfoSnapshot,
             IReadOnlyList<RequestInfo> sampledRequestInfo,
-            Func<string, Task> callback)
+            Func<string, Task> callback,
+            ClientTelemetryConfig config)
         {
             if (properties == null)
             {
                 throw new ArgumentNullException(nameof(properties));
             }
             
-            StringBuilder stringBuilder = new StringBuilder(ClientTelemetryOptions.PayloadSizeThreshold);
+            StringBuilder stringBuilder = new StringBuilder(config.ClientTelemetryServiceConfig.PayloadSizeThreshold);
             
             JsonWriter writer = ClientTelemetryPayloadWriter.GetWriterWithSectionStartTag(stringBuilder, properties, "operationInfo");
             
@@ -51,7 +52,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                     string requestChargeMetrics = JsonConvert.SerializeObject(payloadForRequestCharge);
 
                     int thisSectionLength = latencyMetrics.Length + requestChargeMetrics.Length;
-                    if (lengthNow + thisSectionLength > ClientTelemetryOptions.PayloadSizeThreshold)
+                    if (lengthNow + thisSectionLength > config.ClientTelemetryServiceConfig.PayloadSizeThreshold)
                     {
                         writer.WriteEndArray();
                         writer.WriteEndObject();
@@ -83,7 +84,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
 
                     string latencyMetrics = JsonConvert.SerializeObject(payloadForLatency);
 
-                    if (lengthNow + latencyMetrics.Length > ClientTelemetryOptions.PayloadSizeThreshold)
+                    if (lengthNow + latencyMetrics.Length > config.ClientTelemetryServiceConfig.PayloadSizeThreshold)
                     {
                         writer.WriteEndArray();
                         writer.WriteEndObject();
@@ -110,7 +111,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                   
                     string latencyMetrics = JsonConvert.SerializeObject(entry);
 
-                    if (lengthNow + latencyMetrics.Length > ClientTelemetryOptions.PayloadSizeThreshold)
+                    if (lengthNow + latencyMetrics.Length > config.ClientTelemetryServiceConfig.PayloadSizeThreshold)
                     {
                         writer.WriteEndArray();
                         writer.WriteEndObject();

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryProcessor.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryProcessor.cs
@@ -23,11 +23,13 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         
         private readonly AuthorizationTokenProvider tokenProvider;
         private readonly CosmosHttpClient httpClient;
-            
-        internal ClientTelemetryProcessor(CosmosHttpClient httpClient, AuthorizationTokenProvider tokenProvider)
+        private readonly ClientTelemetryConfig configuration;
+
+        internal ClientTelemetryProcessor(CosmosHttpClient httpClient, AuthorizationTokenProvider tokenProvider, ClientTelemetryConfig configuration)
         {
             this.httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
             this.tokenProvider = tokenProvider ?? throw new ArgumentNullException(nameof(tokenProvider));
+            this.configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
         }
 
         /// <summary>
@@ -48,7 +50,8 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                     operationInfoSnapshot: operationInfoSnapshot,
                     cacheRefreshInfoSnapshot: cacheRefreshInfoSnapshot,
                     sampledRequestInfo: requestInfoSnapshot,
-                    callback: async (payload) => await this.SendAsync(clientTelemetryInfo.GlobalDatabaseAccountName, payload, cancellationToken));
+                    callback: async (payload) => await this.SendAsync(clientTelemetryInfo.GlobalDatabaseAccountName, payload, cancellationToken),
+                    this.configuration);
             }
             catch (Exception ex)
             {

--- a/Microsoft.Azure.Cosmos/src/Telemetry/Models/Configs/ClientTelemetryConfig.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/Models/Configs/ClientTelemetryConfig.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Azure.Cosmos.Telemetry.Models
 
     internal class ClientTelemetryConfig
     {
+        internal int AggregationIntervalInSeconds { get; set; } = 600;
+
         internal MetricsPrecision MetricsPrecisions { get; set; } = new MetricsPrecision();
         internal NetworkTelemetryConfig NetworkTelemetryConfig { get; set; } = new NetworkTelemetryConfig();
         internal ClientTelemetryServiceConfig ClientTelemetryServiceConfig { get; set; } = new ClientTelemetryServiceConfig();

--- a/Microsoft.Azure.Cosmos/src/Telemetry/Models/Configs/ClientTelemetryConfig.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/Models/Configs/ClientTelemetryConfig.cs
@@ -1,0 +1,45 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Telemetry.Models
+{
+    using System;
+    using System.Collections.Generic;
+    using Microsoft.Azure.Documents;
+
+    internal class ClientTelemetryConfig
+    {
+        internal MetricsPrecision precisions { get; set; } = new MetricsPrecision();
+        internal NetworkTelemetryConfig networkTelemetryConfig { get; set; }
+        internal ClientTelemetryServiceConfig clientTelemetryServiceConfig { get; set; }
+        
+        internal ResourceType AllowedResourceTypes { get; set; } = ResourceType.Document;
+        internal TimeSpan ClientTelemetryProcessorTimeOut { get; set; } = TimeSpan.FromMinutes(5);
+    }
+
+    internal class MetricsPrecision
+    {
+        internal int RequestLatencyPrecision { get; set; } = 4;
+        internal int RequestChargePrecision { get; set; } = 2;
+        internal int CpuPrecision { get; set; } = 2;
+        internal int MemoryPrecision { get; set; } = 2;
+        internal int AvailableThreadsPrecision { get; set; } = 2;
+        internal int ThreadWaitIntervalInMsPrecision { get; set; } = 2;
+        internal int NumberOfTcpConnectionPrecision { get; set; } = 2;
+    }
+
+    internal class NetworkTelemetryConfig
+    {
+        // Why 5 sec? As of now, if any network request is taking more than 5 millisecond sec, we will consider it slow request this value can be revisited in future
+        internal TimeSpan NetworkLatencyThreshold { get; set; } = TimeSpan.FromMilliseconds(5);
+        internal int NetworkRequestsSampleSizeThreshold { get; set; } = 10;
+        internal int NetworkTelemetrySampleSize { get; set; } = 200;
+        internal List<int> ExcludedStatusCodes { get; set; } = new List<int> { 404, 409, 412 };
+    }
+
+    internal class ClientTelemetryServiceConfig
+    {
+        internal int PayloadSizeThreshold { get; set; } = 1024 * 1024 * 2; // 2MB
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Telemetry/Models/Configs/ClientTelemetryConfig.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/Models/Configs/ClientTelemetryConfig.cs
@@ -10,34 +10,34 @@ namespace Microsoft.Azure.Cosmos.Telemetry.Models
 
     internal class ClientTelemetryConfig
     {
-        internal int AggregationIntervalInSeconds { get; set; } = 600;
+        internal int AggregationIntervalInSeconds { get; } = 600;
 
-        internal MetricsPrecision MetricsPrecisions { get; set; } = new MetricsPrecision();
-        internal NetworkTelemetryConfig NetworkTelemetryConfig { get; set; } = new NetworkTelemetryConfig();
-        internal ClientTelemetryServiceConfig ClientTelemetryServiceConfig { get; set; } = new ClientTelemetryServiceConfig();
+        internal MetricsPrecision MetricsPrecisions { get; } = new MetricsPrecision();
+        internal NetworkTelemetryConfig NetworkTelemetryConfig { get; } = new NetworkTelemetryConfig();
+        internal ClientTelemetryServiceConfig ClientTelemetryServiceConfig { get; } = new ClientTelemetryServiceConfig();
         
-        internal ResourceType AllowedResourceTypes { get; set; } = ResourceType.Document;
-        internal TimeSpan ClientTelemetryProcessorTimeOut { get; set; } = TimeSpan.FromMinutes(5);
+        internal ResourceType AllowedResourceTypes { get; } = ResourceType.Document;
+        internal TimeSpan ClientTelemetryProcessorTimeOut { get; } = TimeSpan.FromMinutes(5);
     }
 
     internal class MetricsPrecision
     {
-        internal int RequestLatencyPrecision { get; set; } = 4;
-        internal int RequestChargePrecision { get; set; } = 2;
-        internal int CpuPrecision { get; set; } = 2;
-        internal int MemoryPrecision { get; set; } = 2;
-        internal int AvailableThreadsPrecision { get; set; } = 2;
-        internal int ThreadWaitIntervalInMsPrecision { get; set; } = 2;
-        internal int NumberOfTcpConnectionPrecision { get; set; } = 2;
+        internal int RequestLatencyPrecision { get; } = 4;
+        internal int RequestChargePrecision { get; } = 2;
+        internal int CpuPrecision { get; } = 2;
+        internal int MemoryPrecision { get; } = 2;
+        internal int AvailableThreadsPrecision { get; } = 2;
+        internal int ThreadWaitIntervalInMsPrecision { get; } = 2;
+        internal int NumberOfTcpConnectionPrecision { get; } = 2;
     }
 
     internal class NetworkTelemetryConfig
     {
         // Why 5 sec? As of now, if any network request is taking more than 5 millisecond sec, we will consider it slow request this value can be revisited in future
-        internal TimeSpan NetworkLatencyThreshold { get; set; } = TimeSpan.FromMilliseconds(5);
-        internal int NetworkRequestsSampleSizeThreshold { get; set; } = 10;
-        internal int NetworkTelemetrySampleSize { get; set; } = 200;
-        internal List<int> ExcludedStatusCodes { get; set; } = new List<int> { 404, 409, 412 };
+        internal TimeSpan NetworkLatencyThreshold { get; } = TimeSpan.FromMilliseconds(5);
+        internal int NetworkRequestsSampleSizeThreshold { get; } = 10;
+        internal int NetworkTelemetrySampleSize { get; } = 200;
+        internal List<int> ExcludedStatusCodes { get; } = new List<int> { 404, 409, 412 };
     }
 
     internal class ClientTelemetryServiceConfig

--- a/Microsoft.Azure.Cosmos/src/Telemetry/Models/Configs/ClientTelemetryConfig.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/Models/Configs/ClientTelemetryConfig.cs
@@ -10,9 +10,9 @@ namespace Microsoft.Azure.Cosmos.Telemetry.Models
 
     internal class ClientTelemetryConfig
     {
-        internal MetricsPrecision precisions { get; set; } = new MetricsPrecision();
-        internal NetworkTelemetryConfig networkTelemetryConfig { get; set; }
-        internal ClientTelemetryServiceConfig clientTelemetryServiceConfig { get; set; }
+        internal MetricsPrecision MetricsPrecisions { get; set; } = new MetricsPrecision();
+        internal NetworkTelemetryConfig NetworkTelemetryConfig { get; set; } = new NetworkTelemetryConfig();
+        internal ClientTelemetryServiceConfig ClientTelemetryServiceConfig { get; set; } = new ClientTelemetryServiceConfig();
         
         internal ResourceType AllowedResourceTypes { get; set; } = ResourceType.Document;
         internal TimeSpan ClientTelemetryProcessorTimeOut { get; set; } = TimeSpan.FromMinutes(5);

--- a/Microsoft.Azure.Cosmos/src/Telemetry/Sampler/DataSampler.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/Sampler/DataSampler.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
     /// </summary>
     internal sealed class DataSampler
     {
-        public static List<RequestInfo> OrderAndSample(List<RequestInfo> requestInfoList, IComparer<RequestInfo> comparer)
+        public static List<RequestInfo> OrderAndSample(List<RequestInfo> requestInfoList, IComparer<RequestInfo> comparer, NetworkTelemetryConfig config)
         {
             // It will store final result
             List<RequestInfo> sampledData = new List<RequestInfo>(capacity: requestInfoList.Count);
@@ -45,12 +45,12 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             // If list is greater than threshold then sort it and get top N objects otherwise add list as it is
             foreach (List<RequestInfo> sampledRequestInfo in sampledRawData.Values)
             {
-                if (sampledRequestInfo.Count > ClientTelemetryOptions.NetworkRequestsSampleSizeThreshold)
+                if (sampledRequestInfo.Count > config.NetworkRequestsSampleSizeThreshold)
                 {
                     sampledRequestInfo.Sort(comparer);
                     sampledData.AddRange(sampledRequestInfo.GetRange(
                         index: 0,
-                        count: ClientTelemetryOptions.NetworkRequestsSampleSizeThreshold));
+                        count: config.NetworkRequestsSampleSizeThreshold));
                 }
                 else
                 {

--- a/Microsoft.Azure.Cosmos/src/Telemetry/TelemetrySystemUsage.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/TelemetrySystemUsage.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
 {
     using System;
     using System.Collections.Generic;
+    using System.Runtime.CompilerServices;
     using HdrHistogram;
     using Microsoft.Azure.Cosmos.Telemetry.Models;
     using Microsoft.Azure.Documents.Rntbd;
@@ -19,12 +20,13 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         /// Collecting CPU usage information and aggregating that data using Histogram
         /// </summary>
         /// <param name="systemUsageCollection"></param>
+        /// <param name="config"></param>
         /// <returns>SystemInfo</returns>
-        public static SystemInfo GetCpuInfo(IReadOnlyCollection<SystemUsageLoad> systemUsageCollection)
+        public static SystemInfo GetCpuInfo(IReadOnlyCollection<SystemUsageLoad> systemUsageCollection, ClientTelemetryConfig config)
         {
             LongConcurrentHistogram histogram = new LongConcurrentHistogram(ClientTelemetryOptions.CpuMin,
                                                         ClientTelemetryOptions.CpuMax,
-                                                        ClientTelemetryOptions.CpuPrecision);
+                                                        config.MetricsPrecisions.CpuPrecision);
 
             SystemInfo systemInfo = new SystemInfo(ClientTelemetryOptions.CpuName, ClientTelemetryOptions.CpuUnit);
             foreach (SystemUsageLoad load in systemUsageCollection)
@@ -53,12 +55,13 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         /// Collecting Memory Remaining information and aggregating that data using Histogram
         /// </summary>
         /// <param name="systemUsageCollection"></param>
+        /// <param name="config"></param>
         /// <returns>SystemInfo</returns>
-        public static SystemInfo GetMemoryRemainingInfo(IReadOnlyCollection<SystemUsageLoad> systemUsageCollection)
+        public static SystemInfo GetMemoryRemainingInfo(IReadOnlyCollection<SystemUsageLoad> systemUsageCollection, ClientTelemetryConfig config)
         {
             LongConcurrentHistogram histogram = new LongConcurrentHistogram(ClientTelemetryOptions.MemoryMin,
                                                         ClientTelemetryOptions.MemoryMax,
-                                                        ClientTelemetryOptions.MemoryPrecision);
+                                                        config.MetricsPrecisions.MemoryPrecision);
 
             SystemInfo systemInfo = new SystemInfo(ClientTelemetryOptions.MemoryName, ClientTelemetryOptions.MemoryUnit);
             foreach (SystemUsageLoad load in systemUsageCollection)
@@ -82,12 +85,13 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         /// Collecting Available Thread information and aggregating that data using Histogram
         /// </summary>
         /// <param name="systemUsageCollection"></param>
+        /// <param name="config"></param>
         /// <returns>SystemInfo</returns>
-        public static SystemInfo GetAvailableThreadsInfo(IReadOnlyCollection<SystemUsageLoad> systemUsageCollection)
+        public static SystemInfo GetAvailableThreadsInfo(IReadOnlyCollection<SystemUsageLoad> systemUsageCollection, ClientTelemetryConfig config)
         {
             LongConcurrentHistogram histogram = new LongConcurrentHistogram(ClientTelemetryOptions.AvailableThreadsMin,
                                                         ClientTelemetryOptions.AvailableThreadsMax,
-                                                        ClientTelemetryOptions.AvailableThreadsPrecision);
+                                                        config.MetricsPrecisions.AvailableThreadsPrecision);
 
             SystemInfo systemInfo = new SystemInfo(ClientTelemetryOptions.AvailableThreadsName, ClientTelemetryOptions.AvailableThreadsUnit);
             foreach (SystemUsageLoad load in systemUsageCollection)
@@ -136,12 +140,13 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         /// Collecting Thread Wait Interval in Millisecond and aggregating using Histogram
         /// </summary>
         /// <param name="systemUsageCollection"></param>
+        /// <param name="config"></param>
         /// <returns>SystemInfo</returns>
-        public static SystemInfo GetThreadWaitIntervalInMs(IReadOnlyCollection<SystemUsageLoad> systemUsageCollection)
+        public static SystemInfo GetThreadWaitIntervalInMs(IReadOnlyCollection<SystemUsageLoad> systemUsageCollection, ClientTelemetryConfig config)
         {
             LongConcurrentHistogram histogram = new LongConcurrentHistogram(ClientTelemetryOptions.ThreadWaitIntervalInMsMin,
                                                         ClientTelemetryOptions.ThreadWaitIntervalInMsMax,
-                                                        ClientTelemetryOptions.ThreadWaitIntervalInMsPrecision);
+                                                        config.MetricsPrecisions.ThreadWaitIntervalInMsPrecision);
 
             SystemInfo systemInfo = new SystemInfo(ClientTelemetryOptions.ThreadWaitIntervalInMsName, ClientTelemetryOptions.ThreadWaitIntervalInMsUnit);
             foreach (SystemUsageLoad load in systemUsageCollection)
@@ -165,12 +170,13 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         /// Collecting TCP Connection Count and aggregating using Histogram
         /// </summary>
         /// <param name="systemUsageCollection"></param>
+        /// <param name="config"></param>
         /// <returns>SystemInfo</returns>
-        public static SystemInfo GetTcpConnectionCount(IReadOnlyCollection<SystemUsageLoad> systemUsageCollection)
+        public static SystemInfo GetTcpConnectionCount(IReadOnlyCollection<SystemUsageLoad> systemUsageCollection, ClientTelemetryConfig config)
         {
             LongConcurrentHistogram histogram = new LongConcurrentHistogram(ClientTelemetryOptions.NumberOfTcpConnectionMin,
                                                         ClientTelemetryOptions.NumberOfTcpConnectionMax,
-                                                        ClientTelemetryOptions.NumberOfTcpConnectionPrecision);
+                                                        config.MetricsPrecisions.NumberOfTcpConnectionPrecision);
 
             SystemInfo systemInfo = new SystemInfo(ClientTelemetryOptions.NumberOfTcpConnectionName, ClientTelemetryOptions.NumberOfTcpConnectionUnit);
             foreach (SystemUsageLoad load in systemUsageCollection)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Telemetry/ClientTelemetryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Telemetry/ClientTelemetryTests.cs
@@ -163,7 +163,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Telemetry
             ClientTelemetryProcessor processor = new ClientTelemetryProcessor(
                 MockCosmosUtil.CreateCosmosHttpClient(() => new HttpClient(new HttpHandlerHelper(mockHttpHandler.Object))),
                 Mock.Of<AuthorizationTokenProvider>(),
-                new ClientTelemetryConfig());
+                this.clientTelemetryConfig);
 
             ConcurrentDictionary<OperationInfo, (LongConcurrentHistogram latency, LongConcurrentHistogram requestcharge)> operationInfoSnapshot 
                 = new ConcurrentDictionary<OperationInfo, (LongConcurrentHistogram latency, LongConcurrentHistogram requestcharge)> ();
@@ -344,6 +344,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Telemetry
             {
                 CancellationTokenSource cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(1));
                 await Task.Delay(1000, cts.Token); // Making this task wait to ensure that processir is taking more time.
+
                 await processor.ProcessAndSendAsync(clientTelemetryProperties,
                                                     operationInfoSnapshot,
                                                     cacheRefreshInfoSnapshot,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Telemetry/DataSamplerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Telemetry/DataSamplerTests.cs
@@ -6,8 +6,6 @@ namespace Microsoft.Azure.Cosmos.Tests.Telemetry
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics;
-    using System.Linq;
     using Microsoft.Azure.Cosmos.Telemetry;
     using Microsoft.Azure.Cosmos.Telemetry.Models;
     using Microsoft.Azure.Documents;
@@ -16,10 +14,12 @@ namespace Microsoft.Azure.Cosmos.Tests.Telemetry
     [TestClass]
     public class DataSamplerTests
     {
+        private readonly ClientTelemetryConfig clientTelemetryConfig = new ClientTelemetryConfig();
+
         [TestMethod]
         public void TestNetworkRequestSamplerForThreshold()
         {
-            int numberOfElementsInEachGroup = ClientTelemetryOptions.NetworkRequestsSampleSizeThreshold;
+            int numberOfElementsInEachGroup = this.clientTelemetryConfig.NetworkTelemetryConfig.NetworkRequestsSampleSizeThreshold;
             int numberOfGroups = 5;
                
             List<RequestInfo> requestInfoList = new List<RequestInfo>();
@@ -54,10 +54,10 @@ namespace Microsoft.Azure.Cosmos.Tests.Telemetry
                 requestInfoList.Add(requestInfo);
             }
             
-            List<RequestInfo> sampleDataByLatency = DataSampler.OrderAndSample(requestInfoList, DataLatencyComparer.Instance);
+            List<RequestInfo> sampleDataByLatency = DataSampler.OrderAndSample(requestInfoList, DataLatencyComparer.Instance, this.clientTelemetryConfig.NetworkTelemetryConfig);
             Assert.AreEqual(numberOfGroups * numberOfElementsInEachGroup, sampleDataByLatency.Count);
 
-            List<RequestInfo> sampleDataBySampleCount = DataSampler.OrderAndSample(requestInfoList, DataSampleCountComparer.Instance);
+            List<RequestInfo> sampleDataBySampleCount = DataSampler.OrderAndSample(requestInfoList, DataSampleCountComparer.Instance, this.clientTelemetryConfig.NetworkTelemetryConfig);
             Assert.AreEqual(numberOfGroups * numberOfElementsInEachGroup, sampleDataBySampleCount.Count);
         }
 
@@ -66,14 +66,13 @@ namespace Microsoft.Azure.Cosmos.Tests.Telemetry
         {
             List<RequestInfo> requestInfoList = new List<RequestInfo>();
 
-            Assert.AreEqual(0, DataSampler.OrderAndSample(requestInfoList, DataSampleCountComparer.Instance).Count);
-            Assert.AreEqual(0, DataSampler.OrderAndSample(requestInfoList, DataLatencyComparer.Instance).Count);
+            Assert.AreEqual(0, DataSampler.OrderAndSample(requestInfoList, DataSampleCountComparer.Instance, this.clientTelemetryConfig.NetworkTelemetryConfig).Count);
+            Assert.AreEqual(0, DataSampler.OrderAndSample(requestInfoList, DataLatencyComparer.Instance, this.clientTelemetryConfig.NetworkTelemetryConfig).Count);
         }
 
         [TestMethod]
         public void TestNetworkRequestSamplerForLessThanThresholdSize()
         {
-            int numberOfElementsInEachGroup = ClientTelemetryOptions.NetworkRequestsSampleSizeThreshold;
             int numberOfGroups = 3;
 
             List<RequestInfo> requestInfoList = new List<RequestInfo>();
@@ -108,10 +107,10 @@ namespace Microsoft.Azure.Cosmos.Tests.Telemetry
                 requestInfoList.Add(requestInfo);
             }
 
-            List<RequestInfo> sampleDataByLatency = DataSampler.OrderAndSample(requestInfoList, DataLatencyComparer.Instance);
+            List<RequestInfo> sampleDataByLatency = DataSampler.OrderAndSample(requestInfoList, DataLatencyComparer.Instance, this.clientTelemetryConfig.NetworkTelemetryConfig);
             Assert.AreEqual(10, sampleDataByLatency.Count);
 
-            List<RequestInfo> sampleDataBySampleCount = DataSampler.OrderAndSample(requestInfoList, DataSampleCountComparer.Instance);
+            List<RequestInfo> sampleDataBySampleCount = DataSampler.OrderAndSample(requestInfoList, DataSampleCountComparer.Instance, this.clientTelemetryConfig.NetworkTelemetryConfig);
             Assert.AreEqual(10, sampleDataBySampleCount.Count);
         }
 


### PR DESCRIPTION
## Description

As per current design of client telemetry, every value is constant. As part of this PR, all those values which has potential to be configurable in future, are put in `ClientTelemetryConfig` file.
It does not mean that, we are going to expose all of them definitely in future.

**Why is this refactoring required?**
It will give us a clear picture of the options we have, to control client telemetry job. 

In this PR, making sure that `ClientTelemetryConfig` is getting initialized only at `DocumentClient` when we are starting the job and flowing wherever these values are required.

## Type of change
- [] This change requires a documentation update
