### PR TITLE
HttpTransport: Fixes HttpTimeoutPolicies to not accidentally suppress retries

### DIFF
--- a/Microsoft.Azure.Cosmos/src/HttpClient/CosmosHttpClientCore.cs
+++ b/Microsoft.Azure.Cosmos/src/HttpClient/CosmosHttpClientCore.cs
@@ -438,8 +438,7 @@ namespace Microsoft.Azure.Cosmos
             DateTime startDateTimeUtc,
             IEnumerator<(TimeSpan requestTimeout, TimeSpan delayForNextRequest)> timeoutEnumerator)
         {
-            return (DateTime.UtcNow - startDateTimeUtc) > timeoutPolicy.MaximumRetryTimeLimit || // Maximum of time for all retries
-                !timeoutEnumerator.MoveNext(); // No more retries are configured
+            return !timeoutEnumerator.MoveNext(); // No more retries are configured
         }
 
         private async Task<HttpResponseMessage> ExecuteHttpHelperAsync(

--- a/Microsoft.Azure.Cosmos/src/HttpClient/HttpTimeoutPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/HttpClient/HttpTimeoutPolicy.cs
@@ -11,7 +11,6 @@ namespace Microsoft.Azure.Cosmos
     internal abstract class HttpTimeoutPolicy
     {
         public abstract string TimeoutPolicyName { get; }
-        public abstract TimeSpan MaximumRetryTimeLimit { get; }
         public abstract int TotalRetryCount { get; }
         public abstract IEnumerator<(TimeSpan requestTimeout, TimeSpan delayForNextRequest)> GetTimeoutEnumerator();
         public abstract bool IsSafeToRetry(HttpMethod httpMethod);

--- a/Microsoft.Azure.Cosmos/src/HttpClient/HttpTimeoutPolicyControlPlaneRead.cs
+++ b/Microsoft.Azure.Cosmos/src/HttpClient/HttpTimeoutPolicyControlPlaneRead.cs
@@ -25,8 +25,6 @@ namespace Microsoft.Azure.Cosmos
 
         public override string TimeoutPolicyName => HttpTimeoutPolicyControlPlaneRead.Name;
 
-        public override TimeSpan MaximumRetryTimeLimit => CosmosHttpClient.GatewayRequestTimeout;
-
         public override int TotalRetryCount => this.TimeoutsAndDelays.Count;
 
         public override IEnumerator<(TimeSpan requestTimeout, TimeSpan delayForNextRequest)> GetTimeoutEnumerator()

--- a/Microsoft.Azure.Cosmos/src/HttpClient/HttpTimeoutPolicyControlPlaneRetriableHotPath.cs
+++ b/Microsoft.Azure.Cosmos/src/HttpClient/HttpTimeoutPolicyControlPlaneRetriableHotPath.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.Cosmos
 
         public override string TimeoutPolicyName => HttpTimeoutPolicyControlPlaneRetriableHotPath.Name;
 
-        public override TimeSpan MaximumRetryTimeLimit => CosmosHttpClient.GatewayRequestTimeout;
+        public override TimeSpan MaximumRetryTimeLimit => CosmosHttpClient.GatewayRequestTimeout + TimeSpan.FromSeconds(7.5); // 0.5s + 5 s + 65s + 1s delay + 1s buffer
 
         public override int TotalRetryCount => this.TimeoutsAndDelays.Count;
 

--- a/Microsoft.Azure.Cosmos/src/HttpClient/HttpTimeoutPolicyControlPlaneRetriableHotPath.cs
+++ b/Microsoft.Azure.Cosmos/src/HttpClient/HttpTimeoutPolicyControlPlaneRetriableHotPath.cs
@@ -29,8 +29,6 @@ namespace Microsoft.Azure.Cosmos
 
         public override string TimeoutPolicyName => HttpTimeoutPolicyControlPlaneRetriableHotPath.Name;
 
-        public override TimeSpan MaximumRetryTimeLimit => CosmosHttpClient.GatewayRequestTimeout + TimeSpan.FromSeconds(7.5); // 0.5s + 5 s + 65s + 1s delay + 1s buffer
-
         public override int TotalRetryCount => this.TimeoutsAndDelays.Count;
 
         public override IEnumerator<(TimeSpan requestTimeout, TimeSpan delayForNextRequest)> GetTimeoutEnumerator()

--- a/Microsoft.Azure.Cosmos/src/HttpClient/HttpTimeoutPolicyDefault.cs
+++ b/Microsoft.Azure.Cosmos/src/HttpClient/HttpTimeoutPolicyDefault.cs
@@ -29,8 +29,6 @@ namespace Microsoft.Azure.Cosmos
 
         public override string TimeoutPolicyName => HttpTimeoutPolicyDefault.Name;
 
-        public override TimeSpan MaximumRetryTimeLimit => TimeSpan.FromSeconds((3 * CosmosHttpClient.GatewayRequestTimeout.TotalSeconds) + 1); // 3 times 65s + 1s delay + 1s buffer
-
         public override int TotalRetryCount => this.TimeoutsAndDelays.Count;
 
         public override IEnumerator<(TimeSpan requestTimeout, TimeSpan delayForNextRequest)> GetTimeoutEnumerator()

--- a/Microsoft.Azure.Cosmos/src/HttpClient/HttpTimeoutPolicyDefault.cs
+++ b/Microsoft.Azure.Cosmos/src/HttpClient/HttpTimeoutPolicyDefault.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.Cosmos
 
         public override string TimeoutPolicyName => HttpTimeoutPolicyDefault.Name;
 
-        public override TimeSpan MaximumRetryTimeLimit => CosmosHttpClient.GatewayRequestTimeout;
+        public override TimeSpan MaximumRetryTimeLimit => TimeSpan.FromSeconds((3 * CosmosHttpClient.GatewayRequestTimeout.TotalSeconds) + 1); // 3 times 65s + 1s delay + 1s buffer
 
         public override int TotalRetryCount => this.TimeoutsAndDelays.Count;
 

--- a/Microsoft.Azure.Cosmos/src/HttpClient/HttpTimeoutPolicyNoRetry.cs
+++ b/Microsoft.Azure.Cosmos/src/HttpClient/HttpTimeoutPolicyNoRetry.cs
@@ -24,8 +24,6 @@ namespace Microsoft.Azure.Cosmos
 
         public override string TimeoutPolicyName => HttpTimeoutPolicyNoRetry.Name;
 
-        public override TimeSpan MaximumRetryTimeLimit => TimeSpan.Zero;
-
         public override int TotalRetryCount => 0;
 
         public override IEnumerator<(TimeSpan requestTimeout, TimeSpan delayForNextRequest)> GetTimeoutEnumerator()


### PR DESCRIPTION
# Pull Request Template

## Description

Current HttpTimeoutPolicies had too short MaxRetryTime - effectively suppressing any retries

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber