### PR TITLE
[Internal] Query: Fixes Aggregate Pipelines resetting headers

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Aggregate/AggregateQueryPipelineStage.Client.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Aggregate/AggregateQueryPipelineStage.Client.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Aggregate
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Aggregate.Aggregators;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
     using Microsoft.Azure.Cosmos.Tracing;
+    using Microsoft.Azure.Documents;
 
     internal abstract partial class AggregateQueryPipelineStage : QueryPipelineStageBase
     {
@@ -105,10 +106,12 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Aggregate
                     responseLengthBytes += sourcePage.ResponseLengthInBytes;
 
                     // Note-2024-02-02:
-                    // QueryExecMetrics header is accumulated pre this pipeline, so we can safely ignore it here.
-                    // Other than that, the other query related header is IndexMetrics and it's non-cumulative
-                    // So we copy the source page headers from the source page to the final result.
-                    cumulativeAdditionalHeaders = sourcePage.AdditionalHeaders;
+                    // Here the IndexMetrics headers are non-accumulative, so we are copying that header from the source page.
+                    // Other headers might need similar traeatment, and it's up to the area owner to implement that here.
+                    cumulativeAdditionalHeaders = new Dictionary<string, string>()
+                                                { 
+                                                    { HttpConstants.HttpHeaders.IndexUtilization, sourcePage.AdditionalHeaders[HttpConstants.HttpHeaders.IndexUtilization] } 
+                                                };
 
                     foreach (CosmosElement element in sourcePage.Documents)
                     {

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Aggregate/AggregateQueryPipelineStage.Client.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Aggregate/AggregateQueryPipelineStage.Client.cs
@@ -108,10 +108,13 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Aggregate
                     // Note-2024-02-02:
                     // Here the IndexMetrics headers are non-accumulative, so we are copying that header from the source page.
                     // Other headers might need similar traeatment, and it's up to the area owner to implement that here.
-                    cumulativeAdditionalHeaders = new Dictionary<string, string>()
-                                                { 
-                                                    { HttpConstants.HttpHeaders.IndexUtilization, sourcePage.AdditionalHeaders[HttpConstants.HttpHeaders.IndexUtilization] } 
+                    if (sourcePage.AdditionalHeaders.ContainsKey(HttpConstants.HttpHeaders.IndexUtilization))
+                    {
+                        cumulativeAdditionalHeaders = new Dictionary<string, string>()
+                                                {
+                                                    { HttpConstants.HttpHeaders.IndexUtilization, sourcePage.AdditionalHeaders[HttpConstants.HttpHeaders.IndexUtilization] }
                                                 };
+                    }
 
                     foreach (CosmosElement element in sourcePage.Documents)
                     {

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Aggregate/AggregateQueryPipelineStage.Client.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Aggregate/AggregateQueryPipelineStage.Client.cs
@@ -110,10 +110,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Aggregate
                     // Other headers might need similar traeatment, and it's up to the area owner to implement that here.
                     if (sourcePage.AdditionalHeaders.ContainsKey(HttpConstants.HttpHeaders.IndexUtilization))
                     {
-                        cumulativeAdditionalHeaders = new Dictionary<string, string>()
-                                                {
-                                                    { HttpConstants.HttpHeaders.IndexUtilization, sourcePage.AdditionalHeaders[HttpConstants.HttpHeaders.IndexUtilization] }
-                                                };
+                        cumulativeAdditionalHeaders = new Dictionary<string, string>() {{ HttpConstants.HttpHeaders.IndexUtilization, sourcePage.AdditionalHeaders[HttpConstants.HttpHeaders.IndexUtilization] }};
                     }
 
                     foreach (CosmosElement element in sourcePage.Documents)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/IndexMetricsParserBaselineTest.IndexUtilizationClientSideExistenceTest.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/IndexMetricsParserBaselineTest.IndexUtilizationClientSideExistenceTest.xml
@@ -1,0 +1,290 @@
+﻿<Results>
+  <Result>
+    <Input>
+      <Description><![CDATA[Simple 1]]></Description>
+      <Query><![CDATA[SELECT * FROM c WHERE c.id = "1"]]></Query>
+    </Input>
+    <Output>
+      <IndexMetric><![CDATA[{"UtilizedSingleIndexes":[{"FilterExpression":"","IndexSpec":"\/id\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"}],"PotentialSingleIndexes":[],"UtilizedCompositeIndexes":[],"PotentialCompositeIndexes":[]}]]></IndexMetric>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[Simple 2]]></Description>
+      <Query><![CDATA[SELECT * FROM c WHERE c.id = "1" and c.name = "Abc"]]></Query>
+    </Input>
+    <Output>
+      <IndexMetric><![CDATA[{"UtilizedSingleIndexes":[{"FilterExpression":"","IndexSpec":"\/id\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"},{"FilterExpression":"","IndexSpec":"\/name\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"}],"PotentialSingleIndexes":[],"UtilizedCompositeIndexes":[],"PotentialCompositeIndexes":[]}]]></IndexMetric>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[Simple 3]]></Description>
+      <Query><![CDATA[SELECT * FROM c WHERE c.id = "1" and c.name > "Abc"]]></Query>
+    </Input>
+    <Output>
+      <IndexMetric><![CDATA[{"UtilizedSingleIndexes":[{"FilterExpression":"","IndexSpec":"\/id\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"},{"FilterExpression":"","IndexSpec":"\/name\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"}],"PotentialSingleIndexes":[],"UtilizedCompositeIndexes":[],"PotentialCompositeIndexes":[{"IndexSpecs":["\/id ASC","\/name ASC"],"IndexPreciseSet":false,"IndexImpactScore":"High"}]}]]></IndexMetric>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[Simple 4]]></Description>
+      <Query><![CDATA[SELECT * FROM c WHERE c.id > "1" and c.name > "Abc"]]></Query>
+    </Input>
+    <Output>
+      <IndexMetric><![CDATA[{"UtilizedSingleIndexes":[{"FilterExpression":"","IndexSpec":"\/id\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"},{"FilterExpression":"","IndexSpec":"\/name\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"}],"PotentialSingleIndexes":[],"UtilizedCompositeIndexes":[],"PotentialCompositeIndexes":[]}]]></IndexMetric>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[Aggregate 1]]></Description>
+      <Query><![CDATA[SELECT COUNT(1) FROM c WHERE c.id = "1"]]></Query>
+    </Input>
+    <Output>
+      <IndexMetric><![CDATA[{"UtilizedSingleIndexes":[{"FilterExpression":"","IndexSpec":"\/id\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"}],"PotentialSingleIndexes":[],"UtilizedCompositeIndexes":[],"PotentialCompositeIndexes":[]}]]></IndexMetric>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[Aggregate 2]]></Description>
+      <Query><![CDATA[SELECT COUNT(1) FROM c WHERE c.id = "1" and c.name = "Abc"]]></Query>
+    </Input>
+    <Output>
+      <IndexMetric><![CDATA[{"UtilizedSingleIndexes":[{"FilterExpression":"","IndexSpec":"\/id\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"},{"FilterExpression":"","IndexSpec":"\/name\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"}],"PotentialSingleIndexes":[],"UtilizedCompositeIndexes":[],"PotentialCompositeIndexes":[]}]]></IndexMetric>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[Aggregate 3]]></Description>
+      <Query><![CDATA[SELECT COUNT(1) FROM c WHERE c.id = "1" and c.name > "Abc"]]></Query>
+    </Input>
+    <Output>
+      <IndexMetric><![CDATA[{"UtilizedSingleIndexes":[{"FilterExpression":"","IndexSpec":"\/id\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"},{"FilterExpression":"","IndexSpec":"\/name\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"}],"PotentialSingleIndexes":[],"UtilizedCompositeIndexes":[],"PotentialCompositeIndexes":[{"IndexSpecs":["\/id ASC","\/name ASC"],"IndexPreciseSet":false,"IndexImpactScore":"High"}]}]]></IndexMetric>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[Aggregate 4]]></Description>
+      <Query><![CDATA[SELECT COUNT(1) FROM c WHERE c.id > "1" and c.name > "Abc"]]></Query>
+    </Input>
+    <Output>
+      <IndexMetric><![CDATA[{"UtilizedSingleIndexes":[{"FilterExpression":"","IndexSpec":"\/id\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"},{"FilterExpression":"","IndexSpec":"\/name\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"}],"PotentialSingleIndexes":[],"UtilizedCompositeIndexes":[],"PotentialCompositeIndexes":[]}]]></IndexMetric>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[Aggregate Value 1]]></Description>
+      <Query><![CDATA[SELECT VALUE COUNT(1) FROM c WHERE c.id = "1"]]></Query>
+    </Input>
+    <Output>
+      <IndexMetric><![CDATA[{"UtilizedSingleIndexes":[{"FilterExpression":"","IndexSpec":"\/id\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"}],"PotentialSingleIndexes":[],"UtilizedCompositeIndexes":[],"PotentialCompositeIndexes":[]}]]></IndexMetric>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[Aggregate Value 2]]></Description>
+      <Query><![CDATA[SELECT VALUE COUNT(1) FROM c WHERE c.id = "1" and c.name = "Abc"]]></Query>
+    </Input>
+    <Output>
+      <IndexMetric><![CDATA[{"UtilizedSingleIndexes":[{"FilterExpression":"","IndexSpec":"\/id\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"},{"FilterExpression":"","IndexSpec":"\/name\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"}],"PotentialSingleIndexes":[],"UtilizedCompositeIndexes":[],"PotentialCompositeIndexes":[]}]]></IndexMetric>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[Aggregate Value 3]]></Description>
+      <Query><![CDATA[SELECT VALUE COUNT(1) FROM c WHERE c.id = "1" and c.name > "Abc"]]></Query>
+    </Input>
+    <Output>
+      <IndexMetric><![CDATA[{"UtilizedSingleIndexes":[{"FilterExpression":"","IndexSpec":"\/id\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"},{"FilterExpression":"","IndexSpec":"\/name\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"}],"PotentialSingleIndexes":[],"UtilizedCompositeIndexes":[],"PotentialCompositeIndexes":[{"IndexSpecs":["\/id ASC","\/name ASC"],"IndexPreciseSet":false,"IndexImpactScore":"High"}]}]]></IndexMetric>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[Aggregate Value 4]]></Description>
+      <Query><![CDATA[SELECT VALUE COUNT(1) FROM c WHERE c.id > "1" and c.name > "Abc"]]></Query>
+    </Input>
+    <Output>
+      <IndexMetric><![CDATA[{"UtilizedSingleIndexes":[{"FilterExpression":"","IndexSpec":"\/id\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"},{"FilterExpression":"","IndexSpec":"\/name\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"}],"PotentialSingleIndexes":[],"UtilizedCompositeIndexes":[],"PotentialCompositeIndexes":[]}]]></IndexMetric>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[OrderBy 1]]></Description>
+      <Query><![CDATA[SELECT * FROM c WHERE c.id = "1" ORDER BY c.id ASC]]></Query>
+    </Input>
+    <Output>
+      <IndexMetric><![CDATA[{"UtilizedSingleIndexes":[{"FilterExpression":"","IndexSpec":"\/id\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"}],"PotentialSingleIndexes":[],"UtilizedCompositeIndexes":[],"PotentialCompositeIndexes":[]}]]></IndexMetric>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[OrderBy 2]]></Description>
+      <Query><![CDATA[SELECT * FROM c WHERE c.id = "1" and c.name = "Abc" ORDER BY c.id ASC]]></Query>
+    </Input>
+    <Output>
+      <IndexMetric><![CDATA[{"UtilizedSingleIndexes":[{"FilterExpression":"","IndexSpec":"\/name\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"}],"PotentialSingleIndexes":[],"UtilizedCompositeIndexes":[],"PotentialCompositeIndexes":[]}]]></IndexMetric>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[OrderBy 3]]></Description>
+      <Query><![CDATA[SELECT * FROM c WHERE c.id = "1" and c.name > "Abc" ORDER BY c.id ASC]]></Query>
+    </Input>
+    <Output>
+      <IndexMetric><![CDATA[{"UtilizedSingleIndexes":[{"FilterExpression":"","IndexSpec":"\/id\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"},{"FilterExpression":"","IndexSpec":"\/name\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"}],"PotentialSingleIndexes":[],"UtilizedCompositeIndexes":[],"PotentialCompositeIndexes":[{"IndexSpecs":["\/id ASC","\/name ASC"],"IndexPreciseSet":false,"IndexImpactScore":"High"}]}]]></IndexMetric>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[OrderBy 4]]></Description>
+      <Query><![CDATA[SELECT * FROM c WHERE c.id > "1" and c.name > "Abc" ORDER BY c.id ASC]]></Query>
+    </Input>
+    <Output>
+      <IndexMetric><![CDATA[{"UtilizedSingleIndexes":[{"FilterExpression":"","IndexSpec":"\/name\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"}],"PotentialSingleIndexes":[],"UtilizedCompositeIndexes":[],"PotentialCompositeIndexes":[]}]]></IndexMetric>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[GroupBy 1]]></Description>
+      <Query><![CDATA[SELECT COUNT(1) FROM c WHERE c.id = "1" GROUP BY c.id]]></Query>
+    </Input>
+    <Output>
+      <IndexMetric><![CDATA[{"UtilizedSingleIndexes":[{"FilterExpression":"","IndexSpec":"\/id\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"}],"PotentialSingleIndexes":[],"UtilizedCompositeIndexes":[],"PotentialCompositeIndexes":[]}]]></IndexMetric>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[GroupBy 2]]></Description>
+      <Query><![CDATA[SELECT COUNT(1) FROM c WHERE c.id = "1" and c.name = "Abc" GROUP BY c.id]]></Query>
+    </Input>
+    <Output>
+      <IndexMetric><![CDATA[{"UtilizedSingleIndexes":[{"FilterExpression":"","IndexSpec":"\/id\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"},{"FilterExpression":"","IndexSpec":"\/name\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"}],"PotentialSingleIndexes":[],"UtilizedCompositeIndexes":[],"PotentialCompositeIndexes":[]}]]></IndexMetric>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[GroupBy 3]]></Description>
+      <Query><![CDATA[SELECT COUNT(1) FROM c WHERE c.id = "1" and c.name > "Abc" GROUP BY c.id]]></Query>
+    </Input>
+    <Output>
+      <IndexMetric><![CDATA[{"UtilizedSingleIndexes":[{"FilterExpression":"","IndexSpec":"\/id\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"},{"FilterExpression":"","IndexSpec":"\/name\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"}],"PotentialSingleIndexes":[],"UtilizedCompositeIndexes":[],"PotentialCompositeIndexes":[{"IndexSpecs":["\/id ASC","\/name ASC"],"IndexPreciseSet":false,"IndexImpactScore":"High"}]}]]></IndexMetric>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[GroupBy 4]]></Description>
+      <Query><![CDATA[SELECT COUNT(1) FROM c WHERE c.id > "1" and c.name > "Abc" GROUP BY c.id]]></Query>
+    </Input>
+    <Output>
+      <IndexMetric><![CDATA[{"UtilizedSingleIndexes":[{"FilterExpression":"","IndexSpec":"\/id\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"},{"FilterExpression":"","IndexSpec":"\/name\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"}],"PotentialSingleIndexes":[],"UtilizedCompositeIndexes":[],"PotentialCompositeIndexes":[]}]]></IndexMetric>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[GroupBy 5]]></Description>
+      <Query><![CDATA[SELECT COUNT(1) FROM c WHERE c.id = "1" GROUP BY c.id, c.name]]></Query>
+    </Input>
+    <Output>
+      <IndexMetric><![CDATA[{"UtilizedSingleIndexes":[{"FilterExpression":"","IndexSpec":"\/id\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"}],"PotentialSingleIndexes":[],"UtilizedCompositeIndexes":[],"PotentialCompositeIndexes":[]}]]></IndexMetric>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[GroupBy 6]]></Description>
+      <Query><![CDATA[SELECT COUNT(1) FROM c WHERE c.id = "1" and c.name = "Abc" GROUP BY c.id, c.name]]></Query>
+    </Input>
+    <Output>
+      <IndexMetric><![CDATA[{"UtilizedSingleIndexes":[{"FilterExpression":"","IndexSpec":"\/id\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"},{"FilterExpression":"","IndexSpec":"\/name\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"}],"PotentialSingleIndexes":[],"UtilizedCompositeIndexes":[],"PotentialCompositeIndexes":[]}]]></IndexMetric>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[GroupBy 7]]></Description>
+      <Query><![CDATA[SELECT COUNT(1) FROM c WHERE c.id = "1" and c.name > "Abc" GROUP BY c.id, c.name]]></Query>
+    </Input>
+    <Output>
+      <IndexMetric><![CDATA[{"UtilizedSingleIndexes":[{"FilterExpression":"","IndexSpec":"\/id\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"},{"FilterExpression":"","IndexSpec":"\/name\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"}],"PotentialSingleIndexes":[],"UtilizedCompositeIndexes":[],"PotentialCompositeIndexes":[{"IndexSpecs":["\/id ASC","\/name ASC"],"IndexPreciseSet":false,"IndexImpactScore":"High"}]}]]></IndexMetric>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[GroupBy 8]]></Description>
+      <Query><![CDATA[SELECT COUNT(1) FROM c WHERE c.id > "1" and c.name > "Abc" GROUP BY c.id, c.name]]></Query>
+    </Input>
+    <Output>
+      <IndexMetric><![CDATA[{"UtilizedSingleIndexes":[{"FilterExpression":"","IndexSpec":"\/id\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"},{"FilterExpression":"","IndexSpec":"\/name\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"}],"PotentialSingleIndexes":[],"UtilizedCompositeIndexes":[],"PotentialCompositeIndexes":[]}]]></IndexMetric>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[GroupBy Value 1]]></Description>
+      <Query><![CDATA[SELECT VALUE COUNT(1) FROM c WHERE c.id = "1"]]></Query>
+    </Input>
+    <Output>
+      <IndexMetric><![CDATA[{"UtilizedSingleIndexes":[{"FilterExpression":"","IndexSpec":"\/id\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"}],"PotentialSingleIndexes":[],"UtilizedCompositeIndexes":[],"PotentialCompositeIndexes":[]}]]></IndexMetric>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[GroupBy Value 2]]></Description>
+      <Query><![CDATA[SELECT VALUE COUNT(1) FROM c WHERE c.id = "1" and c.name = "Abc"]]></Query>
+    </Input>
+    <Output>
+      <IndexMetric><![CDATA[{"UtilizedSingleIndexes":[{"FilterExpression":"","IndexSpec":"\/id\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"},{"FilterExpression":"","IndexSpec":"\/name\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"}],"PotentialSingleIndexes":[],"UtilizedCompositeIndexes":[],"PotentialCompositeIndexes":[]}]]></IndexMetric>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[GroupBy Value 3]]></Description>
+      <Query><![CDATA[SELECT VALUE COUNT(1) FROM c WHERE c.id = "1" and c.name > "Abc"]]></Query>
+    </Input>
+    <Output>
+      <IndexMetric><![CDATA[{"UtilizedSingleIndexes":[{"FilterExpression":"","IndexSpec":"\/id\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"},{"FilterExpression":"","IndexSpec":"\/name\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"}],"PotentialSingleIndexes":[],"UtilizedCompositeIndexes":[],"PotentialCompositeIndexes":[{"IndexSpecs":["\/id ASC","\/name ASC"],"IndexPreciseSet":false,"IndexImpactScore":"High"}]}]]></IndexMetric>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[GroupBy Value 4]]></Description>
+      <Query><![CDATA[SELECT VALUE COUNT(1) FROM c WHERE c.id > "1" and c.name > "Abc"]]></Query>
+    </Input>
+    <Output>
+      <IndexMetric><![CDATA[{"UtilizedSingleIndexes":[{"FilterExpression":"","IndexSpec":"\/id\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"},{"FilterExpression":"","IndexSpec":"\/name\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"}],"PotentialSingleIndexes":[],"UtilizedCompositeIndexes":[],"PotentialCompositeIndexes":[]}]]></IndexMetric>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[GroupBy Value 5]]></Description>
+      <Query><![CDATA[SELECT VALUE COUNT(1) FROM c WHERE c.id = "1" GROUP BY c.id, c.name]]></Query>
+    </Input>
+    <Output>
+      <IndexMetric><![CDATA[{"UtilizedSingleIndexes":[{"FilterExpression":"","IndexSpec":"\/id\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"}],"PotentialSingleIndexes":[],"UtilizedCompositeIndexes":[],"PotentialCompositeIndexes":[]}]]></IndexMetric>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[GroupBy Value 6]]></Description>
+      <Query><![CDATA[SELECT VALUE COUNT(1) FROM c WHERE c.id = "1" and c.name = "Abc" GROUP BY c.id, c.name]]></Query>
+    </Input>
+    <Output>
+      <IndexMetric><![CDATA[{"UtilizedSingleIndexes":[{"FilterExpression":"","IndexSpec":"\/id\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"},{"FilterExpression":"","IndexSpec":"\/name\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"}],"PotentialSingleIndexes":[],"UtilizedCompositeIndexes":[],"PotentialCompositeIndexes":[]}]]></IndexMetric>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[GroupBy Value 7]]></Description>
+      <Query><![CDATA[SELECT VALUE COUNT(1) FROM c WHERE c.id = "1" and c.name > "Abc" GROUP BY c.id, c.name]]></Query>
+    </Input>
+    <Output>
+      <IndexMetric><![CDATA[{"UtilizedSingleIndexes":[{"FilterExpression":"","IndexSpec":"\/id\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"},{"FilterExpression":"","IndexSpec":"\/name\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"}],"PotentialSingleIndexes":[],"UtilizedCompositeIndexes":[],"PotentialCompositeIndexes":[{"IndexSpecs":["\/id ASC","\/name ASC"],"IndexPreciseSet":false,"IndexImpactScore":"High"}]}]]></IndexMetric>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[GroupBy Value 8]]></Description>
+      <Query><![CDATA[SELECT VALUE COUNT(1) FROM c WHERE c.id > "1" and c.name > "Abc" GROUP BY c.id, c.name]]></Query>
+    </Input>
+    <Output>
+      <IndexMetric><![CDATA[{"UtilizedSingleIndexes":[{"FilterExpression":"","IndexSpec":"\/id\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"},{"FilterExpression":"","IndexSpec":"\/name\/?","FilterPreciseSet":true,"IndexPreciseSet":true,"IndexImpactScore":"High"}],"PotentialSingleIndexes":[],"UtilizedCompositeIndexes":[],"PotentialCompositeIndexes":[]}]]></IndexMetric>
+    </Output>
+  </Result>
+</Results>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/IndexMetricsParserBaselineTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/IndexMetricsParserBaselineTest.cs
@@ -375,7 +375,9 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests
         }
 
         public override IndexMetricsParserTestOutput ExecuteTest(IndexMetricsParserTestInput input)
