### PR TITLE
Release 3.36.0 : Fixes Client Telemetry Release Test

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryReleaseTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryReleaseTests.cs
@@ -4,11 +4,9 @@
 
 namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 {
-    using System;
     using System.Net.Http;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Fluent;
-    using Microsoft.Azure.Cosmos.Telemetry;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     /// <summary>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTestsBase.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTestsBase.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             {
                 RequestCallBack = (request, cancellation) =>
                 {
-                    if (request.RequestUri.AbsoluteUri.Contains(telemetryServiceEndpoint.PathAndQuery))
+                    if (request.RequestUri.AbsoluteUri.Equals(telemetryServiceEndpoint.AbsoluteUri))
                     {
                         string jsonObject = request.Content.ReadAsStringAsync().GetAwaiter().GetResult();
 
@@ -82,7 +82,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 },
                 ResponseIntercepter = (response) =>
                 {
-                    if (response.RequestMessage != null && response.RequestMessage.RequestUri.AbsoluteUri.Contains(telemetryServiceEndpoint.PathAndQuery))
+                    if (response.RequestMessage != null && response.RequestMessage.RequestUri.AbsoluteUri.Equals(telemetryServiceEndpoint.AbsoluteUri))
                     {
                         Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
                     }
@@ -91,7 +91,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 },
                 ExceptionIntercepter = (request, exception) =>
                 {
-                    if (request.RequestUri.AbsoluteUri.Contains(telemetryServiceEndpoint.PathAndQuery))
+                    if (request.RequestUri.AbsoluteUri.Equals(telemetryServiceEndpoint.AbsoluteUri))
                     {
                         this.isClientTelemetryAPICallFailed = true;
                     }
@@ -108,7 +108,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                         return Task.FromResult(result);
                     }
 
-                    if (request.RequestUri.AbsoluteUri.Contains(telemetryServiceEndpoint.PathAndQuery))
+                    if (request.RequestUri.AbsoluteUri.Equals(telemetryServiceEndpoint.AbsoluteUri))
                     {
                         string jsonObject = request.Content.ReadAsStringAsync().GetAwaiter().GetResult();
 
@@ -122,7 +122,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 },
                 ResponseIntercepter = (response) =>
                 {
-                    if (response.RequestMessage != null && response.RequestMessage.RequestUri.AbsoluteUri.Contains(telemetryServiceEndpoint.PathAndQuery))
+                    if (response.RequestMessage != null && response.RequestMessage.RequestUri.AbsoluteUri.Equals(telemetryServiceEndpoint.AbsoluteUri))
                     {
                         Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
                     }
@@ -130,7 +130,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 },
                 ExceptionIntercepter = (request, exception) =>
                 {
-                    if (request.RequestUri.AbsoluteUri.Contains(telemetryServiceEndpoint.PathAndQuery))
+                    if (request.RequestUri.AbsoluteUri.Equals(telemetryServiceEndpoint.AbsoluteUri))
                     {
                         this.isClientTelemetryAPICallFailed = true;
                     }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTestsBase.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTestsBase.cs
@@ -15,11 +15,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Microsoft.Azure.Cosmos.Tracing;
     using Microsoft.Azure.Cosmos.Telemetry;
-    using Microsoft.Azure.Cosmos.Handler;
     using Microsoft.Azure.Documents;
     using Newtonsoft.Json.Linq;
     using Newtonsoft.Json;
-    using Documents.Rntbd;
     using System.Globalization;
     using System.Linq;
     using Cosmos.Util;
@@ -27,7 +25,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
     public abstract class ClientTelemetryTestsBase : BaseCosmosClientHelper
     {
-        protected static readonly Uri telemetryServiceEndpoint = new Uri("http://dummy.telemetry.service/api/url");
+        protected static readonly Uri telemetryServiceEndpoint = new Uri("https://tools.cosmos.azure.com/api/clienttelemetry/trace");
 
         private static readonly List<string> preferredRegionList = new List<string>
         {
@@ -71,7 +69,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             {
                 RequestCallBack = (request, cancellation) =>
                 {
-                    if (request.RequestUri.AbsoluteUri.Equals(telemetryServiceEndpoint.AbsoluteUri))
+                    if (request.RequestUri.AbsoluteUri.Contains(telemetryServiceEndpoint.PathAndQuery))
                     {
                         string jsonObject = request.Content.ReadAsStringAsync().GetAwaiter().GetResult();
 
@@ -84,7 +82,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 },
                 ResponseIntercepter = (response) =>
                 {
-                    if (response.RequestMessage != null && response.RequestMessage.RequestUri.AbsoluteUri.Equals(telemetryServiceEndpoint.AbsoluteUri))
+                    if (response.RequestMessage != null && response.RequestMessage.RequestUri.AbsoluteUri.Contains(telemetryServiceEndpoint.PathAndQuery))
                     {
                         Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
                     }
@@ -93,7 +91,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 },
                 ExceptionIntercepter = (request, exception) =>
                 {
-                    if (request.RequestUri.AbsoluteUri.Equals(telemetryServiceEndpoint.AbsoluteUri))
+                    if (request.RequestUri.AbsoluteUri.Contains(telemetryServiceEndpoint.PathAndQuery))
                     {
                         this.isClientTelemetryAPICallFailed = true;
                     }
@@ -110,7 +108,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                         return Task.FromResult(result);
                     }
 
-                    if (request.RequestUri.AbsoluteUri.Equals(telemetryServiceEndpoint.AbsoluteUri))
+                    if (request.RequestUri.AbsoluteUri.Contains(telemetryServiceEndpoint.PathAndQuery))
                     {
                         string jsonObject = request.Content.ReadAsStringAsync().GetAwaiter().GetResult();
 
@@ -124,7 +122,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 },
                 ResponseIntercepter = (response) =>
                 {
-                    if (response.RequestMessage != null && response.RequestMessage.RequestUri.AbsoluteUri.Equals(telemetryServiceEndpoint.AbsoluteUri))
+                    if (response.RequestMessage != null && response.RequestMessage.RequestUri.AbsoluteUri.Contains(telemetryServiceEndpoint.PathAndQuery))
                     {
                         Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
                     }
@@ -132,7 +130,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 },
                 ExceptionIntercepter = (request, exception) =>
                 {
-                    if (request.RequestUri.AbsoluteUri.Equals(telemetryServiceEndpoint.AbsoluteUri))
+                    if (request.RequestUri.AbsoluteUri.Contains(telemetryServiceEndpoint.PathAndQuery))
                     {
                         this.isClientTelemetryAPICallFailed = true;
                     }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTestsBase.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTestsBase.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
     public abstract class ClientTelemetryTestsBase : BaseCosmosClientHelper
     {
-        protected static readonly Uri telemetryServiceEndpoint = new Uri("https://tools.cosmos.azure.com/api/clienttelemetry/trace");
+        protected static readonly Uri telemetryServiceEndpoint = new Uri(ConfigurationManager.GetEnvironmentVariable<string>("CLIENT_TELEMETRY_SERVICE_ENDPOINT", "https://dummy.url/api/clienttelemetry"));
 
         private static readonly List<string> preferredRegionList = new List<string>
         {

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -54,6 +54,7 @@ stages:
           testRunTitle: Microsoft.Azure.Cosmos.EmulatorTests
         env:
           COSMOSDB_ACCOUNT_CONNECTION_STRING: $(COSMOSDB_ACCOUNT_CONNECTION_STRING) # Real Account Connection String used by Integration Tests while running as part of release pipeline
+          CLIENT_TELEMETRY_SERVICE_ENDPOINT: $(CLIENT_TELEMETRY_SERVICE_ENDPOINT) # Client telemetry service url returned by configured account client config API
 
 - stage:
   displayName: Publish 


### PR DESCRIPTION
## Description

Client Telemetry Release Test was added as part of PR https://github.com/Azure/azure-cosmos-dotnet-v3/pull/3900, during that time, client telemetry service URL was configured as environment variable and for Integration and emulator tests, we had corresponding URL configured.

But during PR https://github.com/Azure/azure-cosmos-dotnet-v3/pull/4050 when environment variable was removed at that time emulator test were fixed but it broke integration test as assertion code of these tests is common and No url was configured for Integration test.

We don't run integration tests as part of PR pipeline, hence it never got caught. Now found this issue while running release pipeline where we run this integration test also.

## Type of change
- [] Bug fix (non-breaking change which fixes an issue)
