### PR TITLE
[Internal] DocumentClient: Adds TryGetAccountProperties

### DIFF
--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -1236,6 +1236,23 @@ namespace Microsoft.Azure.Cosmos
         }
 
         /// <summary>
+        /// Returns the account properties available in the service configuration if the client was initialized.
+        /// </summary>
+        public bool TryGetAccountProperties(out AccountProperties properties)
+        {
+            if (this.isSuccessfullyInitialized
+                && this.accountServiceConfiguration != null
+                && this.accountServiceConfiguration.AccountProperties != null)
+            {
+                properties = this.accountServiceConfiguration.AccountProperties;
+                return true;
+            }
+
+            properties = null;
+            return false;
+        }
+
+        /// <summary>
         /// Disposes the client for the Azure Cosmos DB service.
         /// </summary>
         /// <example>

--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -1238,7 +1238,7 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Returns the account properties available in the service configuration if the client was initialized.
         /// </summary>
-        public bool TryGetAccountProperties(out AccountProperties properties)
+        public bool TryGetCachedAccountProperties(out AccountProperties properties)
         {
             if (this.isSuccessfullyInitialized
                 && this.accountServiceConfiguration != null

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTests.cs
@@ -298,11 +298,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 ConfigurationManager.AppSettings["MasterKey"]
             );
 
-            Assert.IsFalse(cosmosClient.DocumentClient.TryGetAccountProperties(out AccountProperties propertiesFromMethod));
+            Assert.IsFalse(cosmosClient.DocumentClient.TryGetCachedAccountProperties(out AccountProperties propertiesFromMethod));
 
             AccountProperties accountProperties = await cosmosClient.ReadAccountAsync();
 
-            Assert.IsTrue(cosmosClient.DocumentClient.TryGetAccountProperties(out propertiesFromMethod));
+            Assert.IsTrue(cosmosClient.DocumentClient.TryGetCachedAccountProperties(out propertiesFromMethod));
 
             Assert.AreEqual(accountProperties.Consistency.DefaultConsistencyLevel, propertiesFromMethod.Consistency.DefaultConsistencyLevel);
             Assert.AreEqual(accountProperties.Id, propertiesFromMethod.Id);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTests.cs
@@ -290,6 +290,24 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
         }
 
+        [TestMethod]
+        public async Task ValidateTryGetAccountProperties()
+        {
+            using CosmosClient cosmosClient = new CosmosClient(
+                ConfigurationManager.AppSettings["GatewayEndpoint"],
+                ConfigurationManager.AppSettings["MasterKey"]
+            );
+
+            Assert.IsFalse(cosmosClient.DocumentClient.TryGetAccountProperties(out AccountProperties propertiesFromMethod));
+
+            AccountProperties accountProperties = await cosmosClient.ReadAccountAsync();
+
+            Assert.IsTrue(cosmosClient.DocumentClient.TryGetAccountProperties(out propertiesFromMethod));
+
+            Assert.AreEqual(accountProperties.Consistency.DefaultConsistencyLevel, propertiesFromMethod.Consistency.DefaultConsistencyLevel);
+            Assert.AreEqual(accountProperties.Id, propertiesFromMethod.Id);
+        }
+
         private int TaskStartedCount = 0;
 
         private async Task<Exception> ReadNotFound(Container container)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/InterfaceParityTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/InterfaceParityTest.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.Cosmos
             string[] excludedMethods = new string[]
             {
                 "OpenAsync", // exposed public methods.
-                "TryGetAccountProperties", // currently only internal
+                "TryGetCachedAccountProperties", // currently only internal
                 "get_PartitionResolvers", "get_ResourceTokens", // Obsolete getters.
                 "ToString", "Equals", "GetHashCode", "GetType", "get_httpClient"
             };

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/InterfaceParityTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/InterfaceParityTest.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Azure.Cosmos
             string[] excludedMethods = new string[]
             {
                 "OpenAsync", // exposed public methods.
+                "TryGetAccountProperties", // currently only internal
                 "get_PartitionResolvers", "get_ResourceTokens", // Obsolete getters.
                 "ToString", "Equals", "GetHashCode", "GetType", "get_httpClient"
             };


### PR DESCRIPTION
The CosmosClient performs a deferred initialization that obtains the Account Properties (Consistency, Read/Write regions, etc). 

This deferred initialization happens on two cases:

* If `CosmosClient.CreateAndInitialize` is used, the returned `CosmosClient` instance is already initialized.
* If any operation is performed on the client, the client will first initialize, and then execute the operation.

After any of these steps, the proposed API would return the AccountProperties it knows about.

Starting with this as an internal API, that if valuable can be proposed as public.