### PR TITLE
Documentations: Adds links to PatchItems docs

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
@@ -751,6 +751,7 @@ namespace Microsoft.Azure.Cosmos
         /// ]]>
         /// </code>
         /// </example>
+        /// <seealso href="https://learn.microsoft.com/azure/cosmos-db/partial-document-update#supported-modes">Supported partial document update modes</seealso>
         public abstract Task<ItemResponse<T>> PatchItemAsync<T>(
             string id,
             PartitionKey partitionKey,
@@ -783,6 +784,7 @@ namespace Microsoft.Azure.Cosmos
         /// <example>
         /// <see cref="Container.PatchItemAsync"/>
         /// </example>
+        /// <seealso href="https://learn.microsoft.com/azure/cosmos-db/partial-document-update#supported-modes">Supported partial document update modes</seealso>
         public abstract Task<ResponseMessage> PatchItemStreamAsync(
             string id,
             PartitionKey partitionKey,

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerInternal.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerInternal.cs
@@ -140,7 +140,6 @@ namespace Microsoft.Azure.Cosmos
         /// <returns>
         /// A <see cref="Task"/> containing a <see cref="ResponseMessage"/> which wraps a <see cref="Stream"/> containing the patched resource record.
         /// </returns>
-        /// <seealso href="https://learn.microsoft.com/azure/cosmos-db/partial-document-update#supported-modes">Supported partial document update modes</seealso>
         public abstract Task<ResponseMessage> PatchItemStreamAsync(
             string id,
             PartitionKey partitionKey,

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerInternal.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerInternal.cs
@@ -140,6 +140,7 @@ namespace Microsoft.Azure.Cosmos
         /// <returns>
         /// A <see cref="Task"/> containing a <see cref="ResponseMessage"/> which wraps a <see cref="Stream"/> containing the patched resource record.
         /// </returns>
+        /// <seealso href="https://learn.microsoft.com/azure/cosmos-db/partial-document-update#supported-modes">Supported partial document update modes</seealso>
         public abstract Task<ResponseMessage> PatchItemStreamAsync(
             string id,
             PartitionKey partitionKey,


### PR DESCRIPTION
## Description
Added links of supported patch modes as part of the API documentation on Container.PatchItem methods.

## Type of change

- [x] This change requires a documentation update

## Closing issues

To automatically close an issue: close #3898