### PR TITLE
[Hotfix] Query: Adds environment variable for overriding `EnableOptimisticDirectExecution` default

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,9 +1,9 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
-		<ClientOfficialVersion>3.38.0</ClientOfficialVersion>
+		<ClientOfficialVersion>3.38.1</ClientOfficialVersion>
 		<ClientPreviewVersion>3.39.0</ClientPreviewVersion>
-		<ClientPreviewSuffixVersion>preview.0</ClientPreviewSuffixVersion>
-		<DirectVersion>3.32.0</DirectVersion>
+		<ClientPreviewSuffixVersion>preview.1</ClientPreviewSuffixVersion>
+		<DirectVersion>3.32.1</DirectVersion>
 		<EncryptionOfficialVersion>2.0.4</EncryptionOfficialVersion>
 		<EncryptionPreviewVersion>2.1.0</EncryptionPreviewVersion>
 		<EncryptionPreviewSuffixVersion>preview4</EncryptionPreviewSuffixVersion>

--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,21 @@ Preview features are treated as a separate branch and will not be included in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### <a name="3.39.0-preview.1"/> [3.39.0-preview.1](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.39.0-preview.1) - 2024-02-02
+### <a name="3.38.1"/> [3.38.1](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.38.1) - 2024-02-02
+
+#### Fixed
+- [4294](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/4294) DisableServerCertificateValidation: Fixes Default HttpClient to honor DisableServerCertificateValidation (#4294)
+
+#### Added
+- [4299](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/4299) Query: Adds environment variable for overriding EnableOptimisticDirectExecution default (#4299)
+  > Note: This change provides another way to manage the upgrade to `3.38`. It provides an option to avoid potential disruption due to the breaking change (see the note below) if only config deployment is preferred, instead of any explicit code modification.
+  > With this change, users can set the environment variable AZURE_COSMOS_OPTIMISTIC_DIRECT_EXECUTION_ENABLED to false in their production environments while upgrading from previous minor version (`3.37` or below) to `3.38.1` (or above).
+  > This will signal the SDK to disable Optimistic Direct Execution by default.
+  > Once the environment is fully upgraded to the target version, the environment variable can be removed (or set to true) to enable ODE.
+  > It is recommended that the environment variable is used only to manage the upgrade and removed once the deployment is complete.
+  > Please note that environment variable acts as the override only for choosing the default value. If the code explicitly modifies the setting, that value will be honored during actual operations.
+
 ### <a name="3.39.0-preview.0"/> [3.39.0-preview.0](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.39.0-preview.0) - 2024-01-31
 
 #### Added


### PR DESCRIPTION
# Pull Request Template

## Description

Cherry-pick of following PR from master:

- #4299 

This change adds an ability to override the default value of EnableOptimisticDirectExecution setting using an environment variable named `AZURE_COSMOS_OPTIMISTIC_DIRECT_EXECUTION_ENABLED`.
The environment variable should have a value that can be parsed as a `Boolean` in order for the override to work.

As before the default value is true and also the backend setting using `clientDisableOptimisticDirectExecution` acts as a master switch and acts as global account-level override to disable/enable ODE behavior (in clients).

The environment variable can be used while upgrading the sdk package to 3.38 onwards, which turns on ODE by default. As mentioned in the release notes (of [`3.38.0`](https://github.com/Azure/azure-cosmos-dotnet-v3/releases/tag/3.38.0)), due to the use of a new type of continuation token, applications that execute queries (and their continuations) in a stateless manner on machines that can be using different versions of sdk, failures can be observed.

This environment variable can be set to true before upgrading the sdk package to avoid such failures during the sdk deployment process in production environment. Once the upgrade is complete the environment variable can be removed or set to false.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #IssueNumber