### PR TITLE
[Internal] Fault Injection: Refactors CreateInterceptor to Async Method

### DIFF
--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -115,7 +115,9 @@ namespace Microsoft.Azure.Cosmos
         private readonly bool IsLocalQuorumConsistency = false;
         private readonly bool isReplicaAddressValidationEnabled;
 
-        private readonly IChaosInterceptor chaosInterceptor;
+        //Fault Injection
+        private readonly IChaosInterceptorFactory chaosInterceptorFactory;
+        private IChaosInterceptor chaosInterceptor;
 
         //Auth
         internal readonly AuthorizationTokenProvider cosmosAuthorization;
@@ -487,7 +489,7 @@ namespace Microsoft.Azure.Cosmos
             this.transportClientHandlerFactory = transportClientHandlerFactory;
             this.IsLocalQuorumConsistency = isLocalQuorumConsistency;
             this.initTaskCache = new AsyncCacheNonBlocking<string, bool>(cancellationToken: this.cancellationTokenSource.Token);
-            this.chaosInterceptor = chaosInterceptorFactory?.CreateInterceptor(this);
+            this.chaosInterceptorFactory = chaosInterceptorFactory;
 
             this.Initialize(
                 serviceEndpoint: serviceEndpoint,
@@ -1015,6 +1017,14 @@ namespace Microsoft.Azure.Cosmos
         // Always called from under the lock except when called from Intilialize method during construction.
         private async Task<bool> GetInitializationTaskAsync(IStoreClientFactory storeClientFactory)
         {
+            //Create the chaos interceptor if using fault injection
+            //Creating the chaos interceptor requires async calls, so we do it here instead of in the constructor
+            //This must also be done before creating the storeClientFactory for direct mode
+            if (this.chaosInterceptorFactory != null)
+            {
+                this.chaosInterceptor = await this.chaosInterceptorFactory.CreateInterceptorAsync(this);
+            }
+
             await this.InitializeGatewayConfigurationReaderAsync();
 
             if (this.desiredConsistencyLevel.HasValue)

--- a/Microsoft.Azure.Cosmos/src/FaultInjection/IChaosInterceptorFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/FaultInjection/IChaosInterceptorFactory.cs
@@ -3,6 +3,7 @@
 //------------------------------------------------------------
 namespace Microsoft.Azure.Cosmos
 {
+    using System.Threading.Tasks;
     using Microsoft.Azure.Documents.FaultInjection;
 
     /// <summary>
@@ -15,6 +16,6 @@ namespace Microsoft.Azure.Cosmos
         /// Creates the IChaosInterceptor interceptor that will be used to inject fault injection rules. 
         /// </summary>
         /// <param name="documentClient"></param>
-        public IChaosInterceptor CreateInterceptor(DocumentClient documentClient);
+        public Task<IChaosInterceptor> CreateInterceptorAsync(DocumentClient documentClient);
     }
 }


### PR DESCRIPTION
# Pull Request Template

## Description

When creating the `IChaosInterceptor`, there must be async calls. This PR refactors the `IChaosInterceptorFactory` class so that the method is now asynchronous.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #IssueNumber