### PR TITLE
BulkMode: Adds PartitionKeyRangeId in Bulk Mode and TransactionalBatch Response Headers

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Batch/TransactionalBatchOperationResult.cs
+++ b/Microsoft.Azure.Cosmos/src/Batch/TransactionalBatchOperationResult.cs
@@ -99,6 +99,11 @@ namespace Microsoft.Azure.Cosmos
         internal virtual string SessionToken { get; set; }
 
         /// <summary>
+        /// A string containing the partition key range id assigned to this result.
+        /// </summary>
+        internal virtual string PartitionKeyRangeId { get; set; }
+
+        /// <summary>
         /// ActivityId related to the operation
         /// </summary>
         internal virtual string ActivityId { get; set; }
@@ -218,6 +223,7 @@ namespace Microsoft.Azure.Cosmos
                 RetryAfter = this.RetryAfter,
                 RequestCharge = this.RequestCharge,
                 Session = this.SessionToken,
+                PartitionKeyRangeId = this.PartitionKeyRangeId,
                 ActivityId = this.ActivityId,
             };
 

--- a/Microsoft.Azure.Cosmos/src/Batch/TransactionalBatchResponse.cs
+++ b/Microsoft.Azure.Cosmos/src/Batch/TransactionalBatchResponse.cs
@@ -312,6 +312,7 @@ namespace Microsoft.Azure.Cosmos
                     SubStatusCode = this.SubStatusCode,
                     RetryAfter = TimeSpan.FromMilliseconds(retryAfterMilliseconds),
                     SessionToken = this.Headers.Session,
+                    PartitionKeyRangeId = this.Headers.PartitionKeyRangeId,
                     ActivityId = this.ActivityId,
                 };
 
@@ -345,6 +346,7 @@ namespace Microsoft.Azure.Cosmos
 
                     operationResult.Trace = trace;
                     operationResult.SessionToken = responseMessage.Headers.Session;
+                    operationResult.PartitionKeyRangeId = responseMessage.Headers.PartitionKeyRangeId;
                     operationResult.ActivityId = responseMessage.Headers.ActivityId;
 
                     results.Add(operationResult);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Batch/BatchAsyncContainerExecutorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Batch/BatchAsyncContainerExecutorTests.cs
@@ -61,6 +61,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                 MyDocument document = cosmosDefaultJsonSerializer.FromStream<MyDocument>(result.ResourceStream);
                 Assert.AreEqual(i.ToString(), document.id);
+                Assert.IsNotNull(result.PartitionKeyRangeId);
 
                 ItemResponse<MyDocument> storedDoc = await this.cosmosContainer.ReadItemAsync<MyDocument>(i.ToString(), new Cosmos.PartitionKey(i.ToString()));
                 Assert.IsNotNull(storedDoc.Resource);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Batch/CosmosItemBulkTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Batch/CosmosItemBulkTests.cs
@@ -96,6 +96,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Assert.IsTrue(result.Headers.RequestCharge > 0);
                 Assert.IsNotNull(result.Headers.Session);
                 Assert.IsNotNull(result.Headers.ActivityId);
+                Assert.IsNotNull(result.Headers.PartitionKeyRangeId);
                 Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
                 ToDoActivity document = TestCommon.SerializerCore.FromStream<ToDoActivity>(result.Content);
                 Assert.AreEqual(i.ToString(), document.id);
@@ -120,6 +121,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Assert.IsTrue(result.Headers.RequestCharge > 0);
                 Assert.IsNotNull(result.Headers.Session);
                 Assert.IsNotNull(result.Headers.ActivityId);
+                Assert.IsNotNull(result.Headers.PartitionKeyRangeId);
                 Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
                 Assert.AreEqual(HttpStatusCode.Created, result.StatusCode);
             }
@@ -197,6 +199,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Task<ItemResponse<ToDoActivity>> task = tasks[i];
                 ItemResponse<ToDoActivity> result = await task;
                 Assert.IsTrue(result.Headers.RequestCharge > 0);
+                Assert.IsNotNull(result.Headers.PartitionKeyRangeId);
                 Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
                 Assert.AreEqual(HttpStatusCode.Created, result.StatusCode);
             }
@@ -228,6 +231,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Task<ItemResponse<ToDoActivity>> task = tasks[i];
                 ItemResponse<ToDoActivity> result = await task;
                 Assert.IsTrue(result.Headers.RequestCharge > 0);
+                Assert.IsNotNull(result.Headers.PartitionKeyRangeId);
                 Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
                 Assert.AreEqual(HttpStatusCode.Created, result.StatusCode);
             }
@@ -251,6 +255,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Assert.IsTrue(result.Headers.RequestCharge > 0);
                 Assert.IsNotNull(result.Headers.Session);
                 Assert.IsNotNull(result.Headers.ActivityId);
