### PR TITLE
Query : Adds Missing QueryMetrics Documentation

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/ServerSidePartitionedMetrics.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/ServerSidePartitionedMetrics.cs
@@ -22,6 +22,9 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Gets the partition key range id for the partition.
         /// </summary>
+        /// <remarks>
+        /// Only has a value in direct mode.  When using gateway mode, this is null.
+        /// </remarks>
         public abstract int? PartitionKeyRangeId { get; }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/ServerSidePartitionedMetrics.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/ServerSidePartitionedMetrics.cs
@@ -23,7 +23,7 @@ namespace Microsoft.Azure.Cosmos
         /// Gets the partition key range id for the partition.
         /// </summary>
         /// <remarks>
-        /// Only has a value in direct mode.  When using gateway mode, this is null.
+        /// Only has a value in direct mode. When using gateway mode, this is null.
         /// </remarks>
         public abstract int? PartitionKeyRangeId { get; }
     }


### PR DESCRIPTION
# Pull Request Template

## Description

Adds remark to expect null values for `PartitionKeyRangeId` in Gateway Mode.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update