-        { 
+        {
+            string indexMetricsNonODE = default;
+            // Execute without ODE
             QueryRequestOptions requestOptions = new QueryRequestOptions() { PopulateIndexMetrics = true, EnableOptimisticDirectExecution = false };
 
             FeedIterator<CosmosElement> itemQuery = testContainer.GetItemQueryIterator<CosmosElement>(
@@ -383,12 +385,61 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests
                 requestOptions: requestOptions);
 
             // Index Metrics is returned fully on the first page so no need to worry about result set
-            FeedResponse<CosmosElement> page = itemQuery.ReadNextAsync().Result;
-            Assert.IsTrue(page.Headers.AllKeys().Length > 1);
-            Assert.IsNotNull(page.Headers.Get(HttpConstants.HttpHeaders.IndexUtilization), "Expected index utilization headers for query");
-            Assert.IsNotNull(page.IndexMetrics, "Expected index metrics response for query");
+            int roundTripCount = 1;
+            while (itemQuery.HasMoreResults)
+            {
+                FeedResponse<CosmosElement> page = itemQuery.ReadNextAsync().Result;
+                Assert.IsTrue(page.Headers.AllKeys().Length > 1);
 
-            return new IndexMetricsParserTestOutput(page.IndexMetrics);            
+                if (roundTripCount > 1)
+                {
+                     if (page.IndexMetrics != null) Assert.Fail("Expected only Index Metrics on first round trip. Current round trip %n", roundTripCount);
+                }
+                else
+                {
+                    Assert.IsNotNull(page.Headers.Get(HttpConstants.HttpHeaders.IndexUtilization), "Expected index utilization headers for query");
+                    Assert.IsNotNull(page.IndexMetrics, "Expected index metrics response for query");
+
+                    indexMetricsNonODE = page.IndexMetrics;
+                }
+
+                roundTripCount++;
+            }
+
+            // Execute with ODE
+            string indexMetricsODE = default;
+            QueryRequestOptions requestOptions2 = new QueryRequestOptions() { PopulateIndexMetrics = true, EnableOptimisticDirectExecution = true };
+
+            FeedIterator<CosmosElement> itemQuery2 = testContainer.GetItemQueryIterator<CosmosElement>(
+                input.Query,
+                requestOptions: requestOptions2);
+
+            // Index Metrics is returned fully on the first page so no need to worry about result set
+            int roundTripCount2 = 1;
+            while (itemQuery2.HasMoreResults)
+            {
+                FeedResponse<CosmosElement> page2 = itemQuery2.ReadNextAsync().Result;
+                Assert.IsTrue(page2.Headers.AllKeys().Length > 1);
+
+                if (roundTripCount2 > 1)
+                {
+                    if (page2.IndexMetrics != null) Assert.Fail("Expected only Index Metrics on first round trip. Current round trip %n", roundTripCount2);
+                }
+                else
+                {
+                    Assert.IsNotNull(page2.Headers.Get(HttpConstants.HttpHeaders.IndexUtilization), "Expected index utilization headers for query");
+                    Assert.IsNotNull(page2.IndexMetrics, "Expected index metrics response for query");
+
+                    indexMetricsODE = page2.IndexMetrics;
+                }
+
+                roundTripCount2++;
+            }
+
+            // Make sure ODE and non-ODE is consistent
+            Assert.AreEqual(indexMetricsNonODE, indexMetricsODE);
+
+            return new IndexMetricsParserTestOutput(indexMetricsNonODE);            
         }
     }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Microsoft.Azure.Cosmos.EmulatorTests.csproj
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Microsoft.Azure.Cosmos.EmulatorTests.csproj
@@ -34,6 +34,7 @@
     <None Remove="BaselineTest\TestBaseline\EndToEndTraceWriterBaselineTests.ReadManyAsync.xml" />
     <None Remove="BaselineTest\TestBaseline\EndToEndTraceWriterBaselineTests.StreamPointOperationsAsync.xml" />
     <None Remove="BaselineTest\TestBaseline\EndToEndTraceWriterBaselineTests.TypedPointOperationsAsync.xml" />
