### PR TITLE
[Internal] Versioning: Adds guidance for versioning SDK releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ using (FeedIterator<dynamic> feedIterator = container.GetItemQueryIterator<dynam
 
 `Install-Package Microsoft.Azure.Cosmos`
 
+For available versions, see [SDK versioning](./docs/versioning.md).
+
 ## Useful links
 
 - [Get Started APP](https://docs.microsoft.com/azure/cosmos-db/sql-api-get-started)

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,6 +1,6 @@
 # Versioning
 
-The Azure Cosmos DB SDK ships two Nuget package versions:
+The Azure Cosmos DB SDK ships two [Nuget package](https://www.nuget.org/packages/Microsoft.Azure.Cosmos) versions:
 
 * GA SDK: Versioned with `3.X.Y`, it contains APIs and features that are considered General Availability
 * Preview SDK: Versioned with `3.X.Y-preview`, it contains APIs and features that are in Preview. These APIs or features might be service features that are in Preview (such as a new Cosmos DB Service feature or operation) or SDK client specific features that are unrelated to a service feature (such as improvements in connection handling).

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -3,13 +3,13 @@
 The Azure Cosmos DB SDK ships two [Nuget package](https://www.nuget.org/packages/Microsoft.Azure.Cosmos) versions:
 
 * GA SDK: Versioned with `3.X.Y`, it contains APIs and features that are considered General Availability
-* Preview SDK: Versioned with `3.X.Y-preview`, it contains APIs and features that are in Preview. These APIs or features might be service features that are in Preview (such as a new Cosmos DB Service feature or operation) or SDK client specific features that are unrelated to a service feature (such as improvements in connection handling).
+* Preview SDK: Versioned with `3.(X + 1).Y-preview`, it contains APIs and features that are in Preview. These APIs or features might be service features that are in Preview (such as a new Cosmos DB Service feature or operation) or SDK client specific features that are unrelated to a service feature (such as improvements in connection handling).
 
 > :information_source: General Availability of an API or feature present in a Preview SDK is not guaranteed on the next GA SDK release following the Preview SDK release when it was introduced. Each Preview API can have an independent GA cycle that can be dependent on the Azure Cosmos DB Service.
 
-## Major releases
+## Minor releases
 
-Major releases are defined by: 
+Minor releases are defined by: 
 
 * Changes in the public API surface of the SDK, such as new features, or GAing APIs that were in preview
 * Changes in the version of one of the dependencies

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -3,7 +3,7 @@
 The Azure Cosmos DB SDK ships two [Nuget package](https://www.nuget.org/packages/Microsoft.Azure.Cosmos) versions:
 
 * GA SDK: Versioned with `3.X.Y`, it contains APIs and features that are considered General Availability
-* Preview SDK: Versioned with `3.(X + 1).Y-preview`, it contains APIs and features that are in Preview. These APIs or features might be service features that are in Preview (such as a new Cosmos DB Service feature or operation) or SDK client specific features that are unrelated to a service feature (such as improvements in connection handling).
+* Preview SDK: Versioned with `3.(X + 1).0-previewY` (where `Y` is omitted in the case of `0`), it contains APIs and features that are in Preview. These APIs or features might be service features that are in Preview (such as a new Cosmos DB Service feature or operation) or SDK client specific features that are unrelated to a service feature (such as improvements in connection handling).
 
 > :information_source: General Availability of an API or feature present in a Preview SDK is not guaranteed on the next GA SDK release following the Preview SDK release when it was introduced. Each Preview API can have an independent GA cycle that can be dependent on the Azure Cosmos DB Service.
 
@@ -27,4 +27,6 @@ Hotfix releases are defined by:
 
 In these cases, the **GA SDK** should **increase the hotfix version** and **Preview SDK** should **increase the preview suffix version**.
 
-For example, if `3.10.0` is being hotfixed, for **GA SDK** we would release `3.10.1` and for **Preview SDK** we would release `3.11.0-preview2`.
+For example, if `3.10.0` is being hotfixed, for **GA SDK** we would release `3.10.1` and for **Preview SDK** we would release `3.11.0-preview1`.
+
+If `3.10.1` is being hotfixed, for **GA SDK** we would release `3.10.2` and for **Preview SDK** we would release `3.11.0-preview2`.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -3,7 +3,7 @@
 The Azure Cosmos DB SDK ships two [Nuget package](https://www.nuget.org/packages/Microsoft.Azure.Cosmos) versions:
 
 * GA SDK: Versioned with `3.X.Y`, it contains APIs and features that are considered General Availability
-* Preview SDK: Versioned with `3.(X + 1).0-previewY` (where `Y` is omitted in the case of `0`), it contains APIs and features that are in Preview. These APIs or features might be service features that are in Preview (such as a new Cosmos DB Service feature or operation) or SDK client specific features that are unrelated to a service feature (such as improvements in connection handling).
+* Preview SDK: Versioned with `3.(X + 1).0-preview.Y`, it contains APIs and features that are in Preview. These APIs or features might be service features that are in Preview (such as a new Cosmos DB Service feature or operation) or SDK client specific features that are unrelated to a service feature (such as improvements in connection handling).
 
 > :information_source: General Availability of an API or feature present in a Preview SDK is not guaranteed on the next GA SDK release following the Preview SDK release when it was introduced. Each Preview API can have an independent GA cycle that can be dependent on the Azure Cosmos DB Service.
 
@@ -16,7 +16,7 @@ Minor releases are defined by:
 
 In these cases, the **GA SDK** should **increase the minor version** and **Preview SDK** should **increase the minor version to be one more than GA SDK**.
 
-For example, if `3.10.0` is being released for **GA SDK**, then `3.11.0-preview` should be released for **Preview SDK**.
+For example, if `3.10.0` is being released for **GA SDK**, then `3.11.0-preview.0` should be released for **Preview SDK**.
 
 ## Patch releases
 
@@ -29,4 +29,4 @@ In these cases, the **GA SDK** should **increase the patch version** and **Previ
 
 For example, if `3.10.0` is being patched, for **GA SDK** we would release `3.10.1` and for **Preview SDK** we would release `3.11.0-preview1`.
 
-If `3.10.1` is being patched, for **GA SDK** we would release `3.10.2` and for **Preview SDK** we would release `3.11.0-preview2`.
+If `3.10.1` is being patched, for **GA SDK** we would release `3.10.2` and for **Preview SDK** we would release `3.11.0-preview.2`.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -18,15 +18,15 @@ In these cases, the **GA SDK** should **increase the minor version** and **Previ
 
 For example, if `3.10.0` is being released for **GA SDK**, then `3.11.0-preview` should be released for **Preview SDK**.
 
-## Hotfix releases
+## Patch releases
 
-Hotfix releases are defined by:
+Patch releases are defined by:
 
 * No Public API changes
 * Includes a subset bug fixes reported after the last major release
 
-In these cases, the **GA SDK** should **increase the hotfix version** and **Preview SDK** should **increase the preview suffix version**.
+In these cases, the **GA SDK** should **increase the patch version** and **Preview SDK** should **increase the preview suffix version**.
 
-For example, if `3.10.0` is being hotfixed, for **GA SDK** we would release `3.10.1` and for **Preview SDK** we would release `3.11.0-preview1`.
+For example, if `3.10.0` is being patched, for **GA SDK** we would release `3.10.1` and for **Preview SDK** we would release `3.11.0-preview1`.
 
-If `3.10.1` is being hotfixed, for **GA SDK** we would release `3.10.2` and for **Preview SDK** we would release `3.11.0-preview2`.
+If `3.10.1` is being patched, for **GA SDK** we would release `3.10.2` and for **Preview SDK** we would release `3.11.0-preview2`.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,0 +1,30 @@
+# Versioning
+
+The Azure Cosmos DB SDK ships two Nuget package versions:
+
+* GA SDK: Versioned with `3.X.Y`, it contains APIs and features that are considered General Availability
+* Preview SDK: Versioned with `3.X.Y-preview`, it contains APIs and features that are in Preview. These APIs or features might be service features that are in Preview (such as a new Cosmos DB Service feature or operation) or SDK client specific features that are unrelated to a service feature (such as improvements in connection handling).
+
+> :information_source: General Availability of an API or feature present in a Preview SDK is not guaranteed on the next GA SDK release following the Preview SDK release when it was introduced. Each Preview API can have an independent GA cycle that can be dependent on the Azure Cosmos DB Service.
+
+## Major releases
+
+Major releases are defined by: 
+
+* Changes in the public API surface of the SDK, such as new features, or GAing APIs that were in preview
+* Changes in the version of one of the dependencies
+
+In these cases, the **GA SDK** should **increase the minor version** and **Preview SDK** should **increase the minor version to be one more than GA SDK**.
+
+For example, if `3.10.0` is being released for **GA SDK**, then `3.11.0-preview` should be released for **Preview SDK**.
+
+## Hotfix releases
+
+Hotfix releases are defined by:
+
+* No Public API changes
+* Includes a subset bug fixes reported after the last major release
+
+In these cases, the **GA SDK** should **increase the hotfix version** and **Preview SDK** should **increase the preview suffix version**.
+
+For example, if `3.10.0` is being hotfixed, for **GA SDK** we would release `3.10.1` and for **Preview SDK** we would release `3.11.0-preview2`.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -7,6 +7,15 @@ The Azure Cosmos DB SDK ships two [Nuget package](https://www.nuget.org/packages
 
 > :information_source: General Availability of an API or feature present in a Preview SDK is not guaranteed on the next GA SDK release following the Preview SDK release when it was introduced. Each Preview API can have an independent GA cycle that can be dependent on the Azure Cosmos DB Service.
 
+## Major releases
+
+Major releases are defined by:
+
+* Significant breaking changes to the API surface of the SDK.
+* Significant breaking changes to dependencies
+
+> :information_source: No new major release is currently planned.
+
 ## Minor releases
 
 Minor releases are defined by: 

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -39,3 +39,12 @@ In these cases, the **GA SDK** should **increase the patch version** and **Previ
 For example, if `3.10.0` is being patched, for **GA SDK** we would release `3.10.1` and for **Preview SDK** we would release `3.11.0-preview.1`.
 
 If `3.10.1` is being patched, for **GA SDK** we would release `3.10.2` and for **Preview SDK** we would release `3.11.0-preview.2`.
+
+## Complete full example
+
+| GA         | Preview     |
+|----------|-----------|
+| 3.10.0 | 3.11.0-preview.0 |
+| 3.10.1 | 3.11.0-preview.1 |
+| 3.10.2 | 3.11.0-preview.2 |
+| 3.11.0 | 3.12.0-preview.0 |

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -23,10 +23,10 @@ For example, if `3.10.0` is being released for **GA SDK**, then `3.11.0-preview.
 Patch releases are defined by:
 
 * No Public API changes
-* Includes a subset bug fixes reported after the last major release
+* Includes a subset of the bug fixes reported after the last major release
 
 In these cases, the **GA SDK** should **increase the patch version** and **Preview SDK** should **increase the preview suffix version**.
 
-For example, if `3.10.0` is being patched, for **GA SDK** we would release `3.10.1` and for **Preview SDK** we would release `3.11.0-preview1`.
+For example, if `3.10.0` is being patched, for **GA SDK** we would release `3.10.1` and for **Preview SDK** we would release `3.11.0-preview.1`.
 
 If `3.10.1` is being patched, for **GA SDK** we would release `3.10.2` and for **Preview SDK** we would release `3.11.0-preview.2`.


### PR DESCRIPTION
The following PR adds a versioning guideline that clarifies which are the released versions.

The current SDK release method is to always release version `X` and `X-preview` but this causes a wide range of issues with Nuget and chained dependencies (package A depends on SDK version `X`, if the user wants to use `X-preview` they can't because Nuget would attempt to use `X` because `X` is semantically newer than `X-preview`).

The goal is to improve the release methodology to address the versioning issues arising in tooling used by our customers.

Preview of the document: https://github.com/Azure/azure-cosmos-dotnet-v3/blob/users/ealsur/versioning/docs/versioning.md

Closes #4169