### PR TITLE
[Internal] Upgrade Resiliency: Refactors Code to Enable Replica Validation Feature Through `CosmosClientOptions` And Environment Variable

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ConnectionPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/ConnectionPolicy.cs
@@ -460,6 +460,18 @@ namespace Microsoft.Azure.Cosmos
         }
 
         /// <summary>
+        /// Gets or sets the boolean flag to enable replica validation.
+        /// </summary>
+        /// <value>
+        /// The default value for this parameter is false.
+        /// </value>
+        public bool EnableAdvancedReplicaSelectionForTcp
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// (Direct/TCP) This is an advanced setting that controls the number of TCP connections that will be opened eagerly to each Cosmos DB back-end.
         /// </summary>
         /// <value>

--- a/Microsoft.Azure.Cosmos/src/ConnectionPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/ConnectionPolicy.cs
@@ -465,7 +465,7 @@ namespace Microsoft.Azure.Cosmos
         /// <value>
         /// The default value for this parameter is false.
         /// </value>
-        public bool EnableAdvancedReplicaSelectionForTcp
+        public bool? EnableAdvancedReplicaSelectionForTcp
         {
             get;
             set;

--- a/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
@@ -347,6 +347,17 @@ namespace Microsoft.Azure.Cosmos
         public bool? EnableContentResponseOnWrite { get; set; }
 
         /// <summary>
+        /// Gets or sets the advanced replica selection flag. The advanced replica selection logic keeps track of the replica connection
+        /// status, and based on status, it prioritizes the replicas which show healthy stable connections, so that the requests can be sent
+        /// confidently to the particular replica. This helps the cosmos client to become more resilient and effective to any connectivity issues.
+        /// The default value for this parameter is 'false'.
+        /// </summary>
+        /// <remarks>
+        /// <para>This is optimal for latency-sensitive workloads. Does not apply if <see cref="ConnectionMode.Gateway"/> is used.</para>
+        /// </remarks>
+        internal bool? EnableAdvancedReplicaSelectionForTcp { get; set; }
+
+        /// <summary>
         /// (Direct/TCP) Controls the amount of idle time after which unused connections are closed.
         /// </summary>
         /// <value>
@@ -758,6 +769,7 @@ namespace Microsoft.Azure.Cosmos
                 EnablePartitionLevelFailover = this.EnablePartitionLevelFailover,
                 PortReuseMode = this.portReuseMode,
                 EnableTcpConnectionEndpointRediscovery = this.EnableTcpConnectionEndpointRediscovery,
+                EnableAdvancedReplicaSelectionForTcp = this.EnableAdvancedReplicaSelectionForTcp.HasValue && this.EnableAdvancedReplicaSelectionForTcp.Value,
                 HttpClientFactory = this.httpClientFactory,
                 ServerCertificateCustomValidationCallback = this.ServerCertificateCustomValidationCallback
             };

--- a/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
@@ -769,7 +769,7 @@ namespace Microsoft.Azure.Cosmos
                 EnablePartitionLevelFailover = this.EnablePartitionLevelFailover,
                 PortReuseMode = this.portReuseMode,
                 EnableTcpConnectionEndpointRediscovery = this.EnableTcpConnectionEndpointRediscovery,
-                EnableAdvancedReplicaSelectionForTcp = this.EnableAdvancedReplicaSelectionForTcp.HasValue && this.EnableAdvancedReplicaSelectionForTcp.Value,
+                EnableAdvancedReplicaSelectionForTcp = this.EnableAdvancedReplicaSelectionForTcp,
                 HttpClientFactory = this.httpClientFactory,
                 ServerCertificateCustomValidationCallback = this.ServerCertificateCustomValidationCallback
             };

--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -233,7 +233,7 @@ namespace Microsoft.Azure.Cosmos
 
             this.Initialize(serviceEndpoint, connectionPolicy, desiredConsistencyLevel);
             this.initTaskCache = new AsyncCacheNonBlocking<string, bool>(cancellationToken: this.cancellationTokenSource.Token);
-            this.isReplicaAddressValidationEnabled = ConfigurationManager.IsReplicaAddressValidationEnabled();
+            this.isReplicaAddressValidationEnabled = ConfigurationManager.IsReplicaAddressValidationEnabled(connectionPolicy);
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Routing/GlobalAddressResolver.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GlobalAddressResolver.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.Cosmos.Routing
 
             this.enableTcpConnectionEndpointRediscovery = connectionPolicy.EnableTcpConnectionEndpointRediscovery;
 
-            this.isReplicaAddressValidationEnabled = ConfigurationManager.IsReplicaAddressValidationEnabled();
+            this.isReplicaAddressValidationEnabled = ConfigurationManager.IsReplicaAddressValidationEnabled(connectionPolicy);
 
             this.maxEndpoints = maxBackupReadEndpoints + 2; // for write and alternate write endpoint (during failover)
 

--- a/Microsoft.Azure.Cosmos/src/Util/ConfigurationManager.cs
+++ b/Microsoft.Azure.Cosmos/src/Util/ConfigurationManager.cs
@@ -32,13 +32,20 @@ namespace Microsoft.Azure.Cosmos
         /// both preview and GA. The method will eventually be removed, once replica valdiatin is enabled by default
         /// for  both preview and GA.
         /// </summary>
+        /// <param name="connectionPolicy">An instance of <see cref="ConnectionPolicy"/> containing the client options.</param>
         /// <returns>A boolean flag indicating if replica validation is enabled.</returns>
-        public static bool IsReplicaAddressValidationEnabled()
+        public static bool IsReplicaAddressValidationEnabled(
+            ConnectionPolicy connectionPolicy)
         {
             bool replicaValidationDefaultValue = false;
 #if PREVIEW
             replicaValidationDefaultValue = true;
 #endif
+            if (connectionPolicy != null
+                && connectionPolicy.EnableAdvancedReplicaSelectionForTcp)
+            {
+                return true;
+            }
 
             return ConfigurationManager
                     .GetEnvironmentVariable(

--- a/Microsoft.Azure.Cosmos/src/Util/ConfigurationManager.cs
+++ b/Microsoft.Azure.Cosmos/src/Util/ConfigurationManager.cs
@@ -42,9 +42,9 @@ namespace Microsoft.Azure.Cosmos
             replicaValidationDefaultValue = true;
 #endif
             if (connectionPolicy != null
-                && connectionPolicy.EnableAdvancedReplicaSelectionForTcp)
+                && connectionPolicy.EnableAdvancedReplicaSelectionForTcp.HasValue)
             {
-                return true;
+                return connectionPolicy.EnableAdvancedReplicaSelectionForTcp.Value;
             }
 
             return ConfigurationManager

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosReadManyItemsTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosReadManyItemsTests.cs
@@ -51,27 +51,58 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        public async Task ReadManyTypedTest()
+        [DataRow(true, DisplayName = "Validates Read Many scenario with advanced replica selection enabled.")]
+        [DataRow(false, DisplayName = "Validates Read Many scenario with advanced replica selection disabled.")]
+        public async Task ReadManyTypedTestWithAdvancedReplicaSelection(
+            bool advancedReplicaSelectionEnabled)
         {
-            List<(string, PartitionKey)> itemList = new List<(string, PartitionKey)>();
-            for (int i=0; i<10; i++)
+            CosmosClientOptions clientOptions = new ()
             {
-                itemList.Add((i.ToString(), new PartitionKey("pk" + i.ToString())));
-            }
+                EnableAdvancedReplicaSelectionForTcp = advancedReplicaSelectionEnabled,
+            };
 
-            FeedResponse<ToDoActivity> feedResponse= await this.Container.ReadManyItemsAsync<ToDoActivity>(itemList);
-            Assert.IsNotNull(feedResponse);
-            Assert.AreEqual(feedResponse.Count, 10);
-            Assert.IsTrue(feedResponse.Headers.RequestCharge > 0);
-            Assert.IsNotNull(feedResponse.Diagnostics);
-
-            int count = 0;
-            foreach (ToDoActivity item in feedResponse)
+            Database database = null;
+            CosmosClient cosmosClient = TestCommon.CreateCosmosClient(clientOptions);
+            try
             {
-                count++;
-                Assert.IsNotNull(item);
+                database = await cosmosClient.CreateDatabaseAsync("ReadManyTypedTestScenarioDb");
+                Container container = await database.CreateContainerAsync("ReadManyTypedTestContainer", "/pk");
+
+                // Create items with different pk values
+                for (int i = 0; i < 500; i++)
+                {
+                    ToDoActivity item = ToDoActivity.CreateRandomToDoActivity();
+                    item.pk = "pk" + i.ToString();
+                    item.id = i.ToString();
+                    ItemResponse<ToDoActivity> itemResponse = await container.CreateItemAsync(item);
+                    Assert.AreEqual(HttpStatusCode.Created, itemResponse.StatusCode);
+                }
+
+                List<(string, PartitionKey)> itemList = new List<(string, PartitionKey)>();
+                for (int i = 0; i < 20; i++)
+                {
+                    itemList.Add((i.ToString(), new PartitionKey("pk" + i.ToString())));
+                }
+
+                FeedResponse<ToDoActivity> feedResponse = await container.ReadManyItemsAsync<ToDoActivity>(itemList);
+                Assert.IsNotNull(feedResponse);
+                Assert.AreEqual(20, feedResponse.Count);
+                Assert.IsTrue(feedResponse.Headers.RequestCharge > 0);
+                Assert.IsNotNull(feedResponse.Diagnostics);
+
+                int count = 0;
+                foreach (ToDoActivity item in feedResponse)
+                {
+                    count++;
+                    Assert.IsNotNull(item);
+                }
+                Assert.AreEqual(20, count);
             }
-            Assert.AreEqual(count, 10);
+            finally
+            {
+                await database.DeleteAsync();
+                cosmosClient.Dispose();
+            }
         }
 
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosBadReplicaTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosBadReplicaTests.cs
@@ -63,28 +63,28 @@ namespace Microsoft.Azure.Cosmos.Tests
                     cRid,
                     out IReadOnlyList<string> partitionKeyRanges);
 
