### PR TITLE
[Internal] Security: Fixes NuGetAudit fail on VS 17.8 for Newtonsoft 10.0.2

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
+++ b/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
@@ -117,7 +117,7 @@
 		<PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
 		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.0.0" />
 		<PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.0.102" PrivateAssets="All" />
-		<PackageReference Include="Newtonsoft.Json" Version="10.0.2" />
+		<PackageReference Include="Newtonsoft.Json" Version="10.0.2" NoWarn="NU1903" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
 
 		<!--Direct Dependencies-->


### PR DESCRIPTION
VS 17.8 auto runs NuGetAudit and flagging 10.0.2, CosmosDB SDK already mitigated it by changing the MAXDEPATH
Adding a NoWarn for Newtonsoft package. 

Reference SDK fix: https://github.com/Azure/azure-cosmos-dotnet-v3/pull/3313
