### PR TITLE
Direct Package Upgrade 3.31.0: Refactors code to make compatible with latest direct

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
 		<ClientOfficialVersion>3.34.0</ClientOfficialVersion>
 		<ClientPreviewVersion>3.34.0</ClientPreviewVersion>
 		<ClientPreviewSuffixVersion>preview</ClientPreviewSuffixVersion>
-		<DirectVersion>3.30.8</DirectVersion>
+		<DirectVersion>3.31.0</DirectVersion>
 		<EncryptionOfficialVersion>2.0.1</EncryptionOfficialVersion>
 		<EncryptionPreviewVersion>2.0.1</EncryptionPreviewVersion>
 		<EncryptionPreviewSuffixVersion>preview</EncryptionPreviewSuffixVersion>

--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -6644,6 +6644,11 @@ namespace Microsoft.Azure.Cosmos
             }
             else
             {
+                Documents.Telemetry.DistributedTracingOptions distributedTracingOptions = new ()
+                {
+                    IsDistributedTracingEnabled = this.isDistributedTracingEnabled
+                };
+
                 StoreClientFactory newClientFactory = new StoreClientFactory(
                     this.ConnectionPolicy.ConnectionProtocol,
                     (int)this.ConnectionPolicy.RequestTimeout.TotalSeconds,
@@ -6667,7 +6672,7 @@ namespace Microsoft.Azure.Cosmos
                     addressResolver: this.AddressResolver,
                     rntbdMaxConcurrentOpeningConnectionCount: this.rntbdMaxConcurrentOpeningConnectionCount,
                     remoteCertificateValidationCallback: this.remoteCertificateValidationCallback,
-                    isDistributedTracingEnabled: this.isDistributedTracingEnabled);
+                    distributedTracingOptions: distributedTracingOptions);
 
                 if (this.transportClientHandlerFactory != null)
                 {

--- a/Microsoft.Azure.Cosmos/src/Regions.cs
+++ b/Microsoft.Azure.Cosmos/src/Regions.cs
@@ -349,5 +349,15 @@ namespace Microsoft.Azure.Cosmos
         /// Name of the Azure Poland Central region in the Azure Cosmos DB service.
         /// </summary>
         public const string PolandCentral = "Poland Central";
+
+        /// <summary>
+        /// Name of the Azure Malaysia South region in the Azure Cosmos DB service.
+        /// </summary>
+        public const string MalaysiaSouth = "Malaysia South";
+
+        /// <summary>
+        /// Name of the Azure Italy North region in the Azure Cosmos DB service.
+        /// </summary>
+        public const string ItalyNorth = "Italy North";
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
@@ -85,7 +85,7 @@ namespace Microsoft.Azure.Cosmos.Routing
                 GatewayAddressCache.ProtocolString(this.protocol));
 
             this.openConnectionsHandler = openConnectionsHandler;
-            this.isReplicaAddressValidationEnabled = Helpers.GetEnvironmentVariableAsBool(
+            this.isReplicaAddressValidationEnabled = Helpers.GetEnvironmentVariable<bool>(
                 name: Constants.EnvironmentVariables.ReplicaConnectivityValidationEnabled,
                 defaultValue: false);
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/Util.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/Util.cs
@@ -548,11 +548,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             // Open Telemetry Listener
             Util.OTelTracerProvider = Sdk.CreateTracerProviderBuilder()
                 .AddCustomOtelExporter() // use any exporter here
-                .AddSource($"{OpenTelemetryAttributeKeys.DiagnosticNamespace}.*")
+                .AddSource($"{OpenTelemetryAttributeKeys.DiagnosticNamespace}.Operation")
                 .Build();
 
             // Custom Listener
-            Util.TestListener = new CustomListener($"{OpenTelemetryAttributeKeys.DiagnosticNamespace}.*", "Azure-Cosmos-Operation-Request-Diagnostics");
+            Util.TestListener = new CustomListener($"{OpenTelemetryAttributeKeys.DiagnosticNamespace}.Operation", "Azure-Cosmos-Operation-Request-Diagnostics");
 
             return Util.TestListener;
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetSDKAPI.json
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetSDKAPI.json
@@ -6680,6 +6680,11 @@
           "Attributes": [],
           "MethodInfo": "System.String GermanyWestCentral;IsInitOnly:False;IsStatic:True;"
         },
+        "System.String ItalyNorth": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": "System.String ItalyNorth;IsInitOnly:False;IsStatic:True;"
+        },
         "System.String JapanEast": {
           "Type": "Field",
           "Attributes": [],
@@ -6709,6 +6714,11 @@
           "Type": "Field",
           "Attributes": [],
           "MethodInfo": "System.String KoreaSouth;IsInitOnly:False;IsStatic:True;"
+        },
+        "System.String MalaysiaSouth": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": "System.String MalaysiaSouth;IsInitOnly:False;IsStatic:True;"
         },
         "System.String NorthCentralUS": {
           "Type": "Field",


### PR DESCRIPTION
## Description

It has 3 minor changes:
1. Upgrade Direct Package to 3.31.0, As side effect of this, made below changes.
2. Use correct function GatewayCache to get environment variable as boolean
3. Pass DistributedTracing Options instead of flag directly in Store factory
4. Added 2 new regions "_Malaysia South_", "_Italy North_".
5. Enable Distributing Tracing only for Operations. Request level tracing will be enabled as separate PR.