### PR TITLE
[Internal] Client Telemetry: Adds client config api call to get latest flag status

### DIFF
--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/BenchmarkConfig.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/BenchmarkConfig.cs
@@ -138,6 +138,9 @@ namespace CosmosBenchmark
         [Option(Required = false, HelpText = "Application Insights connection string")]
         public string AppInsightsConnectionString { get; set; }
 
+        [Option(Required = false, HelpText = "Enable Client Telemetry Feature in SDK. Make sure you enable it from the portal also.")]
+        public bool EnableClientTelemetry { get; set; } = true;
+
         internal int GetTaskCount(int containerThroughput)
         {
             int taskCount = this.DegreeOfParallelism;
@@ -217,7 +220,7 @@ namespace CosmosBenchmark
                 MaxRetryAttemptsOnRateLimitedRequests = 0,
                 MaxRequestsPerTcpConnection = this.MaxRequestsPerTcpConnection,
                 MaxTcpConnectionsPerEndpoint = this.MaxTcpConnectionsPerEndpoint,
-                EnableClientTelemetry = true // Always enable client telemetry feature as it will be controlled from the portal
+                EnableClientTelemetry = this.EnableClientTelemetry 
             };
 
             if (!string.IsNullOrWhiteSpace(this.ConsistencyLevel))

--- a/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/BenchmarkConfig.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/Benchmark/BenchmarkConfig.cs
@@ -215,29 +215,9 @@ namespace CosmosBenchmark
                 ApplicationName = this.GetUserAgentPrefix(),
                 MaxRetryAttemptsOnRateLimitedRequests = 0,
                 MaxRequestsPerTcpConnection = this.MaxRequestsPerTcpConnection,
-                MaxTcpConnectionsPerEndpoint = this.MaxTcpConnectionsPerEndpoint
+                MaxTcpConnectionsPerEndpoint = this.MaxTcpConnectionsPerEndpoint,
+                EnableClientTelemetry = this.EnableTelemetry
             };
