### PR TITLE
[Internal] Query: Fixes occasional hang while querying using partial partition key against a sub-partitioned container

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/Parallel/ParallelCrossPartitionQueryPipelineStage.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/Parallel/ParallelCrossPartitionQueryPipelineStage.cs
@@ -14,6 +14,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.Parallel
     using Microsoft.Azure.Cosmos.Query.Core.Exceptions;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
+    using Microsoft.Azure.Cosmos.Query.Core.QueryClient;
     using Microsoft.Azure.Cosmos.Tracing;
     using static Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.PartitionMapper;
 
@@ -134,6 +135,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.Parallel
             IReadOnlyList<FeedRangeEpk> targetRanges,
             Cosmos.PartitionKey? partitionKey,
             QueryPaginationOptions queryPaginationOptions,
+            ContainerQueryProperties containerQueryProperties,
             int maxConcurrency,
             PrefetchPolicy prefetchPolicy,
             CosmosElement continuationToken)
@@ -158,7 +160,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.Parallel
 
             CrossPartitionRangePageAsyncEnumerator<QueryPage, QueryState> crossPartitionPageEnumerator = new CrossPartitionRangePageAsyncEnumerator<QueryPage, QueryState>(
                 feedRangeProvider: documentContainer,
-                createPartitionRangeEnumerator: ParallelCrossPartitionQueryPipelineStage.MakeCreateFunction(documentContainer, sqlQuerySpec, queryPaginationOptions, partitionKey),
+                createPartitionRangeEnumerator: ParallelCrossPartitionQueryPipelineStage.MakeCreateFunction(documentContainer, sqlQuerySpec, queryPaginationOptions, partitionKey, containerQueryProperties),
                 comparer: Comparer.Singleton,
                 maxConcurrency: maxConcurrency,
                 prefetchPolicy: prefetchPolicy,
@@ -243,12 +245,14 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.Parallel
             IQueryDataSource queryDataSource,
             SqlQuerySpec sqlQuerySpec,
             QueryPaginationOptions queryPaginationOptions,
-            Cosmos.PartitionKey? partitionKey) => (FeedRangeState<QueryState> feedRangeState) => new QueryPartitionRangePageAsyncEnumerator(
+            Cosmos.PartitionKey? partitionKey,
+            ContainerQueryProperties containerQueryProperties) => (FeedRangeState<QueryState> feedRangeState) => new QueryPartitionRangePageAsyncEnumerator(
                 queryDataSource,
                 sqlQuerySpec,
                 feedRangeState,
                 partitionKey,
-                queryPaginationOptions);
+                queryPaginationOptions,
+                containerQueryProperties);
 
         private sealed class Comparer : IComparer<PartitionRangePageAsyncEnumerator<QueryPage, QueryState>>
         {

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/Parallel/QueryPartitionRangePageAsyncEnumerator.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/Parallel/QueryPartitionRangePageAsyncEnumerator.cs
@@ -68,66 +68,77 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.Parallel
             // We sadly need to check the partition key, since a user can set a partition key in the request options with a different continuation token.
             // In the future the partition filtering and continuation information needs to be a tightly bounded contract (like cross feed range state).
             FeedRangeInternal feedRange = this.FeedRangeState.FeedRange;
-
-            if (feedRange is FeedRangeEpk feedRangeEpk && this.partitionKey.HasValue)
+            if (this.partitionKey.HasValue)
             {
-                if (this.containerQueryProperties.EffectiveRangesForPartitionKey == null ||
-                    this.containerQueryProperties.EffectiveRangesForPartitionKey.Count == 0)
+                // ISSUE-HACK-adityasa-3/25/2024 - We should not update the original feed range inside this class.
+                // Instead we should guarantee that when enumerator is instantiated it is limited to a single physical partition.
+                // Ultimately we should remove enumerator's dependency on PartitionKey.
+                if ((this.containerQueryProperties.PartitionKeyDefinition.Paths.Count > 1) &&
+                    (this.partitionKey.Value.InternalKey.Components.Count != this.containerQueryProperties.PartitionKeyDefinition.Paths.Count) &&
+                    (feedRange is FeedRangeEpk feedRangeEpk))
                 {
-                    throw new InvalidOperationException(
-                        "EffectiveRangesForPartitionKey should be populated when PK is specified in request options.");
-                }
-
-                foreach (Documents.Routing.Range<String> epkForPartitionKey in
-                    this.containerQueryProperties.EffectiveRangesForPartitionKey)
-                {
-                    if (Documents.Routing.Range<String>.CheckOverlapping(
-                            feedRangeEpk.Range,
-                            epkForPartitionKey))
+                    if (this.containerQueryProperties.EffectiveRangesForPartitionKey == null ||
+                        this.containerQueryProperties.EffectiveRangesForPartitionKey.Count == 0)
                     {
-                        if (!feedRangeEpk.Range.Equals(epkForPartitionKey))
-                        {
-                            String overlappingMin;
-                            bool minInclusive;
-                            String overlappingMax;
-                            bool maxInclusive;
-
-                            if (Documents.Routing.Range<String>.MinComparer.Instance.Compare(
-                                    epkForPartitionKey,
-                                    feedRangeEpk.Range) < 0)
-                            {
-                                overlappingMin = feedRangeEpk.Range.Min;
-                                minInclusive = feedRangeEpk.Range.IsMinInclusive;
-                            }
-                            else
-                            {
-                                overlappingMin = epkForPartitionKey.Min;
-                                minInclusive = epkForPartitionKey.IsMinInclusive;
-                            }
-
-                            if (Documents.Routing.Range<String>.MaxComparer.Instance.Compare(
-                                    epkForPartitionKey,
-                                    feedRangeEpk.Range) > 0)
-                            {
-                                overlappingMax = feedRangeEpk.Range.Max;
-                                maxInclusive = feedRangeEpk.Range.IsMaxInclusive;
-                            }
-                            else
-                            {
-                                overlappingMax = epkForPartitionKey.Max;
-                                maxInclusive = epkForPartitionKey.IsMaxInclusive;
-                            }
-
-                            feedRange = new FeedRangeEpk(
-                                new Documents.Routing.Range<String>(
-                                    overlappingMin,
-                                    overlappingMax,
-                                    minInclusive,
-                                    maxInclusive));
-                        }
-
-                        break;
+                        throw new InvalidOperationException(
+                            "EffectiveRangesForPartitionKey should be populated when PK is specified in request options.");
                     }
+
+                    foreach (Documents.Routing.Range<String> epkForPartitionKey in
+                        this.containerQueryProperties.EffectiveRangesForPartitionKey)
+                    {
+                        if (Documents.Routing.Range<String>.CheckOverlapping(
+                                feedRangeEpk.Range,
+                                epkForPartitionKey))
+                        {
+                            if (!feedRangeEpk.Range.Equals(epkForPartitionKey))
+                            {
+                                String overlappingMin;
+                                bool minInclusive;
+                                String overlappingMax;
+                                bool maxInclusive;
+
+                                if (Documents.Routing.Range<String>.MinComparer.Instance.Compare(
+                                        epkForPartitionKey,
+                                        feedRangeEpk.Range) < 0)
+                                {
+                                    overlappingMin = feedRangeEpk.Range.Min;
+                                    minInclusive = feedRangeEpk.Range.IsMinInclusive;
+                                }
+                                else
+                                {
+                                    overlappingMin = epkForPartitionKey.Min;
+                                    minInclusive = epkForPartitionKey.IsMinInclusive;
+                                }
+
+                                if (Documents.Routing.Range<String>.MaxComparer.Instance.Compare(
+                                        epkForPartitionKey,
+                                        feedRangeEpk.Range) > 0)
+                                {
+                                    overlappingMax = feedRangeEpk.Range.Max;
+                                    maxInclusive = feedRangeEpk.Range.IsMaxInclusive;
+                                }
+                                else
+                                {
+                                    overlappingMax = epkForPartitionKey.Max;
+                                    maxInclusive = epkForPartitionKey.IsMaxInclusive;
+                                }
+
+                                feedRange = new FeedRangeEpk(
+                                    new Documents.Routing.Range<String>(
+                                        overlappingMin,
+                                        overlappingMax,
+                                        minInclusive,
+                                        maxInclusive));
+                            }
+
+                            break;
+                        }
+                    }
+                }
+                else
+                {
+                    feedRange = new FeedRangePartitionKey(this.partitionKey.Value);
                 }
             }
 

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/Parallel/QueryPartitionRangePageAsyncEnumerator.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/Parallel/QueryPartitionRangePageAsyncEnumerator.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.Parallel
     using Microsoft.Azure.Cosmos.Pagination;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
+    using Microsoft.Azure.Cosmos.Query.Core.QueryClient;
     using Microsoft.Azure.Cosmos.Tracing;
 
     internal sealed class QueryPartitionRangePageAsyncEnumerator : PartitionRangePageAsyncEnumerator<QueryPage, QueryState>
@@ -17,6 +18,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.Parallel
         private readonly IQueryDataSource queryDataSource;
         private readonly SqlQuerySpec sqlQuerySpec;
         private readonly QueryPaginationOptions queryPaginationOptions;
+        private readonly ContainerQueryProperties containerQueryProperties;
         private readonly Cosmos.PartitionKey? partitionKey;
 
         public QueryPartitionRangePageAsyncEnumerator(
@@ -24,13 +26,15 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.Parallel
             SqlQuerySpec sqlQuerySpec,
             FeedRangeState<QueryState> feedRangeState,
             Cosmos.PartitionKey? partitionKey,
-            QueryPaginationOptions queryPaginationOptions)
+            QueryPaginationOptions queryPaginationOptions,
+            ContainerQueryProperties containerQueryProperties)
             : base(feedRangeState)
         {
             this.queryDataSource = queryDataSource ?? throw new ArgumentNullException(nameof(queryDataSource));
             this.sqlQuerySpec = sqlQuerySpec ?? throw new ArgumentNullException(nameof(sqlQuerySpec));
             this.queryPaginationOptions = queryPaginationOptions;
             this.partitionKey = partitionKey;
+            this.containerQueryProperties = containerQueryProperties;
         }
 
         public override ValueTask DisposeAsync() => default;
