### PR TITLE
[Internal] Automation: Adds logic to tag customer-reported issues

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -39,6 +39,19 @@ configuration:
           label: needs-investigation
       description: 
     - if:
+      - payloadType: Issues
+      - isAction:
+          action: Opened
+      - or:
+        - activitySenderHasPermission:
+            permission: Read
+        - activitySenderHasPermission:
+            permission: None
+      then:
+      - addLabel:
+          label: customer-reported
+      description: Identifies issues created by users without write access as customers
+    - if:
       - payloadType: Pull_Request
       - hasLabel:
           label: auto-merge


### PR DESCRIPTION
When a user without write/admin access creates an issue, tag the issue with `customer-reported`.

A user that is part of our team would have `write` and in some cases `admin` permissions, but a user that is external (cannot push branches on the repo) has either `none` or `read` permissions.

Based on `none`/`read` we can identify that this is an external users, hence a "customer".