+                Assert.IsNotNull(result.Headers.PartitionKeyRangeId);
                 Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
                 Assert.AreEqual(HttpStatusCode.Created, result.StatusCode);
             }
@@ -275,6 +280,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Assert.IsTrue(result.Headers.RequestCharge > 0);
                 Assert.IsNotNull(result.Headers.Session);
                 Assert.IsNotNull(result.Headers.ActivityId);
+                Assert.IsNotNull(result.Headers.PartitionKeyRangeId);
                 Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
                 ToDoActivity document = TestCommon.SerializerCore.FromStream<ToDoActivity>(result.Content);
                 Assert.AreEqual(i.ToString(), document.id);
@@ -299,6 +305,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Assert.IsTrue(result.Headers.RequestCharge > 0);
                 Assert.IsNotNull(result.Headers.Session);
                 Assert.IsNotNull(result.Headers.ActivityId);
+                Assert.IsNotNull(result.Headers.PartitionKeyRangeId);
                 Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
                 Assert.AreEqual(HttpStatusCode.Created, result.StatusCode);
             }
@@ -334,6 +341,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Assert.IsTrue(result.Headers.RequestCharge > 0);
                 Assert.IsNotNull(result.Headers.Session);
                 Assert.IsNotNull(result.Headers.ActivityId);
+                Assert.IsNotNull(result.Headers.PartitionKeyRangeId);
                 Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
                 Assert.AreEqual(HttpStatusCode.NoContent, result.StatusCode);
             }
@@ -369,6 +377,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Assert.IsTrue(result.Headers.RequestCharge > 0);
                 Assert.IsNotNull(result.Headers.Session);
                 Assert.IsNotNull(result.Headers.ActivityId);
+                Assert.IsNotNull(result.Headers.PartitionKeyRangeId);
                 Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
                 Assert.AreEqual(HttpStatusCode.NoContent, result.StatusCode);
             }
@@ -404,6 +413,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Assert.IsTrue(result.Headers.RequestCharge > 0);
                 Assert.IsNotNull(result.Headers.Session);
                 Assert.IsNotNull(result.Headers.ActivityId);
+                Assert.IsNotNull(result.Headers.PartitionKeyRangeId);
                 Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
                 Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
             }
@@ -439,6 +449,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Assert.IsTrue(result.Headers.RequestCharge > 0);
                 Assert.IsNotNull(result.Headers.Session);
                 Assert.IsNotNull(result.Headers.ActivityId);
+                Assert.IsNotNull(result.Headers.PartitionKeyRangeId);
                 Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
                 Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
             }
@@ -474,6 +485,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Assert.IsTrue(result.Headers.RequestCharge > 0);
                 Assert.IsNotNull(result.Headers.Session);
                 Assert.IsNotNull(result.Headers.ActivityId);
+                Assert.IsNotNull(result.Headers.PartitionKeyRangeId);
                 Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
                 Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
             }
@@ -509,6 +521,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Assert.IsTrue(result.Headers.RequestCharge > 0);
                 Assert.IsNotNull(result.Headers.Session);
                 Assert.IsNotNull(result.Headers.ActivityId);
+                Assert.IsNotNull(result.Headers.PartitionKeyRangeId);
                 Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
                 Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
             }
@@ -548,6 +561,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Assert.IsTrue(result.Headers.RequestCharge > 0);
                 Assert.IsNotNull(result.Headers.Session);
                 Assert.IsNotNull(result.Headers.ActivityId);
+                Assert.IsNotNull(result.Headers.PartitionKeyRangeId);
                 Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
                 Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
             }
@@ -587,6 +601,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Assert.IsTrue(result.Headers.RequestCharge > 0);
                 Assert.IsNotNull(result.Headers.Session);
                 Assert.IsNotNull(result.Headers.ActivityId);
+                Assert.IsNotNull(result.Headers.PartitionKeyRangeId);
                 Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
                 Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
                 Assert.AreEqual("patched", result.Resource.description);
@@ -630,6 +645,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     Assert.IsTrue(result.Headers.RequestCharge > 0);
                     Assert.IsNotNull(result.Headers.Session);
                     Assert.IsNotNull(result.Headers.ActivityId);
+                    Assert.IsNotNull(result.Headers.PartitionKeyRangeId);
                     Assert.IsFalse(string.IsNullOrEmpty(result.Diagnostics.ToString()));
                     Assert.AreEqual(HttpStatusCode.Created, result.StatusCode);
                 }


### PR DESCRIPTION
# Pull Request Template

## Description

This PR adds the `PartitionKeyRangeId` in both Bulk mode and Transactional Batch response headers.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Closing issues

To automatically close an issue: closes #4235