@@ -42,15 +46,92 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.Parallel
                 throw new ArgumentNullException(nameof(trace));
             }
 
-            // We sadly need to check the partition key, since a user can set a partition key in the request options with a different continuation token.
-            // In the future the partition filtering and continuation information needs to be a tightly bounded contract (like cross feed range state).
-            FeedRangeInternal feedRange = this.partitionKey.HasValue ? new FeedRangePartitionKey(this.partitionKey.Value) : this.FeedRangeState.FeedRange;
+            FeedRangeInternal feedRange = this.LimitFeedRangeToSinglePartition();
             return this.queryDataSource.MonadicQueryAsync(
               sqlQuerySpec: this.sqlQuerySpec,
               feedRangeState: new FeedRangeState<QueryState>(feedRange, this.FeedRangeState.State),
               queryPaginationOptions: this.queryPaginationOptions,
               trace: trace,
               cancellationToken);
+        }
+
+        /// <summary>
+        /// Updates the FeedRange to limit the scope of this enumerator to single physical partition.
+        /// Generally speaking, a subpartitioned container can experience split partition at any level of hierarchical partition key.
+        /// This could cause a situation where more than one physical partition contains the data for a partial partition key.
+        /// Currently, enumerator instantiation does not honor physical partition boundary and allocates entire epk range which could spans across multiple physical partitions to the enumerator.
+        /// Since such an epk range does not exist at the container level, Service generates a GoneException.
+        /// This method restrics the range of each container by shrinking the ends of the range so that they do not span across physical partition.
+        /// </summary>
+        private FeedRangeInternal LimitFeedRangeToSinglePartition()
+        {
+            // We sadly need to check the partition key, since a user can set a partition key in the request options with a different continuation token.
+            // In the future the partition filtering and continuation information needs to be a tightly bounded contract (like cross feed range state).
+            FeedRangeInternal feedRange = this.FeedRangeState.FeedRange;
+
+            if (feedRange is FeedRangeEpk feedRangeEpk && this.partitionKey.HasValue)
+            {
+                if (this.containerQueryProperties.EffectiveRangesForPartitionKey == null ||
+                    this.containerQueryProperties.EffectiveRangesForPartitionKey.Count == 0)
+                {
+                    throw new InvalidOperationException(
+                        "EffectiveRangesForPartitionKey should be populated when PK is specified in request options.");
+                }
+
+                foreach (Documents.Routing.Range<String> epkForPartitionKey in
+                    this.containerQueryProperties.EffectiveRangesForPartitionKey)
+                {
+                    if (Documents.Routing.Range<String>.CheckOverlapping(
+                            feedRangeEpk.Range,
+                            epkForPartitionKey))
+                    {
+                        if (!feedRangeEpk.Range.Equals(epkForPartitionKey))
+                        {
+                            String overlappingMin;
+                            bool minInclusive;
+                            String overlappingMax;
+                            bool maxInclusive;
+
+                            if (Documents.Routing.Range<String>.MinComparer.Instance.Compare(
+                                    epkForPartitionKey,
+                                    feedRangeEpk.Range) < 0)
+                            {
+                                overlappingMin = feedRangeEpk.Range.Min;
+                                minInclusive = feedRangeEpk.Range.IsMinInclusive;
+                            }
+                            else
+                            {
+                                overlappingMin = epkForPartitionKey.Min;
+                                minInclusive = epkForPartitionKey.IsMinInclusive;
+                            }
+
+                            if (Documents.Routing.Range<String>.MaxComparer.Instance.Compare(
+                                    epkForPartitionKey,
+                                    feedRangeEpk.Range) > 0)
+                            {
+                                overlappingMax = feedRangeEpk.Range.Max;
+                                maxInclusive = feedRangeEpk.Range.IsMaxInclusive;
+                            }
+                            else
+                            {
+                                overlappingMax = epkForPartitionKey.Max;
+                                maxInclusive = epkForPartitionKey.IsMaxInclusive;
+                            }
+
+                            feedRange = new FeedRangeEpk(
+                                new Documents.Routing.Range<String>(
+                                    overlappingMin,
+                                    overlappingMax,
+                                    minInclusive,
+                                    maxInclusive));
+                        }
+
+                        break;
+                    }
+                }
+            }
+
+            return feedRange;
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/OptimisticDirectExecution/OptimisticDirectExecutionQueryPipelineStage.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/OptimisticDirectExecution/OptimisticDirectExecutionQueryPipelineStage.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.OptimisticDirectExecutionQu
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.Parallel;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
+    using Microsoft.Azure.Cosmos.Query.Core.QueryClient;
     using Microsoft.Azure.Cosmos.Tracing;
     using Microsoft.Azure.Documents;
 
@@ -137,6 +138,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.OptimisticDirectExecutionQu
             DocumentContainer documentContainer,
             CosmosQueryExecutionContextFactory.InputParameters inputParameters,
             FeedRangeEpk targetRange,
+            ContainerQueryProperties containerQueryProperties,
             FallbackQueryPipelineStageFactory fallbackQueryPipelineStageFactory,
             CancellationToken cancellationToken)
         {
@@ -147,6 +149,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.OptimisticDirectExecutionQu
                 targetRange: targetRange,
                 queryPaginationOptions: paginationOptions,
                 partitionKey: inputParameters.PartitionKey,
+                containerQueryProperties: containerQueryProperties,
                 continuationToken: inputParameters.InitialUserContinuationToken,
                 cancellationToken: cancellationToken);
 
@@ -237,6 +240,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.OptimisticDirectExecutionQu
                 FeedRangeEpk targetRange,
                 Cosmos.PartitionKey? partitionKey,
                 QueryPaginationOptions queryPaginationOptions,
