### PR TITLE
[Internal] Distributed Tracing: Fixes Client Config Test 

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Telemetry/OpenTelemetry/OpenTelemetryRecorderFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/OpenTelemetry/OpenTelemetryRecorderFactory.cs
@@ -57,7 +57,15 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                         clientContext: clientContext,
                         config: requestOptions?.CosmosThresholdOptions ?? clientContext.ClientOptions?.CosmosClientTelemetryOptions.CosmosThresholdOptions);
                 }
-
+#if !INTERNAL
+                // If there are no listeners at operation level and no parent activity created.
+                // Then create a dummy activity as there should be a parent level activity always to send a traceid to the backend services through context propagation.
+                // The parent activity id logged in diagnostics, can be used for tracing purpose in backend.
+                if (Activity.Current is null)
+                {
+                    openTelemetryRecorder = OpenTelemetryCoreRecorder.CreateParentActivity(operationName);
+                }
+#endif
                 // Safety check as diagnostic logs should not break the code.
                 if (Activity.Current?.TraceId != null)
                 {

--- a/Microsoft.Azure.Cosmos/src/Telemetry/OpenTelemetry/OpenTelemetryRecorderFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/OpenTelemetry/OpenTelemetryRecorderFactory.cs
@@ -57,15 +57,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                         clientContext: clientContext,
                         config: requestOptions?.CosmosThresholdOptions ?? clientContext.ClientOptions?.CosmosClientTelemetryOptions.CosmosThresholdOptions);
                 }
-#if !INTERNAL
-                // If there are no listeners at operation level and no parent activity created.
-                // Then create a dummy activity as there should be a parent level activity always to send a traceid to the backend services through context propagation.
-                // The parent activity id logged in diagnostics, can be used for tracing purpose in backend.
-                if (Activity.Current is null)
-                {
-                    openTelemetryRecorder = OpenTelemetryCoreRecorder.CreateParentActivity(operationName);
-                }
-#endif
+
                 // Safety check as diagnostic logs should not break the code.
                 if (Activity.Current?.TraceId != null)
                 {

--- a/Microsoft.Azure.Cosmos/src/Telemetry/OpenTelemetry/OpenTelemetryRecorderFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/OpenTelemetry/OpenTelemetryRecorderFactory.cs
@@ -69,7 +69,6 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                 // Safety check as diagnostic logs should not break the code.
                 if (Activity.Current?.TraceId != null)
                 {
-                    // This id would be useful to trace calls at backend services when distributed tracing feature is available there.
                     trace.AddDatum("DistributedTraceId", Activity.Current.TraceId);
                 }
             }

--- a/Microsoft.Azure.Cosmos/src/Telemetry/OpenTelemetry/OpenTelemetryRecorderFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/OpenTelemetry/OpenTelemetryRecorderFactory.cs
@@ -57,10 +57,19 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                         clientContext: clientContext,
                         config: requestOptions?.CosmosThresholdOptions ?? clientContext.ClientOptions?.CosmosClientTelemetryOptions.CosmosThresholdOptions);
                 }
-
+#if !INTERNAL
+                // If there are no listeners at operation level and no parent activity created.
+                // Then create a dummy activity as there should be a parent level activity always to send a traceid to the backend services through context propagation.
+                // The parent activity id logged in diagnostics, can be used for tracing purpose in backend.
+                if (Activity.Current is null)
+                {
+                    openTelemetryRecorder = OpenTelemetryCoreRecorder.CreateParentActivity(operationName);
+                }
+#endif
                 // Safety check as diagnostic logs should not break the code.
                 if (Activity.Current?.TraceId != null)
                 {
+                    // This id would be useful to trace calls at backend services when distributed tracing feature is available there.
                     trace.AddDatum("DistributedTraceId", Activity.Current.TraceId);
                 }
             }

--- a/Microsoft.Azure.Cosmos/src/Telemetry/OpenTelemetry/OpenTelemetryRecorderFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/OpenTelemetry/OpenTelemetryRecorderFactory.cs
@@ -69,6 +69,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                 // Safety check as diagnostic logs should not break the code.
                 if (Activity.Current?.TraceId != null)
                 {
+                    // This id would be useful to trace calls at backend services when distributed tracing feature is available there.
                     trace.AddDatum("DistributedTraceId", Activity.Current.TraceId);
                 }
             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientConfigurationDiagnosticTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientConfigurationDiagnosticTest.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics;
     using System.Linq;
     using System.Text;
     using System.Threading;
@@ -47,9 +46,9 @@
             Assert.IsNotNull(response.Diagnostics);
             ITrace trace = ((CosmosTraceDiagnostics)response.Diagnostics).Value;
 #if PREVIEW
-            Assert.AreEqual(trace.Data.Count, 2, string.Join(",", trace.Data.Select(a => $"{a.Key}: {a.Value}")));  // Distributed Tracing Id
+            Assert.AreEqual(actual: trace.Data.Count, expected: 2, message: string.Join(",", trace.Data.Select(a => $"{a.Key}: {a.Value}")));  // Distributed Tracing Id
 #else
-            Assert.AreEqual(trace.Data.Count, 1, string.Join(",", trace.Data.Select(a => $"{a.Key}: {a.Value}")));
+            Assert.AreEqual(actual: trace.Data.Count, expected: 1, message: string.Join(",", trace.Data.Select(a => $"{a.Key}: {a.Value}")));
 #endif
             ClientConfigurationTraceDatum clientConfigurationTraceDatum = (ClientConfigurationTraceDatum)trace.Data["Client Configuration"];
             Assert.IsNotNull(clientConfigurationTraceDatum.UserAgentContainer.UserAgent);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientConfigurationDiagnosticTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientConfigurationDiagnosticTest.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.Linq;
     using System.Text;
     using System.Threading;
@@ -46,9 +47,9 @@
             Assert.IsNotNull(response.Diagnostics);
             ITrace trace = ((CosmosTraceDiagnostics)response.Diagnostics).Value;
 #if PREVIEW
-            Assert.AreEqual(actual: trace.Data.Count, expected: 2, message: string.Join(",", trace.Data.Select(a => $"{a.Key}: {a.Value}")));  // Distributed Tracing Id
+            Assert.AreEqual(trace.Data.Count, 2, string.Join(",", trace.Data.Select(a => $"{a.Key}: {a.Value}")));  // Distributed Tracing Id
 #else
-            Assert.AreEqual(actual: trace.Data.Count, expected: 1, message: string.Join(",", trace.Data.Select(a => $"{a.Key}: {a.Value}")));
+            Assert.AreEqual(trace.Data.Count, 1, string.Join(",", trace.Data.Select(a => $"{a.Key}: {a.Value}")));
 #endif
             ClientConfigurationTraceDatum clientConfigurationTraceDatum = (ClientConfigurationTraceDatum)trace.Data["Client Configuration"];
             Assert.IsNotNull(clientConfigurationTraceDatum.UserAgentContainer.UserAgent);


### PR DESCRIPTION
## Description

**What is the change?**
Added "back", logic to generate activity id, even if customer is not subscribed to any source.

**Why is change required?**
As part of PR https://github.com/Azure/azure-cosmos-dotnet-v3/pull/4333, I removed network level traces generation, along with that, this code was also removed where we were making sure that _traceid_ is generated, even if customer is not subscribed to the any traces.

**Why was it not caught in PR pipelines?**
It is part of emulator test, and we don't run emulator test in "preview" mode, in our PR pipelines.

## Type of change
- [] Bug fix (non-breaking change which fixes an issue)

## Closing issues
This would unblock 3.39.0 release