### PR TITLE
Diagnostics: Fixes verbose levels for "Operation will NOT be retried"

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ResourceThrottleRetryPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/ResourceThrottleRetryPolicy.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Azure.Cosmos
             {
                 if (!this.IsValidThrottleStatusCode(dce.StatusCode))
                 {
-                    DefaultTrace.TraceError(
+                    DefaultTrace.TraceVerbose(
                         "Operation will NOT be retried. Current attempt {0}, Status Code: {1} ",
                         this.currentAttemptCount,
                         dce.StatusCode);
@@ -81,7 +81,7 @@ namespace Microsoft.Azure.Cosmos
         {
             if (!this.IsValidThrottleStatusCode(cosmosResponseMessage?.StatusCode))
             {
-                DefaultTrace.TraceError(
+                DefaultTrace.TraceVerbose(
                     "Operation will NOT be retried. Current attempt {0}, Status Code: {1} ",
                     this.currentAttemptCount,
                     cosmosResponseMessage?.StatusCode);


### PR DESCRIPTION
# Pull Request Template

## Description

Changed verbose levels for some "Operation will NOT be retried" messages in the ResourceThrottleRetryPolicy to be able to suppress it in the traces.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #3964