+                ContainerQueryProperties containerQueryProperties,
                 CosmosElement continuationToken,
                 CancellationToken cancellationToken)
             {
@@ -272,7 +276,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.OptimisticDirectExecutionQu
                     updatedSqlQuerySpec,
                     feedRangeState,
                     partitionKey,
-                    queryPaginationOptions);
+                    queryPaginationOptions,
+                    containerQueryProperties);
 
                 OptimisticDirectExecutionQueryPipelineImpl stage = new OptimisticDirectExecutionQueryPipelineImpl(partitionPageEnumerator);
                 return TryCatch<IQueryPipelineStage>.FromResult(stage);

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/PipelineFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/PipelineFactory.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Skip;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Take;
+    using Microsoft.Azure.Cosmos.Query.Core.QueryClient;
     using Microsoft.Azure.Cosmos.Query.Core.QueryPlan;
 
     internal static class PipelineFactory
@@ -32,6 +33,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline
             PartitionKey? partitionKey,
             QueryInfo queryInfo,
             QueryPaginationOptions queryPaginationOptions,
+            ContainerQueryProperties containerQueryProperties,
             int maxConcurrency,
             CosmosElement requestContinuationToken)
         {
@@ -87,6 +89,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline
                     targetRanges: targetRanges,
                     queryPaginationOptions: queryPaginationOptions,
                     partitionKey: partitionKey,
+                    containerQueryProperties: containerQueryProperties,
                     prefetchPolicy: prefetchPolicy,
                     maxConcurrency: maxConcurrency,
                     continuationToken: continuationToken);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BaselineTest/TestBaseline/SubpartitionTests.TestQueriesOnSplitContainer.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BaselineTest/TestBaseline/SubpartitionTests.TestQueriesOnSplitContainer.xml
@@ -1,6 +1,39 @@
 ﻿<Results>
   <Result>
