### PR TITLE
Upgrade Resiliency: Fixes Race Condition by Calling Dispose Too Early.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
 		<ClientOfficialVersion>3.35.3</ClientOfficialVersion>
 		<ClientPreviewVersion>3.35.3</ClientPreviewVersion>
 		<ClientPreviewSuffixVersion>preview</ClientPreviewSuffixVersion>
-		<DirectVersion>3.31.3</DirectVersion>
+		<DirectVersion>3.31.4</DirectVersion>
 		<EncryptionOfficialVersion>2.0.3</EncryptionOfficialVersion>
 		<EncryptionPreviewVersion>2.0.3</EncryptionPreviewVersion>
 		<EncryptionPreviewSuffixVersion>preview</EncryptionPreviewSuffixVersion>


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes a bug #4013 that causes intermittent errors in the `CosmosClient.Dispose()`, with multiple parallel requests.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #4013 