### PR TITLE
[Internal] GlobalEndpointManager: Fixes Memory Leak

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Routing/GlobalEndpointManager.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GlobalEndpointManager.cs
@@ -351,14 +351,10 @@ namespace Microsoft.Azure.Cosmos.Routing
 
             public void Dispose()
             {
-                lock (this)
+                if (Interlocked.Increment(ref this.disposeCounter) == 1)
                 {
-                    if (this.disposeCounter == 0)
-                    {
-                        Interlocked.Increment(ref this.disposeCounter);
-                        this.CancellationTokenSource?.Cancel();
-                        this.CancellationTokenSource?.Dispose();
-                    }
+                    this.CancellationTokenSource?.Cancel();
+                    this.CancellationTokenSource?.Dispose();
                 }
             }
         }

--- a/Microsoft.Azure.Cosmos/src/Routing/GlobalEndpointManager.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GlobalEndpointManager.cs
@@ -128,13 +128,6 @@ namespace Microsoft.Azure.Cosmos.Routing
             {
                 return threadSafeGetAccountHelper.GetAccountPropertiesAsync();
             }
-            //GetAccountPropertiesHelper threadSafeGetAccountHelper = new GetAccountPropertiesHelper(
-            //   defaultEndpoint,
-            //   locations?.GetEnumerator(),
-            //   getDatabaseAccountFn,
-            //   cancellationToken);
-
-            //return threadSafeGetAccountHelper.GetAccountPropertiesAsync();
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Routing/GlobalEndpointManager.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GlobalEndpointManager.cs
@@ -114,7 +114,7 @@ namespace Microsoft.Azure.Cosmos.Routing
         /// The 2 additional tasks will go through all the preferred regions in parallel
         /// It will return the first success and stop the parallel tasks.
         /// </summary>
-        public static Task<AccountProperties> GetDatabaseAccountFromAnyLocationsAsync(
+        public static async Task<AccountProperties> GetDatabaseAccountFromAnyLocationsAsync(
             Uri defaultEndpoint,
             IList<string>? locations,
             Func<Uri, Task<AccountProperties>> getDatabaseAccountFn,
@@ -126,7 +126,7 @@ namespace Microsoft.Azure.Cosmos.Routing
                getDatabaseAccountFn,
                cancellationToken))
             {
-                return threadSafeGetAccountHelper.GetAccountPropertiesAsync();
+                return await threadSafeGetAccountHelper.GetAccountPropertiesAsync();
             }
         }
 

--- a/Microsoft.Azure.Cosmos/src/Routing/GlobalEndpointManager.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GlobalEndpointManager.cs
@@ -142,7 +142,7 @@ namespace Microsoft.Azure.Cosmos.Routing
             private readonly List<Exception> TransientExceptions = new List<Exception>();
             private AccountProperties? AccountProperties = null;
             private Exception? NonRetriableException = null;
-            private bool isDisposed = false;
+            private int disposeCounter = 0;
 
             public GetAccountPropertiesHelper(
                 Uri defaultEndpoint,
@@ -351,11 +351,14 @@ namespace Microsoft.Azure.Cosmos.Routing
 
             public void Dispose()
             {
-                if (!this.isDisposed)
+                lock (this)
                 {
-                    this.CancellationTokenSource?.Cancel();
-                    this.CancellationTokenSource?.Dispose();
-                    this.isDisposed = true;
+                    if (this.disposeCounter == 0)
+                    {
+                        Interlocked.Increment(ref this.disposeCounter);
+                        this.CancellationTokenSource?.Cancel();
+                        this.CancellationTokenSource?.Dispose();
+                    }
                 }
             }
         }


### PR DESCRIPTION
# Pull Request Template

## Description

This will fix the memory leak in `GlobalEndpointManager` where `CancellationTokenSources` are not disposed. 

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #IssueNumber