### PR TITLE
DisableServerCertificateValidation: Fixes Default HttpClient to honor DisableServerCertificateValidation

### DIFF
--- a/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
@@ -808,7 +808,6 @@ namespace Microsoft.Azure.Cosmos
             this.ValidateDirectTCPSettings();
             this.ValidateLimitToEndpointSettings();
             this.ValidatePartitionLevelFailoverSettings();
-            this.ValidateAndSetServerCallbackSettings();
 
             ConnectionPolicy connectionPolicy = new ConnectionPolicy()
             {
@@ -979,19 +978,6 @@ namespace Microsoft.Azure.Cosmos
                 && (this.ApplicationPreferredRegions == null || this.ApplicationPreferredRegions.Count == 0))
             {
                 throw new ArgumentException($"{nameof(this.ApplicationPreferredRegions)} is required when {nameof(this.EnablePartitionLevelFailover)} is enabled.");
-            }
-        }
-
-        private void ValidateAndSetServerCallbackSettings()
-        {
-            if (this.DisableServerCertificateValidation && this.ServerCertificateCustomValidationCallback != null)
-            {
-                throw new ArgumentException($"Cannot specify {nameof(this.DisableServerCertificateValidation)} flag in Connection String and {nameof(this.ServerCertificateCustomValidationCallback)}. Only one can be set.");
-            }
-            
-            if (this.DisableServerCertificateValidation)
-            {
-                this.ServerCertificateCustomValidationCallback = (_, _, _) => true;
             }
         }
 

--- a/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
@@ -668,7 +668,26 @@ namespace Microsoft.Azure.Cosmos
         /// </para>
         /// </remarks>
         public Func<X509Certificate2, X509Chain, SslPolicyErrors, bool> ServerCertificateCustomValidationCallback { get; set; }
-       
+
+        /// <summary>
+        /// Real call back that will be hooked down-stream to the transport clients (both http and tcp).
+        /// NOTE: All down stream real-usage shows by only through this API only and not through the public API.
+        /// </summary>
+        internal Func<X509Certificate2, X509Chain, SslPolicyErrors, bool> GetServerCertificateCustomValidationCallback()
+        {
+            if (this.DisableServerCertificateValidation && this.ServerCertificateCustomValidationCallback != null)
+            {
+                throw new ArgumentException($"Cannot specify {nameof(this.DisableServerCertificateValidation)} flag in Connection String and {nameof(this.ServerCertificateCustomValidationCallback)}. Only one can be set.");
+            }
+
+            if (this.DisableServerCertificateValidation)
+            {
+                return (_, _, _) => true;
+            }
+
+            return this.ServerCertificateCustomValidationCallback;
+        }
+
         /// <summary>
         /// API type for the account
         /// </summary>
@@ -773,7 +792,6 @@ namespace Microsoft.Azure.Cosmos
             this.ValidateDirectTCPSettings();
             this.ValidateLimitToEndpointSettings();
             this.ValidatePartitionLevelFailoverSettings();
-            this.ValidateAndSetServerCallbackSettings();
 
             ConnectionPolicy connectionPolicy = new ConnectionPolicy()
             {
@@ -793,7 +811,7 @@ namespace Microsoft.Azure.Cosmos
                 EnableTcpConnectionEndpointRediscovery = this.EnableTcpConnectionEndpointRediscovery,
                 EnableAdvancedReplicaSelectionForTcp = this.EnableAdvancedReplicaSelectionForTcp,
                 HttpClientFactory = this.httpClientFactory,
-                ServerCertificateCustomValidationCallback = this.ServerCertificateCustomValidationCallback,
+                ServerCertificateCustomValidationCallback = this.GetServerCertificateCustomValidationCallback(),
                 CosmosClientTelemetryOptions = new CosmosClientTelemetryOptions()
             };
 
@@ -944,19 +962,6 @@ namespace Microsoft.Azure.Cosmos
                 && (this.ApplicationPreferredRegions == null || this.ApplicationPreferredRegions.Count == 0))
             {
                 throw new ArgumentException($"{nameof(this.ApplicationPreferredRegions)} is required when {nameof(this.EnablePartitionLevelFailover)} is enabled.");
-            }
-        }
-
-        private void ValidateAndSetServerCallbackSettings()
-        {
-            if (this.DisableServerCertificateValidation && this.ServerCertificateCustomValidationCallback != null)
-            {
-                throw new ArgumentException($"Cannot specify {nameof(this.DisableServerCertificateValidation)} flag in Connection String and {nameof(this.ServerCertificateCustomValidationCallback)}. Only one can be set.");
-            }
-            
-            if (this.DisableServerCertificateValidation)
-            {
-                this.ServerCertificateCustomValidationCallback = (_, _, _) => true;
             }
         }
 

