### PR TITLE
Documentation refresh: Fixes DeleteItem API will not return context in response

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
@@ -820,8 +820,7 @@ namespace Microsoft.Azure.Cosmos
         /// </returns>
         /// <exception>https://aka.ms/cosmosdb-dot-net-exceptions#stream-api</exception>
         /// <remarks>
-        /// Item content is not expected in response for delete operations
-        /// <see cref="ResponseMessage.Content"/> will be null for delete operations.
+        /// For delete operations, the <see cref="ResponseMessage.Content"/> will be null. Item content is not expected in the response.
         /// 
         /// The Stream operation only throws on client side exceptions. This is to increase performance and prevent the overhead of throwing exceptions. Check the HTTP status code on the response to check if the operation failed.
         /// </remarks>
@@ -857,8 +856,7 @@ namespace Microsoft.Azure.Cosmos
         /// <remarks>
         /// <see cref="ItemResponse{T}.Resource"/> is <see href="https://docs.microsoft.com/rest/api/cosmos-db/delete-a-document#body">always null</see>
         /// </remarks>
-        /// Item content is not expected in response for delete operations
-        /// <see cref="ItemResponse{T}.Resource"/> will be null for delete operations.
+        /// For delete operations, the <see cref="ItemResponse{T}.Resource"/> will be null. Item content is not expected in the response.
         /// 
         /// <exception>https://aka.ms/cosmosdb-dot-net-exceptions#typed-api</exception>
         /// <example>

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
@@ -820,6 +820,9 @@ namespace Microsoft.Azure.Cosmos
         /// </returns>
         /// <exception>https://aka.ms/cosmosdb-dot-net-exceptions#stream-api</exception>
         /// <remarks>
+        /// Item content is not expected in response for delete operations
+        /// <see cref="ResponseMessage.Content"/> will be null for delete operations.
+        /// 
         /// The Stream operation only throws on client side exceptions. This is to increase performance and prevent the overhead of throwing exceptions. Check the HTTP status code on the response to check if the operation failed.
         /// </remarks>
         /// <example>
@@ -854,6 +857,9 @@ namespace Microsoft.Azure.Cosmos
         /// <remarks>
         /// <see cref="ItemResponse{T}.Resource"/> is <see href="https://docs.microsoft.com/rest/api/cosmos-db/delete-a-document#body">always null</see>
         /// </remarks>
+        /// Item content is not expected in response for delete operations
+        /// <see cref="ItemResponse{T}.Resource"/> will be null for delete operations.
+        /// 
         /// <exception>https://aka.ms/cosmosdb-dot-net-exceptions#typed-api</exception>
         /// <example>
         /// <code language="c#">


### PR DESCRIPTION
## Description
Documentation refresh: Fix DeleteItem API will not return context in response

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

ref: https://github.com/Azure/azure-cosmos-dotnet-v3/issues/1273#issuecomment-1917959931

closes: #1273