### PR TITLE
AI Integration: Fixes event generation for failed requests

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Telemetry/OpenTelemetry/CosmosDbEventSource.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/OpenTelemetry/CosmosDbEventSource.cs
@@ -35,17 +35,17 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             Documents.OperationType operationType,
             OpenTelemetryAttributes response)
         {
-            if (DiagnosticsFilterHelper.IsLatencyThresholdCrossed(
+            if (!DiagnosticsFilterHelper.IsSuccessfulResponse(
+                        response: response) && CosmosDbEventSource.IsEnabled(EventLevel.Warning))
+            {
+                CosmosDbEventSource.Singleton.FailedRequest(response.Diagnostics.ToString());
+            } 
+            else if (DiagnosticsFilterHelper.IsLatencyThresholdCrossed(
                     config: config,
                     operationType: operationType,
                     response: response) && CosmosDbEventSource.IsEnabled(EventLevel.Warning))
             {
                 CosmosDbEventSource.Singleton.LatencyOverThreshold(response.Diagnostics.ToString());
-            }
-            else if (!DiagnosticsFilterHelper.IsSuccessfulResponse(
-                        response: response) && CosmosDbEventSource.IsEnabled(EventLevel.Warning))
-            {
-                CosmosDbEventSource.Singleton.FailedRequest(response.Diagnostics.ToString());
             }
         }
 

--- a/Microsoft.Azure.Cosmos/src/Telemetry/OpenTelemetry/CosmosDbEventSource.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/OpenTelemetry/CosmosDbEventSource.cs
@@ -42,10 +42,10 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             {
                 CosmosDbEventSource.Singleton.LatencyOverThreshold(response.Diagnostics.ToString());
             }
-            else if (DiagnosticsFilterHelper.IsNonSuccessResponse(
+            else if (!DiagnosticsFilterHelper.IsSuccessfulResponse(
                         response: response) && CosmosDbEventSource.IsEnabled(EventLevel.Warning))
             {
-                CosmosDbEventSource.Singleton.NonSuccessResponse(response.Diagnostics.ToString());
+                CosmosDbEventSource.Singleton.FailedResponse(response.Diagnostics.ToString());
             }
         }
 
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         }
 
         [Event(3, Level = EventLevel.Warning)]
-        private void NonSuccessResponse(string message)
+        private void FailedResponse(string message)
         {
             this.WriteEvent(3, message);
         }

--- a/Microsoft.Azure.Cosmos/src/Telemetry/OpenTelemetry/CosmosDbEventSource.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/OpenTelemetry/CosmosDbEventSource.cs
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             else if (!DiagnosticsFilterHelper.IsSuccessfulResponse(
                         response: response) && CosmosDbEventSource.IsEnabled(EventLevel.Warning))
             {
-                CosmosDbEventSource.Singleton.FailedResponse(response.Diagnostics.ToString());
+                CosmosDbEventSource.Singleton.FailedRequest(response.Diagnostics.ToString());
             }
         }
 
@@ -70,8 +70,8 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             this.WriteEvent(2, message);
         }
 
-        [Event(3, Level = EventLevel.Warning)]
-        private void FailedResponse(string message)
+        [Event(3, Level = EventLevel.Error)]
+        private void FailedRequest(string message)
         {
             this.WriteEvent(3, message);
         }