--- a/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
@@ -671,7 +671,8 @@ namespace Microsoft.Azure.Cosmos
 
         /// <summary>
         /// Real call back that will be hooked down-stream to the transport clients (both http and tcp).
-        /// NOTE: All down stream real-usage shows by only through this API only and not through the public API.
+        /// NOTE: All down stream real-usage should come through this API only and not through the public API.
+
         /// 
         /// Test hook DisableServerCertificateValidationInvocationCallback 
         /// - When configured will invoke it when ever custom validation is done

--- a/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
@@ -664,7 +664,7 @@ namespace Microsoft.Azure.Cosmos
         /// <para>
         /// Emulator: To ignore SSL Certificate please suffix connectionstring with "DisableServerCertificateValidation=True;". 
         /// When CosmosClientOptions.HttpClientFactory is used, SSL certificate needs to be handled appropriately.
-        /// NOTE: DO NOT use this flag in production (only for emulator)
+        /// NOTE: DO NOT use the `DisableServerCertificateValidation` flag in production (only for emulator)
         /// </para>
         /// </remarks>
         public Func<X509Certificate2, X509Chain, SslPolicyErrors, bool> ServerCertificateCustomValidationCallback { get; set; }

--- a/Microsoft.Azure.Cosmos/src/Resource/ClientContextCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/ClientContextCore.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.Cosmos
             HttpMessageHandler httpMessageHandler = CosmosHttpClientCore.CreateHttpClientHandler(
                 clientOptions.GatewayModeMaxConnectionLimit,
                 clientOptions.WebProxy,
-                clientOptions.ServerCertificateCustomValidationCallback);
+                clientOptions.GetServerCertificateCustomValidationCallback());
 
             DocumentClient documentClient = new DocumentClient(
                cosmosClient.Endpoint,
@@ -81,7 +81,7 @@ namespace Microsoft.Azure.Cosmos
                handler: httpMessageHandler,
                sessionContainer: clientOptions.SessionContainer,
                cosmosClientId: cosmosClient.Id,
-               remoteCertificateValidationCallback: ClientContextCore.SslCustomValidationCallBack(clientOptions.ServerCertificateCustomValidationCallback),
+               remoteCertificateValidationCallback: ClientContextCore.SslCustomValidationCallBack(clientOptions.GetServerCertificateCustomValidationCallback()),
                cosmosClientTelemetryOptions: clientOptions.CosmosClientTelemetryOptions,
                chaosInterceptorFactory: clientOptions.ChaosInterceptorFactory);
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTests.cs
@@ -18,7 +18,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
-    using Antlr4.Runtime.Misc;
     using global::Azure;
     using Microsoft.Azure.Cosmos.Query.Core;
     using Microsoft.Azure.Cosmos.Services.Management.Tests.LinqProviderTests;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTests.cs