-    <Input />
+    <Input>
+      <Description>SELECT</Description>
+      <Query><![CDATA[SELECT c.id, c.value2 FROM c]]></Query>
+      <ODE>True</ODE>
+    </Input>
+    <Output>
+      <Documents><![CDATA[{"id":"2","value2":"12"},
+{"id":"2","value2":"17"},
+{"id":"2","value2":"2"},
+{"id":"2","value2":"22"},
+{"id":"2","value2":"27"},
+{"id":"2","value2":"32"},
+{"id":"2","value2":"37"},
+{"id":"2","value2":"42"},
+{"id":"2","value2":"47"},
+{"id":"2","value2":"52"},
+{"id":"2","value2":"57"},
+{"id":"2","value2":"62"},
+{"id":"2","value2":"67"},
+{"id":"2","value2":"7"},
+{"id":"2","value2":"72"},
+{"id":"2","value2":"77"},
+{"id":"2","value2":"82"},
+{"id":"2","value2":"87"},
+{"id":"2","value2":"92"},
+{"id":"2","value2":"97"}]]></Documents>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>SELECT without ODE</Description>
+      <Query><![CDATA[SELECT c.id, c.value2 FROM c]]></Query>
+      <ODE>False</ODE>
+    </Input>
     <Output>
       <Documents><![CDATA[{"id":"2","value2":"12"},
 {"id":"2","value2":"17"},

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BaselineTest/TestBaseline/SubpartitionTests.TestQueriesOnSplitContainer.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BaselineTest/TestBaseline/SubpartitionTests.TestQueriesOnSplitContainer.xml
@@ -1,0 +1,27 @@
+﻿<Results>
+  <Result>
+    <Input />
+    <Output>
+      <Documents><![CDATA[{"id":"2","value2":"12"},
+{"id":"2","value2":"17"},
+{"id":"2","value2":"2"},
+{"id":"2","value2":"22"},
+{"id":"2","value2":"27"},
+{"id":"2","value2":"32"},
+{"id":"2","value2":"37"},
+{"id":"2","value2":"42"},
+{"id":"2","value2":"47"},
+{"id":"2","value2":"52"},
+{"id":"2","value2":"57"},
+{"id":"2","value2":"62"},
+{"id":"2","value2":"67"},
+{"id":"2","value2":"7"},
+{"id":"2","value2":"72"},
+{"id":"2","value2":"77"},
+{"id":"2","value2":"82"},
+{"id":"2","value2":"87"},
+{"id":"2","value2":"92"},
+{"id":"2","value2":"97"}]]></Documents>
+    </Output>
+  </Result>
+</Results>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Microsoft.Azure.Cosmos.Tests.csproj
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Microsoft.Azure.Cosmos.Tests.csproj
@@ -31,6 +31,7 @@
     <None Remove="BaselineTest\TestBaseline\SqlObjectVisitorBaselineTests.SqlQueries.xml" />
     <None Remove="BaselineTest\TestBaseline\SqlObjectVisitorBaselineTests.SqlScalarExpression.xml" />
     <None Remove="BaselineTest\TestBaseline\SqlObjectVisitorBaselineTests.SqlUnaryScalarOperators.xml" />
+    <None Remove="BaselineTest\TestBaseline\SubpartitionTests.TestQueriesOnSplitContainer.xml" />
     <None Remove="BaselineTest\TestBaseline\TraceWriterBaselineTests.ScenariosAsync.xml" />
     <None Remove="BaselineTest\TestBaseline\TraceWriterBaselineTests.Serialization.xml" />
     <None Remove="BaselineTest\TestBaseline\TraceWriterBaselineTests.TraceData.xml" />
@@ -349,6 +350,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Content Include="BaselineTest\TestBaseline\SubpartitionTests.TestQueriesOnSplitContainer.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="BaselineTest\TestBaseline\TraceWriterBaselineTests.TraceData.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/InMemoryContainer.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/InMemoryContainer.cs
@@ -8,15 +8,18 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
     using System.Collections;
     using System.Collections.Generic;
     using System.Collections.Immutable;
+    using Debug = System.Diagnostics.Debug;
     using System.IO;
     using System.Linq;
     using System.Reflection;
+    using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos;
     using Microsoft.Azure.Cosmos.ChangeFeed.Pagination;
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.CosmosElements.Numbers;
+    using Microsoft.Azure.Cosmos.Handlers;
     using Microsoft.Azure.Cosmos.Json;
     using Microsoft.Azure.Cosmos.Pagination;
     using Microsoft.Azure.Cosmos.Query.Core;
@@ -35,6 +38,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
     using static Microsoft.Azure.Cosmos.Query.Core.SqlQueryResumeFilter;
     using ResourceIdentifier = Cosmos.Pagination.ResourceIdentifier;
     using UInt128 = UInt128;
+    using Microsoft.Azure.Documents.Routing;
 
     // Collection useful for mocking requests and repartitioning (splits / merge).
     internal class InMemoryContainer : IMonadicDocumentContainer
@@ -46,9 +50,13 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
         private PartitionKeyHashRangeDictionary<List<Change>> partitionedChanges;
         private Dictionary<int, PartitionKeyHashRange> partitionKeyRangeIdToHashRange;
         private Dictionary<int, PartitionKeyHashRange> cachedPartitionKeyRangeIdToHashRange;
+        private readonly bool createSplitForMultiHashAtSecondlevel;
+        private readonly bool resolvePartitionsBasedOnPrefix;
 
         public InMemoryContainer(
-            PartitionKeyDefinition partitionKeyDefinition)
+            PartitionKeyDefinition partitionKeyDefinition,
+            bool createSplitForMultiHashAtSecondlevel = false,
+            bool resolvePartitionsBasedOnPrefix = false)
         {
             this.partitionKeyDefinition = partitionKeyDefinition ?? throw new ArgumentNullException(nameof(partitionKeyDefinition));
             PartitionKeyHashRange fullRange = new PartitionKeyHashRange(startInclusive: null, endExclusive: new PartitionKeyHash(Cosmos.UInt128.MaxValue));
@@ -66,6 +74,8 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
                 { 0, fullRange }
             };
             this.parentToChildMapping = new Dictionary<int, (int, int)>();
+            this.createSplitForMultiHashAtSecondlevel = createSplitForMultiHashAtSecondlevel;
+            this.resolvePartitionsBasedOnPrefix = resolvePartitionsBasedOnPrefix;
         }
 
         public Task<TryCatch<List<FeedRangeEpk>>> MonadicGetFeedRangesAsync(
@@ -472,7 +482,10 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
 
             using (ITrace childTrace = trace.StartChild("Query Transport", TraceComponent.Transport, TraceLevel.Info))
             {
-                TryCatch<int> monadicPartitionKeyRangeId = this.MonadicGetPartitionKeyRangeIdFromFeedRange(feedRangeState.FeedRange);
+                FeedRange feedRange = this.resolvePartitionsBasedOnPrefix ? 
+                    ResolveFeedRangeBasedOnPrefixContainer(feedRangeState.FeedRange, this.partitionKeyDefinition) :
+                    feedRangeState.FeedRange;
+                TryCatch<int> monadicPartitionKeyRangeId = this.MonadicGetPartitionKeyRangeIdFromFeedRange(feedRange);
                 if (monadicPartitionKeyRangeId.Failed)
                 {
                     return Task.FromResult(TryCatch<QueryPage>.FromException(monadicPartitionKeyRangeId.Exception));
@@ -943,6 +956,29 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
             return Task.FromResult(TryCatch.FromResult());
         }
 
+        internal static FeedRange ResolveFeedRangeBasedOnPrefixContainer(
+            FeedRange feedRange,
+            PartitionKeyDefinition partitionKeyDefinition)
+        {
+            if (feedRange is FeedRangePartitionKey feedRangePartitionKey)
+            {
+                if (partitionKeyDefinition != null && partitionKeyDefinition.Kind == PartitionKind.MultiHash
+                    && feedRangePartitionKey.PartitionKey.InternalKey?.Components?.Count < partitionKeyDefinition.Paths?.Count)
+                {
+                    PartitionKeyHash partitionKeyHash = feedRangePartitionKey.PartitionKey.InternalKey.Components[0] switch
+                    {
+                        null => PartitionKeyHash.V2.HashUndefined(),
+                        StringPartitionKeyComponent stringPartitionKey => PartitionKeyHash.V2.Hash((string)stringPartitionKey.ToObject()),
+                        NumberPartitionKeyComponent numberPartitionKey => PartitionKeyHash.V2.Hash(Number64.ToDouble(numberPartitionKey.Value)),
+                        _ => throw new ArgumentOutOfRangeException(),
+                    };
+                    feedRange = new FeedRangeEpk(new Documents.Routing.Range<string>(min: partitionKeyHash.Value, max: partitionKeyHash.Value + "-FF", isMinInclusive:true, isMaxInclusive: false));
+                }
+            }
+
+            return feedRange;
+        }
+
         public Task<TryCatch> MonadicMergeAsync(
             FeedRangeInternal feedRange1,
             FeedRangeInternal feedRange2,
@@ -1337,7 +1373,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
             }
         }
 
-        private TryCatch<int> MonadicGetPartitionKeyRangeIdFromFeedRange(FeedRange feedRange)
+        internal TryCatch<int> MonadicGetPartitionKeyRangeIdFromFeedRange(FeedRange feedRange)
         {
             int partitionKeyRangeId;
             if (feedRange is FeedRangeEpk feedRangeEpk)
@@ -1406,10 +1442,116 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
 
         private static PartitionKeyHashRange FeedRangeEpkToHashRange(FeedRangeEpk feedRangeEpk)
         {
-            PartitionKeyHash? start = feedRangeEpk.Range.Min == string.Empty ? (PartitionKeyHash?)null : PartitionKeyHash.Parse(feedRangeEpk.Range.Min);
-            PartitionKeyHash? end = feedRangeEpk.Range.Max == string.Empty || feedRangeEpk.Range.Max == "FF" ? (PartitionKeyHash?)null : PartitionKeyHash.Parse(feedRangeEpk.Range.Max);
+            PartitionKeyHash? start =
+                feedRangeEpk.Range.Min == string.Empty ?
+                (PartitionKeyHash?)null :
+                FromHashString(feedRangeEpk.Range.Min);
+            PartitionKeyHash? end = 
+                feedRangeEpk.Range.Max == string.Empty || feedRangeEpk.Range.Max == "FF" ?
+                (PartitionKeyHash?)null :
+                FromHashString(feedRangeEpk.Range.Max);
             PartitionKeyHashRange hashRange = new PartitionKeyHashRange(start, end);
             return hashRange;
+        }
+
+        /// <summary>
+        /// Creates a partition key hash from a rangeHash value. Supports if the rangeHash is over a hierarchical partition key.
+        /// </summary>
+        private static PartitionKeyHash FromHashString(string rangeHash)
+        {
+            List<UInt128> hashes = new();
+            foreach(string hashComponent in GetHashComponents(rangeHash))
+            {
+                // Hash FF has a special meaning in CosmosDB stack. It represents the max range which needs to be correctly represented for UInt128 parsing.
+                string value = hashComponent.Equals("FF", StringComparison.OrdinalIgnoreCase) ?
+                    "FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF-FF" :
+                    hashComponent;
+
+                bool success = UInt128.TryParse(value, out UInt128 uInt128);
+                Debug.Assert(success, "InMemoryContainer Assert!", "UInt128 parsing must succeed");
+                hashes.Add(uInt128);
+            }
+
+            return new PartitionKeyHash(hashes.ToArray());
+        }
+
+        /// <summary>
+        /// PartitionKeyHash.Parse requires a UInt128 parse-able string which itself requires hyphens to be present between subsequent byte values.
+        /// The hash values generated by rest of the (test) code may or may not honor this.
+        /// Furthermore, in case of hierarchical partitions, the hash values are concatenated together and therefore need to be broken into separate segments for parsing each one individually.
+        /// </summary>
+        /// <param name="rangeValue"></param>
+        /// <returns></returns>
+        private static IEnumerable<string> GetHashComponents(string rangeValue)
+        {
+            int start = 0;
+
+            while (start < rangeValue.Length)
+            {
+                string uInt128Segment = FixupUInt128(rangeValue, ref start);
+                yield return uInt128Segment;
+            }
+        }
+
+        private static string FixupUInt128(string buffer, ref int start)
+        {
+            string result;
+            if (buffer.Length <= start + 2)
+            {
+                result = buffer.Substring(start);
+                start = buffer.Length;
+            }
+            else
+            {
+                StringBuilder stringBuilder = new StringBuilder();
+                int index = start;
+                bool done = false;
+                int count = 0;
+                while (!done)
+                {
+                    Debug.Assert(buffer[index] != '-', "InMemoryContainer Assert!", "First character of a chunk cannot be a hyphen");
+                    stringBuilder.Append(buffer[index]);
+                    index++;
+
+                    Debug.Assert(index < buffer.Length, "InMemoryContainer Assert!", "At least 2 characters must be found in a chunk");
+                    Debug.Assert(buffer[index] != '-', "InMemoryContainer Assert!", "Second character of a chunk cannot be a hyphen");
+                    stringBuilder.Append(buffer[index]);
+                    index++;
+
+                    if ((index < buffer.Length) && (buffer[index] == '-'))
+                    {
+                        index++;
+                    }
+
+                    count++;
+                    done = count == 16 || (index >= buffer.Length);
+
+                    if (!done)
+                    {
+                        stringBuilder.Append('-');
+                    }
+                }
+
+                start = index;
+
+                result = stringBuilder.ToString();
+                Debug.Assert(
+                    result.Length >= 2,
+                    "InMemoryContainer Assert!",
+                    "At least 1 byte must be present in hash value");
+                Debug.Assert(
+                    result[0] != '-' && result[result.Length - 1] != '-',
+                    "InMemoryContainer Assert!",
+                    "Hyphens should NOT be present at the start of end of the string");
+                Debug.Assert(
+                    Enumerable
+                        .Range(1, result.Length - 1)
+                        .All(i => (i % 3 == 2) == (result[i] == '-')),
+                    "InMemoryContainer Assert!",
+                    "Hyphens should be (only) present after every subsequent byte value");
+            }
+
+            return result;
         }
 
         private static FeedRangeEpk HashRangeToFeedRangeEpk(PartitionKeyHashRange hashRange)
@@ -1441,7 +1583,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
 
             // For MultiHash Collection, split at top level to ensure documents for top level key exist across partitions
             // after split
-            if (medianPkHash.HashValues.Count > 1)
+            if (medianPkHash.HashValues.Count > 1 && !this.createSplitForMultiHashAtSecondlevel)
             {
                 return new PartitionKeyHash(medianPkHash.HashValues[0]);
             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OptimisticDirectExecutionQueryBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OptimisticDirectExecutionQueryBaselineTests.cs
@@ -1257,18 +1257,18 @@
 
         public override Task<ContainerQueryProperties> GetCachedContainerQueryPropertiesAsync(string containerLink, Cosmos.PartitionKey? partitionKey, ITrace trace, CancellationToken cancellationToken)
         {
-           return Task.FromResult(new ContainerQueryProperties(
-                "test",
-                new List<Range<string>>
-                { 
-                    new Range<string>(
-                        PartitionKeyInternal.MinimumInclusiveEffectivePartitionKey,
-                        PartitionKeyInternal.MaximumExclusiveEffectivePartitionKey,
-                        true,
-                        true)
-                },
-                new PartitionKeyDefinition(),
-                Cosmos.GeospatialType.Geometry));
+            return Task.FromResult(new ContainerQueryProperties(
+                 "test",
+                 new List<Range<string>>
+                 { 
+                     new Range<string>(
+                         PartitionKeyInternal.MinimumInclusiveEffectivePartitionKey,
+                         PartitionKeyInternal.MaximumExclusiveEffectivePartitionKey,
+                         true,
+                         true)
+                 },
+                 new PartitionKeyDefinition(),
+                 Cosmos.GeospatialType.Geometry));
         }
 
         public override Task<bool> GetClientDisableOptimisticDirectExecutionAsync()

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/FactoryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/FactoryTests.cs
@@ -28,6 +28,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                 sqlQuerySpec: new SqlQuerySpec("SELECT * FROM c"),
                 targetRanges: new List<FeedRangeEpk>() { FeedRangeEpk.FullRange },
                 partitionKey: null,
+                containerQueryProperties: new Cosmos.Query.Core.QueryClient.ContainerQueryProperties(),
                 queryInfo: new QueryInfo() { },
                 queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: 10),
                 maxConcurrency: 10,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/FullPipelineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/FullPipelineTests.cs
@@ -590,6 +590,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                 partitionKey: null,
                 GetQueryPlan(query),
                 queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: pageSize),
+                containerQueryProperties: new ContainerQueryProperties(),
                 maxConcurrency: 10,
                 requestContinuationToken: state);
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/ParallelCrossPartitionQueryPipelineStageTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/ParallelCrossPartitionQueryPipelineStageTests.cs
@@ -36,6 +36,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                 targetRanges: new List<FeedRangeEpk>() { FeedRangeEpk.FullRange },
                 queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: 10),
                 partitionKey: null,
