### PR TITLE
Make `RegionNameMapper` static

### DIFF
--- a/Microsoft.Azure.Cosmos.Samples/Tools/FaultInjection/src/FaultInjectionCondition.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/FaultInjection/src/FaultInjectionCondition.cs
@@ -28,9 +28,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection
             string? region = null,
             FaultInjectionEndpoint? endpoint = null)
         {
-
-            RegionNameMapper mapper = new RegionNameMapper();
-            this.region = string.IsNullOrEmpty(region) ? string.Empty : mapper.GetCosmosDBRegionName(region);
+            this.region = string.IsNullOrEmpty(region) ? string.Empty : RegionNameMapper.GetCosmosDBRegionName(region);
 
             this.operationType = operationType ?? FaultInjectionOperationType.All;
             this.connectionType = connectionType ?? FaultInjectionConnectionType.All;
@@ -41,8 +39,8 @@ namespace Microsoft.Azure.Cosmos.FaultInjection
         /// The operation type the rule will target.
         /// </summary>
         /// <returns>the <see cref="FaultInjectionOperationType"/>.</returns>
-        public FaultInjectionOperationType GetOperationType() 
-        { 
+        public FaultInjectionOperationType GetOperationType()
+        {
             return this.operationType;
         }
 
@@ -84,7 +82,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection
                 "FaultInjectionCondition{{ OperationType: {0}, ConnectionType: {1}, Region: {2}, Endpoint: {3}",
                 this.operationType,
                 this.connectionType,
-                this.region,  
+                this.region,
                 this.endpoint.ToString());
         }
     }

--- a/Microsoft.Azure.Cosmos.Samples/Tools/FaultInjection/src/FaultInjectionConditionBuilder.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/FaultInjection/src/FaultInjectionConditionBuilder.cs
@@ -48,9 +48,8 @@ namespace Microsoft.Azure.Cosmos.FaultInjection
         /// <returns>the <see cref="FaultInjectionConditionBuilder"/></returns>
         public FaultInjectionConditionBuilder WithRegion(string region)
         {
-            RegionNameMapper mapper = new RegionNameMapper();
-            string regionName = mapper.GetCosmosDBRegionName(region);
-            this.region = string.IsNullOrEmpty(regionName) 
+            string regionName = RegionNameMapper.GetCosmosDBRegionName(region);
+            this.region = string.IsNullOrEmpty(regionName)
                 ? throw new ArgumentNullException(nameof(region), "Argument 'region' cannot be null.") 
                 : regionName;
 
@@ -77,11 +76,10 @@ namespace Microsoft.Azure.Cosmos.FaultInjection
         public FaultInjectionCondition Build()
         {
             return new FaultInjectionCondition(
-                this.operationType, 
-                this.connectionType, 
-                this.region, 
+                this.operationType,
+                this.connectionType,
+                this.region,
                 this.endpoint);
         }
-
     }
 }

--- a/Microsoft.Azure.Cosmos.Samples/Tools/FaultInjection/src/implementataion/FaultInjectionRuleProcessor.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/FaultInjection/src/implementataion/FaultInjectionRuleProcessor.cs
@@ -24,8 +24,6 @@ namespace Microsoft.Azure.Cosmos.FaultInjection
         private readonly IRoutingMapProvider routingMapProvider;
         private readonly FaultInjectionApplicationContext applicationContext;
 
-        private readonly RegionNameMapper regionNameMapper = new RegionNameMapper();
-
         /// <summary>
         /// Initializes a new instance of the <see cref="FaultInjectionRuleProcessor"/> class.
         /// </summary>
