### PR TITLE
[Internal] Client Telemetry: Adds condition to make sure metrics is always there

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryHelper.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryHelper.cs
@@ -51,7 +51,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                 SystemUsageHistory systemUsageHistory, 
                 bool isDirectConnectionMode)
         {
-            if (systemUsageHistory.Values == null)
+            if (systemUsageHistory.Values == null || systemUsageHistory.Values.Count == 0)
             {
                 return null;
             }

--- a/Microsoft.Azure.Cosmos/src/Telemetry/TelemetrySystemUsage.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/TelemetrySystemUsage.cs
@@ -41,11 +41,8 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                 }
             }
 
-            if (histogram.TotalCount > 0)
-            {
-                systemInfo.SetAggregators(histogram, ClientTelemetryOptions.HistogramPrecisionFactor);
-            }
-            
+            systemInfo.SetAggregators(histogram, ClientTelemetryOptions.HistogramPrecisionFactor);
+
             return systemInfo;
         }
 
@@ -70,10 +67,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                 }
             }
 
-            if (histogram.TotalCount > 0)
-            {
-                systemInfo.SetAggregators(histogram, ClientTelemetryOptions.KbToMbFactor);
-            }
+            systemInfo.SetAggregators(histogram, ClientTelemetryOptions.KbToMbFactor);
 
             return systemInfo;
         }
@@ -99,10 +93,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                 }
             }
 
-            if (histogram.TotalCount > 0)
-            {
-                systemInfo.SetAggregators(histogram);
-            }
+            systemInfo.SetAggregators(histogram);
 
             return systemInfo;
         }
@@ -153,10 +144,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                 }
             }
 
-            if (histogram.TotalCount > 0)
-            {
-                systemInfo.SetAggregators(histogram, ClientTelemetryOptions.TicksToMsFactor);
-            }
+            systemInfo.SetAggregators(histogram, ClientTelemetryOptions.TicksToMsFactor);
 
             return systemInfo;
         }
@@ -189,10 +177,12 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                 }
             }
 
-            if (histogram.TotalCount > 0)
+            if (histogram.TotalCount == 0)
             {
-                systemInfo.SetAggregators(histogram);
+                return null;
             }
+
+            systemInfo.SetAggregators(histogram);
 
             return systemInfo;
         }


### PR DESCRIPTION
## Description
Client Telemetry Service do not accept partial metric information except `SystemPool_IsThreadStarving_True` metrics because service knows this particular metrics doesn't have percentile calculated.

As part of this PR, making sure metrics is added in payload only if there is metrics information available. It means if corresponding histogram has any value then only do any calculations otherwise just skip that metrics.