+                containerQueryProperties: new Cosmos.Query.Core.QueryClient.ContainerQueryProperties(),
                 maxConcurrency: 10,
                 prefetchPolicy: PrefetchPolicy.PrefetchSinglePage,
                 continuationToken: null);
@@ -53,6 +54,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                 targetRanges: new List<FeedRangeEpk>() { FeedRangeEpk.FullRange },
                 queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: 10),
                 partitionKey: null,
+                containerQueryProperties: new Cosmos.Query.Core.QueryClient.ContainerQueryProperties(),
                 maxConcurrency: 10,
                 prefetchPolicy: PrefetchPolicy.PrefetchSinglePage,
                 continuationToken: CosmosObject.Create(new Dictionary<string, CosmosElement>()));
@@ -71,6 +73,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                 targetRanges: new List<FeedRangeEpk>() { FeedRangeEpk.FullRange },
                 queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: 10),
                 partitionKey: null,
+                containerQueryProperties: new Cosmos.Query.Core.QueryClient.ContainerQueryProperties(),
                 maxConcurrency: 10,
                 prefetchPolicy: PrefetchPolicy.PrefetchSinglePage,
                 continuationToken: CosmosArray.Create(new List<CosmosElement>()));
@@ -89,6 +92,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                 targetRanges: new List<FeedRangeEpk>() { FeedRangeEpk.FullRange },
                 queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: 10),
                 partitionKey: null,
+                containerQueryProperties: new Cosmos.Query.Core.QueryClient.ContainerQueryProperties(),
                 maxConcurrency: 10,
                 prefetchPolicy: PrefetchPolicy.PrefetchSinglePage,
                 continuationToken: CosmosArray.Create(new List<CosmosElement>() { CosmosString.Create("asdf") }));
@@ -111,6 +115,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                 targetRanges: new List<FeedRangeEpk>() { new FeedRangeEpk(new Documents.Routing.Range<string>(min: "A", max: "B", isMinInclusive: true, isMaxInclusive: false)) },
                 queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: 10),
                 partitionKey: null,
+                containerQueryProperties: new Cosmos.Query.Core.QueryClient.ContainerQueryProperties(),
                 maxConcurrency: 10,
                 prefetchPolicy: PrefetchPolicy.PrefetchSinglePage,
                 continuationToken: CosmosArray.Create(new List<CosmosElement>() { ParallelContinuationToken.ToCosmosElement(token) }));
@@ -140,6 +145,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                 },
                 queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: 10),
                 partitionKey: null,
+                containerQueryProperties: new Cosmos.Query.Core.QueryClient.ContainerQueryProperties(),
                 maxConcurrency: 10,
                 prefetchPolicy: PrefetchPolicy.PrefetchSinglePage,
                 continuationToken: CosmosArray.Create(
@@ -180,6 +186,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                         cancellationToken: default),
                     queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: 10),
                     partitionKey: null,
+                    containerQueryProperties: new Cosmos.Query.Core.QueryClient.ContainerQueryProperties(),
                     maxConcurrency: 10,
                     prefetchPolicy: aggressivePrefetch ? PrefetchPolicy.PrefetchAll : PrefetchPolicy.PrefetchSinglePage,
                     continuationToken: continuationToken);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/QueryPartitionRangePageEnumeratorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/QueryPartitionRangePageEnumeratorTests.cs
@@ -100,6 +100,7 @@
                             sqlQuerySpec: new Cosmos.Query.Core.SqlQuerySpec("SELECT * FROM c"),
                             feedRangeState: feedRangeState,
                             partitionKey: null,
+                            containerQueryProperties: new Cosmos.Query.Core.QueryClient.ContainerQueryProperties(),
                             queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: 10)),
                         trace: NoOpTrace.Singleton);
                     HashSet<string> resourceIdentifiers = await this.DrainFullyAsync(enumerable);
@@ -142,6 +143,7 @@
                         sqlQuerySpec: new Cosmos.Query.Core.SqlQuerySpec("SELECT * FROM c"),
                         feedRangeState: feedRangeState,
                         partitionKey: null,
+                        containerQueryProperties: new Cosmos.Query.Core.QueryClient.ContainerQueryProperties(),
                         queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: 10)),
                     trace: NoOpTrace.Singleton);
             }
@@ -164,9 +166,10 @@
                         sqlQuerySpec: new Cosmos.Query.Core.SqlQuerySpec("SELECT * FROM c"),
                         feedRangeState: new FeedRangeState<QueryState>(ranges[0], state),
                         partitionKey: null,
+                        containerQueryProperties: new Cosmos.Query.Core.QueryClient.ContainerQueryProperties(),
                         queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: 10)),
                     trace: NoOpTrace.Singleton,
