### PR TITLE
Linq: fixes error when comparing field with custom converter to null

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Linq/ExpressionToSQL.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/ExpressionToSQL.cs
@@ -503,10 +503,11 @@ namespace Microsoft.Azure.Cosmos.Linq
                     memberType = memberType.NullableUnderlyingType();
                 }
 
-                bool requiresCustomSerializatior = context.CosmosLinqSerializer.RequiresCustomSerialization(memberExpression, memberType);
-                if (requiresCustomSerializatior)
+                bool requiresCustomSerialization = context.CosmosLinqSerializer.RequiresCustomSerialization(memberExpression, memberType);
+                if (requiresCustomSerialization && right.Literal is not SqlNullLiteral)
                 {
                     object value = default(object);
+
                     // Enum
                     if (memberType.IsEnum())
                     {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqTranslationBaselineTests.TestNullableFields.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqTranslationBaselineTests.TestNullableFields.xml
@@ -71,4 +71,16 @@ FROM root
 WHERE (NOT IS_DEFINED(root["NullableField"]))]]></SqlQuery>
     </Output>
   </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[Filter w/ null comparison and custom converter]]></Description>
+      <Expression><![CDATA[query.Where(doc => (doc.NullableDateTime != null))]]></Expression>
+    </Input>
+    <Output>
+      <SqlQuery><![CDATA[
+SELECT VALUE root 
+FROM root 
+WHERE (root["NullableDateTime"] != null)]]></SqlQuery>
+    </Output>
+  </Result>
 </Results>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Linq/LinqTranslationBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Linq/LinqTranslationBaselineTests.cs
@@ -144,6 +144,9 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests.LinqProviderTests
             [JsonConverter(typeof(DateJsonConverter))]
             public DateTime IsoDateOnly;
 
+            [JsonConverter(typeof(IsoDateTimeConverter))]
+            public DateTime? NullableDateTime;
+
             // This field should serialize as ISO Date
             // as this is the default DateTimeConverter
             // used by Newtonsoft
@@ -463,6 +466,8 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests.LinqProviderTests
                     {
                         obj.NullableField = random.Next();
                     }
+
+                    obj.NullableDateTime = null;
                 }
                 obj.Id = Guid.NewGuid().ToString();
                 obj.Pk = "Test";
@@ -477,7 +482,8 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests.LinqProviderTests
                 new LinqTestInput("Filter w/ .HasValue", b => getQuery(b).Where(doc => doc.NullableField.HasValue)),
                 new LinqTestInput("Filter w/ .HasValue comparison true", b => getQuery(b).Where(doc => doc.NullableField.HasValue == true)),
                 new LinqTestInput("Filter w/ .HasValue comparison false", b => getQuery(b).Where(doc => doc.NullableField.HasValue == false)),
-                new LinqTestInput("Filter w/ .HasValue not", b => getQuery(b).Where(doc => !doc.NullableField.HasValue))
+                new LinqTestInput("Filter w/ .HasValue not", b => getQuery(b).Where(doc => !doc.NullableField.HasValue)),
+                new LinqTestInput("Filter w/ null comparison and custom converter", b => getQuery(b).Where(doc => doc.NullableDateTime != null))
             };
             this.ExecuteTestSuite(inputs);
         }


### PR DESCRIPTION
## Description

When comparing a field with a custom json converter to null in a query, an exception is thrown. The code was always expecting the constant to be a string or number literal. However, when compared to null it can be `SqlNullLiteral`.

When the value is null, custom converters are not applied anyway. So a simple check is added if the literal value is of type `SqlNullLiteral`, and if so, the custom serialization is skipped.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Closing issues

closes #4193