### PR TITLE
[Internal] Automation: Fixes check for issue assignment

### DIFF
--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -20,7 +20,7 @@ configuration:
           label: needs-more-information
       - noActivitySince:
           days: 14
-      - isNotAssigned
+      - isNotAssigne
       actions:
       - addReply:
           reply: '@${issueAuthor} this issue requires more information for the team to be able to help. In case this information is available, please add it and re-open the Issue.'

--- a/.github/policies/resourceManagement.yml
+++ b/.github/policies/resourceManagement.yml
@@ -20,7 +20,6 @@ configuration:
           label: needs-more-information
       - noActivitySince:
           days: 14
-      - isNotAssigne
       actions:
       - addReply:
           reply: '@${issueAuthor} this issue requires more information for the team to be able to help. In case this information is available, please add it and re-open the Issue.'


### PR DESCRIPTION
Our current automation will automatically close Issues without activity in 2 weeks if they **have the label** with `needs-more-information`.

The goal of the label is to mark that we have responded but now in order to proceed, we need input from the creator of the Issue.

So far the automation would only trigger if the issue has noone assigned, but this was leaving cases where there was someone assigned, which asked for more information, but there was no answer from the creator.

This PR removes the requirement of "Issue not being assigned"