+	<None Remove="BaselineTest\TestBaseline\IndexMetricsParserBaselineTest.IndexUtilizationClientSideExistenceTest.xml" />
 	<None Remove="BaselineTest\TestBaseline\IndexMetricsParserBaselineTest.IndexUtilizationParse.xml" />
 	<None Remove="BaselineTest\TestBaseline\IndexMetricsParserBaselineTest.IndexUtilizationHeaderLengthTest.xml" />
 	<None Remove="BaselineTest\TestBaseline\LinqGeneralBaselineTests.TestLambdaReuse.xml" />
@@ -102,6 +103,9 @@
     <Content Include="BaselineTest\TestBaseline\EndToEndTraceWriterBaselineTests.ChangeFeedAsync.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+	<Content Include="BaselineTest\TestBaseline\IndexMetricsParserBaselineTest.IndexUtilizationClientSideExistenceTest.xml">
+		<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+	</Content>
 	<Content Include="BaselineTest\TestBaseline\IndexMetricsParserBaselineTest.IndexUtilizationParse.xml">
 		<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 	</Content>


### PR DESCRIPTION
# Pull Request Template

## Description

The AggregateQueryPipelineStageClient after aggregating results erroneously removed all additional headers in the response message, resulting in a loss of IndexMetrics advice from the SDK side. This is repro-able on all Aggregate queries.

This PR adds back the additional headers in the final aggregated Query Page. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #4210