### PR TITLE
Query: Adds ODE continuation token support for non-ODE pipelines

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CosmosQueryExecutionContextFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CosmosQueryExecutionContextFactory.cs
@@ -32,7 +32,6 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
     {
         private const string InternalPartitionKeyDefinitionProperty = "x-ms-query-partitionkey-definition";
         private const string OptimisticDirectExecution = "OptimisticDirectExecution";
-        private const string OptimisticDirectExecutionToken = "OptimisticDirectExecutionToken";
         private const string Passthrough = "Passthrough";
         private const string Specialized = "Specialized";
         private const int PageSizeFactorForTop = 5;

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CosmosQueryExecutionContextFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CosmosQueryExecutionContextFactory.cs
@@ -753,17 +753,12 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
             ContainerQueryProperties containerQueryProperties,
             ITrace trace)
         {
-            if (!inputParameters.EnableOptimisticDirectExecution)
+            if (!inputParameters.EnableOptimisticDirectExecution
+                && inputParameters.InitialUserContinuationToken != null
+                && OptimisticDirectExecutionContinuationToken.IsOptimisticDirectExecutionContinuationToken(inputParameters.InitialUserContinuationToken))
             {
-                if (inputParameters.InitialUserContinuationToken != null)
-                {
-                    if (OptimisticDirectExecutionContinuationToken.IsOptimisticDirectExecutionContinuationToken(inputParameters.InitialUserContinuationToken))
-                    {
-                        throw new MalformedContinuationTokenException($"The continuation token supplied requires the Optimistic Direct Execution flag to be enabled in QueryRequestOptions for the query execution to resume. " +
-                                    $"{inputParameters.InitialUserContinuationToken}");
-                    }
-                }
-                
+                throw new MalformedContinuationTokenException($"The continuation token supplied requires the Optimistic Direct Execution flag to be enabled in QueryRequestOptions for the query execution to resume. " +
+                            $"{inputParameters.InitialUserContinuationToken}");
             }
 
             Debug.Assert(containerQueryProperties.ResourceId != null, "CosmosQueryExecutionContextFactory Assert!", "Container ResourceId cannot be null!");

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CosmosQueryExecutionContextFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CosmosQueryExecutionContextFactory.cs
@@ -753,12 +753,16 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
             ContainerQueryProperties containerQueryProperties,
             ITrace trace)
         {
-            if (!inputParameters.EnableOptimisticDirectExecution
-                && inputParameters.InitialUserContinuationToken != null
-                && OptimisticDirectExecutionContinuationToken.IsOptimisticDirectExecutionContinuationToken(inputParameters.InitialUserContinuationToken))
+            if (!inputParameters.EnableOptimisticDirectExecution)
             {
-                throw new MalformedContinuationTokenException($"The continuation token supplied requires the Optimistic Direct Execution flag to be enabled in QueryRequestOptions for the query execution to resume. " +
+                if (inputParameters.InitialUserContinuationToken != null 
+                    && OptimisticDirectExecutionContinuationToken.IsOptimisticDirectExecutionContinuationToken(inputParameters.InitialUserContinuationToken))
+                {
+                    throw new MalformedContinuationTokenException($"The continuation token supplied requires the Optimistic Direct Execution flag to be enabled in QueryRequestOptions for the query execution to resume. " +
                             $"{inputParameters.InitialUserContinuationToken}");
+                }
+
+                return null;
             }
 
             Debug.Assert(containerQueryProperties.ResourceId != null, "CosmosQueryExecutionContextFactory Assert!", "Container ResourceId cannot be null!");

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/OptimisticDirectExecution/OptimisticDirectExecutionContinuationToken.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/OptimisticDirectExecution/OptimisticDirectExecutionContinuationToken.cs
@@ -31,14 +31,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.OptimisticDirectExecutionQu
         public static bool IsOptimisticDirectExecutionContinuationToken(CosmosElement continuationToken)
         {
             CosmosObject cosmosObjectContinuationToken = continuationToken as CosmosObject;
-            if (cosmosObjectContinuationToken == null || !cosmosObjectContinuationToken.ContainsKey(OptimisticDirectExecutionToken))
-            {
-                return false;
-            }
-            else
-            {
-                return true;
-            }
+            return !(cosmosObjectContinuationToken == null || !cosmosObjectContinuationToken.ContainsKey(OptimisticDirectExecutionToken));
         }
 
         public static CosmosElement ToCosmosElement(OptimisticDirectExecutionContinuationToken continuationToken)

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/OptimisticDirectExecution/OptimisticDirectExecutionContinuationToken.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/OptimisticDirectExecution/OptimisticDirectExecutionContinuationToken.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.OptimisticDirectExecutionQu
 
         public static bool IsOptimisticDirectExecutionContinuationToken(CosmosElement continuationToken)
         {
-            CosmosObject cosmosObjectContinuationToken = continuationToken as CosmosObject;
+            CosmosObject cosmosObjectContinuationToken = (CosmosObject)continuationToken;
             return !(cosmosObjectContinuationToken == null || !cosmosObjectContinuationToken.ContainsKey(OptimisticDirectExecutionToken));
         }
 
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.OptimisticDirectExecutionQu
                                             message: $"Malformed Continuation Token: Expected OptimisticDirectExecutionToken\r\n"));
             }
 
-            CosmosObject cosmosObjectContinuationToken = cosmosElement as CosmosObject;
+            CosmosObject cosmosObjectContinuationToken = (CosmosObject)cosmosElement;
             TryCatch<ParallelContinuationToken> inner = ParallelContinuationToken.TryCreateFromCosmosElement(cosmosObjectContinuationToken[OptimisticDirectExecutionToken]);
 
             return inner.Succeeded ?

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/OptimisticDirectExecution/OptimisticDirectExecutionContinuationToken.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/OptimisticDirectExecution/OptimisticDirectExecutionContinuationToken.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.OptimisticDirectExecutionQu
 
         public static bool IsOptimisticDirectExecutionContinuationToken(CosmosElement continuationToken)
         {
-            CosmosObject cosmosObjectContinuationToken = (CosmosObject)continuationToken;
+            CosmosObject cosmosObjectContinuationToken = continuationToken as CosmosObject;
             return !(cosmosObjectContinuationToken == null || !cosmosObjectContinuationToken.ContainsKey(OptimisticDirectExecutionToken));
         }
 

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/OptimisticDirectExecution/OptimisticDirectExecutionContinuationToken.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/OptimisticDirectExecution/OptimisticDirectExecutionContinuationToken.cs
@@ -4,9 +4,7 @@
 
 namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.OptimisticDirectExecutionQuery
 {
-    using System;
     using System.Collections.Generic;
-    using Microsoft.Azure.Cosmos.ChangeFeed;
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Query.Core.Exceptions;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
@@ -30,6 +28,19 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.OptimisticDirectExecutionQu
 
         public Range<string> Range => this.Token.Range;
 
+        public static bool IsOptimisticDirectExecutionContinuationToken(CosmosElement continuationToken)
+        {
+            CosmosObject cosmosObjectContinuationToken = continuationToken as CosmosObject;
+            if (cosmosObjectContinuationToken == null || !cosmosObjectContinuationToken.ContainsKey(OptimisticDirectExecutionToken))
+            {
+                return false;
+            }
+            else
+            {
+                return true;
+            }
+        }
+
         public static CosmosElement ToCosmosElement(OptimisticDirectExecutionContinuationToken continuationToken)
         {
             CosmosElement inner = ParallelContinuationToken.ToCosmosElement(continuationToken.Token);
@@ -42,14 +53,14 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.OptimisticDirectExecutionQu
 
         public static TryCatch<OptimisticDirectExecutionContinuationToken> TryCreateFromCosmosElement(CosmosElement cosmosElement)
         {
-            CosmosObject cosmosObjectContinuationToken = cosmosElement as CosmosObject;
-            if (cosmosObjectContinuationToken == null || !cosmosObjectContinuationToken.ContainsKey(OptimisticDirectExecutionToken))
+            if (!IsOptimisticDirectExecutionContinuationToken(cosmosElement))
             {
                 return TryCatch<OptimisticDirectExecutionContinuationToken>.FromException(
-                                    new MalformedContinuationTokenException(
-                                        message: $"Malformed Continuation Token: Expected OptimisticDirectExecutionToken\r\n"));
+                                        new MalformedContinuationTokenException(
+                                            message: $"Malformed Continuation Token: Expected OptimisticDirectExecutionToken\r\n"));
             }
 
+            CosmosObject cosmosObjectContinuationToken = cosmosElement as CosmosObject;
             TryCatch<ParallelContinuationToken> inner = ParallelContinuationToken.TryCreateFromCosmosElement(cosmosObjectContinuationToken[OptimisticDirectExecutionToken]);
 
             return inner.Succeeded ?

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosBasicQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosBasicQueryTests.cs
@@ -786,7 +786,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        public async Task TesOdeTokenCompatibilityWithSpecializedPipeline()
+        public async Task TesOdeTokenCompatibilityWithNonOdePipeline()
         {
             using (ITrace rootTrace = Trace.GetRootTrace("Root Trace"))
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosBasicQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosBasicQueryTests.cs
@@ -791,12 +791,12 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             using (ITrace rootTrace = Trace.GetRootTrace("Root Trace"))
             {
                 ResponseMessage responseMessage = null;
-                int count = 0;
                 string query = "select top 200 * from c";
                 string expectedErrorMessage = "Operation cannot be resumed with the following token, as it requires Optimistic Direct Execution pipeline, which has been disabled for your SDK";
 
                 CosmosClient client = DirectCosmosClient;
                 Container container = client.GetContainer(DatabaseId, ContainerId);
+                
                 // Create items
                 for (int i = 0; i < 500; i++)
                 {
@@ -817,8 +817,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                 responseMessage = await feedIterator.ReadNextAsync(rootTrace, CancellationToken.None);
                 string continuationToken = responseMessage.ContinuationToken;
-                Collection<ToDoActivity> response = TestCommon.SerializerCore.FromStream<CosmosFeedResponseUtil<ToDoActivity>>(responseMessage.Content).Data;
-                count += response.Count;
 
                 QueryRequestOptions newQueryRequestOptions = new QueryRequestOptions
                 {
@@ -836,11 +834,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 while (feedIteratorNew.HasMoreResults)
                 {
                     responseMessage = await feedIteratorNew.ReadNextAsync(rootTrace, CancellationToken.None);
-                    if (responseMessage.Content != null)
-                    {
-                        Collection<ToDoActivity> newResponse = TestCommon.SerializerCore.FromStream<CosmosFeedResponseUtil<ToDoActivity>>(responseMessage.Content).Data;
-                        count += newResponse.Count;
-                    }
                 }
 
                 Assert.IsTrue(responseMessage.CosmosException.ToString().Contains(expectedErrorMessage));

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosBasicQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosBasicQueryTests.cs
@@ -792,7 +792,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             {
                 ResponseMessage responseMessage = null;
                 string query = "select top 200 * from c";
-                string expectedErrorMessage = "Operation cannot be resumed with the following token, as it requires Optimistic Direct Execution pipeline, which has been disabled for your SDK";
+                string expectedErrorMessage = "The continuation token supplied requires the Optimistic Direct Execution flag to be enabled in QueryRequestOptions for the query execution to resume. ";
 
                 CosmosClient client = DirectCosmosClient;
                 Container container = client.GetContainer(DatabaseId, ContainerId);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosBasicQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosBasicQueryTests.cs
@@ -785,6 +785,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
         }
 
+        //TODO: Remove Ignore flag once emulator is updated to 0415
+        [Ignore]
         [TestMethod]
         public async Task TesOdeTokenCompatibilityWithNonOdePipeline()
         {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OptimisticDirectExecutionQueryBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OptimisticDirectExecutionQueryBaselineTests.cs
@@ -19,6 +19,7 @@
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.Parallel;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.OptimisticDirectExecutionQuery;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
     using Microsoft.Azure.Cosmos.Query.Core.QueryClient;
     using Microsoft.Azure.Cosmos.Query.Core.QueryPlan;
@@ -188,6 +189,52 @@
             }
 
             Assert.AreEqual(100, documentCountInSinglePartition);
+        }
+
+        [TestMethod]
+        public async Task TestOdeTokenWithSpecializedPipeline()
+        {
+            ParallelContinuationToken parallelContinuationToken = new ParallelContinuationToken(
+                    token: Guid.NewGuid().ToString(),
+                    range: new Documents.Routing.Range<string>("A", "B", true, false));
+
+            OptimisticDirectExecutionContinuationToken optimisticDirectExecutionContinuationToken = new OptimisticDirectExecutionContinuationToken(parallelContinuationToken);
+            CosmosElement cosmosElementContinuationToken = OptimisticDirectExecutionContinuationToken.ToCosmosElement(optimisticDirectExecutionContinuationToken);
+
+            OptimisticDirectExecutionTestInput input = CreateInput(
+                    description: @"Single Partition Key and Value Field",
+                    query: "SELECT VALUE COUNT(1) FROM c",
+                    expectedOptimisticDirectExecution: false,
+                    partitionKeyPath: @"/pk",
+                    partitionKeyValue: "a",
+                    continuationToken: cosmosElementContinuationToken);
+
+            IMonadicDocumentContainer monadicDocumentContainer = new InMemoryContainer(input.PartitionKeyDefinition);
+            DocumentContainer documentContainer = new DocumentContainer(monadicDocumentContainer);
+
+            QueryRequestOptions queryRequestOptions = GetQueryRequestOptions(enableOptimisticDirectExecution: input.ExpectedOptimisticDirectExecution);
+
+            (CosmosQueryExecutionContextFactory.InputParameters inputParameters, CosmosQueryContextCore cosmosQueryContextCore) = CreateInputParamsAndQueryContext(input, queryRequestOptions);
+
+            IQueryPipelineStage queryPipelineStage = CosmosQueryExecutionContextFactory.Create(
+                      documentContainer,
+                      cosmosQueryContextCore,
+                      inputParameters,
+                      NoOpTrace.Singleton);
+
+            string expectedErrorMessage = "The continuation token supplied requires the Optimistic Direct Execution flag to be enabled in QueryRequestOptions for the query execution to resume. ";
+
+            while (await queryPipelineStage.MoveNextAsync(NoOpTrace.Singleton))
+            {
+                if (queryPipelineStage.Current.Failed)
+                {
+                    Assert.IsTrue(queryPipelineStage.Current.InnerMostException.ToString().Contains(expectedErrorMessage));
+                    return;
+                }
+
+                Assert.IsFalse(true);
+                break;
+            }
         }
 
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OptimisticDirectExecutionQueryBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OptimisticDirectExecutionQueryBaselineTests.cs
@@ -194,6 +194,7 @@
         [TestMethod]
         public async Task TestOdeTokenWithSpecializedPipeline()
         {
+            int numItems = 100;
             ParallelContinuationToken parallelContinuationToken = new ParallelContinuationToken(
                     token: Guid.NewGuid().ToString(),
                     range: new Documents.Routing.Range<string>("A", "B", true, false));
@@ -209,13 +210,9 @@
                     partitionKeyValue: "a",
                     continuationToken: cosmosElementContinuationToken);
 
-            IMonadicDocumentContainer monadicDocumentContainer = new InMemoryContainer(input.PartitionKeyDefinition);
-            DocumentContainer documentContainer = new DocumentContainer(monadicDocumentContainer);
-
+            DocumentContainer documentContainer = await CreateDocumentContainerAsync(numItems, multiPartition: false);
             QueryRequestOptions queryRequestOptions = GetQueryRequestOptions(enableOptimisticDirectExecution: input.ExpectedOptimisticDirectExecution);
-
             (CosmosQueryExecutionContextFactory.InputParameters inputParameters, CosmosQueryContextCore cosmosQueryContextCore) = CreateInputParamsAndQueryContext(input, queryRequestOptions);
-
             IQueryPipelineStage queryPipelineStage = CosmosQueryExecutionContextFactory.Create(
                       documentContainer,
                       cosmosQueryContextCore,

--- a/changelog.md
+++ b/changelog.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Added
 - [3668](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/3668) Query : Adds string comparison alternative when converting LINQ to SQL (Thanks [@ernesto1596](https://github.com/ernesto1596))
 - [3834](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/3834) Query : Adds support for newtonsoft member access via ExtensionData (Thanks [@onionhammer](https://github.com/onionhammer))
+- [3939](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/3939) CreateAndInitializeAsync: Adds Code to Optimize Rntbd Open Connection Logic to Open Connections in Parallel
 
 ### <a name="3.35.1-preview"/> [3.35.1-preview](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.35.1-preview) - 2023-06-27
 ### <a name="3.35.1"/> [3.35.1](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.35.1) - 2023-06-27


### PR DESCRIPTION
# Pull Request Template

## Description

With Optimistic Direct Execution (ODE) being enabled by default in preview mode, a certain concern is brought up. 
What happens if an ODE continuation token goes into a non-ODE pipeline?
This would happen for 2 reasons:
1: Customer has multiple SDKs which are not all of the same version. The newer SDK generates an ODE continuation token and sends it to an older SDK that does not have ODE capabilities. In such a case, a different pipeline would have to handle this ODE token.
2: Customer gets an ODE continuation token, turns off ODE from QueryRequestOptions, and then passes the continuation token back to the SDK. With ODE turned off, a non-ODE pipeline would have to handle this token. 

The first case gets handled by a continuation token check which confirms that the incoming continuation token is of the same version as the SDK. If they are not, then a Malformed Continuation Token exception is thrown. 

This PR looks to add support for the second case. 
In the current behavior, the non-ODE pipeline returns 0 results and ends execution. This behavior is incorrect as it would lead to customers getting wrong results. 
This PR fixes this issue by throwing a Malformed Continuation Token Exception when an ODE continuation token reaches a non-ODE pipeline and lets the customer know that they need to turn on their ODE flag to avoid this issue. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #IssueNumber