### PR TITLE
[Internal] ChangeFeedIteratorCore_WithFullFidelityReadFromBeginning test to remove Assert on Emulator exception message.

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/FeedToken/ChangeFeedIteratorCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/FeedToken/ChangeFeedIteratorCoreTests.cs
@@ -792,7 +792,6 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.FeedRanges
 
             CosmosException cosmosException = await Assert.ThrowsExceptionAsync<CosmosException>(() => fullFidelityIterator.ReadNextAsync());
             Assert.AreEqual(HttpStatusCode.BadRequest, cosmosException.StatusCode, "Full Fidelity Change Feed does not work with StartFromBeginning currently.");
-            Assert.IsTrue(cosmosException.Message.Contains("FullFidelity Change Feed must have valid If-None-Match header."));
         }
 
         /// <summary>


### PR DESCRIPTION
# Pull Request Template

## Description

See [4273](https://github.com/Azure/azure-cosmos-dotnet-v3/issues/4273) for details.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #4273