### PR TITLE
[Query] Fixes empty property name parsing exception

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CosmosQueryExecutionContextFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CosmosQueryExecutionContextFactory.cs
@@ -188,7 +188,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
                     // If the query would go to gateway, but we have a partition key,
                     // then try seeing if we can execute as a passthrough using client side only logic.
                     // This is to short circuit the need to go to the gateway to get the query plan.
-                    if (cosmosQueryContext.QueryClient.ByPassQueryParsing()
+                    if (cosmosQueryContext.QueryClient.BypassQueryParsing()
                         && inputParameters.PartitionKey.HasValue)
                     {
                         bool parsed;
@@ -586,7 +586,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
            CancellationToken cancellationToken)
         {
             PartitionedQueryExecutionInfo partitionedQueryExecutionInfo;
-            if (cosmosQueryContext.QueryClient.ByPassQueryParsing())
+            if (cosmosQueryContext.QueryClient.BypassQueryParsing())
             {
                 // For non-Windows platforms(like Linux and OSX) in .NET Core SDK, we cannot use ServiceInterop, so need to bypass in that case.
                 // We are also now bypassing this for 32 bit host process running even on Windows as there are many 32 bit apps that will not work without this

--- a/Microsoft.Azure.Cosmos/src/Query/Core/QueryClient/CosmosQueryClient.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/QueryClient/CosmosQueryClient.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryClient
             bool forceRefresh,
             ITrace trace);
 
-        public abstract bool ByPassQueryParsing();
+        public abstract bool BypassQueryParsing();
 
         public abstract Task ForceRefreshCollectionCacheAsync(
             string collectionLink,

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/CosmosQueryClientCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/CosmosQueryClientCore.cs
@@ -285,7 +285,7 @@ namespace Microsoft.Azure.Cosmos
             }
         }
 
-        public override bool ByPassQueryParsing()
+        public override bool BypassQueryParsing()
         {
             return CustomTypeExtensions.ByPassQueryParsing();
         }

--- a/Microsoft.Azure.Cosmos/src/SqlObjects/SqlPropertyName.cs
+++ b/Microsoft.Azure.Cosmos/src/SqlObjects/SqlPropertyName.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Azure.Cosmos.SqlObjects
 
         private SqlPropertyName(string value)
         {
-            this.Value = value ?? throw new ArgumentException($"{nameof(value)} must not be null.");
+            this.Value = value ?? throw new ArgumentNullException(nameof(value));
         }
 
         public string Value { get; }

--- a/Microsoft.Azure.Cosmos/src/SqlObjects/SqlPropertyName.cs
+++ b/Microsoft.Azure.Cosmos/src/SqlObjects/SqlPropertyName.cs
@@ -68,10 +68,11 @@ namespace Microsoft.Azure.Cosmos.SqlObjects
 
         private SqlPropertyName(string value)
         {
-            if (string.IsNullOrWhiteSpace(value))
-            {
-                throw new ArgumentException($"{nameof(value)} must not be null, empty, or whitespace.");
-            }
+            // Todo: confirm purpose
+            //if (string.IsNullOrWhiteSpace(value))
+            //{
+            //    throw new ArgumentException($"{nameof(value)} must not be null, empty, or whitespace.");
+            //}
 
             this.Value = value;
         }

--- a/Microsoft.Azure.Cosmos/src/SqlObjects/SqlPropertyName.cs
+++ b/Microsoft.Azure.Cosmos/src/SqlObjects/SqlPropertyName.cs
@@ -68,7 +68,7 @@ namespace Microsoft.Azure.Cosmos.SqlObjects
 
         private SqlPropertyName(string value)
         {
-            this.Value = value;
+            this.Value = value ?? throw new ArgumentException($"{nameof(value)} must not be null.");
         }
 
         public string Value { get; }

--- a/Microsoft.Azure.Cosmos/src/SqlObjects/SqlPropertyName.cs
+++ b/Microsoft.Azure.Cosmos/src/SqlObjects/SqlPropertyName.cs
@@ -68,12 +68,6 @@ namespace Microsoft.Azure.Cosmos.SqlObjects
 
         private SqlPropertyName(string value)
         {
-            // Todo: confirm purpose
-            //if (string.IsNullOrWhiteSpace(value))
-            //{
-            //    throw new ArgumentException($"{nameof(value)} must not be null, empty, or whitespace.");
-            //}
-
             this.Value = value;
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosGatewayTimeoutTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosGatewayTimeoutTests.cs
@@ -163,7 +163,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             {
             }
 
-            public override bool ByPassQueryParsing()
+            public override bool BypassQueryParsing()
             {
                 return true;
             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/BypassQueryParsingTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/BypassQueryParsingTests.cs
@@ -15,39 +15,11 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
         public async Task TestBypassQueryParsingWithNonePartitionKey()
         {
             int documentCount = 400;
-            QueryRequestOptions feedOptions = new QueryRequestOptions { PartitionKey = PartitionKey.None };
+
             string query = "SELECT VALUE r.numberField FROM r";
-            IReadOnlyList<int> expected = Enumerable.Range(0, documentCount).ToList();
+            IReadOnlyList<string> expectedOutput = Enumerable.Range(0, documentCount).Select(i => i.ToString()).ToList();
 
-            async Task ImplementationAsync(Container container, IReadOnlyList<CosmosObject> documents)
-            {
-                ContainerInternal containerCore = container as ContainerInlineCore;
-
-                MockCosmosQueryClient cosmosQueryClientCore = new MockCosmosQueryClient(
-                    containerCore.ClientContext,
-                    containerCore,
-                    forceQueryPlanGatewayElseServiceInterop: true);
-
-                ContainerInternal containerWithBypassParsing = new ContainerInlineCore(
-                    containerCore.ClientContext,
-                    (DatabaseCore)containerCore.Database,
-                    containerCore.Id,
-                    cosmosQueryClientCore);
-
-                List<CosmosElement> items = await RunQueryAsync(containerWithBypassParsing, query, feedOptions);
-                int[] actual = items.Cast<CosmosNumber>().Select(x => (int)Number64.ToLong(x.Value)).ToArray();
-
-                Assert.IsTrue(expected.SequenceEqual(actual));
-            }
-
-            IReadOnlyList<string> documents = CreateDocuments(documentCount);
-
-            await this.CreateIngestQueryDeleteAsync(
-                ConnectionModes.Direct | ConnectionModes.Gateway,
-                CollectionTypes.NonPartitioned | CollectionTypes.SinglePartition | CollectionTypes.MultiPartition,
-                documents,
-                ImplementationAsync,
-                "/undefinedPartitionKey");
+            await this.ValidateQueryBypassWithNonePartitionKey(documentCount, query, expectedOutput);
         }
 
         [TestMethod]
@@ -56,9 +28,15 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
         {
             int documentCount = 400;
 
-            QueryRequestOptions feedOptions = new QueryRequestOptions { PartitionKey = PartitionKey.None };
             string query = @"SELECT VALUE { """" : r.numberField } FROM r";
-            IReadOnlyList<string> expected = Enumerable.Range(0, documentCount).Select(i => String.Format("{{\"\":{0}}}", i)).ToList();
+            IReadOnlyList<string> expectedOutput = Enumerable.Range(0, documentCount).Select(i => String.Format("{{\"\":{0}}}", i)).ToList();
+
+            await this.ValidateQueryBypassWithNonePartitionKey(documentCount, query, expectedOutput);
+        }
+
+        private async Task ValidateQueryBypassWithNonePartitionKey(int documentCount, string query, IReadOnlyList<string> expectedOutput)
+        {
+            QueryRequestOptions feedOptions = new QueryRequestOptions { PartitionKey = PartitionKey.None };
 
             async Task ImplementationAsync(Container container, IReadOnlyList<CosmosObject> documents)
             {
@@ -76,9 +54,9 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
                     cosmosQueryClientCore);
 
                 List<CosmosElement> items = await RunQueryAsync(containerWithBypassParsing, query, feedOptions);
-                string[] actual = items.Select(x => x.ToString()).ToArray();
+                string[] actualOutput = items.Select(x => x.ToString()).ToArray();
 
-                Assert.IsTrue(expected.SequenceEqual(actual));
+                Assert.IsTrue(expectedOutput.SequenceEqual(actualOutput));
             }
 
             IReadOnlyList<string> documents = CreateDocuments(documentCount);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/BypassQueryParsingTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/BypassQueryParsingTests.cs
@@ -1,5 +1,6 @@
 namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
 {
+    using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
@@ -57,7 +58,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
 
             QueryRequestOptions feedOptions = new QueryRequestOptions { PartitionKey = PartitionKey.None };
             string query = @"SELECT VALUE { """" : r.numberField } FROM r";
-            IReadOnlyList<string> expected = Enumerable.Range(0, documentCount).Select(i => "{\"\":" + i.ToString() + "}").ToList();
+            IReadOnlyList<string> expected = Enumerable.Range(0, documentCount).Select(i => String.Format("{{\"\":{0}}}", i)).ToList();
 
             async Task ImplementationAsync(Container container, IReadOnlyList<CosmosObject> documents)
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/BypassQueryParsingTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/BypassQueryParsingTests.cs
@@ -49,6 +49,47 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
                 "/undefinedPartitionKey");
         }
 
+        [TestMethod]
+        [TestCategory("Query")]
+        public async Task TestBypassQueryParsingWithNonePartitionKeyEmptyPropertyName()
+        {
+            int documentCount = 400;
+
+            QueryRequestOptions feedOptions = new QueryRequestOptions { PartitionKey = PartitionKey.None };
+            string query = @"SELECT VALUE { """" : r.numberField } FROM r";
+            IReadOnlyList<string> expected = Enumerable.Range(0, documentCount).Select(i => "{\"\":" + i.ToString() + "}").ToList();
+
+            async Task ImplementationAsync(Container container, IReadOnlyList<CosmosObject> documents)
+            {
+                ContainerInternal containerCore = container as ContainerInlineCore;
+
+                MockCosmosQueryClient cosmosQueryClientCore = new MockCosmosQueryClient(
+                    containerCore.ClientContext,
+                    containerCore,
+                    forceQueryPlanGatewayElseServiceInterop: true);
+
+                ContainerInternal containerWithBypassParsing = new ContainerInlineCore(
+                    containerCore.ClientContext,
+                    (DatabaseCore)containerCore.Database,
+                    containerCore.Id,
+                    cosmosQueryClientCore);
+
+                List<CosmosElement> items = await RunQueryAsync(containerWithBypassParsing, query, feedOptions);
+                string[] actual = items.Select(x => x.ToString()).ToArray();
+
+                Assert.IsTrue(expected.SequenceEqual(actual));
+            }
+
+            IReadOnlyList<string> documents = CreateDocuments(documentCount);
+
+            await this.CreateIngestQueryDeleteAsync(
+                ConnectionModes.Direct | ConnectionModes.Gateway,
+                CollectionTypes.NonPartitioned | CollectionTypes.SinglePartition | CollectionTypes.MultiPartition,
+                documents,
+                ImplementationAsync,
+                "/undefinedPartitionKey");
+        }
+
         private static IReadOnlyList<string> CreateDocuments(int documentCount)
         {
             List<string> documents = new List<string>(documentCount);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/MockCosmosQueryClient.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/MockCosmosQueryClient.cs
@@ -35,7 +35,7 @@
 
         public int QueryPlanCalls { get; private set; }
 
-        public override bool ByPassQueryParsing()
+        public override bool BypassQueryParsing()
         {
             return this.forceQueryPlanGatewayElseServiceInterop;
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OptimisticDirectExecutionQueryBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OptimisticDirectExecutionQueryBaselineTests.cs
@@ -927,7 +927,7 @@
     {
         public override Action<IQueryable> OnExecuteScalarQueryCallback => throw new NotImplementedException();
 
-        public override bool ByPassQueryParsing()
+        public override bool BypassQueryParsing()
         {
             return false;
         }


### PR DESCRIPTION
## Description

Updates property name parsing checks to allow for empty and whitespace property names.  These types of property names are currently allowed via the portal. Previously, an exception would be thrown upon parsing empty/whitespace property names when the gateway was bypassed and routing logic performed on the client side. Specifically, this would be the case when using macOS or Linux.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Closing issues

closes #2879 