### PR TITLE
Remove Timer from Pool if it is already completed.

### DIFF
--- a/Microsoft.Azure.Cosmos/src/direct/PooledTimer.cs
+++ b/Microsoft.Azure.Cosmos/src/direct/PooledTimer.cs
@@ -70,6 +70,14 @@ namespace Microsoft.Azure.Documents
         }
 
         /// <summary>
+        /// The timed task is already completed.
+        /// </summary>
+        public bool IsCompleted
+        {
+            get { return this.tcs.Task.IsCompleted; }
+        }
+
+        /// <summary>
         /// Starts the timer for the timeout period specfied in constructor
         /// </summary>
         /// <returns>Returns the Task upon which you can await on until completion</returns>

--- a/Microsoft.Azure.Cosmos/src/direct/TimerPool.cs
+++ b/Microsoft.Azure.Cosmos/src/direct/TimerPool.cs
@@ -128,7 +128,7 @@ namespace Microsoft.Azure.Documents
                             // element whose timeout has not occcured.
                             if (pooledTimerQueue.TryPeek(out pooledTimer))
                             {
-                                if (currentTicks >= pooledTimer.TimeoutTicks)
+                                if (currentTicks >= pooledTimer.TimeoutTicks || pooledTimer.IsCompleted)
                                 {
                                     if (pooledTimer.TimeoutTicks < lastTicks)
                                     {


### PR DESCRIPTION
# Pull Request Template

## Description

In #4027 a high memory consumption is described. This only occures when a lot of requests are sent and the TimeOut is high.

With this change timers which are completed are treated as if there time is reached.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Closing issues

closes #4027 
