### PR TITLE
CosmosClientOptions: Adds validation to check DisableServerCertificateValidation and ServerCertificateCustomValidationCallback are set together

### DIFF
--- a/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
@@ -758,6 +758,7 @@ namespace Microsoft.Azure.Cosmos
             this.ValidateDirectTCPSettings();
             this.ValidateLimitToEndpointSettings();
             this.ValidatePartitionLevelFailoverSettings();
+            this.ValidateServerCallbackSettings();
 
             ConnectionPolicy connectionPolicy = new ConnectionPolicy()
             {
@@ -928,6 +929,14 @@ namespace Microsoft.Azure.Cosmos
                 && (this.ApplicationPreferredRegions == null || this.ApplicationPreferredRegions.Count == 0))
             {
                 throw new ArgumentException($"{nameof(this.ApplicationPreferredRegions)} is required when {nameof(this.EnablePartitionLevelFailover)} is enabled.");
+            }
+        }
+
+        private void ValidateServerCallbackSettings()
+        {
+            if (this.HttpClientFactory != null && this.ServerCertificateCustomValidationCallback != null)
+            {
+                throw new ArgumentException($"Cannot specify {nameof(this.HttpClientFactory)} and {nameof(this.ServerCertificateCustomValidationCallback)}. Only one can be set.");
             }
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
@@ -914,6 +914,18 @@ namespace Microsoft.Azure.Cosmos.Tests
             }
         }
 
+        [TestMethod]
+        [DataRow(ConnectionString + "DisableServerCertificateValidation=true;")]
+        [ExpectedException(typeof(ArgumentException))]
+        public void TestServerCertificatesValidationWithHttpFactoryCallback(string connStr)
+        {
+            CosmosClientOptions options = new CosmosClientOptions
+            {
+                HttpClientFactory = () => new HttpClient()
+            };
+            CosmosClient cosmosClient = new CosmosClient(connStr, options);
+        }
+
         private class TestWebProxy : IWebProxy
         {
             public ICredentials Credentials { get; set; }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
@@ -892,6 +892,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         [TestMethod]
         [DataRow(ConnectionString, false)]
         [DataRow(ConnectionString + "DisableServerCertificateValidation=true;", true)]
+        [DataRow(ConnectionString + "DisableServerCertificateValidation=false;", false)]
         public void TestServerCertificatesValidationCallback(string connStr, bool expectedIgnoreCertificateFlag)
         {
             //Arrange
@@ -917,11 +918,11 @@ namespace Microsoft.Azure.Cosmos.Tests
         [TestMethod]
         [DataRow(ConnectionString + "DisableServerCertificateValidation=true;")]
         [ExpectedException(typeof(ArgumentException))]
-        public void TestServerCertificatesValidationWithHttpFactoryCallback(string connStr)
+        public void TestServerCertificatesValidationWithDisableSSLFlagTrue(string connStr)
         {
             CosmosClientOptions options = new CosmosClientOptions
             {
-                HttpClientFactory = () => new HttpClient()
+               ServerCertificateCustomValidationCallback = (certificate, chain, sslPolicyErrors) => true
             };
             CosmosClient cosmosClient = new CosmosClient(connStr, options);
         }


### PR DESCRIPTION
## Description

As part of this PR, validating `DisableServerCertificateValidation` flag and `ServerCertificateCustomValidationCallback` option are set together. Throws `ArgumentException` if it is true.

## Type of change
- [] Bug fix (non-breaking change which fixes an issue)
