### PR TITLE
Release 3.36.0: Fixes client config test and preview pipeline

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientConfigurationDiagnosticTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientConfigurationDiagnosticTest.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
+    using System.Linq;
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
@@ -45,7 +46,11 @@
             ItemResponse<ToDoActivity> response = await this.Container.CreateItemAsync(testItem, new Cosmos.PartitionKey(testItem.pk));
             Assert.IsNotNull(response.Diagnostics);
             ITrace trace = ((CosmosTraceDiagnostics)response.Diagnostics).Value;
-            Assert.AreEqual(trace.Data.Count, 1);
+#if PREVIEW
+            Assert.AreEqual(trace.Data.Count, 2, string.Join(",", trace.Data.Select(a => $"{a.Key}: {a.Value}")));  // Distributed Tracing Id
+#else
+            Assert.AreEqual(trace.Data.Count, 1, string.Join(",", trace.Data.Select(a => $"{a.Key}: {a.Value}")));
+#endif
             ClientConfigurationTraceDatum clientConfigurationTraceDatum = (ClientConfigurationTraceDatum)trace.Data["Client Configuration"];
             Assert.IsNotNull(clientConfigurationTraceDatum.UserAgentContainer.UserAgent);
         }

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -4,10 +4,9 @@ pr: none
 
 variables:
   ReleaseArguments: ' --filter "TestCategory!=Quarantine" --verbosity normal ' 
-  VmImage: windows-latest # https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops 
   BuildConfiguration: Release
   Packaging.EnableSBOMSigning: true
-  OS: 'Windows'
+  VmImage: windows-latest # https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops 
 
 stages:
 - stage:
@@ -15,19 +14,18 @@ stages:
   jobs:
     - template:  templates/static-tools.yml
       parameters:
-        BuildConfiguration: $(BuildConfiguration)
-        VmImage: $(VmImage)
+        BuildConfiguration: '${{ variables.BuildConfiguration }}'
+        VmImage: '${{ variables.VmImage }}'
 
     - template:  templates/build-test.yml
       parameters:
-        BuildConfiguration: $(BuildConfiguration)
-        Arguments: $(ReleaseArguments)
-        VmImage: $(VmImage)
+        BuildConfiguration: '${{ variables.BuildConfiguration }}'
+        Arguments: '${{ variables.ReleaseArguments }}'
+        VmImage: '${{ variables.VmImage }}'
         
     - job:
-      displayName: TelemetryToService $(BuildConfiguration)
+      displayName: TelemetryToService '${{ variables.BuildConfiguration }}'
       timeoutInMinutes: 120
-      condition: and(succeeded(), eq('$(OS)', 'Windows'))
       pool:
         vmImage: windows-2019
       
@@ -48,7 +46,7 @@ stages:
         inputs:
           command: test
           projects: 'Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/*.csproj'
-          arguments: --filter "TestCategory=ClientTelemetryRelease" --verbosity normal --configuration $(BuildConfiguration) /p:OS=$(OS)
+          arguments: --filter "TestCategory=ClientTelemetryRelease" --verbosity normal --configuration '${{ variables.BuildConfiguration }}' /p:OS=$(OS)
           nugetConfigPath: NuGet.config
           publishTestResults: true
           testRunTitle: Microsoft.Azure.Cosmos.EmulatorTests
@@ -62,7 +60,7 @@ stages:
     - template:  templates/nuget-pack.yml
       parameters:
         BuildConfiguration: Release
-        VmImage: $(VmImage)
+        VmImage: '${{ variables.VmImage }}'
         ReleasePackage: true
-        OutputPath: '$(Build.ArtifactStagingDirectory)/bin/AnyCPU/$(BuildConfiguration)/Microsoft.Azure.Cosmos'
+        OutputPath: '$(Build.ArtifactStagingDirectory)/bin/AnyCPU/Release/Microsoft.Azure.Cosmos'
         BlobVersion: $(BlobVersion)

--- a/azure-pipelines-official.yml
+++ b/azure-pipelines-official.yml
@@ -24,7 +24,7 @@ stages:
         VmImage: '${{ variables.VmImage }}'
         
     - job:
-      displayName: TelemetryToService '${{ variables.BuildConfiguration }}'
+      displayName: TelemetryToService ${{ variables.BuildConfiguration }}
       timeoutInMinutes: 120
       pool:
         vmImage: windows-2019
@@ -46,7 +46,7 @@ stages:
         inputs:
           command: test
           projects: 'Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/*.csproj'
-          arguments: --filter "TestCategory=ClientTelemetryRelease" --verbosity normal --configuration '${{ variables.BuildConfiguration }}' /p:OS=$(OS)
+          arguments: --filter "TestCategory=ClientTelemetryRelease" --verbosity normal --configuration ${{ variables.BuildConfiguration }} /p:OS=Windows
           nugetConfigPath: NuGet.config
           publishTestResults: true
           testRunTitle: Microsoft.Azure.Cosmos.EmulatorTests


### PR DESCRIPTION
## Description

As part of this PR, we are fixing below 2 things:

1. Fixing preview release pipeline where it is find out that, this pipeline was never taking the passed variables.
2. ClientConfig test is fixed on preview package. As distributedtracingId is also added.

## Type of change
- [] Bug fix (non-breaking change which fixes an issue)
