### PR TITLE
Change Feed Processor: Fixes disposal of unused CancellationTokenSource

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedManagement/PartitionControllerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedManagement/PartitionControllerCore.cs
@@ -89,8 +89,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedManagement
                 throw;
             }
 
-            PartitionSupervisor supervisor = this.partitionSupervisorFactory.Create(lease);
-            this.ProcessPartitionAsync(supervisor, lease).LogException();
+            this.ProcessPartitionAsync(lease).LogException();
         }
 
         public override async Task ShutdownAsync()
@@ -146,8 +145,10 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedManagement
             }
         }
 
-        private async Task ProcessPartitionAsync(PartitionSupervisor partitionSupervisor, DocumentServiceLease lease)
+        private async Task ProcessPartitionAsync(DocumentServiceLease lease)
         {
+            using PartitionSupervisor partitionSupervisor = this.partitionSupervisorFactory.Create(lease);
+
             try
             {
                 await partitionSupervisor.RunAsync(this.shutdownCts.Token).ConfigureAwait(false);
@@ -167,8 +168,6 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedManagement
             }
 
             await this.RemoveLeaseAsync(lease: lease, wasAcquired: true).ConfigureAwait(false);
-
-            partitionSupervisor.Dispose();
         }
 
         private async Task HandlePartitionGoneAsync(DocumentServiceLease lease, string lastContinuationToken)

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedManagement/PartitionControllerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedManagement/PartitionControllerCore.cs
@@ -167,6 +167,8 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedManagement
             }
 
             await this.RemoveLeaseAsync(lease: lease, wasAcquired: true).ConfigureAwait(false);
+
+            partitionSupervisor.Dispose();
         }
 
         private async Task HandlePartitionGoneAsync(DocumentServiceLease lease, string lastContinuationToken)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/PartitionControllerSplitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/PartitionControllerSplitTests.cs
@@ -48,6 +48,9 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
             await sut.ShutdownAsync().ConfigureAwait(false);
 
             Mock.Get(synchronizer).VerifyAll();
+
+            Mock.Get(partitionSupervisor)
+                .Verify(s => s.Dispose(), Times.Once);
         }
 
         [TestMethod]
@@ -76,6 +79,9 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
             await sut.ShutdownAsync().ConfigureAwait(false);
 
             Mock.Get(synchronizer).VerifyAll();
+
+            Mock.Get(partitionSupervisor)
+                .Verify(s => s.Dispose(), Times.Once);
         }
 
         [TestMethod]
@@ -108,6 +114,9 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
                     .VerifySet(l => l.Properties = customProperties, Times.Once);
             Mock.Get(leaseChild2)
                 .VerifySet(l => l.Properties = customProperties, Times.Once);
+
+            Mock.Get(partitionSupervisor)
+                .Verify(s => s.Dispose(), Times.Once);
         }
 
         [TestMethod]
@@ -132,6 +141,9 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
             await sut.ShutdownAsync().ConfigureAwait(false);
 
             Mock.Get(leaseManager).Verify(manager => manager.DeleteAsync(lease), Times.Never);
+
+            Mock.Get(partitionSupervisor)
+                .Verify(s => s.Dispose(), Times.Once);
         }
 
         [TestMethod]
@@ -180,6 +192,13 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
 
             monitor.Verify(m => m.NotifyLeaseAcquireAsync(leaseChild1.CurrentLeaseToken), Times.Once);
             monitor.Verify(m => m.NotifyLeaseReleaseAsync(leaseChild2.CurrentLeaseToken), Times.Once);
+
+            Mock.Get(partitionSupervisor)
+                .Verify(s => s.Dispose(), Times.Once);
+            Mock.Get(partitionSupervisor1)
+                .Verify(s => s.Dispose(), Times.Once);
+            Mock.Get(partitionSupervisor2)
+                .Verify(s => s.Dispose(), Times.Once);
         }
 
         [TestMethod]


### PR DESCRIPTION
Once a lease is finished processing, due to split or merge happening or any of the known conditions:

https://github.com/Azure/azure-cosmos-dotnet-v3/blob/ea269c99b54a2ac2a4394edbcb50b2ed0cb6c0b0/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedManagement/PartitionSupervisorCore.cs#L52-L80

The PartitionSupervisor variable is no longer used and goes out of scope to be GCed.

The PartitionSupervisor implements `IDisposable` but there is no path that explicitly calls Dispose when the supervisor is no longer used.

Closes #4208