--- a/Microsoft.Azure.Cosmos/src/Telemetry/OpenTelemetry/CosmosDbEventSource.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/OpenTelemetry/CosmosDbEventSource.cs
@@ -35,12 +35,17 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             Documents.OperationType operationType,
             OpenTelemetryAttributes response)
         {
-            if (DiagnosticsFilterHelper.IsTracingNeeded(
+            if (DiagnosticsFilterHelper.IsLatencyThresholdCrossed(
                     config: config,
                     operationType: operationType,
                     response: response) && CosmosDbEventSource.IsEnabled(EventLevel.Warning))
             {
                 CosmosDbEventSource.Singleton.LatencyOverThreshold(response.Diagnostics.ToString());
+            }
+            else if (DiagnosticsFilterHelper.IsNonSuccessResponse(
+                        response: response) && CosmosDbEventSource.IsEnabled(EventLevel.Warning))
+            {
+                CosmosDbEventSource.Singleton.NonSuccessResponse(response.Diagnostics.ToString());
             }
         }
 
@@ -63,6 +68,12 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         private void LatencyOverThreshold(string message)
         {
             this.WriteEvent(2, message);
+        }
+
+        [Event(3, Level = EventLevel.Warning)]
+        private void NonSuccessResponse(string message)
+        {
+            this.WriteEvent(3, message);
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Telemetry/OpenTelemetry/Filters/DiagnosticsFilterHelper.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/OpenTelemetry/Filters/DiagnosticsFilterHelper.cs
@@ -33,13 +33,17 @@ namespace Microsoft.Azure.Cosmos.Telemetry.Diagnostics
         }
 
         /// <summary>
-        /// Allow only when HTTP status code is not Success
+        /// Check if response HTTP status code is returning successful
         /// </summary>
         /// <returns>true or false</returns>
-        public static bool IsNonSuccessResponse(
-          OpenTelemetryAttributes response)
+        public static bool IsSuccessfulResponse(OpenTelemetryAttributes response)
         { 
-            return !response.StatusCode.IsSuccess();
+            return response.StatusCode.IsSuccess() 
+                        || (response.StatusCode == System.Net.HttpStatusCode.NotFound && response.SubStatusCode == 0)
+                        || (response.StatusCode == System.Net.HttpStatusCode.NotModified && response.SubStatusCode == 0)
+                        || (response.StatusCode == System.Net.HttpStatusCode.Conflict && response.SubStatusCode == 0)
+                        || (response.StatusCode == System.Net.HttpStatusCode.PreconditionFailed && response.SubStatusCode == 0)
+                        ;
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Telemetry/OpenTelemetry/Filters/DiagnosticsFilterHelper.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/OpenTelemetry/Filters/DiagnosticsFilterHelper.cs
@@ -10,12 +10,10 @@ namespace Microsoft.Azure.Cosmos.Telemetry.Diagnostics
     internal static class DiagnosticsFilterHelper
     {
         /// <summary>
-        /// Allow only when either of below is <b>True</b><br></br>
-        /// 1) Latency is not more than 100/250 (query) ms<br></br>
-        /// 3) HTTP status code is not Success<br></br>
+        /// Allow only when Latency is not more than 100 (non-query) /250 (query) ms
         /// </summary>
         /// <returns>true or false</returns>
-        public static bool IsTracingNeeded(
+        public static bool IsLatencyThresholdCrossed(
             DistributedTracingOptions config,
             OperationType operationType,
             OpenTelemetryAttributes response)
@@ -31,7 +29,17 @@ namespace Microsoft.Azure.Cosmos.Telemetry.Diagnostics
                 latencyThreshold = operationType == OperationType.Query ? DistributedTracingOptions.DefaultQueryTimeoutThreshold : DistributedTracingOptions.DefaultCrudLatencyThreshold;
             }
 
-            return response.Diagnostics.GetClientElapsedTime() > latencyThreshold || !response.StatusCode.IsSuccess();
+            return response.Diagnostics.GetClientElapsedTime() > latencyThreshold;
+        }
+
+        /// <summary>
+        /// Allow only when HTTP status code is not Success
+        /// </summary>
+        /// <returns>true or false</returns>
+        public static bool IsNonSuccessResponse(
+          OpenTelemetryAttributes response)
+        { 
+            return !response.StatusCode.IsSuccess();
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Telemetry/OpenTelemetry/Filters/DiagnosticsFilterHelper.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/OpenTelemetry/Filters/DiagnosticsFilterHelper.cs
@@ -42,8 +42,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry.Diagnostics
                         || (response.StatusCode == System.Net.HttpStatusCode.NotFound && response.SubStatusCode == 0)
                         || (response.StatusCode == System.Net.HttpStatusCode.NotModified && response.SubStatusCode == 0)
                         || (response.StatusCode == System.Net.HttpStatusCode.Conflict && response.SubStatusCode == 0)
-                        || (response.StatusCode == System.Net.HttpStatusCode.PreconditionFailed && response.SubStatusCode == 0)
-                        ;
+                        || (response.StatusCode == System.Net.HttpStatusCode.PreconditionFailed && response.SubStatusCode == 0);
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.BatchOperationsAsync.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/EndToEndTraceWriterBaselineTests.BatchOperationsAsync.xml
@@ -162,7 +162,7 @@
     <ATTRIBUTE key="tcp.sub_status_code">1001</ATTRIBUTE>
     <ATTRIBUTE key="tcp.status_code">207</ATTRIBUTE>
   </ACTIVITY>
-  <EVENT name="LatencyOverThreshold" />
+  <EVENT name="FailedRequest" />
 </OTelActivities></Output>
   </Result>
 </Results>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Telemetry/DiagnosticsFilterHelperTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Telemetry/DiagnosticsFilterHelperTest.cs
@@ -70,8 +70,8 @@ namespace Microsoft.Azure.Cosmos.Tests.Telemetry
             };
 
             Assert.IsTrue(
-                DiagnosticsFilterHelper
-                    .IsNonSuccessResponse(response),
+                !DiagnosticsFilterHelper
+                    .IsSuccessfulResponse(response),
                 $" Response time is {response.Diagnostics.GetClientElapsedTime().Milliseconds}ms " +
                 $"and Configured threshold value is {distributedTracingOptions.LatencyThresholdForDiagnosticEvent.Value.Milliseconds}ms " +
                 $"and Is response Success : {response.StatusCode.IsSuccess()}");

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Telemetry/DiagnosticsFilterHelperTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Telemetry/DiagnosticsFilterHelperTest.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Telemetry
 
             Assert.IsFalse(
                 DiagnosticsFilterHelper
-                                .IsTracingNeeded(distributedTracingOptions, OperationType.Read, response), 
+                                .IsLatencyThresholdCrossed(distributedTracingOptions, OperationType.Read, response), 
                 $" Response time is {response.Diagnostics.GetClientElapsedTime().Milliseconds}ms " +
                 $"and Configured threshold value is {distributedTracingOptions.LatencyThresholdForDiagnosticEvent.Value.Milliseconds}ms " +
                 $"and Is response Success : {response.StatusCode.IsSuccess()}" );
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Telemetry
 
             Assert.IsTrue(
                 DiagnosticsFilterHelper
-                    .IsTracingNeeded(distributedTracingOptions, OperationType.Read, response),
+                    .IsNonSuccessResponse(response),
                 $" Response time is {response.Diagnostics.GetClientElapsedTime().Milliseconds}ms " +
                 $"and Configured threshold value is {distributedTracingOptions.LatencyThresholdForDiagnosticEvent.Value.Milliseconds}ms " +
                 $"and Is response Success : {response.StatusCode.IsSuccess()}");

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -4,6 +4,10 @@
 
 **Source to capture operation level activities**: _Azure.Cosmos.Operation_\
 **Source to capture event with request diagnostics** : _Azure-Cosmos-Operation-Request-Diagnostics_
+There are 3 kind of events generated:
+1. LatencyOverThrehold: If particular operation latency is more than threshold.
+2. FailedRequest: If particular reequest failed. Status codes, not considered as failed, are 404/0, 304/0, 409/0, 412/0
+3. Exception: If any exception occured.
 
 For detail about usage of this feature, please see the [Azure Cosmos DB SDK observability](https://learn.microsoft.com/azure/cosmos-db/nosql/sdk-observability?tabs=dotnet)
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -4,6 +4,7 @@
 
 **Source to capture operation level activities**: _Azure.Cosmos.Operation_\
 **Source to capture event with request diagnostics** : _Azure-Cosmos-Operation-Request-Diagnostics_
+
 There are 3 kind of events generated:
 1. LatencyOverThrehold: If particular operation latency is more than threshold.
 2. FailedRequest: If particular reequest failed. Status codes not considered as failed, are anything below 300, 404/0, 304/0, 409/0, and 412/0

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -6,7 +6,7 @@
 **Source to capture event with request diagnostics** : _Azure-Cosmos-Operation-Request-Diagnostics_
 There are 3 kind of events generated:
 1. LatencyOverThrehold: If particular operation latency is more than threshold.
-2. FailedRequest: If particular reequest failed. Status codes, not considered as failed, are 404/0, 304/0, 409/0, 412/0
+2. FailedRequest: If particular reequest failed. Status codes not considered as failed, are anything below 300, 404/0, 304/0, 409/0, and 412/0
 3. Exception: If any exception occured.
 
 For detail about usage of this feature, please see the [Azure Cosmos DB SDK observability](https://learn.microsoft.com/azure/cosmos-db/nosql/sdk-observability?tabs=dotnet)


### PR DESCRIPTION
## Description

Right now, High Latency and Request Failures are generating event with same name i.e `LatencyOverThreshold`, It is confusing for customer for latency threshold was not crossed but was request failure due to some reason.

As part of this PR, generating event with event name as `FailedRequest` if there is request failure.

Below Status codes are considered as "Successful" requests:
1. StatusCode = System.Net.HttpStatusCode.NotFound and SubStatusCode = 0
2. StatusCode = System.Net.HttpStatusCode.NotModified and SubStatusCode = 0
3. StatusCode = System.Net.HttpStatusCode.Conflict and SubStatusCode = 0
4. StatusCode = System.Net.HttpStatusCode.PreconditionFailed and SubStatusCode = 0


## Type of change
- [] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #3972