@@ -508,6 +508,65 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
+        public async Task Verify_DisableCertificateValidationCallBackGetsCalled_ForTCP_HTTP()
+        {
+            bool remoteCertInterceptorSet = false;
+            remoteCertInterceptorSet = false;
+            CosmosClientOptions options = new CosmosClientOptions()
+            {
+                SendingRequestEventArgs = (sender, args) => {
+                    if (!remoteCertInterceptorSet)
+                    {
+                        Trace.TraceInformation($"Failing({remoteCertInterceptorSet}) for request {args.HttpRequest.RequestUri} -> {new StackTrace()}");
+                        throw new Exception("Failing requests: Waiting for remote certificate interceptor set-up");
+                    }
+                },
+            };
+
+            string authKey = ConfigurationManager.AppSettings["MasterKey"];
+            string endpoint = "https://localhost:8081/"; // ConfigurationManager.AppSettings["GatewayEndpoint"];
+            string connectionStringWithSslDisable = $"AccountEndpoint={endpoint};AccountKey={authKey};DisableServerCertificateValidation=true";
+
+            CosmosClient cosmosClient = new CosmosClient(connectionStringWithSslDisable, options);
+
+            CosmosHttpClient httpClient = cosmosClient.DocumentClient.httpClient;
+            DelegatingHandler messageHandler = (DelegatingHandler)httpClient.HttpMessageHandler;
+            SocketsHttpHandler socketsHttpHandler = (SocketsHttpHandler)messageHandler.InnerHandler;
+
+            // Set-up connection cert validation interceptor 
+            int remoteCertificateValidationCallbackCount = 0;
+            {
+                RemoteCertificateValidationCallback httpClientRemoreCertValidationCallback = socketsHttpHandler.SslOptions.RemoteCertificateValidationCallback;
+                socketsHttpHandler.SslOptions.RemoteCertificateValidationCallback =
+                    new RemoteCertificateValidationCallback((object o, X509Certificate certificate, X509Chain x509Chain, SslPolicyErrors sslPolicyErrors) =>
+                    {
+                        Interlocked.Increment(ref remoteCertificateValidationCallbackCount);
+                        Trace.TraceInformation($"RemoteCertificateValidationCallback called -> {new StackTrace()}");
+                        return httpClientRemoreCertValidationCallback(o, certificate, x509Chain, sslPolicyErrors);
+                    });
+
+                // Interceptor set-up
+                remoteCertInterceptorSet = true;
+                Trace.TraceInformation($"SSL cert interceptor in-place {remoteCertInterceptorSet}");
+            }
+
+            string databaseName = Guid.NewGuid().ToString();
+            string databaseId = Guid.NewGuid().ToString();
+
+            //HTTP callback
+            Trace.TraceInformation("Creating test database and container");
+            Cosmos.Database database = await cosmosClient.CreateDatabaseAsync(databaseId);
+            Cosmos.Container container = await database.CreateContainerAsync(Guid.NewGuid().ToString(), "/id");
+
+            //TCP callback
+            ToDoActivity item = ToDoActivity.CreateRandomToDoActivity();
+            ResponseMessage responseMessage = await container.CreateItemStreamAsync(TestCommon.SerializerCore.ToStream(item), new Cosmos.PartitionKey(item.id));
+            Trace.TraceInformation($"CreateItemStreamAsync diagnostics: {responseMessage.Diagnostics.ToString()}");
+
+            Assert.IsTrue(remoteCertificateValidationCallbackCount >= 2);
+        }
+
+        [TestMethod]
         public void SqlQuerySpecSerializationTest()
         {
             Action<string, SqlQuerySpec> verifyJsonSerialization = (expectedText, query) =>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTests.cs
@@ -508,7 +508,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        public async Task Verify_DisableCertificateValidationCallBackGetsCalled_For_HTTP()
+        public async Task Verify_DisableCertificateValidationCallBackGetsCalled_ForTCP_HTTP()
         {
             int counter = 0;
             CosmosClientOptions options = new CosmosClientOptions()

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
@@ -938,14 +938,28 @@ namespace Microsoft.Azure.Cosmos.Tests
 
             if (expectedIgnoreCertificateFlag)
             {
-                Assert.IsNotNull(cosmosClient.ClientOptions.ServerCertificateCustomValidationCallback);
+                Assert.IsNull(cosmosClient.ClientOptions.ServerCertificateCustomValidationCallback);
+                Assert.IsTrue(cosmosClient.ClientOptions.DisableServerCertificateValidation);
                 Assert.IsTrue(cosmosClient
                     .ClientOptions
-                    .ServerCertificateCustomValidationCallback(x509Certificate2, x509Chain, sslPolicyErrors));
+                    .GetServerCertificateCustomValidationCallback()(x509Certificate2, x509Chain, sslPolicyErrors));
+
+                Assert.IsNotNull(cosmosClient.DocumentClient.ConnectionPolicy.ServerCertificateCustomValidationCallback);
+                
+                CosmosHttpClient httpClient = cosmosClient.DocumentClient.httpClient;
+                SocketsHttpHandler socketsHttpHandler = (SocketsHttpHandler)httpClient.HttpMessageHandler;
+
+                RemoteCertificateValidationCallback? httpClientRemoreCertValidationCallback = socketsHttpHandler.SslOptions.RemoteCertificateValidationCallback;
+                Assert.IsNotNull(httpClientRemoreCertValidationCallback);
+
+                Assert.IsTrue(httpClientRemoreCertValidationCallback(this, x509Certificate2, x509Chain, sslPolicyErrors));
             }
             else
             {
                 Assert.IsNull(cosmosClient.ClientOptions.ServerCertificateCustomValidationCallback);
+                Assert.IsFalse(cosmosClient.ClientOptions.DisableServerCertificateValidation);
+
+                Assert.IsNull(cosmosClient.DocumentClient.ConnectionPolicy.ServerCertificateCustomValidationCallback);
             }
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
@@ -949,7 +949,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 CosmosHttpClient httpClient = cosmosClient.DocumentClient.httpClient;
                 SocketsHttpHandler socketsHttpHandler = (SocketsHttpHandler)httpClient.HttpMessageHandler;
 
-                RemoteCertificateValidationCallback? httpClientRemoreCertValidationCallback = socketsHttpHandler.SslOptions.RemoteCertificateValidationCallback;
+                RemoteCertificateValidationCallback httpClientRemoreCertValidationCallback = socketsHttpHandler.SslOptions.RemoteCertificateValidationCallback;
                 Assert.IsNotNull(httpClientRemoreCertValidationCallback);
 
                 Assert.IsTrue(httpClientRemoreCertValidationCallback(this, x509Certificate2, x509Chain, sslPolicyErrors));

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
@@ -939,12 +939,12 @@ namespace Microsoft.Azure.Cosmos.Tests
             if (expectedIgnoreCertificateFlag)
             {
                 Assert.IsNull(cosmosClient.ClientOptions.ServerCertificateCustomValidationCallback);
+                Assert.IsNull(cosmosClient.DocumentClient.ConnectionPolicy.ServerCertificateCustomValidationCallback);
                 Assert.IsTrue(cosmosClient.ClientOptions.DisableServerCertificateValidation);
                 Assert.IsTrue(cosmosClient
                     .ClientOptions
                     .GetServerCertificateCustomValidationCallback()(x509Certificate2, x509Chain, sslPolicyErrors));
 
-                Assert.IsNotNull(cosmosClient.DocumentClient.ConnectionPolicy.ServerCertificateCustomValidationCallback);
                 
                 CosmosHttpClient httpClient = cosmosClient.DocumentClient.httpClient;
                 SocketsHttpHandler socketsHttpHandler = (SocketsHttpHandler)httpClient.HttpMessageHandler;
@@ -981,15 +981,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             CosmosClient cosmosClient = new CosmosClient(connStr, options);
             Assert.IsTrue(cosmosClient.ClientOptions.DisableServerCertificateValidation);
             Assert.AreEqual(cosmosClient.ClientOptions.ServerCertificateCustomValidationCallback, options.ServerCertificateCustomValidationCallback);
-
-            if (setCallback)
-            {
-                Assert.AreNotEqual(cosmosClient.DocumentClient.ConnectionPolicy.ServerCertificateCustomValidationCallback, options.ServerCertificateCustomValidationCallback);
-            }
-            else
-            {
-                Assert.AreEqual(cosmosClient.DocumentClient.ConnectionPolicy.ServerCertificateCustomValidationCallback, options.ServerCertificateCustomValidationCallback);
-            }
+            Assert.AreEqual(cosmosClient.DocumentClient.ConnectionPolicy.ServerCertificateCustomValidationCallback, options.ServerCertificateCustomValidationCallback);
 
             CosmosHttpClient httpClient = cosmosClient.DocumentClient.httpClient;
             SocketsHttpHandler socketsHttpHandler = (SocketsHttpHandler)httpClient.HttpMessageHandler;


### PR DESCRIPTION
## Description
When `DisableServerCertificateValidation` is set:
  `ServerCertificateCustomValidationCallback` is conditionally set after validation when ConnectionPolicy is created. But HttpClient is created before ConnectionPolicy creation resulting in the configuration getting ignored. 


## changes
- Make CosmosClientOptions.ServerCertificateCustomValidationCallback immutable post initialization. 
  - New internal API GetServerCertificateCustomValidationCallback() which abstracts the certificate validation callback definition. 
- Supporting the combination of both DisableServerCertificateValidation and ServerCertificateCustomValidationCallback combination
- Supporting test hook for DisableServerCertificateValidationInvocationCallback (specifically for only Disable checking)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber