### PR TITLE
NugetPackage: Removes ThirdPartyNotice.txt from content and contentFiles folders

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
+++ b/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
@@ -59,7 +59,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<Content Include="..\..\ThirdPartyNotice.txt" Link="ThirdPartyNotice.txt" />
+		<None Include="..\..\ThirdPartyNotice.txt" Pack="true" PackagePath="" Visible="false" Link="ThirdPartyNotice.txt" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
# Pull Request Template

## Description

Removing ThirdPartyNotice.txt from content and contentfiles nuget folder. Unless there is a reason this needs to remain in the content and contentFiles Nuget folders, it seems fine to move it to the root.

Before:
![image](https://github.com/Azure/azure-cosmos-dotnet-v3/assets/86612891/e20169bd-2169-4247-b5ff-c1a3a32b1f22)

After:
![image](https://github.com/Azure/azure-cosmos-dotnet-v3/assets/86612891/5edacd6d-fc6c-4d5e-a6fd-4610cd438da4)


## Closing issues

To automatically close an issue: closes #3667 