### PR TITLE
[Internal] Upgrade Resiliency: Adds Code to Read Replica Health States from Gateway Address Cache.

### DIFF
--- a/Microsoft.Azure.Cosmos/src/direct/AddressSelector.cs
+++ b/Microsoft.Azure.Cosmos/src/direct/AddressSelector.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Azure.Documents
             this.protocol = protocol;
         }
 
-        public async Task<IReadOnlyList<TransportAddressUri>> ResolveAllTransportAddressUriAsync(
+        public async Task<(IReadOnlyList<TransportAddressUri>, IReadOnlyList<string>)> ResolveAllTransportAddressUriAsync(
             DocumentServiceRequest request,
             bool includePrimary,
             bool forceRefresh)
@@ -30,8 +30,8 @@ namespace Microsoft.Azure.Documents
             PerProtocolPartitionAddressInformation partitionPerProtocolAddress = await this.ResolveAddressesAsync(request, forceRefresh);
 
             return includePrimary
-                ? partitionPerProtocolAddress.ReplicaTransportAddressUris
-                : partitionPerProtocolAddress.NonPrimaryReplicaTransportAddressUris;
+                ? (partitionPerProtocolAddress.ReplicaTransportAddressUris, partitionPerProtocolAddress.ReplicaTransportAddressUrisHealthState)
+                : (partitionPerProtocolAddress.NonPrimaryReplicaTransportAddressUris, partitionPerProtocolAddress.ReplicaTransportAddressUrisHealthState);
         }
 
         public async Task<TransportAddressUri> ResolvePrimaryTransportAddressUriAsync(

--- a/Microsoft.Azure.Cosmos/src/direct/StoreReader.cs
+++ b/Microsoft.Azure.Cosmos/src/direct/StoreReader.cs
@@ -176,7 +176,7 @@ namespace Microsoft.Azure.Documents
 
             string requestedCollectionRid = entity.RequestContext.ResolvedCollectionRid;
 
-            IReadOnlyList<TransportAddressUri> resolveApiResults = await this.addressSelector.ResolveAllTransportAddressUriAsync(
+            (IReadOnlyList<TransportAddressUri> resolveApiResults, IReadOnlyList<string> replicaHealthStatuses) = await this.addressSelector.ResolveAllTransportAddressUriAsync(
                      entity,
                      includePrimary,
                      entity.RequestContext.ForceRefreshAddressCache);
@@ -225,17 +225,11 @@ namespace Microsoft.Azure.Documents
             Exception cancellationException = null;
             Exception exceptionToThrow = null;
             SubStatusCodes subStatusCodeForException = SubStatusCodes.Unknown;
-            IEnumerable<TransportAddressUri> transportAddresses = this.addressEnumerator
+            IEnumerator<TransportAddressUri> uriEnumerator = this.addressEnumerator
                                                             .GetTransportAddresses(transportAddressUris: resolveApiResults,
                                                                                    failedEndpoints: entity.RequestContext.FailedEndpoints,
-                                                                                   replicaAddressValidationEnabled: this.isReplicaAddressValidationEnabled);
-
-            // The replica health status of the transport address uri will change eventually with the motonically increasing time.
-            // However, the purpose of this list is to capture the health status snapshot at this moment.
-            IEnumerable<string> replicaHealthStatuses = transportAddresses
-                .Select(x => x.GetCurrentHealthState().GetHealthStatusDiagnosticString());
-
-            IEnumerator<TransportAddressUri> uriEnumerator = transportAddresses.GetEnumerator();
+                                                                                   replicaAddressValidationEnabled: this.isReplicaAddressValidationEnabled)
+                                                            .GetEnumerator();
 
             // Loop until we have the read quorum number of valid responses or if we have read all the replicas
             while (replicasToRead > 0 && uriEnumerator.MoveNext())

--- a/Microsoft.Azure.Cosmos/src/direct/TransportAddressHealthState.cs
+++ b/Microsoft.Azure.Cosmos/src/direct/TransportAddressHealthState.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Azure.Documents
             this.lastUnknownTimestamp = lastUnknownTimestamp;
             this.lastUnhealthyPendingTimestamp = lastUnhealthyPendingTimestamp;
             this.lastUnhealthyTimestamp = lastUnhealthyTimestamp;
-            this.healthStatusDiagnosticString = $"{transportUri.Port}:{healthStatus}";
+            this.healthStatusDiagnosticString = $"(port: {transportUri.Port} | status: {healthStatus} | lkt: {this.GetLastKnownTimestampByHealthStatus(healthStatus)})";
 
             List<string> healthStatusList = new ()
             {
@@ -118,6 +118,7 @@ namespace Microsoft.Azure.Documents
                 HealthStatus.Unhealthy => this.lastUnhealthyTimestamp,
                 HealthStatus.UnhealthyPending => this.lastUnhealthyPendingTimestamp,
                 HealthStatus.Unknown => this.lastUnknownTimestamp,
+                HealthStatus.Connected => DateTime.UtcNow,
                 _ => throw new ArgumentException(
                     message: $"Unsupported Health Status: {healthStatus}"),
             };

--- a/Microsoft.Azure.Cosmos/src/direct/TransportAddressHealthState.cs
+++ b/Microsoft.Azure.Cosmos/src/direct/TransportAddressHealthState.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Azure.Documents
             this.lastUnknownTimestamp = lastUnknownTimestamp;
             this.lastUnhealthyPendingTimestamp = lastUnhealthyPendingTimestamp;
             this.lastUnhealthyTimestamp = lastUnhealthyTimestamp;
-            this.healthStatusDiagnosticString = $"{transportUri}:{healthStatus}";
+            this.healthStatusDiagnosticString = $"{transportUri.Port}:{healthStatus}";
 
             List<string> healthStatusList = new ()
             {


### PR DESCRIPTION
# Pull Request Template

## Description

- Code changes to fix replica health snapshot capture logic (this operation is done behind a feature flag):

     Today, the existing code captures the replica health statuses real-time, which means the replica health statuses can change along with time, with an in-flight request. The purpose of this change is to fix the behavior and capture the replica health status snapshots, which remains unchanged with time. 

- Code changes to read replica health states from gateway address cache: Today, the existing approach reads the replica health states from the returned address from address resolver and snapshots them into a new list for the purpose of diagnostics. This approach has severe drawbacks as it's been done on a hot-path. Therefore, to fix this behavior, this PR refactors the `GatewayAddressCache` to return the replica health states along with the list of replicas.

- Code changes to reduce replica health state diagnostics string content:

Replica health state diagnostics before this change:

```
"RetryAfterInMs": null,
"BELatencyInMs": "0.465",
"ReplicaHealthStatuses": [
    "rntbd://cdb-ms-prod-westcentralus1-be8.documents.azure.com:14338/apps/e7f084bc-fb44-4077-ae01-aff411508418/services/97cf371d-4d47-415c-87a5-dbb1d1794d6a/partitions/94bbe380-6ca7-4849-a396-4f413a76d68c/replicas/133185642015919046p:Connected",
    "rntbd://cdb-ms-prod-westcentralus1-be8.documents.azure.com:15877/apps/e7f084bc-fb44-4077-ae01-aff411508418/services/97cf371d-4d47-415c-87a5-dbb1d1794d6a/partitions/94bbe380-6ca7-4849-a396-4f413a76d68c/replicas/592185666535919046s:Connected",
    "rntbd://cdb-ms-prod-westcentralus1-be8.documents.azure.com:14790/apps/e7f084bc-fb44-4077-ae01-aff411508418/services/97cf371d-4d47-415c-87a5-dbb1d1794d6a/partitions/94bbe380-6ca7-4849-a396-4f413a76d68c/replicas/800988122015919046s:Connected",
    "rntbd://cdb-ms-prod-westcentralus1-be8.documents.azure.com:14338/apps/e7f084bc-fb44-4077-ae01-aff411508418/services/97cf371d-4d47-415c-87a5-dbb1d1794d6a/partitions/94bbe380-6ca7-4849-a396-4f413a76d68c/replicas/433025642015919046s:Unknown"
],
"transportRequestTimeline": {
    "requestTimeline": [
        {
            "event": "Created",
            "startTimeUtc": "2023-01-19T01:12:03.1785624Z",
            "durationInMs": 5.6755
        }
    ]
}
```

Replica health state diagnostics after this change:

```
"RetryAfterInMs": null,
"BELatencyInMs": "0.465",
"ReplicaHealthStatuses": [
    "14338:Connected",
    "15877:Connected",
    "14790:Connected",
    "14338:Unknown"
],
"transportRequestTimeline": {
    "requestTimeline": [
        {
            "event": "Created",
            "startTimeUtc": "2023-01-19T01:12:03.1785624Z",
            "durationInMs": 5.6755
        }
    ]
}
```

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

## Closing issues

To automatically close an issue: closes #IssueNumber