### PR TITLE
GatewayAddressCache: Fixes Unobserved Exception During Background Address Refresh

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
@@ -317,10 +317,7 @@ namespace Microsoft.Azure.Cosmos.Routing
                         }
                         catch (Exception ex)
                         {
-                            DefaultTrace.TraceWarning("Failed to refresh addresses in the background for the collection rid: {0} with exception: {1}. '{2}'",
-                                partitionKeyRangeIdentity.CollectionRid,
-                                ex,
-                                System.Diagnostics.Trace.CorrelationManager.ActivityId);
+                            DefaultTrace.TraceWarning($"Failed to refresh addresses in the background for the collection rid: {partitionKeyRangeIdentity.CollectionRid} with exception: {ex}. '{System.Diagnostics.Trace.CorrelationManager.ActivityId}'");
                         }
                     });
                 }

--- a/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
@@ -311,7 +311,7 @@ namespace Microsoft.Azure.Cosmos.Routing
                                 partitionKeyRangeIdentity.PartitionKeyRangeId,
                                 forceRefresh: true)));
 
-                    refreshAddressesInBackgroundTask.Exception.Handle(ex =>
+                    refreshAddressesInBackgroundTask.Exception?.Handle(ex =>
                     {
                         DefaultTrace.TraceWarning("Failed to refresh addresses in the background for the collection rid: {0} with exception: {1}. '{2}'",
                             partitionKeyRangeIdentity.CollectionRid,

--- a/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
@@ -317,7 +317,10 @@ namespace Microsoft.Azure.Cosmos.Routing
                         }
                         catch (Exception ex)
                         {
-                            DefaultTrace.TraceWarning($"Failed to refresh addresses in the background for the collection rid: {partitionKeyRangeIdentity.CollectionRid} with exception: {ex}. '{System.Diagnostics.Trace.CorrelationManager.ActivityId}'");
+                            DefaultTrace.TraceWarning("Failed to refresh addresses in the background for the collection rid: {0} with exception: {1}. '{2}'",
+                                partitionKeyRangeIdentity.CollectionRid,
+                                ex,
+                                System.Diagnostics.Trace.CorrelationManager.ActivityId);
                         }
                     });
                 }

--- a/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
@@ -311,7 +311,7 @@ namespace Microsoft.Azure.Cosmos.Routing
                                 partitionKeyRangeIdentity.PartitionKeyRangeId,
                                 forceRefresh: true)));
 
-                    refreshAddressesInBackgroundTask.Exception?.Handle(ex =>
+                    refreshAddressesInBackgroundTask.Exception.Handle(ex =>
                     {
                         DefaultTrace.TraceWarning("Failed to refresh addresses in the background for the collection rid: {0} with exception: {1}. '{2}'",
                             partitionKeyRangeIdentity.CollectionRid,

--- a/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
@@ -302,23 +302,26 @@ namespace Microsoft.Azure.Cosmos.Routing
                     .ReplicaTransportAddressUris
                     .Any(x => x.ShouldRefreshHealthStatus()))
                 {
-                    Task refreshAddressesInBackgroundTask = Task.Run(async () => await this.serverPartitionAddressCache.RefreshAsync(
-                        key: partitionKeyRangeIdentity,
-                        singleValueInitFunc: (currentCachedValue) => this.GetAddressesForRangeIdAsync(
-                                request,
-                                cachedAddresses: currentCachedValue,
-                                partitionKeyRangeIdentity.CollectionRid,
-                                partitionKeyRangeIdentity.PartitionKeyRangeId,
-                                forceRefresh: true)));
-
-                    refreshAddressesInBackgroundTask.Exception.Handle(ex =>
+                    Task refreshAddressesInBackgroundTask = Task.Run(async () =>
                     {
-                        DefaultTrace.TraceWarning("Failed to refresh addresses in the background for the collection rid: {0} with exception: {1}. '{2}'",
-                            partitionKeyRangeIdentity.CollectionRid,
-                            ex,
-                            System.Diagnostics.Trace.CorrelationManager.ActivityId);
-
-                        return true;
+                        try
+                        {
+                            await this.serverPartitionAddressCache.RefreshAsync(
+                                key: partitionKeyRangeIdentity,
+                                singleValueInitFunc: (currentCachedValue) => this.GetAddressesForRangeIdAsync(
+                                    request,
+                                    cachedAddresses: currentCachedValue,
+                                    partitionKeyRangeIdentity.CollectionRid,
+                                    partitionKeyRangeIdentity.PartitionKeyRangeId,
+                                    forceRefresh: true));
+                        }
+                        catch (Exception ex)
+                        {
+                            DefaultTrace.TraceWarning("Failed to refresh addresses in the background for the collection rid: {0} with exception: {1}. '{2}'",
+                                partitionKeyRangeIdentity.CollectionRid,
+                                ex,
+                                System.Diagnostics.Trace.CorrelationManager.ActivityId);
+                        }
                     });
                 }
 


### PR DESCRIPTION
# Pull Request Template

## Description

During the background address refresh stage to validate all the `Unhealthy` replicas which remained unhealthy for a period of `1` minute or more, the SDK doesn't act on a potential exception thrown while resolving the addresses from gateway, and instead throws it from the background task. This essentially causes the exceptions to be unmonitored and unobserved.

This PR fixes the above behavior.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #4010 