### PR TITLE
Diagnostics Logs: Fixes ContactReplicas to only include the successful replica contacted per physical partition.

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Tracing/TraceWriter.TraceJsonWriter.cs
+++ b/Microsoft.Azure.Cosmos/src/Tracing/TraceWriter.TraceJsonWriter.cs
@@ -194,7 +194,7 @@ namespace Microsoft.Azure.Cosmos.Tracing
                 this.jsonWriter.WriteFieldName("Id");
                 this.jsonWriter.WriteStringValue("AggregatedClientSideRequestStatistics");
 
-                this.WriteJsonUriArrayWithDuplicatesCounted("ContactedReplicas", clientSideRequestStatisticsTraceDatum.ContactedReplicas);
+                this.WriteJsonUriArrayWithDuplicatesCounted("ContactedReplicas", TraceWriter.TraceDatumJsonWriter.GetFinalContactedReplica(clientSideRequestStatisticsTraceDatum));
 
                 this.WriteRegionsContactedArray("RegionsContacted", clientSideRequestStatisticsTraceDatum.RegionsContacted);
                 this.WriteJsonUriArray("FailedReplicas", clientSideRequestStatisticsTraceDatum.FailedReplicas);
@@ -206,7 +206,7 @@ namespace Microsoft.Azure.Cosmos.Tracing
 
                 foreach (KeyValuePair<string, ClientSideRequestStatisticsTraceDatum.AddressResolutionStatistics> stat in clientSideRequestStatisticsTraceDatum.EndpointToAddressResolutionStatistics)
                 {
-                   this.VisitAddressResolutionStatistics(stat.Value);
+                    this.VisitAddressResolutionStatistics(stat.Value);
                 }
 
                 this.jsonWriter.WriteArrayEnd();
@@ -235,6 +235,11 @@ namespace Microsoft.Azure.Cosmos.Tracing
                 }
 
                 this.jsonWriter.WriteObjectEnd();
+            }
+
+            private static List<TransportAddressUri> GetFinalContactedReplica(ClientSideRequestStatisticsTraceDatum clientSideRequestStatisticsTraceDatum)
+            {
+                return new List<TransportAddressUri> { clientSideRequestStatisticsTraceDatum.ContactedReplicas.LastOrDefault() };
             }
 
             private void VisitHttpResponseStatistics(ClientSideRequestStatisticsTraceDatum.HttpResponseStatistics stat, IJsonWriter jsonWriter)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BaselineTest/BaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BaselineTest/BaselineTests.cs
@@ -110,7 +110,6 @@ namespace Microsoft.Azure.Cosmos.Test.BaselineTest
 
             // Compare the output to the baseline and fail if they differ.
             string outputText = Regex.Replace(File.ReadAllText(outputPath), @"\s+", "");
-            Console.WriteLine(outputText);
             string baselineText = Regex.Replace(File.ReadAllText(baselinePath), @"\s+", "");
             int commonPrefixLength = 0;
             foreach (Tuple<char, char> characters in outputText.Zip(baselineText, (first, second) => new Tuple<char, char>(first, second)))
@@ -126,7 +125,6 @@ namespace Microsoft.Azure.Cosmos.Test.BaselineTest
             }
 
             string baselineTextSuffix = new string(baselineText.Skip(Math.Max(commonPrefixLength - 30, 0)).Take(100).ToArray());
-            Console.WriteLine(baselineTextSuffix);
             string outputTextSuffix = new string(outputText.Skip(Math.Max(commonPrefixLength - 30, 0)).Take(100).ToArray());
 
             bool matched = baselineText.Equals(outputText);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BaselineTest/BaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BaselineTest/BaselineTests.cs
@@ -110,6 +110,7 @@ namespace Microsoft.Azure.Cosmos.Test.BaselineTest
 
             // Compare the output to the baseline and fail if they differ.
             string outputText = Regex.Replace(File.ReadAllText(outputPath), @"\s+", "");
+            Console.WriteLine(outputText);
             string baselineText = Regex.Replace(File.ReadAllText(baselinePath), @"\s+", "");
             int commonPrefixLength = 0;
             foreach (Tuple<char, char> characters in outputText.Zip(baselineText, (first, second) => new Tuple<char, char>(first, second)))
