### PR TITLE
[Internal] Query: Adds environment variable for overriding EnableOptimisticDirectExecution default

### DIFF
--- a/Microsoft.Azure.Cosmos/src/RequestOptions/QueryRequestOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/RequestOptions/QueryRequestOptions.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.Cosmos
         /// <value>
         /// Direct (optimistic) execution offers improved performance for several kinds of queries such as a single partition streaming query.
         /// </value>
-        public bool EnableOptimisticDirectExecution { get; set; } = true;
+        public bool EnableOptimisticDirectExecution { get; set; } = ConfigurationManager.IsOptimisticDirectExecutionEnabled(defaultValue: true);
 
         /// <summary>
         /// Gets or sets the maximum number of items that can be buffered client side during 

--- a/Microsoft.Azure.Cosmos/src/Util/ConfigurationManager.cs
+++ b/Microsoft.Azure.Cosmos/src/Util/ConfigurationManager.cs
@@ -22,6 +22,11 @@ namespace Microsoft.Azure.Cosmos
         /// </summary>
         internal static readonly string PartitionLevelFailoverEnabled = "AZURE_COSMOS_PARTITION_LEVEL_FAILOVER_ENABLED";
 
+        /// <summary>
+        /// Environment variable name for overriding optimistic direct execution of queries.
+        /// </summary>
+        internal static readonly string OptimisticDirectExecutionEnabled = "AZURE_COSMOS_OPTIMISTIC_DIRECT_EXECUTION_ENABLED";
+
         public static T GetEnvironmentVariable<T>(string variable, T defaultValue)
         {
             string value = Environment.GetEnvironmentVariable(variable);
@@ -70,6 +75,18 @@ namespace Microsoft.Azure.Cosmos
             return ConfigurationManager
                     .GetEnvironmentVariable(
                         variable: ConfigurationManager.PartitionLevelFailoverEnabled,
+                        defaultValue: defaultValue);
+        }
+
+        /// <summary>
+        /// Gets the boolean value indicating whether optimistic direct execution is enabled based on the environment variable override.
+        /// </summary>
+        public static bool IsOptimisticDirectExecutionEnabled(
+            bool defaultValue)
+        {
+            return ConfigurationManager
+                    .GetEnvironmentVariable(
+                        variable: OptimisticDirectExecutionEnabled,
                         defaultValue: defaultValue);
         }
     }


### PR DESCRIPTION
# Pull Request Template

## Description

Cherry-pick of following PR from master:
https://github.com/Azure/azure-cosmos-dotnet-v3/pull/4299

This change adds an ability to override the default value of EnableOptimisticDirectExecution setting using an environment variable named "AZURE_COSMOS_OPTIMISTIC_DIRECT_EXECUTION_ENABLED".
The environment variable should have a value that can be parsed as a boolean in order for the override to work.

As before the default value is true and also the backend setting using clientDisableOptimisticDirectExecution acts as a master switch and acts as global account-level override to disable/enable ODE behavior (in clients).

The environment variable can be used while upgrading the sdk package to 3.38 onwards, which turns on ODE by default. As mentioned in the release notes (of 3.38), due to the use of a new type of continuation token, applications that execute queries (and their continuations) in a stateless manner on machines that can be using different versions of sdk, failures can be observed.
This environment variable can be set to true before upgrading the sdk package to avoid such failures during the sdk deployment process in production environment. Once the upgrade is complete the environment variable can be removed or set to false.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber