### PR TITLE
Benchmark metrics dashboard

### DIFF
--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/AzureVmBenchmark/azuredeploy.json
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/AzureVmBenchmark/azuredeploy.json
@@ -152,9 +152,16 @@
             "type": "string",
             "defaultValue": "CosmosDBBenchmarkTestAppInsights",
             "metadata": {
-                "description": "Specifies Application Insights Account Nmae"
+                "description": "Specifies Application Insights Account Name"
             }
-        }
+        },
+    "dashboardName": {
+      "type": "string",
+      "defaultValue": "Cosmos Benchmark Statistics",
+      "metadata": {
+                "description": "Specifies Application Insights Dashboard Name"
+            }
+    }
     },
     "variables": {
         "vmName": "[concat(parameters('projectName'), '-vm')]",
@@ -165,7 +172,8 @@
         "cloudInitScriptUrl": "[concat('https://raw.githubusercontent.com/',parameters('benchmarkingToolsRepoName'),'/',parameters('benchmarkingToolsBranchName'),'/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/AzureVmBenchmark/system/cloud-init.txt')]",
         "vmScriptExtensionScriptUrl": "[concat('https://raw.githubusercontent.com/',parameters('benchmarkingToolsRepoName'),'/',parameters('benchmarkingToolsBranchName'),'/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/AzureVmBenchmark/scripts/execute.sh')]",
         "customScriptUrl": "[concat('https://raw.githubusercontent.com/',parameters('benchmarkingToolsRepoName'),'/',parameters('benchmarkingToolsBranchName'),'/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/AzureVmBenchmark/scripts/custom-script.sh')]",
-        "vmScriptExtensionScriptName": "execute.sh"
+        "vmScriptExtensionScriptName": "execute.sh",
+        "appInsightsResourceIds": "[concat('/subscriptions/', subscription().subscriptionId, '/resourceGroups/', resourceGroup().name, '/providers/microsoft.insights/components/', parameters('applicationInsightsName'))]"
     },
     "resources": [
         {
@@ -392,7 +400,181 @@
                 "name": "vmextensioncopy",
                 "count": "[parameters('vmCount')]"
             }
+        },
+    {
+      "name": "CosmosDBBenchmarkDashboard",
+      "type": "Microsoft.Portal/dashboards",
+      "location": "[resourceGroup().location]",
+      "apiVersion": "2015-08-01-preview",
+      "tags": {
+        "hidden-title": "[parameters('dashboardName')]"
+      },
+
+      "properties": {
+        "lenses": {
+          "0": {
+            "order": 0,
+            "parts": {
+              "0": {
+                "position": {
+                  "x": 0,
+                  "y": 0,
+                  "colSpan": 11,
+                  "rowSpan": 5
+                },
+                "metadata": {
+                  "inputs": [
+                    {
+                      "name": "resourceTypeMode",
+                      "isOptional": true
+                    },
+                    {
+                      "name": "ComponentId",
+                      "isOptional": true
+                    },
+                    {
+                      "name": "Scope",
+                      "value": {
+                        "resourceIds": [
+                          "[variables('appInsightsResourceIds')]"
+                        ]
+                      },
+                      "isOptional": true
+                    },
+                    {
+                      "name": "PartId",
+                      "value": "104528fc-0216-49c6-bf70-fffe9d37f93d",
+                      "isOptional": true
+                    },
+                    {
+                      "name": "Version",
+                      "value": "2.0",
+                      "isOptional": true
+                    },
+                    {
+                      "name": "TimeRange",
+                      "isOptional": true
+                    },
+                    {
+                      "name": "DashboardId",
+                      "isOptional": true
+                    },
+                    {
+                      "name": "DraftRequestParameters",
+                      "isOptional": true
+                    },
+                    {
+                      "name": "Query",
+                      "value": "customMetrics\n| where name == \"ReadOperationLatencyInMs\" and timestamp > ago(1d)\n| summarize\n    percentile(value, 50),\n    percentile(value, 75),\n    percentile(value, 90),\n    percentile(value, 95),\n    percentile(value, 99),\n    percentile(value, 99.9),\n    percentile(value, 99.99)\n    by ts = bin(timestamp, 5s)\n| render timechart \n\n",
+                      "isOptional": true
+                    },
+                    {
+                      "name": "ControlType",
+                      "value": "FrameControlChart",
+                      "isOptional": true
+                    },
+                    {
+                      "name": "SpecificChart",
+                      "value": "Line",
+                      "isOptional": true
+                    },
+                    {
+                      "name": "PartTitle",
+                      "value": "Analytics",
+                      "isOptional": true
+                    },
+                    {
+                      "name": "PartSubTitle",
+                      "value": "CosmosDBBenchmarkTestAppInsights",
+                      "isOptional": true
+                    },
+                    {
+                      "name": "Dimensions",
+                      "value": {
+                        "xAxis": {
+                          "name": "ts",
+                          "type": "datetime"
+                        },
+                        "yAxis": [
+                          {
+                            "name": "percentile_value_50",
+                            "type": "real"
+                          },
+                          {
+                            "name": "percentile_value_75",
+                            "type": "real"
+                          },
+                          {
+                            "name": "percentile_value_90",
+                            "type": "real"
+                          },
+                          {
+                            "name": "percentile_value_95",
+                            "type": "real"
+                          }
+                        ],
+                        "splitBy": [],
+                        "aggregation": "Sum"
+                      },
+                      "isOptional": true
+                    },
+                    {
+                      "name": "LegendOptions",
+                      "value": {
+                        "isEnabled": true,
+                        "position": "Bottom"
+                      },
+                      "isOptional": true
+                    },
+                    {
+                      "name": "IsQueryContainTimeRange",
+                      "value": true,
+                      "isOptional": true
+                    }
+                  ],
+                  "type": "Extension/Microsoft_OperationsManagementSuite_Workspace/PartType/LogsDashboardPart",
+                  "settings": {}
+                }
+              }
+            }
+          }
+        },
+        "metadata": {
+          "model": {
+            "timeRange": {
+              "value": {
+                "relative": {
+                  "duration": 24,
+                  "timeUnit": 1
+                }
+              },
+              "type": "MsPortalFx.Composition.Configuration.ValueTypes.TimeRange"
+            },
+            "filterLocale": {
+              "value": "en-us"
+            },
+            "filters": {
+              "value": {
+                "MsPortalFx_TimeRange": {
+                  "model": {
+                    "format": "utc",
+                    "granularity": "auto",
+                    "relative": "24h"
+                  },
+                  "displayCache": {
+                    "name": "UTC Time",
+                    "value": "Past 24 hours"
+                  },
+                  "filteredPartIds": [
+                    "StartboardPart-LogsDashboardPart-4f9d44ab-efbe-4310-8809-63ae942a3091"
+                  ]
+                }
+              }
+            }
+          }
         }
+      }
+    }
     ],
     "outputs": {
         "results": {

--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/BenchmarkConfig.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/BenchmarkConfig.cs
@@ -142,6 +142,18 @@ namespace CosmosBenchmark
         [Option(Required = false, HelpText = "Logging context name. The default value is \"CosmosDBBenchmarkLoggingContext\"")]
         public string LoggingContextIdentifier { get; set; } = "CosmosDBBenchmarkLoggingContext";
 
+        [Option(Required = false, HelpText = "Metrics reporting interval in seconds")]
+        public int MetricsReportingIntervalInSec { get; set; } = 5;
+
+        [Option(Required = false, HelpText = "Application Insights instrumentation key")]
+        public string AppInsightsInstrumentationKey { get; set; }
+
+        [Option(Required = false, HelpText = "The reservoir sample size.")]
+        public int ReservoirSampleSize { get; set; } = 1028;
+
+        [Option(Required = false, HelpText = "Logging context name. The default value is \"CosmosDBBenchmarkLoggingContext\"")]
+        public string LoggingContextIdentifier { get; set; } = "CosmosDBBenchmarkLoggingContext";
+
         internal int GetTaskCount(int containerThroughput)
         {
             int taskCount = this.DegreeOfParallelism;


### PR DESCRIPTION
# Pull Request Template

## Description

There is an ARM template for Cosmos DB Benchmark Application Insights Dashboard with percentiles.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber

Dashboard just after the start of Azure CosmosDB Benchmarking:
![image](https://github.com/Azure/azure-cosmos-dotnet-v3/assets/23213980/c6cb543c-bbbc-4626-a6fe-850c3c629dab)

Dashboard 7 min after the start:
![image](https://github.com/Azure/azure-cosmos-dotnet-v3/assets/23213980/51f112a8-aac9-4e9c-8d80-c45ecc63baf8)

Dashboard 15 min after the start:
![image](https://github.com/Azure/azure-cosmos-dotnet-v3/assets/23213980/d3f05ce1-70df-4d93-a230-40d625b3dc82)

After 30 min after start:
![image](https://github.com/Azure/azure-cosmos-dotnet-v3/assets/23213980/429b4fd4-5614-413b-bfce-58d700f6b0b3)
