### PR TITLE
Release 3.36.0: Fixes pipeline by removing ReleasePackage variable

### DIFF
--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -60,7 +60,7 @@ stages:
   jobs:
     - template:  templates/nuget-pack.yml
       parameters:
-        BuildConfiguration: $(BuildConfiguration)
+        BuildConfiguration: Release
         VmImage: $(VmImage)
         ReleasePackage: true
         OutputPath: '$(Build.ArtifactStagingDirectory)/bin/AnyCPU/$(BuildConfiguration)/Microsoft.Azure.Cosmos'

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -7,7 +7,6 @@ variables:
   VmImage: windows-latest # https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops 
   BuildConfiguration: Release
   Packaging.EnableSBOMSigning: true
-  ReleasePackage: true
   OS: 'Windows'
 
 stages:
@@ -63,6 +62,6 @@ stages:
       parameters:
         BuildConfiguration: $(BuildConfiguration)
         VmImage: $(VmImage)
-        ReleasePackage: $(ReleasePackage)
+        ReleasePackage: true
         OutputPath: '$(Build.ArtifactStagingDirectory)/bin/AnyCPU/$(BuildConfiguration)/Microsoft.Azure.Cosmos'
         BlobVersion: $(BlobVersion)


### PR DESCRIPTION
## Description

During release, it was found that recent changes in release pipeline is breaking because it is not able to resolve a variable as boolean.

![image](https://github.com/Azure/azure-cosmos-dotnet-v3/assets/6362382/29d6f5bc-1fdd-4772-b2b8-bd7d4729752e)

As part of this PR, removing this variable as it is not adding any value and it will unblock the release.

JFYI : here is the difference between master and release 3.35.4 changes, in this particular block

![image](https://github.com/Azure/azure-cosmos-dotnet-v3/assets/6362382/a710d020-ff8c-4afc-b99c-d4d1ffe8b42d)

## Type of change
- [] Bug fix (non-breaking change which fixes an issue)