@@ -136,7 +134,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection
 
             if (!this.CanErrorLimitToOperation(errorType))
             {
-                effectiveAddresses = effectiveAddresses.Select(address => 
+                effectiveAddresses = effectiveAddresses.Select(address =>
                     new Uri(string.Format(
                         "{0}://{1}:{2}/",
                         address.Scheme.ToString(),
@@ -175,7 +173,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection
                 rule.GetCondition(),
                 this.IsWriteOnly(rule.GetCondition()));
 
-            resolvedPhysicalAdresses.ForEach(address => 
+            resolvedPhysicalAdresses.ForEach(address =>
                 new Uri(string.Format(
                 "{0}://{1}:{2}/",
                 address.Scheme.ToString(),
@@ -222,14 +220,14 @@ namespace Microsoft.Azure.Cosmos.FaultInjection
         {
             bool isWriteOnlyEndpoints = this.IsWriteOnly(condition);
 
-            if(!string.IsNullOrEmpty(condition.GetRegion()))
+            if (!string.IsNullOrEmpty(condition.GetRegion()))
             {
                 return new List<Uri> { this.ResolveFaultInjectionServiceEndpoint(condition.GetRegion(), isWriteOnlyEndpoints) };
             }
             else
             {
-                return isWriteOnlyEndpoints 
-                    ? this.globalEndpointManager.GetAvailableWriteEndpointsByLocation().Values.ToList() 
+                return isWriteOnlyEndpoints
+                    ? this.globalEndpointManager.GetAvailableWriteEndpointsByLocation().Values.ToList()
                     : this.globalEndpointManager.GetAvailableReadEndpointsByLocation().Values.ToList();
             }
         }
@@ -239,7 +237,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection
             if (isWriteOnlyEndpoints)
             {
                 if (this.globalEndpointManager.GetAvailableWriteEndpointsByLocation().TryGetValue(
-                    this.regionNameMapper.GetCosmosDBRegionName(region), 
+                    RegionNameMapper.GetCosmosDBRegionName(region),
                     out Uri? endpoint))
                 {
                     return endpoint;
@@ -248,7 +246,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection
             else
             {
                 if (this.globalEndpointManager.GetAvailableReadEndpointsByLocation().TryGetValue(
-                    this.regionNameMapper.GetCosmosDBRegionName(region),
+                    RegionNameMapper.GetCosmosDBRegionName(region),
                     out Uri? endpoint))
                 {
                     return endpoint;
@@ -260,7 +258,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection
 
         private bool IsWriteOnly(FaultInjectionCondition condition)
         {
-            return condition.GetOperationType() != FaultInjectionOperationType.All 
+            return condition.GetOperationType() != FaultInjectionOperationType.All
                 && this.GetEffectiveOperationType(condition.GetOperationType()).IsWriteOperation();
         }
 
@@ -268,11 +266,11 @@ namespace Microsoft.Azure.Cosmos.FaultInjection
             List<Uri> regionEndpoints,
             FaultInjectionCondition condition,
             bool isWriteOnly)
-        {           
+        {
             FaultInjectionEndpoint addressEndpoints = condition.GetEndpoint();
             if (addressEndpoints == null || addressEndpoints == FaultInjectionEndpoint.Empty)
             {
-                return new List<Uri>{ };
+                return new List<Uri> { };
             }
 
             List<Uri> resolvedPhysicalAddresses = new List<Uri>();
@@ -377,5 +375,5 @@ namespace Microsoft.Azure.Cosmos.FaultInjection
         {
             return this.globalEndpointManager;
         }
-    }   
+    }
 }

--- a/Microsoft.Azure.Cosmos.Samples/Tools/FaultInjection/src/implementataion/RntbdConnectionErrorInjector.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/FaultInjection/src/implementataion/RntbdConnectionErrorInjector.cs
@@ -15,14 +15,13 @@ namespace Microsoft.Azure.Cosmos.FaultInjection
     {
         private readonly FaultInjectionRuleStore ruleStore;
         private readonly FaultInjectionDynamicChannelStore channelStore;
-        private readonly RegionNameMapper regionNameMapper;
         private readonly Dictionary<string, string> regionSpecialCases;
 
         public RntbdConnectionErrorInjector(FaultInjectionRuleStore ruleStore, FaultInjectionDynamicChannelStore channelStore)
         {
             this.ruleStore = ruleStore ?? throw new ArgumentNullException(nameof(ruleStore));
             this.channelStore = channelStore ?? throw new ArgumentNullException(nameof(channelStore));
-            this.regionNameMapper = new RegionNameMapper();
+
             // Some regions have different names in the RNTBD endpoint and in the location endpoint
             // this dictionary maps the RNTBD endpoint region name to the location endpoint region name
             this.regionSpecialCases = new Dictionary<string, string>
@@ -37,7 +36,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection
 
         public bool Accept(IFaultInjectionRuleInternal rule)
         {
-            if ((rule.GetConnectionType() == FaultInjectionConnectionType.Direct 
+            if ((rule.GetConnectionType() == FaultInjectionConnectionType.Direct
                 || rule.GetConnectionType() == FaultInjectionConnectionType.All)
                 && (rule.GetType() == typeof(FaultInjectionConnectionErrorRule)))
             {
@@ -120,7 +119,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection
                                         continue;
                                     }
 
-                                    if(this.ParseRntbdEndpointForNormalizedRegion(serverUri).Equals(this.ParseRntbdEndpointForNormalizedRegion(regionEndpoint)))
+                                    if (this.ParseRntbdEndpointForNormalizedRegion(serverUri).Equals(this.ParseRntbdEndpointForNormalizedRegion(regionEndpoint)))
                                     {
                                         if (random.NextDouble() < rule.GetResult().GetThresholdPercentage())
                                         {
@@ -152,7 +151,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection
                                 //and marked unhealthy
                                 continue;
                             }
-                            
+
                             if (random.NextDouble() < rule.GetResult().GetThresholdPercentage())
                             {
                                 rule.ApplyRule();
@@ -215,8 +214,8 @@ namespace Microsoft.Azure.Cosmos.FaultInjection
         private string ParseRntbdEndpointForNormalizedRegion(Uri endpoint)
         {
             string region = endpoint.ToString().Split(new char[] { '-' })[3];
-            region = this.regionNameMapper.GetCosmosDBRegionName(
-                this.regionSpecialCases.ContainsKey(region) 
+            region = RegionNameMapper.GetCosmosDBRegionName(
+                this.regionSpecialCases.ContainsKey(region)
                 ? this.regionSpecialCases[region]
                 : region);
             return region;
@@ -226,7 +225,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection
         {
             string region = endpoint.ToString().Split(new char[] { '-' }).Last();
             region = region[0..region.IndexOf('.')];
-            region = this.regionNameMapper.GetCosmosDBRegionName(region);
+            region = RegionNameMapper.GetCosmosDBRegionName(region);
             return region;
         }
     }

--- a/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Azure.Cosmos
     ///     },
     ///     ConnectionMode = ConnectionMode.Gateway,
     /// };
-    /// 
+    ///
     /// CosmosClient client = new CosmosClient("endpoint", "key", clientOptions);
     /// ]]>
     /// </code>
@@ -148,7 +148,7 @@ namespace Microsoft.Azure.Cosmos
         /// {
         ///     ApplicationRegion = Regions.EastUS
         /// };
-        /// 
+        ///
         /// CosmosClient client = new CosmosClient("endpoint", "key", clientOptions);
         /// ]]>
         /// </code>
@@ -184,7 +184,7 @@ namespace Microsoft.Azure.Cosmos
         /// {
         ///     ApplicationPreferredRegions = new List<string>(){ Regions.EastUS, Regions.WestUS }
         /// };
-        /// 
+        ///
         /// CosmosClient client = new CosmosClient("endpoint", "key", clientOptions);
         /// ]]>
         /// </code>
@@ -872,15 +872,14 @@ namespace Microsoft.Azure.Cosmos
                 connectionPolicy.CosmosClientTelemetryOptions = this.CosmosClientTelemetryOptions;
             }
 
-            RegionNameMapper mapper = new RegionNameMapper();
             if (!string.IsNullOrEmpty(this.ApplicationRegion))
             {
-                connectionPolicy.SetCurrentLocation(mapper.GetCosmosDBRegionName(this.ApplicationRegion));
+                connectionPolicy.SetCurrentLocation(RegionNameMapper.GetCosmosDBRegionName(this.ApplicationRegion));
             }
 
             if (this.ApplicationPreferredRegions != null)
             {
-                List<string> mappedRegions = this.ApplicationPreferredRegions.Select(s => mapper.GetCosmosDBRegionName(s)).ToList();
+                List<string> mappedRegions = this.ApplicationPreferredRegions.Select(s => RegionNameMapper.GetCosmosDBRegionName(s)).ToList();
 
                 connectionPolicy.SetPreferredLocations(mappedRegions);
             }

--- a/Microsoft.Azure.Cosmos/src/RegionNameMapper.cs
+++ b/Microsoft.Azure.Cosmos/src/RegionNameMapper.cs
@@ -11,19 +11,18 @@ namespace Microsoft.Azure.Cosmos
     /// <summary>
     /// Maps a normalized region name to the format that CosmosDB is expecting (for e.g. from 'westus2' to 'West US 2')
     /// </summary>
-    internal sealed class RegionNameMapper
+    internal static class RegionNameMapper
     {
-        private readonly Dictionary<string, string> normalizedToCosmosDBRegionNameMapping;
+        private static readonly Dictionary<string, string> normalizedToCosmosDBRegionNameMapping;
 
-        public RegionNameMapper()
+        static RegionNameMapper()
         {
+            normalizedToCosmosDBRegionNameMapping = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
             FieldInfo[] fields = typeof(Regions).GetFields(BindingFlags.Public | BindingFlags.Static);
-
-            this.normalizedToCosmosDBRegionNameMapping = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
-
             foreach (FieldInfo field in fields)
             {
-                this.normalizedToCosmosDBRegionNameMapping[field.Name] = field.GetValue(null).ToString();
+                normalizedToCosmosDBRegionNameMapping[field.Name] = field.GetValue(null).ToString();
             }
         }
 
@@ -33,7 +32,7 @@ namespace Microsoft.Azure.Cosmos
         /// </summary>
         /// <param name="normalizedRegionName">An Azure region name in a normalized format. The input is not case sensitive.</param>
         /// <returns>A string that contains the region name in the format that CosmosDB expects.</returns>
-        public string GetCosmosDBRegionName(string normalizedRegionName)
+        public static string GetCosmosDBRegionName(string normalizedRegionName)
         {
             if (string.IsNullOrEmpty(normalizedRegionName))
             {
@@ -41,7 +40,7 @@ namespace Microsoft.Azure.Cosmos
             }
 
             normalizedRegionName = normalizedRegionName.Replace(" ", string.Empty);
-            if (this.normalizedToCosmosDBRegionNameMapping.TryGetValue(normalizedRegionName,
+            if (normalizedToCosmosDBRegionNameMapping.TryGetValue(normalizedRegionName,
                 out string cosmosDBRegionName))
             {
                 return cosmosDBRegionName;

--- a/Microsoft.Azure.Cosmos/src/Routing/LocationCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/LocationCache.cs
@@ -28,7 +28,6 @@ namespace Microsoft.Azure.Cosmos.Routing
         private readonly TimeSpan unavailableLocationsExpirationTime;
         private readonly int connectionLimit;
         private readonly ConcurrentDictionary<Uri, LocationUnavailabilityInfo> locationUnavailablityInfoByEndpoint;
-        private readonly RegionNameMapper regionNameMapper;
 
         private DatabaseAccountLocationsInfo locationInfo;
         private DateTime lastCacheUpdateTimestamp;
@@ -52,7 +51,6 @@ namespace Microsoft.Azure.Cosmos.Routing
             this.lastCacheUpdateTimestamp = DateTime.MinValue;
             this.enableMultipleWriteLocations = false;
             this.unavailableLocationsExpirationTime = TimeSpan.FromSeconds(LocationCache.DefaultUnavailableLocationsExpirationTimeInSeconds);
-            this.regionNameMapper = new RegionNameMapper();
 
 #if !(NETSTANDARD15 || NETSTANDARD16)
 #if NETSTANDARD20
@@ -348,13 +346,13 @@ namespace Microsoft.Azure.Cosmos.Routing
 
             foreach (string region in excludeRegions)
             {
-                string normalizedRegionName = this.regionNameMapper.GetCosmosDBRegionName(region);
+                string normalizedRegionName = RegionNameMapper.GetCosmosDBRegionName(region);
                 if (regionNameByEndpoint.ContainsKey(normalizedRegionName))
                 {
                     excludeUris.Add(regionNameByEndpoint[normalizedRegionName]);
                 }
             }
-            
+
             foreach (Uri endpoint in endpoints)
             {
                 if (!excludeUris.Contains(endpoint))

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
@@ -901,16 +901,14 @@ namespace Microsoft.Azure.Cosmos.Tests
         [TestMethod]
         public void RegionNameMappingTest()
         {
-            RegionNameMapper mapper = new RegionNameMapper();
-
             // Test normalized name
-            Assert.AreEqual(Regions.WestUS2, mapper.GetCosmosDBRegionName("westus2"));
+            Assert.AreEqual(Regions.WestUS2, RegionNameMapper.GetCosmosDBRegionName("westus2"));
 
             // Test with spaces
-            Assert.AreEqual(Regions.WestUS2, mapper.GetCosmosDBRegionName("west us 2"));
+            Assert.AreEqual(Regions.WestUS2, RegionNameMapper.GetCosmosDBRegionName("west us 2"));
 
             // Test for case insenstive
-            Assert.AreEqual(Regions.WestUS2, mapper.GetCosmosDBRegionName("wEsTuS2"));
+            Assert.AreEqual(Regions.WestUS2, RegionNameMapper.GetCosmosDBRegionName("wEsTuS2"));
         }
 
         [TestMethod]


### PR DESCRIPTION
## Description

Make class `RegionNameMapper` static to save some memory allocations.
Several trailing spaces and non-normalized carriage returns have been fixed, so I advise you to review this PR by hiding the whitespaces.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update
