### PR TITLE
Update AssemblyInfo.cs

### DIFF
--- a/Microsoft.Azure.Cosmos/src/AssemblyInfo.cs
+++ b/Microsoft.Azure.Cosmos/src/AssemblyInfo.cs
@@ -31,3 +31,4 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("CosmosCTL" + AssemblyKeys.TestPublicKey)]
 [assembly: InternalsVisibleTo("CosmosBenchmark" + AssemblyKeys.ProductPublicKey)]
 [assembly: InternalsVisibleTo("CosmosBenchmark" + AssemblyKeys.TestPublicKey)]
+[assembly: InternalsVisibleTo("Microsoft.Azure.Cosmos.CosmosFabric" + AssemblyKeys.TestPublicKey)]


### PR DESCRIPTION
# Pull Request Template

Description
Making the internals of the Microsot.Azure.Cosmos project visible to the Microsoft.Azure.Cosmos.CosmosFabric project. This is because we are trying to use/create a custom CosmosQueryResponse class, in a general effort to mock getting a response (with enumerable elements) from requests to the cosmos db store/container. The purpose of mocking requests to the cosmos store, is to further make our Cosmos Fabric testing framework more closely simulate the production environment.

Type of change
Entry into the Assembly.info file.