-
-            if (this.EnableTelemetry)
-            {
-                Environment.SetEnvironmentVariable(
-                    Microsoft.Azure.Cosmos.Telemetry.ClientTelemetryOptions.EnvPropsClientTelemetryEnabled, 
-                    "true");
-
-                if (this.TelemetryScheduleInSec > 0)
-                {
-                    Environment.SetEnvironmentVariable(
-                        Microsoft.Azure.Cosmos.Telemetry.ClientTelemetryOptions.EnvPropsClientTelemetrySchedulingInSeconds, 
-                        Convert.ToString(this.TelemetryScheduleInSec));
-                }
-
-                if (!string.IsNullOrEmpty(this.TelemetryEndpoint))
-                {
-                    Environment.SetEnvironmentVariable(
-                        Microsoft.Azure.Cosmos.Telemetry.ClientTelemetryOptions.EnvPropsClientTelemetryEndpoint, 
-                        this.TelemetryEndpoint);
-                }
-            }
 
             if (!string.IsNullOrWhiteSpace(this.ConsistencyLevel))
             {

--- a/Microsoft.Azure.Cosmos.Samples/Tools/CTL/CTLConfig.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/CTL/CTLConfig.cs
@@ -103,6 +103,9 @@ namespace CosmosCTL
         [Option("ctl_reservoir_sample_size", Required = false, HelpText = "The reservoir sample size.")]
         public int ReservoirSampleSize { get; set; } = 1028;
 
+        [Option("ctl_enable_client_telemetry", Required = false, HelpText = "Enable Client Telemetry Feature in SDK. Make sure you enable it from the portal also.")]
+        public bool EnableClientTelemetry { get; set; } = true;
+
         internal TimeSpan RunningTimeDurationAsTimespan { get; private set; } = TimeSpan.FromHours(10);
         internal TimeSpan DiagnosticsThresholdDurationAsTimespan { get; private set; } = TimeSpan.FromSeconds(60);
 
@@ -127,7 +130,7 @@ namespace CosmosCTL
             CosmosClientOptions clientOptions = new CosmosClientOptions()
             {
                 ApplicationName = CTLConfig.UserAgentSuffix,
-                EnableClientTelemetry = true // always enable this feature.
+                EnableClientTelemetry = this.EnableClientTelemetry
             };
 
             if (this.UseGatewayMode)

--- a/Microsoft.Azure.Cosmos.Samples/Tools/CTL/CTLConfig.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/CTL/CTLConfig.cs
@@ -97,12 +97,6 @@ namespace CosmosCTL
         [Option("ctl_logging_context", Required = false, HelpText = "Defines a custom context to use on metrics")]
         public string LogginContext { get; set; } = string.Empty;
 
-        [Option("ctl_telemetry_endpoint", Required = false, HelpText = "telemetry juno end point")]
-        public string TelemetryEndpoint { get; set; }
-
-        [Option("ctl_telemetry_schedule_in_sec", Required = false, HelpText = "telemetry task schedule time in sec")]
-        public string TelemetryScheduleInSeconds { get; set; }
-
         [Option("ctl_reservoir_type", Required = false, HelpText = "Defines the reservoir type. Valid values are: Uniform, SlidingWindow and ExponentialDecay. The default value is SlidingWindow.")]
         public ReservoirTypes ReservoirType { get; set; } = ReservoirTypes.SlidingWindow;
 
@@ -133,7 +127,7 @@ namespace CosmosCTL
             CosmosClientOptions clientOptions = new CosmosClientOptions()
             {
                 ApplicationName = CTLConfig.UserAgentSuffix,
-                EnableClientTelemetry = true
+                EnableClientTelemetry = true // always enable this feature.
             };
 
             if (this.UseGatewayMode)

--- a/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Program.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Program.cs
@@ -29,8 +29,6 @@ namespace CosmosCTL
             {
                 CTLConfig config = CTLConfig.From(args);
 
-                SetEnvironmentVariables(config);
-              
                 if (config.OutputEventTraces)
                 {
                     EnableTraceSourcesToConsole();
@@ -55,9 +53,9 @@ namespace CosmosCTL
                     logger.LogInformation("Initialization completed.");
 
                     if(client.ClientOptions.EnableClientTelemetry.GetValueOrDefault()) {
-                        logger.LogInformation("Telemetry is enabled for CTL.");
+                        logger.LogInformation("Telemetry Feature flag is enabled for CTL.");
                     } else {
-                        logger.LogInformation("Telemetry is disabled for CTL.");
+                        logger.LogInformation("Telemetry Feature flag is disabled for CTL.");
                     }
 
                     List<Task> tasks = new List<Task>
@@ -146,12 +144,6 @@ namespace CosmosCTL
             {
                 Utils.LogError(logger, "Unhandled exception during execution", ex);
             }
-        }
-
-        private static void SetEnvironmentVariables(CTLConfig config)
-        {
-            Environment.SetEnvironmentVariable(ClientTelemetryOptions.EnvPropsClientTelemetryEndpoint, config.TelemetryEndpoint);
-            Environment.SetEnvironmentVariable(ClientTelemetryOptions.EnvPropsClientTelemetrySchedulingInSeconds, config.TelemetryScheduleInSeconds);
         }
 
         private static IMetricsRoot ConfigureReporting(

--- a/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Program.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/CTL/Program.cs
@@ -52,12 +52,6 @@ namespace CosmosCTL
 
                     logger.LogInformation("Initialization completed.");
 
-                    if(client.ClientOptions.EnableClientTelemetry.GetValueOrDefault()) {
-                        logger.LogInformation("Telemetry Feature flag is enabled for CTL.");
-                    } else {
-                        logger.LogInformation("Telemetry Feature flag is disabled for CTL.");
-                    }
-
                     List<Task> tasks = new List<Task>
                     {
                         scenario.RunAsync(

--- a/Microsoft.Azure.Cosmos/src/ConnectionPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/ConnectionPolicy.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.Cosmos
             this.MaxConnectionLimit = defaultMaxConcurrentConnectionLimit;
             this.RetryOptions = new RetryOptions();
             this.EnableReadRequestsFallback = null;
-            this.EnableClientTelemetry = ClientTelemetryOptions.IsClientTelemetryEnabled();
+            this.EnableClientTelemetry = false; // by default feature flag is off
             this.ServerCertificateCustomValidationCallback = null;
         }
 
@@ -211,6 +211,9 @@ namespace Microsoft.Azure.Cosmos
             set;
         }
 
+        /// <summary>
+        /// Gets or sets the flag to enable client telemetry feature.
+        /// </summary>
         internal bool EnableClientTelemetry 
         { 
             get; 

--- a/Microsoft.Azure.Cosmos/src/Handler/DiagnosticsHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/DiagnosticsHandler.cs
@@ -4,6 +4,7 @@
 
 namespace Microsoft.Azure.Cosmos.Handlers
 {
+    using System;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Handler;
@@ -26,6 +27,9 @@ namespace Microsoft.Azure.Cosmos.Handlers
 
             // Record the diagnostics on the response to get the CPU of when the request was executing
             SystemUsageHistory systemUsageHistory = DiagnosticsHandlerHelper.GetInstance().GetDiagnosticsSystemHistory();
+
+            Console.WriteLine("DiagnosticsHandler: is systemUsageHistory null? {0}", systemUsageHistory == null);
+
             if (systemUsageHistory != null)
             {
                 request.Trace.AddDatum(

--- a/Microsoft.Azure.Cosmos/src/Handler/DiagnosticsHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/DiagnosticsHandler.cs
@@ -28,8 +28,6 @@ namespace Microsoft.Azure.Cosmos.Handlers
             // Record the diagnostics on the response to get the CPU of when the request was executing
             SystemUsageHistory systemUsageHistory = DiagnosticsHandlerHelper.GetInstance().GetDiagnosticsSystemHistory();
 
-            Console.WriteLine("DiagnosticsHandler: is systemUsageHistory null? {0}", systemUsageHistory == null);
-
             if (systemUsageHistory != null)
             {
                 request.Trace.AddDatum(

--- a/Microsoft.Azure.Cosmos/src/Handler/DiagnosticsHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/DiagnosticsHandler.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Cosmos.Handlers
             ResponseMessage responseMessage = await base.SendAsync(request, cancellationToken);
 
             // Record the diagnostics on the response to get the CPU of when the request was executing
-            SystemUsageHistory systemUsageHistory = DiagnosticsHandlerHelper.Instance.GetDiagnosticsSystemHistory();
+            SystemUsageHistory systemUsageHistory = DiagnosticsHandlerHelper.GetInstance().GetDiagnosticsSystemHistory();
             if (systemUsageHistory != null)
             {
                 request.Trace.AddDatum(

--- a/Microsoft.Azure.Cosmos/src/Handler/DiagnosticsHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/DiagnosticsHandler.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.Cosmos.Handlers
             ResponseMessage responseMessage = await base.SendAsync(request, cancellationToken);
 
             // Record the diagnostics on the response to get the CPU of when the request was executing
-            SystemUsageHistory systemUsageHistory = DiagnosticsHandlerHelper.GetInstance()?.GetDiagnosticsSystemHistory();
+            SystemUsageHistory systemUsageHistory = DiagnosticsHandlerHelper.GetInstance().GetDiagnosticsSystemHistory();
 
             if (systemUsageHistory != null)
             {

--- a/Microsoft.Azure.Cosmos/src/Handler/DiagnosticsHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/DiagnosticsHandler.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.Cosmos.Handlers
             ResponseMessage responseMessage = await base.SendAsync(request, cancellationToken);
 
             // Record the diagnostics on the response to get the CPU of when the request was executing
-            SystemUsageHistory systemUsageHistory = DiagnosticsHandlerHelper.GetInstance().GetDiagnosticsSystemHistory();
+            SystemUsageHistory systemUsageHistory = DiagnosticsHandlerHelper.GetInstance()?.GetDiagnosticsSystemHistory();
 
             if (systemUsageHistory != null)
             {

--- a/Microsoft.Azure.Cosmos/src/Handler/DiagnosticsHandlerHelper.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/DiagnosticsHandlerHelper.cs
@@ -45,8 +45,8 @@ namespace Microsoft.Azure.Cosmos.Handler
             new DiagnosticsHandlerHelper();
 #endif
 
-        private static bool isDiagnosticsMonitoringEnabled = false;
-        private static bool isTelemetryMonitoringEnabled = false;
+        private static bool isDiagnosticsMonitoringEnabled;
+        private static bool isTelemetryMonitoringEnabled;
 
         private readonly SystemUsageMonitor systemUsageMonitor = null;
 
@@ -61,7 +61,6 @@ namespace Microsoft.Azure.Cosmos.Handler
         /// <param name="isClientTelemetryEnabled"></param>
         public static void Refresh(bool isClientTelemetryEnabled)
         {
-            Console.WriteLine("DiagnosticsHandlerHelper.Refresh " + isClientTelemetryEnabled);
             if (isClientTelemetryEnabled != DiagnosticsHandlerHelper.isTelemetryMonitoringEnabled)
             {
                 // Update telemetry flag
@@ -70,7 +69,7 @@ namespace Microsoft.Azure.Cosmos.Handler
                 // Create new instance, it will start a new system monitor job
                 DiagnosticsHandlerHelper newInstance = new DiagnosticsHandlerHelper();
 
-                // Create a new refrence to the old instance
+                // Create a new reference to the old instance
                 DiagnosticsHandlerHelper oldInstance = DiagnosticsHandlerHelper.Instance;
 
                 // Assing new instance to the static refrence,
@@ -79,8 +78,6 @@ namespace Microsoft.Azure.Cosmos.Handler
                 // Stop and dispose old instance of SystemMonitor job
                 oldInstance.StopSystemMonitor();
             }
-
-            Console.WriteLine("DiagnosticsHandlerHelper.Refreshed");
         }
 
         private void StopSystemMonitor()
@@ -99,16 +96,14 @@ namespace Microsoft.Azure.Cosmos.Handler
             // If the CPU monitor fails for some reason don't block the application
             try
             {
-                Console.WriteLine("Added diag recorder");
                 List<SystemUsageRecorder> recorders = new List<SystemUsageRecorder>()
                 {
-                    DiagnosticSystemUsageRecorder,
+                    DiagnosticsHandlerHelper.DiagnosticSystemUsageRecorder,
                 };
 
                 if (DiagnosticsHandlerHelper.isTelemetryMonitoringEnabled)
                 {
-                    Console.WriteLine("Added telemetry recorder");
-                    recorders.Add(TelemetrySystemUsageRecorder);
+                    recorders.Add(DiagnosticsHandlerHelper.TelemetrySystemUsageRecorder);
                 }
 
                 this.systemUsageMonitor = SystemUsageMonitor.CreateAndStart(recorders);
@@ -120,7 +115,6 @@ namespace Microsoft.Azure.Cosmos.Handler
                 DefaultTrace.TraceError(ex.Message);
 
                 DiagnosticsHandlerHelper.isDiagnosticsMonitoringEnabled = false;
-                DiagnosticsHandlerHelper.isTelemetryMonitoringEnabled = false;
             }
         }
 
@@ -137,7 +131,7 @@ namespace Microsoft.Azure.Cosmos.Handler
 
             try
             {
-                return DiagnosticSystemUsageRecorder.Data;
+                return DiagnosticsHandlerHelper.DiagnosticSystemUsageRecorder.Data;
             }
             catch (Exception ex)
             {
@@ -161,12 +155,11 @@ namespace Microsoft.Azure.Cosmos.Handler
 
             try
             {
-                return TelemetrySystemUsageRecorder.Data;
+                return DiagnosticsHandlerHelper.TelemetrySystemUsageRecorder.Data;
             }
             catch (Exception ex)
             {
                 DefaultTrace.TraceError(ex.Message);
-                DiagnosticsHandlerHelper.isTelemetryMonitoringEnabled = false;
                 return null;
             }
         }

--- a/Microsoft.Azure.Cosmos/src/Handler/DiagnosticsHandlerHelper.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/DiagnosticsHandlerHelper.cs
@@ -83,6 +83,8 @@ namespace Microsoft.Azure.Cosmos.Handler
             {
                 DefaultTrace.TraceError($"Error while stopping system usage monitor. Stacktrace: {0} ", ex.StackTrace);
             }
+
+            DiagnosticsHandlerHelper.Instance = null; // refrence is lost, GC will collect it
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Handler/DiagnosticsHandlerHelper.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/DiagnosticsHandlerHelper.cs
@@ -63,19 +63,20 @@ namespace Microsoft.Azure.Cosmos.Handler
         {
             if (isClientTelemetryEnabled != DiagnosticsHandlerHelper.isTelemetryMonitoringEnabled)
             {
-                // Lock this instance
-                lock (DiagnosticsHandlerHelper.Instance)
-                {
-                    // Stop SystemMonitor job
-                    DiagnosticsHandlerHelper.Instance.StopSystemMonitor();
-                    // Make instance eligible for garbage collection
-                    DiagnosticsHandlerHelper.Instance = null;
+                // Update telemetry flag
+                DiagnosticsHandlerHelper.isTelemetryMonitoringEnabled = isClientTelemetryEnabled;
 
-                    // Update telemetry flag
-                    DiagnosticsHandlerHelper.isTelemetryMonitoringEnabled = isClientTelemetryEnabled;
-                    // Create new instance
-                    DiagnosticsHandlerHelper.Instance = new DiagnosticsHandlerHelper();
-                }
+                // Create new instance, it will start a new system monitor job
+                DiagnosticsHandlerHelper newInstance = new DiagnosticsHandlerHelper();
+
+                // Create a new refrence to the old instance
+                DiagnosticsHandlerHelper oldInstance = DiagnosticsHandlerHelper.Instance;
+
+                // Assing new instance to the static refrence,
+                DiagnosticsHandlerHelper.Instance = newInstance;
+
+                // Stop and dispose old instance of SystemMonitor job
+                oldInstance.StopSystemMonitor();
             }
         }
 

--- a/Microsoft.Azure.Cosmos/src/Handler/DiagnosticsHandlerHelper.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/DiagnosticsHandlerHelper.cs
@@ -82,8 +82,6 @@ namespace Microsoft.Azure.Cosmos.Handler
             {
                 DefaultTrace.TraceError($"Error while stopping system usage monitor. {0} ", ex);
             }
-
-            DiagnosticsHandlerHelper.Instance = null; // refrence is lost, GC will collect it
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Handler/DiagnosticsHandlerHelper.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/DiagnosticsHandlerHelper.cs
@@ -81,7 +81,7 @@ namespace Microsoft.Azure.Cosmos.Handler
             }
             catch (ObjectDisposedException ex)
             {
-                DefaultTrace.TraceError($"Error while stopping system usage monitor. Stacktrace: {0} ", ex.StackTrace);
+                DefaultTrace.TraceError($"Error while stopping system usage monitor. {0} ", ex);
             }
 
             DiagnosticsHandlerHelper.Instance = null; // refrence is lost, GC will collect it

--- a/Microsoft.Azure.Cosmos/src/Handler/DiagnosticsHandlerHelper.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/DiagnosticsHandlerHelper.cs
@@ -22,13 +22,13 @@ namespace Microsoft.Azure.Cosmos.Handler
         private const string Telemetrykey = "telemetry";
 
         public static readonly TimeSpan DiagnosticsRefreshInterval = TimeSpan.FromSeconds(10);
-        private readonly SystemUsageRecorder diagnosticSystemUsageRecorder = new SystemUsageRecorder(
+        private static readonly SystemUsageRecorder DiagnosticSystemUsageRecorder = new SystemUsageRecorder(
             identifier: Diagnostickey,
             historyLength: 6,
             refreshInterval: DiagnosticsHandlerHelper.DiagnosticsRefreshInterval);
 
         private static readonly TimeSpan ClientTelemetryRefreshInterval = TimeSpan.FromSeconds(5);
-        private readonly SystemUsageRecorder telemetrySystemUsageRecorder = new SystemUsageRecorder(
+        private static readonly SystemUsageRecorder TelemetrySystemUsageRecorder = new SystemUsageRecorder(
             identifier: Telemetrykey,
             historyLength: 120,
             refreshInterval: DiagnosticsHandlerHelper.ClientTelemetryRefreshInterval);
@@ -61,6 +61,7 @@ namespace Microsoft.Azure.Cosmos.Handler
         /// <param name="isClientTelemetryEnabled"></param>
         public static void Refresh(bool isClientTelemetryEnabled)
         {
+            Console.WriteLine("DiagnosticsHandlerHelper.Refresh " + isClientTelemetryEnabled);
             if (isClientTelemetryEnabled != DiagnosticsHandlerHelper.isTelemetryMonitoringEnabled)
             {
                 // Update telemetry flag
@@ -78,6 +79,8 @@ namespace Microsoft.Azure.Cosmos.Handler
                 // Stop and dispose old instance of SystemMonitor job
                 oldInstance.StopSystemMonitor();
             }
+
+            Console.WriteLine("DiagnosticsHandlerHelper.Refreshed");
         }
 
         private void StopSystemMonitor()
@@ -96,14 +99,16 @@ namespace Microsoft.Azure.Cosmos.Handler
             // If the CPU monitor fails for some reason don't block the application
             try
             {
+                Console.WriteLine("Added diag recorder");
                 List<SystemUsageRecorder> recorders = new List<SystemUsageRecorder>()
                 {
-                    this.diagnosticSystemUsageRecorder,
+                    DiagnosticSystemUsageRecorder,
                 };
 
                 if (DiagnosticsHandlerHelper.isTelemetryMonitoringEnabled)
                 {
-                    recorders.Add(this.telemetrySystemUsageRecorder);
+                    Console.WriteLine("Added telemetry recorder");
+                    recorders.Add(TelemetrySystemUsageRecorder);
                 }
 
                 this.systemUsageMonitor = SystemUsageMonitor.CreateAndStart(recorders);
@@ -132,7 +137,7 @@ namespace Microsoft.Azure.Cosmos.Handler
 
             try
             {
-                return this.diagnosticSystemUsageRecorder.Data;
+                return DiagnosticSystemUsageRecorder.Data;
             }
             catch (Exception ex)
             {
@@ -156,7 +161,7 @@ namespace Microsoft.Azure.Cosmos.Handler
 
             try
             {
-                return this.telemetrySystemUsageRecorder.Data;
+                return TelemetrySystemUsageRecorder.Data;
             }
             catch (Exception ex)
             {

--- a/Microsoft.Azure.Cosmos/src/Handler/DiagnosticsHandlerHelper.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/DiagnosticsHandlerHelper.cs
@@ -8,7 +8,6 @@ namespace Microsoft.Azure.Cosmos.Handler
     using System.Collections.Generic;
     using Documents.Rntbd;
     using Microsoft.Azure.Cosmos.Core.Trace;
-    using Microsoft.Azure.Cosmos.Query.Core.Pipeline;
 
     /// <summary>
     /// This is a helper class that creates a single static instance to avoid each

--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/AccountClientConfiguration.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/AccountClientConfiguration.cs
@@ -1,0 +1,29 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos
+{
+    using System.Collections.Generic;
+    using Microsoft.Azure.Documents;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+
+    internal class AccountClientConfiguration
+    {
+        [JsonProperty(PropertyName = Constants.Properties.ClientTelemetryConfiguration)]
+        public ClientTelemetryConfiguration ClientTelemetryConfiguration { get; set; }
+
+        /// <summary>
+        /// This contains additional values for scenarios where the SDK is not aware of new fields. 
+        /// This ensures that if resource is read and updated none of the fields will be lost in the process.
+        /// </summary>
+        [JsonExtensionData]
+        internal IDictionary<string, JToken> AdditionalProperties { get; private set; }
+
+        internal bool IsClientTelemetryEnabled()
+        {
+            return this.ClientTelemetryConfiguration.IsEnabled && this.ClientTelemetryConfiguration.Endpoint != null;
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/ClientTelemetryConfiguration.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/ClientTelemetryConfiguration.cs
@@ -1,0 +1,27 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos
+{
+    using System.Collections.Generic;
+    using Microsoft.Azure.Documents;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+
+    internal class ClientTelemetryConfiguration
+    {
+        [JsonProperty(PropertyName = Constants.Properties.ClientTelemetryEnabled)]
+        public bool IsEnabled { get; set; }
+
+        [JsonProperty(PropertyName = Constants.Properties.ClientTelemetryEndpoint)]
+        public string Endpoint { get; set; }
+
+        /// <summary>
+        /// This contains additional values for scenarios where the SDK is not aware of new fields. 
+        /// This ensures that if resource is read and updated none of the fields will be lost in the process.
+        /// </summary>
+        [JsonExtensionData]
+        internal IDictionary<string, JToken> AdditionalProperties { get; private set; }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
     /// </summary>
     internal class ClientTelemetry : IDisposable
     {
-        private static readonly TimeSpan observingWindow = ClientTelemetryOptions.DefaultTimeStampInSeconds;
+        private static readonly TimeSpan observingWindow = ClientTelemetryOptions.DefaultIntervalForTelemetryJob;
 
         private readonly ClientTelemetryProperties clientTelemetryInfo;
         private readonly ClientTelemetryProcessor processor;

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
@@ -153,6 +153,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                         this.clientTelemetryInfo.GlobalDatabaseAccountName = accountProperties.Id;
                     }
 
+                    Console.WriteLine("Telemetry Job Started with Observing window : {0}", observingWindow);
                     await Task.Delay(observingWindow, this.cancellationTokenSource.Token);
 
                     this.clientTelemetryInfo.DateTimeUtc = DateTime.UtcNow.ToString(ClientTelemetryOptions.DateFormat);

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
@@ -153,7 +153,6 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                         this.clientTelemetryInfo.GlobalDatabaseAccountName = accountProperties.Id;
                     }
 
-                    Console.WriteLine("Telemetry Job Started with Observing window : {0}", observingWindow);
                     await Task.Delay(observingWindow, this.cancellationTokenSource.Token);
 
                     this.clientTelemetryInfo.DateTimeUtc = DateTime.UtcNow.ToString(ClientTelemetryOptions.DateFormat);

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
@@ -26,11 +26,12 @@ namespace Microsoft.Azure.Cosmos.Telemetry
     /// </summary>
     internal class ClientTelemetry : IDisposable
     {
-        private static readonly TimeSpan observingWindow = ClientTelemetryOptions.GetScheduledTimeSpan();
+        private static readonly TimeSpan observingWindow = ClientTelemetryOptions.DefaultTimeStampInSeconds;
 
         private readonly ClientTelemetryProperties clientTelemetryInfo;
         private readonly ClientTelemetryProcessor processor;
         private readonly DiagnosticsHandlerHelper diagnosticsHelper;
+        private readonly string endpointUrl;
         private readonly NetworkDataRecorder networkDataRecorder;
         
         private readonly CancellationTokenSource cancellationTokenSource;
@@ -63,6 +64,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         /// <param name="diagnosticsHelper"></param>
         /// <param name="preferredRegions"></param>
         /// <param name="globalEndpointManager"></param>
+        /// <param name="endpointUrl"></param>
         /// <returns>ClientTelemetry</returns>
         public static ClientTelemetry CreateAndStartBackgroundTelemetry(
             string clientId,
@@ -72,7 +74,8 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             AuthorizationTokenProvider authorizationTokenProvider,
             DiagnosticsHandlerHelper diagnosticsHelper,
             IReadOnlyList<string> preferredRegions,
-            GlobalEndpointManager globalEndpointManager)
+            GlobalEndpointManager globalEndpointManager,
+            string endpointUrl )
         {
             DefaultTrace.TraceInformation("Initiating telemetry with background task.");
 
@@ -84,7 +87,8 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                 authorizationTokenProvider,
                 diagnosticsHelper,
                 preferredRegions,
-                globalEndpointManager);
+                globalEndpointManager,
+                endpointUrl);
 
             clientTelemetry.StartObserverTask();
 
@@ -99,9 +103,12 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             AuthorizationTokenProvider authorizationTokenProvider,
             DiagnosticsHandlerHelper diagnosticsHelper,
             IReadOnlyList<string> preferredRegions,
-            GlobalEndpointManager globalEndpointManager)
+            GlobalEndpointManager globalEndpointManager,
+            string endpointUrl)
         {
             this.diagnosticsHelper = diagnosticsHelper ?? throw new ArgumentNullException(nameof(diagnosticsHelper));
+            this.endpointUrl = endpointUrl ?? throw new ArgumentNullException(nameof(endpointUrl));
+
             this.globalEndpointManager = globalEndpointManager;
             
             this.processor = new ClientTelemetryProcessor(httpClient, authorizationTokenProvider);
@@ -177,6 +184,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                                                                             operationInfoSnapshot: operationInfoSnapshot,
                                                                             cacheRefreshInfoSnapshot: cacheRefreshInfoSnapshot,
                                                                             requestInfoSnapshot: requestInfoSnapshot,
+                                                                            endpointUrl: this.endpointUrl,
                                                                             cancellationToken: cancellationToken.Token), cancellationToken.Token);
 
                         // Initiating Telemetry Data Processor task which will serialize and send telemetry information to Client Telemetry Service

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryOptions.cs
@@ -72,17 +72,13 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         internal const string IsThreadStarvingName = "SystemPool_IsThreadStarving_True";
         internal const string IsThreadStarvingUnit = "Count";
 
-        internal const double DefaultTimeStampInSeconds = 600;
         internal const double Percentile50 = 50.0;
         internal const double Percentile90 = 90.0;
         internal const double Percentile95 = 95.0;
         internal const double Percentile99 = 99.0;
         internal const double Percentile999 = 99.9;
         internal const string DateFormat = "yyyy-MM-ddTHH:mm:ssZ";
-        internal const string EnvPropsClientTelemetrySchedulingInSeconds = "COSMOS.CLIENT_TELEMETRY_SCHEDULING_IN_SECONDS";
-        internal const string EnvPropsClientTelemetryEnabled = "COSMOS.CLIENT_TELEMETRY_ENABLED";
-        internal const string EnvPropsClientTelemetryVmMetadataUrl = "COSMOS.VM_METADATA_URL";
-        internal const string EnvPropsClientTelemetryEndpoint = "COSMOS.CLIENT_TELEMETRY_ENDPOINT";
+
         internal const string EnvPropsClientTelemetryEnvironmentName = "COSMOS.ENVIRONMENT_NAME";
         
         internal static readonly ResourceType AllowedResourceTypes = ResourceType.Document;
@@ -99,53 +95,11 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         internal static readonly List<int> ExcludedStatusCodes = new List<int> { 404, 409, 412 };
 
         internal static readonly int NetworkTelemetrySampleSize = 200;
+        internal static readonly TimeSpan DefaultTimeStampInSeconds = TimeSpan.FromMinutes(10);
         internal static int PayloadSizeThreshold = 1024 * 1024 * 2; // 2MB
         internal static TimeSpan ClientTelemetryProcessorTimeOut = TimeSpan.FromMinutes(5);
         
-        private static Uri clientTelemetryEndpoint;
         private static string environmentName;
-        private static TimeSpan scheduledTimeSpan = TimeSpan.Zero;
-        
-        internal static bool IsClientTelemetryEnabled()
-        {
-            bool isTelemetryEnabled = ConfigurationManager
-                .GetEnvironmentVariable<bool>(ClientTelemetryOptions
-                                                        .EnvPropsClientTelemetryEnabled, false);
-
-            DefaultTrace.TraceInformation($"Telemetry Flag is set to {isTelemetryEnabled}");
-
-            return isTelemetryEnabled;
-        }
-
-        internal static TimeSpan GetScheduledTimeSpan()
-        {
-            if (scheduledTimeSpan.Equals(TimeSpan.Zero))
-            {
-                double scheduledTimeInSeconds = ClientTelemetryOptions.DefaultTimeStampInSeconds;
-                try
-                {
-                    scheduledTimeInSeconds = ConfigurationManager
-                                                    .GetEnvironmentVariable<double>(
-                                                           ClientTelemetryOptions.EnvPropsClientTelemetrySchedulingInSeconds,
-                                                           ClientTelemetryOptions.DefaultTimeStampInSeconds);
-
-                    if (scheduledTimeInSeconds <= 0)
-                    {
-                        throw new ArgumentException("Telemetry Scheduled time can not be less than or equal to 0.");
-                    }
-                }
-                catch (Exception ex)
-                {
-                    DefaultTrace.TraceError($"Error while getting telemetry scheduling configuration : {ex.Message}. Falling back to default configuration i.e. {scheduledTimeInSeconds}" );
-                }
-               
-                scheduledTimeSpan = TimeSpan.FromSeconds(scheduledTimeInSeconds);
-
-                DefaultTrace.TraceInformation($"Telemetry Scheduled in Seconds {scheduledTimeSpan.TotalSeconds}");
-
-            }
-            return scheduledTimeSpan;
-        }
 
         internal static string GetHostInformation(Compute vmInformation)
         {
@@ -153,23 +107,6 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                     vmInformation?.SKU, "|",
                     vmInformation?.VMSize, "|",
                     vmInformation?.AzEnvironment);
-        }
-
-        internal static Uri GetClientTelemetryEndpoint()
-        {
-            if (clientTelemetryEndpoint == null)
-            {
-                string uriProp = ConfigurationManager
-                    .GetEnvironmentVariable<string>(
-                        ClientTelemetryOptions.EnvPropsClientTelemetryEndpoint, null);
-                if (!String.IsNullOrEmpty(uriProp))
-                {
-                    clientTelemetryEndpoint = new Uri(uriProp);
-                }
-
-                DefaultTrace.TraceInformation($"Telemetry Endpoint URL is  {uriProp}");
-            }
-            return clientTelemetryEndpoint;
         }
 
         internal static string GetEnvironmentName()

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryOptions.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         internal static readonly List<int> ExcludedStatusCodes = new List<int> { 404, 409, 412 };
 
         internal static readonly int NetworkTelemetrySampleSize = 200;
-        internal static readonly TimeSpan DefaultIntervalForTelemetryJob = TimeSpan.FromMinutes(10);
+        internal static TimeSpan DefaultIntervalForTelemetryJob = TimeSpan.FromMinutes(10);
         internal static int PayloadSizeThreshold = 1024 * 1024 * 2; // 2MB
         internal static TimeSpan ClientTelemetryProcessorTimeOut = TimeSpan.FromMinutes(5);
         

--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetryOptions.cs
@@ -95,7 +95,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         internal static readonly List<int> ExcludedStatusCodes = new List<int> { 404, 409, 412 };
 
         internal static readonly int NetworkTelemetrySampleSize = 200;
-        internal static readonly TimeSpan DefaultTimeStampInSeconds = TimeSpan.FromMinutes(10);
+        internal static readonly TimeSpan DefaultIntervalForTelemetryJob = TimeSpan.FromMinutes(10);
         internal static int PayloadSizeThreshold = 1024 * 1024 * 2; // 2MB
         internal static TimeSpan ClientTelemetryProcessorTimeOut = TimeSpan.FromMinutes(5);
         

--- a/Microsoft.Azure.Cosmos/src/Telemetry/TelemetryToServiceHelper.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/TelemetryToServiceHelper.cs
@@ -176,7 +176,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                 }
                 catch (Exception ex)
                 {
-                    DefaultTrace.TraceWarning($"Error While starting Telemetry Job : {0}. Hence disabling Client Telemetry", ex.Message);
+                    DefaultTrace.TraceWarning($"Error While starting Telemetry Job : {0}. Hence disabling Client Telemetry", ex);
                     this.connectionPolicy.EnableClientTelemetry = false;
                 }
             }

--- a/Microsoft.Azure.Cosmos/src/Telemetry/TelemetryToServiceHelper.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/TelemetryToServiceHelper.cs
@@ -5,7 +5,6 @@
 namespace Microsoft.Azure.Cosmos.Telemetry
 {
     using System;
-    using System.Collections.Specialized;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;

--- a/Microsoft.Azure.Cosmos/src/Telemetry/TelemetryToServiceHelper.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/TelemetryToServiceHelper.cs
@@ -5,12 +5,18 @@
 namespace Microsoft.Azure.Cosmos.Telemetry
 {
     using System;
+    using System.Collections.Specialized;
+    using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Core.Trace;
     using Microsoft.Azure.Cosmos.Handler;
+    using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Routing;
     using Microsoft.Azure.Cosmos.Telemetry.Collector;
+    using Microsoft.Azure.Cosmos.Tracing;
+    using Microsoft.Azure.Documents;
+    using Microsoft.Azure.Documents.Collections;
 
     internal class TelemetryToServiceHelper : IDisposable
     {
@@ -70,10 +76,67 @@ namespace Microsoft.Azure.Cosmos.Telemetry
             TelemetryToServiceHelper helper = new TelemetryToServiceHelper(
                 clientId, connectionPolicy, cosmosAuthorization, httpClient, serviceEndpoint, globalEndpointManager, cancellationTokenSource);
 
-            helper.InitializeClientTelemetry();
+            _ = helper.RetrieveConfigAndInitiateTelemetryAsync(); // Let it run in backgroud
 
             return helper;
 #endif
+        }
+
+        private async Task RetrieveConfigAndInitiateTelemetryAsync()
+        {
+            try
+            {
+                Uri serviceEndpointWithPath = new Uri(this.serviceEnpoint + Paths.ClientConfigPathSegment);
+
+                TryCatch<AccountClientConfiguration> databaseAccountClientConfigs = await this.GetDatabaseAccountClientConfigAsync(this.cosmosAuthorization, this.httpClient, serviceEndpointWithPath);
+                if (databaseAccountClientConfigs.Succeeded)
+                {
+                    this.InitializeClientTelemetry(databaseAccountClientConfigs.Result);
+                }
+                else if (!this.cancellationTokenSource.IsCancellationRequested)
+                {
+                    DefaultTrace.TraceWarning($"Exception while calling client config " + databaseAccountClientConfigs.Exception.ToString());
+                }
+            }
+            catch (Exception ex)
+            {
+                DefaultTrace.TraceWarning($"Exception while running client config job " + ex.ToString());
+            }
+        }
+
+        private async Task<TryCatch<AccountClientConfiguration>> GetDatabaseAccountClientConfigAsync(AuthorizationTokenProvider cosmosAuthorization,
+            CosmosHttpClient httpClient,
+            Uri clientConfigEndpoint)
+        {
+            INameValueCollection headers = new RequestNameValueCollection();
+            await cosmosAuthorization.AddAuthorizationHeaderAsync(
+                headersCollection: headers,
+                clientConfigEndpoint,
+                HttpConstants.HttpMethods.Get,
+                AuthorizationTokenType.PrimaryMasterKey);
+
+            using (ITrace trace = Trace.GetRootTrace("Account Client Config Read", TraceComponent.Transport, TraceLevel.Info))
+            {
+                try
+                {
+                    using (HttpResponseMessage responseMessage = await httpClient.GetAsync(
+                        uri: clientConfigEndpoint,
+                        additionalHeaders: headers,
+                        resourceType: ResourceType.DatabaseAccount,
+                        timeoutPolicy: HttpTimeoutPolicyControlPlaneRead.Instance,
+                        clientSideRequestStatistics: null,
+                        cancellationToken: default))
+                    using (DocumentServiceResponse documentServiceResponse = await ClientExtensions.ParseResponseAsync(responseMessage))
+                    {
+                        return TryCatch<AccountClientConfiguration>.FromResult(CosmosResource.FromStream<AccountClientConfiguration>(documentServiceResponse));
+                    }
+                }
+                catch (Exception ex)
+                {
+                    DefaultTrace.TraceWarning($"Exception while calling client config " + ex.StackTrace);
+                    return TryCatch<AccountClientConfiguration>.FromException(ex);
+                }
+            }
         }
 
         public ITelemetryCollector GetCollector()
@@ -89,28 +152,34 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         /// <summary>
         /// Trigger Client Telemetry job when it is enabled and not already running.
         /// </summary>
-        private void InitializeClientTelemetry()
+        private void InitializeClientTelemetry(AccountClientConfiguration clientConfig)
         {
-            try
-            {
-                this.clientTelemetry = ClientTelemetry.CreateAndStartBackgroundTelemetry(
-                    clientId: this.clientId,
-                    httpClient: this.httpClient,
-                    userAgent: this.connectionPolicy.UserAgentContainer.BaseUserAgent,
-                    connectionMode: this.connectionPolicy.ConnectionMode,
-                    authorizationTokenProvider: this.cosmosAuthorization,
-                    diagnosticsHelper: DiagnosticsHandlerHelper.Instance,
-                    preferredRegions: this.connectionPolicy.PreferredLocations,
-                    globalEndpointManager: this.globalEndpointManager);
+            DiagnosticsHandlerHelper.Refresh(clientConfig.IsClientTelemetryEnabled());
 
-                this.collector = new TelemetryCollector(this.clientTelemetry, this.connectionPolicy);
-
-                DefaultTrace.TraceVerbose("Client Telemetry Enabled.");
-            }
-            catch (Exception ex)
+            if (clientConfig.IsClientTelemetryEnabled())
             {
-                DefaultTrace.TraceWarning($"Error While starting Telemetry Job : {0}. Hence disabling Client Telemetry", ex.Message);
-                this.connectionPolicy.EnableClientTelemetry = false;
+                try
+                {
+                    this.clientTelemetry = ClientTelemetry.CreateAndStartBackgroundTelemetry(
+                        clientId: this.clientId,
+                        httpClient: this.httpClient,
+                        userAgent: this.connectionPolicy.UserAgentContainer.BaseUserAgent,
+                        connectionMode: this.connectionPolicy.ConnectionMode,
+                        authorizationTokenProvider: this.cosmosAuthorization,
+                        diagnosticsHelper: DiagnosticsHandlerHelper.GetInstance(),
+                        preferredRegions: this.connectionPolicy.PreferredLocations,
+                        globalEndpointManager: this.globalEndpointManager,
+                        endpointUrl: clientConfig.ClientTelemetryConfiguration.Endpoint);
+
+                    this.collector = new TelemetryCollector(this.clientTelemetry, this.connectionPolicy);
+
+                    DefaultTrace.TraceVerbose("Client Telemetry Enabled.");
+                }
+                catch (Exception ex)
+                {
+                    DefaultTrace.TraceWarning($"Error While starting Telemetry Job : {0}. Hence disabling Client Telemetry", ex.Message);
+                    this.connectionPolicy.EnableClientTelemetry = false;
+                }
             }
         }
 

--- a/Microsoft.Azure.Cosmos/src/Tracing/TraceData/ClientSideRequestStatisticsTraceDatum.cs
+++ b/Microsoft.Azure.Cosmos/src/Tracing/TraceData/ClientSideRequestStatisticsTraceDatum.cs
@@ -419,7 +419,7 @@ namespace Microsoft.Azure.Cosmos.Tracing.TraceData
                 this.systemUsageHistory.Values.Count == 0 ||
                 this.systemUsageHistory.LastTimestamp + DiagnosticsHandlerHelper.DiagnosticsRefreshInterval < DateTime.UtcNow)
             {
-                this.systemUsageHistory = DiagnosticsHandlerHelper.GetInstance().GetDiagnosticsSystemHistory();
+                this.systemUsageHistory = DiagnosticsHandlerHelper.GetInstance()?.GetDiagnosticsSystemHistory();
             }
 #endif
         }

--- a/Microsoft.Azure.Cosmos/src/Tracing/TraceData/ClientSideRequestStatisticsTraceDatum.cs
+++ b/Microsoft.Azure.Cosmos/src/Tracing/TraceData/ClientSideRequestStatisticsTraceDatum.cs
@@ -419,7 +419,7 @@ namespace Microsoft.Azure.Cosmos.Tracing.TraceData
                 this.systemUsageHistory.Values.Count == 0 ||
                 this.systemUsageHistory.LastTimestamp + DiagnosticsHandlerHelper.DiagnosticsRefreshInterval < DateTime.UtcNow)
             {
-                this.systemUsageHistory = DiagnosticsHandlerHelper.GetInstance()?.GetDiagnosticsSystemHistory();
+                this.systemUsageHistory = DiagnosticsHandlerHelper.GetInstance().GetDiagnosticsSystemHistory();
             }
 #endif
         }

--- a/Microsoft.Azure.Cosmos/src/Tracing/TraceData/ClientSideRequestStatisticsTraceDatum.cs
+++ b/Microsoft.Azure.Cosmos/src/Tracing/TraceData/ClientSideRequestStatisticsTraceDatum.cs
@@ -419,7 +419,7 @@ namespace Microsoft.Azure.Cosmos.Tracing.TraceData
                 this.systemUsageHistory.Values.Count == 0 ||
                 this.systemUsageHistory.LastTimestamp + DiagnosticsHandlerHelper.DiagnosticsRefreshInterval < DateTime.UtcNow)
             {
-                this.systemUsageHistory = DiagnosticsHandlerHelper.Instance.GetDiagnosticsSystemHistory();
+                this.systemUsageHistory = DiagnosticsHandlerHelper.GetInstance().GetDiagnosticsSystemHistory();
             }
 #endif
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryReleaseTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryReleaseTests.cs
@@ -41,12 +41,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             ClientTelemetryTestsBase.ClassInitialize(context);
         }
 
-        [ClassCleanup]
-        public static new void FinalCleanup()
-        {
-            ClientTelemetryTestsBase.FinalCleanup();
-        }
-
         [TestInitialize]
         public override void TestInitialize()
         {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryReleaseTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryReleaseTests.cs
@@ -36,9 +36,15 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [ClassInitialize]
-        public static new void ClassInitialize(TestContext context)
+        public static void ClassInit(TestContext context)
         {
             ClientTelemetryTestsBase.ClassInitialize(context);
+        }
+
+        [ClassCleanup]
+        public static void ClassCleanUp()
+        {
+            ClientTelemetryTestsBase.ClassCleanup();
         }
 
         [TestInitialize]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryReleaseTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryReleaseTests.cs
@@ -39,11 +39,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         public static new void ClassInitialize(TestContext context)
         {
             ClientTelemetryTestsBase.ClassInitialize(context);
-
-            // It will go away in next PR
-            Environment.SetEnvironmentVariable(ClientTelemetryOptions.EnvPropsClientTelemetryEnabled, "true");
-            Environment.SetEnvironmentVariable(ClientTelemetryOptions.EnvPropsClientTelemetrySchedulingInSeconds, "1");
-            Environment.SetEnvironmentVariable(ClientTelemetryOptions.EnvPropsClientTelemetryEndpoint, "https://tools.cosmos.azure.com/api/clienttelemetry/trace");
         }
 
         [ClassCleanup]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
@@ -52,9 +52,15 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [ClassInitialize]
-        public static new void ClassInitialize(TestContext context)
+        public static void ClassInit(TestContext context)
         {
             ClientTelemetryTestsBase.ClassInitialize(context);
+        }
+
+        [ClassCleanup]
+        public static void ClassCleanUp()
+        {
+            ClientTelemetryTestsBase.ClassCleanup();
         }
 
         [TestInitialize]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
     {
         public override Task<HttpResponseMessage> HttpHandlerRequestCallbackChecks(HttpRequestMessage request)
         {
-            if (request.RequestUri.AbsoluteUri.Equals(telemetryServiceEndpoint))
+            if (request.RequestUri.AbsoluteUri.Equals(telemetryServiceEndpoint.AbsoluteUri))
             {
                 return Task.FromResult(new HttpResponseMessage(HttpStatusCode.NoContent));  // In Emulator test, send hardcoded response status code as there is no real communication happens with client telemetry service
             }
@@ -55,12 +55,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         public static new void ClassInitialize(TestContext context)
         {
             ClientTelemetryTestsBase.ClassInitialize(context);
-        }
-
-        [ClassCleanup]
-        public static new void FinalCleanup()
-        {
-            ClientTelemetryTestsBase.FinalCleanup();
         }
 
         [TestInitialize]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTestsBase.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTestsBase.cs
@@ -57,6 +57,12 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             ClientTelemetryOptions.DefaultIntervalForTelemetryJob = TimeSpan.FromSeconds(1);
         }
 
+        public static void ClassCleanup()
+        {
+            //undone the changes done in ClassInitialize
+            ClientTelemetryOptions.DefaultIntervalForTelemetryJob = TimeSpan.FromMinutes(10);
+        }
+
         public virtual void TestInitialize()
         {
             this.actualInfo = new List<ClientTelemetryProperties>();

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTestsBase.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTestsBase.cs
@@ -55,8 +55,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
         public static void ClassInitialize(TestContext _)
         {
-            FieldInfo field = typeof(ClientTelemetryOptions).GetField("DefaultTimeStampInSeconds", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Static);
-            field.SetValue(null, TimeSpan.FromSeconds(1));
+            ClientTelemetryOptions.DefaultIntervalForTelemetryJob = TimeSpan.FromSeconds(1);
 
             SystemUsageMonitor oldSystemUsageMonitor = (SystemUsageMonitor)typeof(DiagnosticsHandlerHelper)
                 .GetField("systemUsageMonitor", BindingFlags.Instance | BindingFlags.NonPublic).GetValue(DiagnosticsHandlerHelper.GetInstance());
@@ -86,7 +85,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 },
                 ResponseIntercepter = (response) =>
                 {
-                    if (response.RequestMessage.RequestUri.AbsoluteUri.Equals(telemetryServiceEndpoint))
+                    if (response.RequestMessage != null && response.RequestMessage.RequestUri.AbsoluteUri.Equals(telemetryServiceEndpoint))
                     {
                         Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
                     }
@@ -142,6 +141,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             };
 
             this.cosmosClientBuilder = this.GetBuilder()
+                                                .WithTelemetryEnabled()
                                                 .WithApplicationPreferredRegions(ClientTelemetryTestsBase.preferredRegionList);
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/SynchronizationContextTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/SynchronizationContextTests.cs
@@ -12,7 +12,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Linq;
-    using Microsoft.Azure.Cosmos.Telemetry.Models;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Newtonsoft.Json;
     using Microsoft.Azure.Documents;
@@ -60,6 +59,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 {
                     using (CosmosClient client = TestCommon.CreateCosmosClient(
                                                                 customizeClientBuilder: (builder) => builder
+                                                                                                        .WithTelemetryEnabled()
                                                                                                         .WithHttpClientFactory(() => new HttpClient(httpHandler))))
                     {
                         Cosmos.Database database = client.CreateDatabaseAsync(databaseId).GetAwaiter().GetResult();

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/SynchronizationContextTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/SynchronizationContextTests.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         {
             if (withClientTelemetry)
             {
-                Util.EnableClientTelemetryEnvironmentVariables();
+               
             }
 
             string databaseId = Guid.NewGuid().ToString();
@@ -141,7 +141,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                 if (withClientTelemetry)
                 {
-                    Util.DisableClientTelemetryEnvironmentVariables();
                 }
             }
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/SynchronizationContextTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/SynchronizationContextTests.cs
@@ -6,9 +6,16 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 {
     using System;
     using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using System.Text;
     using System.Threading;
+    using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Linq;
+    using Microsoft.Azure.Cosmos.Telemetry.Models;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Newtonsoft.Json;
+    using Microsoft.Azure.Documents;
 
     [TestClass]
     public class SynchronizationContextTests
@@ -19,10 +26,29 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         [Timeout(30000)]
         public void VerifySynchronizationContextDoesNotLock(bool withClientTelemetry)
         {
-            if (withClientTelemetry)
+            HttpClientHandlerHelper httpHandler = new HttpClientHandlerHelper
             {
-               
-            }
+                RequestCallBack = (request, cancellation) =>
+                {
+                    if (request.RequestUri.AbsoluteUri.Contains(Paths.ClientConfigPathSegment))
+                    {
+                        HttpResponseMessage result = new HttpResponseMessage(HttpStatusCode.OK);
+                        AccountClientConfiguration clientConfigProperties = new AccountClientConfiguration
+                        {
+                            ClientTelemetryConfiguration = new ClientTelemetryConfiguration
+                            {
+                                IsEnabled = withClientTelemetry,
+                                Endpoint = withClientTelemetry? "http://dummy.telemetry.endpoint/" : null
+                            }
+                        };
+                        string payload = JsonConvert.SerializeObject(clientConfigProperties);
+                        result.Content = new StringContent(payload, Encoding.UTF8, "application/json");
+                        return Task.FromResult(result);
+                    }
+
+                    return null;
+                }
+            };
 
             string databaseId = Guid.NewGuid().ToString();
             SynchronizationContext prevContext = SynchronizationContext.Current;
@@ -32,7 +58,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 SynchronizationContext.SetSynchronizationContext(syncContext);
                 syncContext.Post(_ =>
                 {
-                    using (CosmosClient client = TestCommon.CreateCosmosClient())
+                    using (CosmosClient client = TestCommon.CreateCosmosClient(
+                                                                customizeClientBuilder: (builder) => builder
+                                                                                                        .WithHttpClientFactory(() => new HttpClient(httpHandler))))
                     {
                         Cosmos.Database database = client.CreateDatabaseAsync(databaseId).GetAwaiter().GetResult();
                         database = client.CreateDatabaseIfNotExistsAsync(databaseId).GetAwaiter().GetResult();
@@ -124,7 +152,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                         double cost = container.GetItemLinqQueryable<ToDoActivity>(
                             allowSynchronousQueryExecution: true).Select(x => x.cost).Sum();
-                        
+
                         ItemResponse<ToDoActivity> deleteResponse = container.DeleteItemAsync<ToDoActivity>(partitionKey: new Cosmos.PartitionKey(testItem.pk), id: testItem.id).ConfigureAwait(false).GetAwaiter().GetResult();
                         Assert.IsNotNull(deleteResponse);
                     }
@@ -137,10 +165,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 using (CosmosClient client = TestCommon.CreateCosmosClient())
                 {
                     client.GetDatabase(databaseId).DeleteAsync().GetAwaiter().GetResult();
-                }
-
-                if (withClientTelemetry)
-                {
                 }
             }
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/HttpHandlerHelper.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/HttpHandlerHelper.cs
@@ -52,6 +52,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     throw;
                 }
                 this.ExceptionIntercepter.Invoke(request, ex);
+
+                throw;
             }
            
             if (this.ResponseIntercepter != null)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/Util.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/Util.cs
@@ -522,20 +522,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 options.OfferThroughput);
         }
 
-        internal static void EnableClientTelemetryEnvironmentVariables()
-        {
-            Environment.SetEnvironmentVariable(ClientTelemetryOptions.EnvPropsClientTelemetryEnabled, "true");
-            Environment.SetEnvironmentVariable(ClientTelemetryOptions.EnvPropsClientTelemetrySchedulingInSeconds, "1");
-            Environment.SetEnvironmentVariable(ClientTelemetryOptions.EnvPropsClientTelemetryEndpoint, "http://dummy.telemetry.endpoint/");
-        }
-
-        internal static void DisableClientTelemetryEnvironmentVariables()
-        {
-            Environment.SetEnvironmentVariable(ClientTelemetryOptions.EnvPropsClientTelemetryEnabled, null);
-            Environment.SetEnvironmentVariable(ClientTelemetryOptions.EnvPropsClientTelemetrySchedulingInSeconds, null);
-            Environment.SetEnvironmentVariable(ClientTelemetryOptions.EnvPropsClientTelemetryEndpoint, null);
-        }
-
         private static TracerProvider OTelTracerProvider;
         private static CustomListener TestListener;
         

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Mocks/HttpHandlerHelper.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Mocks/HttpHandlerHelper.cs
@@ -2,7 +2,7 @@
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 //------------------------------------------------------------
 
-namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
+namespace Microsoft.Azure.Cosmos.Performance.Tests
 {
     using System;
     using System.Net.Http;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Diagnostics/DiagnosticHandlerHelperTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Diagnostics/DiagnosticHandlerHelperTests.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.Azure.Cosmos.Diagnostics
 {
     using System;
+    using System.Reflection;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Handler;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -11,34 +12,55 @@ namespace Microsoft.Azure.Cosmos.Diagnostics
     [TestClass]
     public class DiagnosticHandlerHelperTests
     {
+        [TestInitialize]
+        public void Initialize()
+        {
+            //Stop the job
+            DiagnosticsHandlerHelper helper = DiagnosticsHandlerHelper.GetInstance();
+            MethodInfo iMethod= helper.GetType().GetMethod("StopSystemMonitor", BindingFlags.NonPublic | BindingFlags.Instance);
+            iMethod.Invoke(helper, new object[] { });
+
+            //Reset the instance woth original value
+            FieldInfo field = typeof(DiagnosticsHandlerHelper).GetField("Instance",
+                            BindingFlags.Static |
+                            BindingFlags.NonPublic);
+            field.SetValue(null, Activator.CreateInstance(typeof(DiagnosticsHandlerHelper), true));
+        }
+
         [TestMethod]
         public void SingletonTest()
         {
             DiagnosticsHandlerHelper diagnosticHandlerHelper1 = DiagnosticsHandlerHelper.GetInstance();
             DiagnosticsHandlerHelper diagnosticHandlerHelper2 = DiagnosticsHandlerHelper.GetInstance();
 
+            Assert.IsNotNull(diagnosticHandlerHelper1);
+            Assert.IsNotNull(diagnosticHandlerHelper2);
             Assert.AreEqual(diagnosticHandlerHelper1, diagnosticHandlerHelper2, "Not Singleton");
         }
 
         [TestMethod]
         public async Task RefreshTestAsync()
         {
+            // Get default instance of DiagnosticsHandlerHelper with client telemetry disabled (default)
             DiagnosticsHandlerHelper diagnosticHandlerHelper1 = DiagnosticsHandlerHelper.GetInstance();
-            await Task.Delay(1000); // Give it some time to warm up
-            Assert.IsTrue(diagnosticHandlerHelper1.GetDiagnosticsSystemHistory().Values.Count < 2, $"Actual Count is {diagnosticHandlerHelper1.GetDiagnosticsSystemHistory().Values.Count}, expected count is less than 2"); // Making sure we collected less than to records
-            await Task.Delay(10000);
+            await Task.Delay(10000); // warm up
             Assert.IsNotNull(diagnosticHandlerHelper1.GetDiagnosticsSystemHistory());
-            Assert.IsTrue(diagnosticHandlerHelper1.GetDiagnosticsSystemHistory().Values.Count == 2, $"Actual Count is {diagnosticHandlerHelper1.GetDiagnosticsSystemHistory().Values.Count}, expected count is 2"); // After 10 of wait, there must be 2 records (collecting every 10 sec)
+            int countBeforeRefresh = diagnosticHandlerHelper1.GetDiagnosticsSystemHistory().Values.Count;
 
+            // Refresh instance of DiagnosticsHandlerHelper with client telemetry enabled
             DiagnosticsHandlerHelper.Refresh(true);
             DiagnosticsHandlerHelper diagnosticHandlerHelper2 = DiagnosticsHandlerHelper.GetInstance();
-            await Task.Delay(1000); // Give it some time to warm up
+            int countAfterRefresh = diagnosticHandlerHelper1.GetDiagnosticsSystemHistory().Values.Count;
+
+            Console.WriteLine(countBeforeRefresh + " " + countAfterRefresh);
+            Assert.IsTrue(countBeforeRefresh <= countAfterRefresh, "After Refresh count should be greater than or equal to before refresh count");
 
             Assert.AreNotEqual(diagnosticHandlerHelper1, diagnosticHandlerHelper2);
+
             Assert.IsNotNull(diagnosticHandlerHelper2.GetDiagnosticsSystemHistory());
-            Assert.IsTrue(diagnosticHandlerHelper2.GetDiagnosticsSystemHistory().Values.Count == 2, $"Actual Count is {diagnosticHandlerHelper2.GetDiagnosticsSystemHistory().Values.Count}, expected count is 2"); // Making sure after refresh we are not loosing old data.
             Assert.IsNotNull(diagnosticHandlerHelper2.GetClientTelemetrySystemHistory());
 
+            // Refresh instance of DiagnosticsHandlerHelper with client telemetry disabled
             DiagnosticsHandlerHelper.Refresh(false);
             DiagnosticsHandlerHelper diagnosticHandlerHelper3 = DiagnosticsHandlerHelper.GetInstance();
             Assert.IsNotNull(diagnosticHandlerHelper3.GetDiagnosticsSystemHistory());

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Diagnostics/DiagnosticHandlerHelperTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Diagnostics/DiagnosticHandlerHelperTests.cs
@@ -1,0 +1,49 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+namespace Microsoft.Azure.Cosmos.Diagnostics
+{
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Handler;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class DiagnosticHandlerHelperTests
+    {
+        [TestMethod]
+        public void SingletonTest()
+        {
+            DiagnosticsHandlerHelper diagnosticHandlerHelper1 = DiagnosticsHandlerHelper.GetInstance();
+            DiagnosticsHandlerHelper diagnosticHandlerHelper2 = DiagnosticsHandlerHelper.GetInstance();
+
+            Assert.AreEqual(diagnosticHandlerHelper1, diagnosticHandlerHelper2);
+        }
+
+        [TestMethod]
+        public async Task RefreshTestAsync()
+        {
+            DiagnosticsHandlerHelper diagnosticHandlerHelper1 = DiagnosticsHandlerHelper.GetInstance();
+            await Task.Delay(1000);
+            Assert.IsNotNull(diagnosticHandlerHelper1.GetDiagnosticsSystemHistory());
+            Assert.IsNull(diagnosticHandlerHelper1.GetClientTelemetrySystemHistory());
+
+            DiagnosticsHandlerHelper.Refresh(true);
+            await Task.Delay(1000);
+            DiagnosticsHandlerHelper diagnosticHandlerHelper2 = DiagnosticsHandlerHelper.GetInstance();
+            Assert.IsNotNull(diagnosticHandlerHelper2.GetDiagnosticsSystemHistory());
+            Assert.IsNotNull(diagnosticHandlerHelper2.GetClientTelemetrySystemHistory());
+
+            DiagnosticsHandlerHelper.Refresh(false);
+            await Task.Delay(1000);
+            DiagnosticsHandlerHelper diagnosticHandlerHelper3 = DiagnosticsHandlerHelper.GetInstance();
+            Assert.IsNotNull(diagnosticHandlerHelper3.GetDiagnosticsSystemHistory());
+            Assert.IsNull(diagnosticHandlerHelper3.GetClientTelemetrySystemHistory());
+
+            DiagnosticsHandlerHelper.Refresh(true);
+            await Task.Delay(1000);
+            DiagnosticsHandlerHelper diagnosticHandlerHelper4 = DiagnosticsHandlerHelper.GetInstance();
+            Assert.IsNotNull(diagnosticHandlerHelper4.GetDiagnosticsSystemHistory());
+            Assert.IsNotNull(diagnosticHandlerHelper4.GetClientTelemetrySystemHistory());
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Diagnostics/DiagnosticHandlerHelperTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Diagnostics/DiagnosticHandlerHelperTests.cs
@@ -12,12 +12,17 @@ namespace Microsoft.Azure.Cosmos.Diagnostics
     [TestClass]
     public class DiagnosticHandlerHelperTests
     {
-        [TestInitialize]
+        [ClassInitialize]
         public void Initialize()
+        {
+            DiagnosticHandlerHelperTests.ResetDiagnosticsHandlerHelper();
+        }
+
+        private static void ResetDiagnosticsHandlerHelper()
         {
             //Stop the job
             DiagnosticsHandlerHelper helper = DiagnosticsHandlerHelper.GetInstance();
-            MethodInfo iMethod= helper.GetType().GetMethod("StopSystemMonitor", BindingFlags.NonPublic | BindingFlags.Instance);
+            MethodInfo iMethod = helper.GetType().GetMethod("StopSystemMonitor", BindingFlags.NonPublic | BindingFlags.Instance);
             iMethod.Invoke(helper, new object[] { });
 
             //Reset the instance woth original value

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Diagnostics/DiagnosticHandlerHelperTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Diagnostics/DiagnosticHandlerHelperTests.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.Cosmos.Diagnostics
     public class DiagnosticHandlerHelperTests
     {
         [ClassInitialize]
-        public void Initialize()
+        public static void Initialize(TestContext _)
         {
             DiagnosticHandlerHelperTests.ResetDiagnosticsHandlerHelper();
         }


### PR DESCRIPTION
## Description

This PR is part 2/3 of this https://github.com/Azure/azure-cosmos-dotnet-v3/pull/3816 PR.

As part of PR, Removing Environment variable configs and using client config API response to enable or disable client telemetry job.

**What is not covered?** dynamically switching on/off client telemetry flag and start/stop job in sdk accordingly.

**Why so many files are touched?**
As part of this PR, changing the way we enabled telemetry feature. Since Previously, it was only possible from Environment Variable, But now **ClientConfig** API gives this information.

Hence summary of the change is :
1. `ConnectionPolicy.EnableClientTelemetry` and `CosmosClientOptions.EnableClientTelemetry` (Internal Options) is now a feature flag. It just unlocks this whole feature which includes calling client config API and get the latest status of the flag. _(Public contract will be implemented as separate PR)_
2. `TelemetryToServiceHelper.cs` : This file contains the ClientConfig API call and initializes the client telemetry job _(dynamically enable/disable will be covered as separate PR)_
3. **CTL Project:** Previously CTL project was setting environment variables. Now, it will use default SDK functionality i.e. client config API response, to decide if telemetry job should be triggered or not. Feature flag can be passed as an argument.
4. **Benchmark Project:** Previously benchmark project was setting environment variables based on the config. Now, it will use it will use default SDK functionality i.e., client config API response, to decide if telemetry job should be triggered or not. Feature flag can be passed as an argument.
5. `DiagnosticHandlerHelper`: Previously it was checking environment variable to identify if telemetry is enabled or not and adding recorder to the monitor accordingly. Now, added a new API to refresh the handler instance, if this feature is switched. _(It is written to keep next PR i.e. dynamically enable/disable of feature, in mind)_. Added test for the same.
6. **Performance Test:** Previously client telemetry was enabled by default for Performance Test. Now, added mocking of external API calls when instance with client telemetry is requested.