### PR TITLE
AI Integration: Fixes Open Telemetry Example

### DIFF
--- a/Microsoft.Azure.Cosmos.Samples/Usage/OpenTelemetry/AppSettings.json
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/OpenTelemetry/AppSettings.json
@@ -1,7 +1,9 @@
 {
   "Logging": {
-    "LogLevel": {
-      "Azure-Cosmos-Operation-Request-Diagnostics": "Information"
+    "OpenTelemetry": {
+      "LogLevel": {
+        "Azure.Cosmos.Operation.Request.Diagnostics": "Warning"
+      }
     }
   },
   "CosmosDBEndPointUrl": "https://localhost:8081",

--- a/Microsoft.Azure.Cosmos.Samples/Usage/OpenTelemetry/OpenTelemetry.csproj
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/OpenTelemetry/OpenTelemetry.csproj
@@ -12,10 +12,11 @@
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.0.0-beta.10" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.33.0-preview" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.6.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
     <PackageReference Include="OpenTelemetry" Version="1.4.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Microsoft.Azure.Cosmos.Samples/Usage/OpenTelemetry/OpenTelemetry.csproj
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/OpenTelemetry/OpenTelemetry.csproj
@@ -12,11 +12,8 @@
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.0.0-beta.10" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.33.0-preview" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.6.3" />
-    <PackageReference Include="OpenTelemetry" Version="1.4.0" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Microsoft.Azure.Cosmos.Samples/Usage/OpenTelemetry/OpenTelemetry.csproj
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/OpenTelemetry/OpenTelemetry.csproj
@@ -13,7 +13,6 @@
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.33.0-preview" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.6.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Microsoft.Azure.Cosmos.Samples/Usage/OpenTelemetry/OpenTelemetry.csproj
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/OpenTelemetry/OpenTelemetry.csproj
@@ -12,11 +12,10 @@
     <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.0.0-beta.10" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.33.0-preview" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.6.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="7.0.1" />
     <PackageReference Include="OpenTelemetry" Version="1.4.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="7.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Microsoft.Azure.Cosmos.Samples/Usage/OpenTelemetry/Program.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/OpenTelemetry/Program.cs
@@ -25,8 +25,8 @@
             try
             {
                 IConfigurationRoot configuration = new ConfigurationBuilder()
-                            .AddJsonFile("AppSettings.json")
-                            .Build();
+                                                            .AddJsonFile("AppSettings.json")
+                                                            .Build();
 
                 string endpoint = configuration["CosmosDBEndPointUrl"];
                 if (string.IsNullOrEmpty(endpoint))
@@ -52,15 +52,16 @@
                             serviceVersion: "1.0.0");
 
                 // Set up logging to forward logs to chosen exporter
-                using ILoggerFactory loggerFactory = LoggerFactory.Create(builder => builder
-                                                                                        .AddConfiguration(configuration)
-                                                                                        .AddOpenTelemetry(options =>
-                                                                                            {
-                                                                                                options.IncludeFormattedMessage = true;
-                                                                                                options.SetResourceBuilder(resource);
-                                                                                                options.AddAzureMonitorLogExporter(o => o.ConnectionString = aiConnectionString); // Set up exporter of your choice
-                                                                                            }));
-                /*.AddFilter(level => level == LogLevel.Error)*/
+                using ILoggerFactory loggerFactory 
+                    = LoggerFactory.Create(builder => builder
+                                                        .AddConfiguration(configuration.GetSection("Logging"))
+                                                        .AddOpenTelemetry(options =>
+                                                            {
+                                                                options.IncludeFormattedMessage = true;
+                                                                options.SetResourceBuilder(resource);
+                                                                options.AddAzureMonitorLogExporter(o => o.ConnectionString = aiConnectionString); // Set up exporter of your choice
+                                                            }));
+                /*.AddFilter(level => level == LogLevel.Error) // Filter  is irrespective of event type or event name*/
 
                 AzureEventSourceLogForwarder logforwader = new AzureEventSourceLogForwarder(loggerFactory);
                 logforwader.Start();
@@ -92,7 +93,6 @@
 
                     await Program.RunCrudDemo(container);
                 }
-
             }
             finally
             {

--- a/Microsoft.Azure.Cosmos.Samples/Usage/OpenTelemetry/Program.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/OpenTelemetry/Program.cs
@@ -124,9 +124,9 @@
             {
                 await container.ReadItemAsync<Item>($"random key", new PartitionKey($"random partition"));
             }
-            catch(Exception ex)
+            catch(Exception)
             {
-                Console.WriteLine($"Exception: {ex}");
+                Console.WriteLine("Generate exception by reading an invalid key");
             }
             
             for (int i = 1; i <= 5; i++)

--- a/Microsoft.Azure.Cosmos.Samples/Usage/OpenTelemetry/Program.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/OpenTelemetry/Program.cs
@@ -52,14 +52,16 @@
                             serviceVersion: "1.0.0");
 
                 // Set up logging to forward logs to chosen exporter
-                using ILoggerFactory loggerFactory = LoggerFactory.Create(builder => builder.AddOpenTelemetry(options =>
-                    {
-                        options.IncludeFormattedMessage = true;
-                        options.SetResourceBuilder(resource);
-                        options.AddAzureMonitorLogExporter(o => o.ConnectionString = aiConnectionString); // Set up exporter of your choice
-                    })
-                   .AddFilter(level => level == LogLevel.Error));
-                
+                using ILoggerFactory loggerFactory = LoggerFactory.Create(builder => builder
+                                                                                        .AddConfiguration(configuration)
+                                                                                        .AddOpenTelemetry(options =>
+                                                                                            {
+                                                                                                options.IncludeFormattedMessage = true;
+                                                                                                options.SetResourceBuilder(resource);
+                                                                                                options.AddAzureMonitorLogExporter(o => o.ConnectionString = aiConnectionString); // Set up exporter of your choice
+                                                                                            }));
+                /*.AddFilter(level => level == LogLevel.Error)*/
+
                 AzureEventSourceLogForwarder logforwader = new AzureEventSourceLogForwarder(loggerFactory);
                 logforwader.Start();
 


### PR DESCRIPTION
## Description

In the sample of Open Telemetry with cosmos DB SDK, Logger Factory is not reading configuration from `appsettings` for Loglevel which is leading to generate events for Warning and Error both, even if LogLevel is configured as Error.

There are 2 ways to fix it:
1. Use `AddFilter()` and filter out only desired event level (doesn't matter what is event name).
2. `LoggerFactory `should read `appsettings `and emit only events with configured level

> Note: `AzureEventSourceLogForwarder` change this `Azure-Cosmos-Operation-Request-Diagnostics` to `Azure.Cosmos.Operation.Request.Diagnostics`
## Type of change
- [] Bug fix (non-breaking change which fixes an issue)