-                List<string> replicaIds1 = new List<string>()
-            {
-                "11111111111111111",
-                "22222222222222222",
-                "33333333333333333",
-                "44444444444444444",
-            };
+                    List<string> replicaIds1 = new List<string>()
+                {
+                    "11111111111111111",
+                    "22222222222222222",
+                    "33333333333333333",
+                    "44444444444444444",
+                };
 
-                HttpResponseMessage replicaSet1 = MockSetupsHelper.CreateAddresses(
-                    replicaIds1,
-                    partitionKeyRanges.First(),
-                    "eastus",
-                    cRid);
+                    HttpResponseMessage replicaSet1 = MockSetupsHelper.CreateAddresses(
+                        replicaIds1,
+                        partitionKeyRanges.First(),
+                        "eastus",
+                        cRid);
 
-                // One replica changed on the refresh
-                List<string> replicaIds2 = new List<string>()
-            {
-                "11111111111111111",
-                "22222222222222222",
-                "33333333333333333",
-                "55555555555555555",
-            };
+                    // One replica changed on the refresh
+                    List<string> replicaIds2 = new List<string>()
+                {
+                    "11111111111111111",
+                    "22222222222222222",
+                    "33333333333333333",
+                    "55555555555555555",
+                };
 
                 HttpResponseMessage replicaSet2 = MockSetupsHelper.CreateAddresses(
                     replicaIds2,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
@@ -81,6 +81,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             Assert.IsNull(clientOptions.HttpClientFactory);
             Assert.AreNotEqual(consistencyLevel, clientOptions.ConsistencyLevel);
             Assert.IsFalse(clientOptions.EnablePartitionLevelFailover);
+            Assert.IsFalse(clientOptions.EnableAdvancedReplicaSelectionForTcp.HasValue);
 
             //Verify GetConnectionPolicy returns the correct values for default
             ConnectionPolicy policy = clientOptions.GetConnectionPolicy(clientId: 0);
@@ -97,6 +98,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             Assert.IsNull(policy.HttpClientFactory);
             Assert.AreNotEqual(Cosmos.ConsistencyLevel.Session, clientOptions.ConsistencyLevel);
             Assert.IsFalse(policy.EnablePartitionLevelFailover);
+            Assert.IsFalse(clientOptions.EnableAdvancedReplicaSelectionForTcp.HasValue);
 
             cosmosClientBuilder.WithApplicationRegion(region)
                 .WithConnectionModeGateway(maxConnections, webProxy)
@@ -112,6 +114,7 @@ namespace Microsoft.Azure.Cosmos.Tests
 
             cosmosClient = cosmosClientBuilder.Build(new MockDocumentClient());
             clientOptions = cosmosClient.ClientOptions;
+            clientOptions.EnableAdvancedReplicaSelectionForTcp = true;
 
             //Verify all the values are updated
             Assert.AreEqual(region, clientOptions.ApplicationRegion);
@@ -131,6 +134,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             Assert.IsTrue(clientOptions.AllowBulkExecution);
             Assert.AreEqual(consistencyLevel, clientOptions.ConsistencyLevel);
             Assert.IsTrue(clientOptions.EnablePartitionLevelFailover);
+            Assert.IsTrue(clientOptions.EnableAdvancedReplicaSelectionForTcp.HasValue && clientOptions.EnableAdvancedReplicaSelectionForTcp.Value);
 
             //Verify GetConnectionPolicy returns the correct values
             policy = clientOptions.GetConnectionPolicy(clientId: 0);
@@ -145,7 +149,8 @@ namespace Microsoft.Azure.Cosmos.Tests
             Assert.AreEqual((int)maxRetryWaitTime.TotalSeconds, policy.RetryOptions.MaxRetryWaitTimeInSeconds);
             Assert.AreEqual((Documents.ConsistencyLevel)consistencyLevel, clientOptions.GetDocumentsConsistencyLevel());
             Assert.IsTrue(policy.EnablePartitionLevelFailover);
-            
+            Assert.IsTrue(clientOptions.EnableAdvancedReplicaSelectionForTcp.Value);
+
             IReadOnlyList<string> preferredLocations = new List<string>() { Regions.AustraliaCentral, Regions.AustraliaCentral2 };
             //Verify Direct Mode settings
             cosmosClientBuilder = new CosmosClientBuilder(


### PR DESCRIPTION
# Pull Request Template

## Description

In reference to a recent conversation with the compute gateway team, we agreed to add an `internal` Boolean flag in `CosmosClientOptions` to programmatically enable (or disable) the feature. This PR adds the flag in `CosmosClientOptions` to enable or disable the replica validation using the cosmos client options. Additionally, it keeps the ability for the external customers, to use the environment variable `AZURE_COSMOS_REPLICA_VALIDATION_ENABLED` to enable or disable the feature. 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Closing issues

To automatically close an issue: closes #3922 