### PR TITLE
[Internal] Pipelines: Adds permissions to workflow

### DIFF
--- a/.github/workflows/prlint.yml
+++ b/.github/workflows/prlint.yml
@@ -6,7 +6,9 @@ on:
 
 jobs:
   pr-lint:
-    permissions: read-all
+    permissions:
+      checks: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
     - uses: morrisoncole/pr-lint-action@v1.7.0

--- a/.github/workflows/prlint.yml
+++ b/.github/workflows/prlint.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   pr-lint:
+    permissions: read-all
     runs-on: ubuntu-latest
     steps:
     - uses: morrisoncole/pr-lint-action@v1.7.0

--- a/.github/workflows/prlint.yml
+++ b/.github/workflows/prlint.yml
@@ -8,7 +8,6 @@ jobs:
   pr-lint:
     permissions:
       checks: write
-      pull-requests: write
     runs-on: ubuntu-latest
     steps:
     - uses: morrisoncole/pr-lint-action@v1.7.0

--- a/.github/workflows/prlint.yml
+++ b/.github/workflows/prlint.yml
@@ -8,7 +8,7 @@ jobs:
   pr-lint:
     permissions:
       checks: write
-      pull-requests: read
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
     - uses: morrisoncole/pr-lint-action@v1.7.0

--- a/.github/workflows/prlint.yml
+++ b/.github/workflows/prlint.yml
@@ -8,6 +8,7 @@ jobs:
   pr-lint:
     permissions:
       checks: write
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
     - uses: morrisoncole/pr-lint-action@v1.7.0


### PR DESCRIPTION
Security notice indicates that `permissions` will be a required field for GitHub workflows: https://docs.opensource.microsoft.com/github/apps/permission-changes/

We only have 1 GitHub flow, which is the PR Linter.

After the permissions scope, the action keeps working as expected:

![image](https://github.com/Azure/azure-cosmos-dotnet-v3/assets/1633401/b20e7df9-40db-4a69-b32d-2af7e05186d8)
