### PR TITLE
Improve CosmosClient initialization ergonomics

### DIFF
--- a/Microsoft.Azure.Cosmos/src/CosmosClient.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClient.cs
@@ -1394,9 +1394,9 @@ namespace Microsoft.Azure.Cosmos
         /// <returns>A task to await on.</returns>
         public async Task InitializeContainersAsync(
             IReadOnlyList<(string databaseId, string containerId)> containers,
-            CancellationToken cancellationToken)
+            CancellationToken cancellationToken = default)
         {
-            List<Task> tasks = new ();
+            List<Task> tasks = new (containers.Count);
             foreach ((string databaseId, string containerId) in containers)
             {
                 ContainerInternal container = (ContainerInternal)this.GetContainer(

--- a/Microsoft.Azure.Cosmos/src/CosmosClient.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClient.cs
@@ -1391,7 +1391,7 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="containers">A read-only list containing the database id
         /// and their respective container id.</param>
         /// <param name="cancellationToken">An instance of <see cref="CancellationToken"/>.</param>
-        internal async Task InitializeContainersAsync(
+        public async Task InitializeContainersAsync(
             IReadOnlyList<(string databaseId, string containerId)> containers,
             CancellationToken cancellationToken)
         {

--- a/Microsoft.Azure.Cosmos/src/CosmosClient.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClient.cs
@@ -1415,6 +1415,8 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Initializes the container by creating the Rntbd
         /// connection to all of the backend replica nodes.
+        ///
+        /// Disposes the client if the initialization fails.
         /// </summary>
         /// <param name="containers">A read-only list containing the database id
         /// and their respective container id.</param>

--- a/Microsoft.Azure.Cosmos/src/CosmosClient.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClient.cs
@@ -1391,6 +1391,7 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="containers">A read-only list containing the database id
         /// and their respective container id.</param>
         /// <param name="cancellationToken">An instance of <see cref="CancellationToken"/>.</param>
+        /// <returns>A task to await on.</returns>
         public async Task InitializeContainersAsync(
             IReadOnlyList<(string databaseId, string containerId)> containers,
             CancellationToken cancellationToken)


### PR DESCRIPTION
# Pull Request Template

## Description

Improves real-world ergonomics over using `CreateAndInitializeAsync`, by making `InitializeContainersAsync` public.

```C#
serviceBuilder.AddSingleton(services =>
{
  return CosmosClient.CreateAndInitializeAsync(...containers...).GetAwaiter().GetResult();
});
```

## A better option would be 

```C#
serviceBuilder.AddSingleton(services =>
{
  var client = new CosmosClient(...);
  _ = client.InitializeContainersAsync(... containers ...);
  return client;
});
```

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [*] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [*] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #4404 