@@ -125,6 +126,7 @@ namespace Microsoft.Azure.Cosmos.Test.BaselineTest
             }
 
             string baselineTextSuffix = new string(baselineText.Skip(Math.Max(commonPrefixLength - 30, 0)).Take(100).ToArray());
+            Console.WriteLine(baselineTextSuffix);
             string outputTextSuffix = new string(outputText.Skip(Math.Max(commonPrefixLength - 30, 0)).Take(100).ToArray());
 
             bool matched = baselineText.Equals(outputText);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BaselineTest/TestBaseline/TraceWriterBaselineTests.TraceData.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BaselineTest/TestBaseline/TraceWriterBaselineTests.TraceData.xml
@@ -287,10 +287,6 @@
       "ContactedReplicas": [
         {
           "Count": 1,
-          "Uri": "http://someuri1.com/"
-        },
-        {
-          "Count": 1,
           "Uri": "http://someuri2.com/"
         }
       ],


### PR DESCRIPTION
# Pull Request Template

## Description

**Describe the bug**
Fixing a bug for ContactedReplicas. It should only display the one replica per physical partition that was contacted successfully, not all replicas contacted for the partition.

**To Reproduce**
Steps to reproduce the behavior. If you can include code snippets or links to repositories containing a repro of the issue that can helps us in detecting the scenario it would speed up the resolution.

Print any diagnostic log string where multiple replicas on the same physical partition failed and one was finally successful.

**Expected behavior**
``` json
"ContactedReplicas": [
	{
		"Count": 1,
		"Uri": "rntbd://cdb-ms-prod-westus-fd4.documents.azure.com:14382/apps/9dc0394e-d25f-4c98-baa5-72f1c700bf3e/services/060067c7-a4e9-4465-a412-25cb0104cb58/partitions/2cda760c-f81f-4094-85d0-7bcfb2acc4e6/replicas/132608933859499990p/"
	}
]
```

**Actual behavior**
``` json
"ContactedReplicas": [
	{
		"Count": 1,
		"Uri": "rntbd://cdb-ms-prod-westus-fd4.documents.azure.com:14382/apps/9dc0394e-d25f-4c98-baa5-72f1c700bf3e/services/060067c7-a4e9-4465-a412-25cb0104cb58/partitions/2cda760c-f81f-4094-85d0-7bcfb2acc4e6/replicas/132608933859499990p/"
	},
	{
		"Count": 1,
		"Uri": "rntbd://cdb-ms-prod-westus-fd4.documents.azure.com:14382/apps/9dc0394e-d25f-4c98-baa5-72f1c700bf3e/services/060067c7-a4e9-4465-a412-25cb0104cb58/partitions/2cda760c-f81f-4094-85d0-7bcfb2acc4e6/replicas/132608933859470000s/"
	},
	{
		"Count": 1,
		"Uri": "rntbd://cdb-ms-prod-westus-fd4.documents.azure.com:14382/apps/9dc0394e-d25f-4c98-baa5-72f1c700bf3e/services/060067c7-a4e9-4465-a412-25cb0104cb58/partitions/2cda760c-f81f-4094-85d0-7bcfb2acc4e6/replicas/132608933859471110s/"
	},
	{
		"Count": 1,
		"Uri": "rntbd://cdb-ms-prod-westus-fd4.documents.azure.com:14382/apps/9dc0394e-d25f-4c98-baa5-72f1c700bf3e/services/060067c7-a4e9-4465-a412-25cb0104cb58/partitions/2cda760c-f81f-4094-85d0-7bcfb2acc4e6/replicas/132608933859472220s/"
	}
]
```

**Environment summary**
SDK Version: All
OS Version (e.g. Windows, Linux, MacOSX)

**Additional context**
Add any other context about the problem here (for example, complete stack traces or logs).

**Solution**

- Identify any tests that contradict the expected behavior. If none exists, create them. Tests should pass.
- Identify the system under test and make the necessary changes.
- Go back to tests, and the tests should fail.
- Fix tests, and tests should pass.

***Impact of change***

**Breaking contracts**: Tempting as it may be, I do not wish to break the current contract which is keeping **ContactedReplicas** as part of an array with a count of 1, even though we are always forcing only the last _contacted replica_ in the array to be revealed. Always open to discuss if we want to break this, but for now, the impact of change is at its minimum.

**Duplicate contact regions**: The method and tests to verify the removing of duplicate contact replicas from the array is unnecessary since we are only revealing the last _contacted region_.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #IssueNumber