-                    cancellationToken: cancellationToken);
+                    cancellationToken: default);
 
                 return Task.FromResult(enumerator);
             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/SubpartitionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/SubpartitionTests.cs
@@ -197,7 +197,7 @@
             return new QueryPartitionProvider(queryEngineConfiguration);
         }
 
-        private static PartitionKeyDefinition CreatePartitionKeyDefinition()
+        internal static PartitionKeyDefinition CreatePartitionKeyDefinition()
         {
             PartitionKeyDefinition partitionKeyDefinition = new PartitionKeyDefinition()
             {
@@ -306,7 +306,7 @@
                             true,
                             true)
                     },
-                    new PartitionKeyDefinition(),
+                    SubpartitionTests.CreatePartitionKeyDefinition(),
                     Cosmos.GeospatialType.Geometry));
             }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/SubpartitionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/SubpartitionTests.cs
@@ -1,0 +1,382 @@
+﻿namespace Microsoft.Azure.Cosmos.Tests.Query
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using System.Xml;
+    using Microsoft.Azure.Cosmos.CosmosElements;
+    using Microsoft.Azure.Cosmos.Pagination;
+    using Microsoft.Azure.Cosmos.Query;
+    using Microsoft.Azure.Cosmos.Query.Core;
+    using Microsoft.Azure.Cosmos.Query.Core.ExecutionContext;
+    using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
+    using Microsoft.Azure.Cosmos.Query.Core.QueryClient;
+    using Microsoft.Azure.Cosmos.Query.Core.QueryPlan;
+    using Microsoft.Azure.Cosmos.Routing;
+    using Microsoft.Azure.Cosmos.Test.BaselineTest;
+    using Microsoft.Azure.Cosmos.Tests.Pagination;
+    using Microsoft.Azure.Cosmos.Tracing;
+    using Microsoft.Azure.Documents;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class SubpartitionTests : BaselineTests<SubpartitionTestInput, SubpartitionTestOutput>
+    {
+        private const int DocumentCount = 100;
+        private const int SplitPartitionKey = 2;
+
+        [TestMethod]
+        public void TestQueriesOnSplitContainer()
+        {
+            this.ExecuteTestSuite(new List<SubpartitionTestInput> { new SubpartitionTestInput("Test Queries on Split container") });
+        }
+
+        /// <summary>
+        /// The test is a baseline for mock framework which splits the container at the top level of a hierarchical partition key.
+        /// After split, it is expected that more than one physical partitions contain data for some value of a top level path of partition key.
+        /// Please note that this does NOT occur in a single-partition key scenario where all data for a given value of a partition key
+        ///  is contained within single physical partition.
+        /// This situation is known to create issues, especially while running queries due to inconsistent handling of FeedRangePartitionKey and FeedRangeEpk in the SDK stack.
+        /// Test framework's behavior in being able to replicate this situation is critical to for ensuring that tests provide sufficient protection against regressions.
+        /// </summary>
+        [TestMethod]
+        public async Task VerifyTestFrameworkSupportsPartitionSplit()
+        {
+            PartitionKeyDefinition partitionKeyDefinition = CreatePartitionKeyDefinition();
+            InMemoryContainer inMemoryContainer = await CreateSplitInMemoryDocumentContainerAsync(DocumentCount, partitionKeyDefinition);
+            Cosmos.PartitionKey partitionKey = new Cosmos.PartitionKeyBuilder().Add(SplitPartitionKey.ToString()).Build();
+            FeedRangePartitionKey feedRangePartitionKey = new FeedRangePartitionKey(partitionKey);
+            FeedRangeEpk feedRangeEpk = InMemoryContainer.ResolveFeedRangeBasedOnPrefixContainer(feedRangePartitionKey, partitionKeyDefinition) as FeedRangeEpk;
+            Assert.IsNotNull(feedRangeEpk);
+            TryCatch<int> pkRangeId = inMemoryContainer.MonadicGetPartitionKeyRangeIdFromFeedRange(feedRangeEpk);
+            Assert.IsTrue(pkRangeId.Failed, $"Expected to fail for partition key {SplitPartitionKey}");
+            Assert.IsTrue(pkRangeId.Exception.InnerException.Message.StartsWith("Epk Range: [B5-D7-B7-26-D6-EA-DB-11-F1-EF-AD-92-12-15-D6-60,B5-D7-B7-26-D6-EA-DB-11-F1-EF-AD-92-12-15-D6-60-FF) is gone."), "Gone exception is expected!");
+        }
+
+        public SubpartitionTestOutput ExecuteTest2(SubpartitionTestInput input)
+        {
+            return new SubpartitionTestOutput(new List<CosmosElement>());
+        }
+
+        public override SubpartitionTestOutput ExecuteTest(SubpartitionTestInput input)
+        {
+            IMonadicDocumentContainer monadicDocumentContainer = CreateSplitDocumentContainerAsync(DocumentCount).Result;
+            DocumentContainer documentContainer = new DocumentContainer(monadicDocumentContainer);
+
+            List<CosmosElement> documents = new List<CosmosElement>();
+            QueryRequestOptions queryRequestOptions = new QueryRequestOptions()
+                {
+                    PartitionKey = new PartitionKeyBuilder().Add(SplitPartitionKey.ToString()).Build()
+                };
+            (CosmosQueryExecutionContextFactory.InputParameters inputParameters, CosmosQueryContextCore cosmosQueryContextCore) =
+                CreateInputParamsAndQueryContext(queryRequestOptions);
+            IQueryPipelineStage queryPipelineStage = CosmosQueryExecutionContextFactory.Create(
+                        documentContainer,
+                        cosmosQueryContextCore,
+                        inputParameters,
+                        NoOpTrace.Singleton);
+            while (queryPipelineStage.MoveNextAsync(NoOpTrace.Singleton, cancellationToken: default).Result)
+            {
+                TryCatch<QueryPage> tryGetPage = queryPipelineStage.Current;
+
+                if (tryGetPage.Failed)
+                {
+                    Assert.Fail("Unexpected error. Gone Exception should not reach till here");
+                }
+
+                documents.AddRange(tryGetPage.Result.Documents);
+            }
+
+            return new SubpartitionTestOutput(documents);
+        }
+
+        private static Tuple<CosmosQueryExecutionContextFactory.InputParameters, CosmosQueryContextCore> CreateInputParamsAndQueryContext(QueryRequestOptions queryRequestOptions, bool clientDisableOde = false)
+        {
+            string query = @"SELECT c.id, c.value2 FROM c";
+            CosmosElement continuationToken = null;
+            PartitionKeyDefinition partitionKeyDefinition = new PartitionKeyDefinition()
+            {
+                Paths = new System.Collections.ObjectModel.Collection<string>()
+                {
+                    "/id",
+                    "/value1",
+                    "/value2"
+                },
+                Kind = PartitionKind.MultiHash,
+                Version = PartitionKeyDefinitionVersion.V2,
+            };
+
+            CosmosSerializerCore serializerCore = new();
+            using StreamReader streamReader = new(serializerCore.ToStreamSqlQuerySpec(new SqlQuerySpec(query), Documents.ResourceType.Document));
+            string sqlQuerySpecJsonString = streamReader.ReadToEnd();
+
+            (PartitionedQueryExecutionInfo partitionedQueryExecutionInfo, QueryPartitionProvider queryPartitionProvider) = GetPartitionedQueryExecutionInfoAndPartitionProvider(sqlQuerySpecJsonString, partitionKeyDefinition, clientDisableOde);
+            CosmosQueryExecutionContextFactory.InputParameters inputParameters = new CosmosQueryExecutionContextFactory.InputParameters(
+                sqlQuerySpec: new SqlQuerySpec(query),
+                initialUserContinuationToken: continuationToken,
+                initialFeedRange: null,
+                maxConcurrency: queryRequestOptions.MaxConcurrency,
+                maxItemCount: queryRequestOptions.MaxItemCount,
+                maxBufferedItemCount: queryRequestOptions.MaxBufferedItemCount,
+                partitionKey: queryRequestOptions.PartitionKey,
+                properties: new Dictionary<string, object>() { { "x-ms-query-partitionkey-definition", partitionKeyDefinition } },
+                partitionedQueryExecutionInfo: null,
+                executionEnvironment: null,
+                returnResultsInDeterministicOrder: null,
+                enableOptimisticDirectExecution: queryRequestOptions.EnableOptimisticDirectExecution,
+                testInjections: queryRequestOptions.TestSettings);
+
+            string databaseId = "db1234";
+            string resourceLink = $"dbs/{databaseId}/colls";
+            CosmosQueryContextCore cosmosQueryContextCore = new CosmosQueryContextCore(
+                client: new TestCosmosQueryClient(queryPartitionProvider),
+                resourceTypeEnum: Documents.ResourceType.Document,
+                operationType: Documents.OperationType.Query,
+                resourceType: typeof(QueryResponseCore),
+                resourceLink: resourceLink,
+                isContinuationExpected: true,
+                allowNonValueAggregateQuery: true,
+                useSystemPrefix: false,
+                correlatedActivityId: Guid.NewGuid());
+
+            return Tuple.Create(inputParameters, cosmosQueryContextCore);
+        }
+
+        internal static Tuple<PartitionedQueryExecutionInfo, QueryPartitionProvider> GetPartitionedQueryExecutionInfoAndPartitionProvider(string querySpecJsonString, PartitionKeyDefinition pkDefinition, bool clientDisableOde = false)
+        {
+            QueryPartitionProvider queryPartitionProvider = CreateCustomQueryPartitionProvider("clientDisableOptimisticDirectExecution", clientDisableOde.ToString().ToLower());
+            TryCatch<PartitionedQueryExecutionInfo> tryGetQueryPlan = queryPartitionProvider.TryGetPartitionedQueryExecutionInfo(
+                querySpecJsonString: querySpecJsonString,
+                partitionKeyDefinition: pkDefinition,
+                requireFormattableOrderByQuery: true,
+                isContinuationExpected: true,
+                allowNonValueAggregateQuery: true,
+                hasLogicalPartitionKey: false,
+                allowDCount: true,
+                useSystemPrefix: false,
+                geospatialType: Cosmos.GeospatialType.Geography);
+
+            PartitionedQueryExecutionInfo partitionedQueryExecutionInfo = tryGetQueryPlan.Succeeded ? tryGetQueryPlan.Result : throw tryGetQueryPlan.Exception;
+            return Tuple.Create(partitionedQueryExecutionInfo, queryPartitionProvider);
+        }
+
+        private static QueryPartitionProvider CreateCustomQueryPartitionProvider(string key, string value)
+        {
+            Dictionary<string, object> queryEngineConfiguration = new Dictionary<string, object>()
+            {
+                {"maxSqlQueryInputLength", 262144},
+                {"maxJoinsPerSqlQuery", 5},
+                {"maxLogicalAndPerSqlQuery", 2000},
+                {"maxLogicalOrPerSqlQuery", 2000},
+                {"maxUdfRefPerSqlQuery", 10},
+                {"maxInExpressionItemsCount", 16000},
+                {"queryMaxGroupByTableCellCount", 500000 },
+                {"queryMaxInMemorySortDocumentCount", 500},
+                {"maxQueryRequestTimeoutFraction", 0.90},
+                {"sqlAllowNonFiniteNumbers", false},
+                {"sqlAllowAggregateFunctions", true},
+                {"sqlAllowSubQuery", true},
+                {"sqlAllowScalarSubQuery", true},
+                {"allowNewKeywords", true},
+                {"sqlAllowLike", true},
+                {"sqlAllowGroupByClause", true},
+                {"maxSpatialQueryCells", 12},
+                {"spatialMaxGeometryPointCount", 256},
+                {"sqlDisableQueryILOptimization", false},
+                {"sqlDisableFilterPlanOptimization", false},
+                {"clientDisableOptimisticDirectExecution", false}
+            };
+
+            queryEngineConfiguration[key] = bool.TryParse(value, out bool boolValue) ? boolValue : value;
+
+            return new QueryPartitionProvider(queryEngineConfiguration);
+        }
+
+        private static PartitionKeyDefinition CreatePartitionKeyDefinition()
+        {
+            PartitionKeyDefinition partitionKeyDefinition = new PartitionKeyDefinition()
+            {
+                Paths = new System.Collections.ObjectModel.Collection<string>()
+                {
+                    "/id",
+                    "/value1",
+                    "/value2"
+                },
+                Kind = PartitionKind.MultiHash,
+                Version = PartitionKeyDefinitionVersion.V2,
+            };
+
+            return partitionKeyDefinition;
+        }
+
+        private static async Task<IDocumentContainer> CreateSplitDocumentContainerAsync(int numItems)
+        {
+            PartitionKeyDefinition partitionKeyDefinition = CreatePartitionKeyDefinition();
+            InMemoryContainer inMemoryContainer = await CreateSplitInMemoryDocumentContainerAsync(numItems, partitionKeyDefinition);
+            DocumentContainer documentContainer = new DocumentContainer(inMemoryContainer);
+            return documentContainer;
+        }
+
+        private static async Task<InMemoryContainer> CreateSplitInMemoryDocumentContainerAsync(int numItems, PartitionKeyDefinition partitionKeyDefinition)
+        {
+            InMemoryContainer inMemoryContainer = new InMemoryContainer(partitionKeyDefinition, createSplitForMultiHashAtSecondlevel: true, resolvePartitionsBasedOnPrefix: true);
+            for (int i = 0; i < numItems; i++)
+            {
+                // Insert an item
+                CosmosObject item = CosmosObject.Parse($"{{\"id\" : \"{i % 5}\", \"value1\" : \"{Guid.NewGuid()}\", \"value2\" : \"{i}\" }}");
+                while (true)
+                {
+                    TryCatch<Record> monadicCreateRecord = await inMemoryContainer.MonadicCreateItemAsync(item, cancellationToken: default);
+                    if (monadicCreateRecord.Succeeded)
+                    {
+                        break;
+                    }
+                }
+            }
+
+            await inMemoryContainer.MonadicSplitAsync(FeedRangeEpk.FullRange, cancellationToken: default);
+
+            return inMemoryContainer;
+        }
+        internal class TestCosmosQueryClient : CosmosQueryClient
+        {
+            private readonly QueryPartitionProvider queryPartitionProvider;
+
+            public TestCosmosQueryClient(QueryPartitionProvider queryPartitionProvider)
+            {
+                this.queryPartitionProvider = queryPartitionProvider;
+            }
+
+            public override Action<IQueryable> OnExecuteScalarQueryCallback => throw new NotImplementedException();
+
+            public override bool BypassQueryParsing()
+            {
+                return false;
+            }
+
+            public override void ClearSessionTokenCache(string collectionFullName)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override Task<TryCatch<QueryPage>> ExecuteItemQueryAsync(string resourceUri, ResourceType resourceType, OperationType operationType, Cosmos.FeedRange feedRange, QueryRequestOptions requestOptions, AdditionalRequestHeaders additionalRequestHeaders, SqlQuerySpec sqlQuerySpec, string continuationToken, int pageSize, ITrace trace, CancellationToken cancellationToken)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override Task<PartitionedQueryExecutionInfo> ExecuteQueryPlanRequestAsync(string resourceUri, ResourceType resourceType, OperationType operationType, SqlQuerySpec sqlQuerySpec, Cosmos.PartitionKey? partitionKey, string supportedQueryFeatures, Guid clientQueryCorrelationId, ITrace trace, CancellationToken cancellationToken)
+            {
+                return Task.FromResult(new PartitionedQueryExecutionInfo());
+            }
+
+            public override Task ForceRefreshCollectionCacheAsync(string collectionLink, CancellationToken cancellationToken)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override Task<ContainerQueryProperties> GetCachedContainerQueryPropertiesAsync(string containerLink, Cosmos.PartitionKey? partitionKey, ITrace trace, CancellationToken cancellationToken)
+            {
+                List<string> hashes = new();
+                foreach (Documents.Routing.IPartitionKeyComponent component in partitionKey.Value.InternalKey.Components)
+                {
+                    PartitionKeyHash partitionKeyHash = component switch
+                    {
+                        null => PartitionKeyHash.V2.HashUndefined(),
+                        Documents.Routing.StringPartitionKeyComponent stringPartitionKey => PartitionKeyHash.V2.Hash((string)stringPartitionKey.ToObject()),
+                        Documents.Routing.NumberPartitionKeyComponent numberPartitionKey => PartitionKeyHash.V2.Hash(Number64.ToDouble(numberPartitionKey.Value)),
+                        _ => throw new ArgumentOutOfRangeException(),
+                    };
+                    hashes.Add(partitionKeyHash.Value);
+                }
+
+                string min = string.Join(string.Empty, hashes);
+                string max = min + "-FF";
+                return Task.FromResult(new ContainerQueryProperties(
+                    "test",
+                    new List<Documents.Routing.Range<string>>
+                    {
+                        new Documents.Routing.Range<string>(
+                            min,
+                            max,
+                            true,
+                            true)
+                    },
+                    new PartitionKeyDefinition(),
+                    Cosmos.GeospatialType.Geometry));
+            }
+
+            public override async Task<bool> GetClientDisableOptimisticDirectExecutionAsync()
+            {
+                return this.queryPartitionProvider.ClientDisableOptimisticDirectExecution;
+            }
+
+            public override Task<List<PartitionKeyRange>> GetTargetPartitionKeyRangeByFeedRangeAsync(string resourceLink, string collectionResourceId, PartitionKeyDefinition partitionKeyDefinition, FeedRangeInternal feedRangeInternal, bool forceRefresh, ITrace trace)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override Task<List<PartitionKeyRange>> GetTargetPartitionKeyRangesAsync(string resourceLink, string collectionResourceId, IReadOnlyList<Documents.Routing.Range<string>> providedRanges, bool forceRefresh, ITrace trace)
+            {
+                return Task.FromResult(new List<PartitionKeyRange>
+                    {
+                        new PartitionKeyRange()
+                        {
+                            MinInclusive = Documents.Routing.PartitionKeyInternal.MinimumInclusiveEffectivePartitionKey,
+                            MaxExclusive = Documents.Routing.PartitionKeyInternal.MaximumExclusiveEffectivePartitionKey
+                        }
+                    });
+            }
+
+            public override Task<IReadOnlyList<PartitionKeyRange>> TryGetOverlappingRangesAsync(string collectionResourceId, Documents.Routing.Range<string> range, bool forceRefresh = false)
+            {
+                throw new NotImplementedException();
+            }
+
+            public override async Task<TryCatch<PartitionedQueryExecutionInfo>> TryGetPartitionedQueryExecutionInfoAsync(SqlQuerySpec sqlQuerySpec, ResourceType resourceType, PartitionKeyDefinition partitionKeyDefinition, bool requireFormattableOrderByQuery, bool isContinuationExpected, bool allowNonValueAggregateQuery, bool hasLogicalPartitionKey, bool allowDCount, bool useSystemPrefix, Cosmos.GeospatialType geospatialType, CancellationToken cancellationToken)
+            {
+                CosmosSerializerCore serializerCore = new();
+                using StreamReader streamReader = new(serializerCore.ToStreamSqlQuerySpec(sqlQuerySpec, Documents.ResourceType.Document));
+                string sqlQuerySpecJsonString = streamReader.ReadToEnd();
+
+                (PartitionedQueryExecutionInfo partitionedQueryExecutionInfo, QueryPartitionProvider queryPartitionProvider) = OptimisticDirectExecutionQueryBaselineTests.GetPartitionedQueryExecutionInfoAndPartitionProvider(sqlQuerySpecJsonString, partitionKeyDefinition);
+                return TryCatch<PartitionedQueryExecutionInfo>.FromResult(partitionedQueryExecutionInfo);
+            }
+        }
+    }
+
+    public class SubpartitionTestInput : BaselineTestInput
+    {
+        public SubpartitionTestInput(string description)
+            :base(description)
+        {
+        }
+
+        public override void SerializeAsXml(XmlWriter xmlWriter)
+        {
+        }
+    }
+
+    public class SubpartitionTestOutput : BaselineTestOutput
+    {
+        private readonly List<CosmosElement> documents;
+
+        internal SubpartitionTestOutput(IReadOnlyList<CosmosElement> documents)
+        {
+            this.documents = documents.ToList();
+        }
+
+        public override void SerializeAsXml(XmlWriter xmlWriter)
+        {
+            xmlWriter.WriteStartElement("Documents");
+            string content = string.Join($",{Environment.NewLine}",
+                this.documents.Select(doc => doc.ToString()).OrderBy(serializedDoc => serializedDoc));
+            xmlWriter.WriteCData(content);
+            xmlWriter.WriteEndElement();
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Tracing/TraceWriterBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Tracing/TraceWriterBaselineTests.cs
@@ -756,6 +756,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Tracing
                 partitionKey: null,
                 GetQueryPlan(query),
                 new QueryPaginationOptions(pageSizeHint: pageSize),
+                containerQueryProperties: new Cosmos.Query.Core.QueryClient.ContainerQueryProperties(),
                 maxConcurrency: 10,
                 requestContinuationToken: state);
 


### PR DESCRIPTION
# Pull Request Template

## Description

This change contains the fix for occasional hang that can occur while querying using partition partition key against a sub-partitioned container. Let's assume a container with partition key definition "/id", "/value1", "/value2". Unlike single-key partition definition, for hierarchical partitions, partition splits occurs such that for a certain value of "/id" (say 2), more than one partition contains the data for this (partial) partition value. When a query is issued with partial partition key ("/id" = 2 in this case), query enumerator (QueryPartitionRangePageAsyncEnumerator L50) attempts to query a feedrange based on this partial value that isn't fully contained inside a single physical partition in the backend. Since such a range cannot be resolved to any single physical partition, enumerator receives a GoneException from the underlying stack. The GoneException is caught by upstream (CrossPartitionRangePageAsyncEnumerator L114) which attempts to resolve the physical partition ranges by consulting the routing map. This is typically a no-op since the GoneException isn't received because of a change in state of the backend.
This doesn't actually help since CrossPartitionRangePageAsyncEnumerator attempts to locate FeedRangeEpk (without the partial partition key, which honors partition boundary) inside a physical partition range - which always succeeds and further downstream (RequestInvokerHandler.ResolveFeedRangeBasedOnPrefixContainerAsync and RequestInvokerHandler L244) ignores this FeedRangeEpk and instead queries using partial partition key (FeedRangePartitionKey) which spans across the partition boundary. The later continues to cause another GoneException and cycle repeats.

This fix limits the epk range for QueryPartitionRangePageAsyncEnumerator such that it does not span across the single physical partition range. It also uses FeedRangeEpk to represent this new partition range, which causes downstream to no longer perform extraneous operations (such as ResolveFeedRangeBasedOnPrefixContainerAsync).

Several parts of the code are suspect here and a more comprehensive fix may be needed to handle all cases generally, _outside this change_.
1. RequestInvokerHandler.ResolveFeedRangeBasedOnPrefixContainerAsync should not happen. Ignoring the FeedRange supplied by the upstream blindly is plain wrong. Instead upstream enumerators etc. should provide explicit range.
2. At the very least using type of FeedRangeInternal (Epk v/s Partition) to determine extra processing in RequestInvokerHandler should not exist. This should be an explicit action.
3. It's not clear how filtering occurs in the backend when partial partition key is specified and request lands on a physical partition where data for other logical partitions also exists. We need to replicate this behavior in the test infrastructure in the SDK so that such scenarios can be tested broadly.
4. Query enumerators should not take a dependency on partition key. Instead partition key -> physical partition resolution should take place upstream before they are instantiated.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #4326