### PR TITLE
Samples: Adds STJ LINQ Serializer Example

### DIFF
--- a/Microsoft.Azure.Cosmos.Samples/Usage/SystemTextJson/CosmosSystemTextJsonSerializer.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/SystemTextJson/CosmosSystemTextJsonSerializer.cs
@@ -1,21 +1,24 @@
 ﻿namespace Cosmos.Samples.Shared
 {
     using System.IO;
+    using System.Reflection;
     using System.Text.Json;
+    using System.Text.Json.Serialization;
     using Azure.Core.Serialization;
-    using Microsoft.Azure.Cosmos;
 
     /// <summary>
     /// Uses <see cref="Azure.Core.Serialization.JsonObjectSerializer"/> which leverages System.Text.Json providing a simple API to interact with on the Azure SDKs.
     /// </summary>
     // <SystemTextJsonSerializer>
-    public class CosmosSystemTextJsonSerializer : CosmosSerializer
+    public class CosmosSystemTextJsonSerializer : CosmosLinqSerializer
     {
         private readonly JsonObjectSerializer systemTextJsonSerializer;
+        private readonly JsonSerializerOptions jsonSerializerOptions;
 
         public CosmosSystemTextJsonSerializer(JsonSerializerOptions jsonSerializerOptions)
         {
             this.systemTextJsonSerializer = new JsonObjectSerializer(jsonSerializerOptions);
+            this.jsonSerializerOptions = jsonSerializerOptions;
         }
 
         public override T FromStream<T>(Stream stream)
@@ -43,6 +46,30 @@
             this.systemTextJsonSerializer.Serialize(streamPayload, input, input.GetType(), default);
             streamPayload.Position = 0;
             return streamPayload;
+        }
+
+        public override string SerializeMemberName(MemberInfo memberInfo)
+        {
+            JsonExtensionDataAttribute jsonExtensionDataAttribute = memberInfo.GetCustomAttribute<JsonExtensionDataAttribute>(true);
+            if (jsonExtensionDataAttribute != null)
+            {
+                return null;
+            }
+
+            JsonPropertyNameAttribute jsonPropertyNameAttribute = memberInfo.GetCustomAttribute<JsonPropertyNameAttribute>(true);
+            if (!string.IsNullOrEmpty(jsonPropertyNameAttribute?.Name))
+            {
+                return jsonPropertyNameAttribute.Name;
+            }
+
+            if (this.jsonSerializerOptions.PropertyNamingPolicy != null)
+            {
+                return this.jsonSerializerOptions.PropertyNamingPolicy.ConvertName(memberInfo.Name);
+            }
+
+            // Do any custom conversions here
+
+            return memberInfo.Name;
         }
     }
     // </SystemTextJsonSerializer>

--- a/Microsoft.Azure.Cosmos.Samples/Usage/SystemTextJson/CosmosSystemTextJsonSerializer.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/SystemTextJson/CosmosSystemTextJsonSerializer.cs
@@ -68,7 +68,7 @@
                 return this.jsonSerializerOptions.PropertyNamingPolicy.ConvertName(memberInfo.Name);
             }
 
-            // Do any custom conversions here
+            // Do any additional handling of JsonSerializerOptions here.
 
             return memberInfo.Name;
         }

--- a/Microsoft.Azure.Cosmos.Samples/Usage/SystemTextJson/CosmosSystemTextJsonSerializer.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/SystemTextJson/CosmosSystemTextJsonSerializer.cs
@@ -5,6 +5,7 @@
     using System.Text.Json;
     using System.Text.Json.Serialization;
     using Azure.Core.Serialization;
+    using Microsoft.Azure.Cosmos;
 
     /// <summary>
     /// Uses <see cref="Azure.Core.Serialization.JsonObjectSerializer"/> which leverages System.Text.Json providing a simple API to interact with on the Azure SDKs.

--- a/Microsoft.Azure.Cosmos.Samples/Usage/SystemTextJson/CosmosSystemTextJsonSerializer.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/SystemTextJson/CosmosSystemTextJsonSerializer.cs
@@ -10,10 +10,10 @@
     /// <summary>
     /// Uses <see cref="Azure.Core.Serialization.JsonObjectSerializer"/> which leverages System.Text.Json providing a simple API to interact with on the Azure SDKs.
     /// </summary>
-    // <SystemTextJsonSerializer>
     /// <remarks>
-    /// For item CRUD operations and non-LINQ queries, implementing CosmosSerializer is sufficient.  To support LINQ query translations as well, CosmosLinqSerializer must be implemented.
+    /// For item CRUD operations and non-LINQ queries, implementing CosmosSerializer is sufficient. To support LINQ query translations as well, CosmosLinqSerializer must be implemented.
     /// </remarks>
+    // <SystemTextJsonSerializer>
     public class CosmosSystemTextJsonSerializer : CosmosLinqSerializer
     {
         private readonly JsonObjectSerializer systemTextJsonSerializer;

--- a/Microsoft.Azure.Cosmos.Samples/Usage/SystemTextJson/CosmosSystemTextJsonSerializer.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/SystemTextJson/CosmosSystemTextJsonSerializer.cs
@@ -11,6 +11,9 @@
     /// Uses <see cref="Azure.Core.Serialization.JsonObjectSerializer"/> which leverages System.Text.Json providing a simple API to interact with on the Azure SDKs.
     /// </summary>
     // <SystemTextJsonSerializer>
+    /// <remarks>
+    /// For item CRUD operations and non-LINQ queries, implementing CosmosSerializer is sufficient.  To support LINQ query translations as well, CosmosLinqSerializer must be implemented.
+    /// </remarks>
     public class CosmosSystemTextJsonSerializer : CosmosLinqSerializer
     {
         private readonly JsonObjectSerializer systemTextJsonSerializer;

--- a/Microsoft.Azure.Cosmos.Samples/Usage/SystemTextJson/Program.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/SystemTextJson/Program.cs
@@ -115,8 +115,6 @@
             Console.WriteLine($"Created Completed activity with id {createCompletedActivity.Resource.Id} that cost {createCompletedActivity.RequestCharge}");
 
             // Execute queries materializing responses using System.Text.Json
-            // NOTE: GetItemLinqQueryable does not support System.Text.Json attributes. LINQ will not translate the name based on the attributes
-            // which can result in no or invalid results coming back. https://github.com/Azure/azure-cosmos-dotnet-v3/issues/3250
             using FeedIterator<ToDoActivity> iterator = container.GetItemQueryIterator<ToDoActivity>("select * from c where c.status = 'Completed'");
             while (iterator.HasMoreResults)
             {
@@ -177,19 +175,15 @@
     // <Model>
     public class ToDoActivity
     {
-        // Note: System.Text.Json attributes such as JsonPropertyName are currently applied on item CRUD operations and non-LINQ queries, but not on LINQ queries
         [JsonPropertyName("id")]
         public string Id { get; set; }
 
-        // Note: System.Text.Json attributes such as JsonPropertyName are currently applied on item CRUD operations and non-LINQ queries, but not on LINQ queries
         [JsonPropertyName("partitionKey")]
         public string PartitionKey { get; set; }
 
-        // Note: System.Text.Json attributes such as JsonPropertyName are currently applied on item CRUD operations and non-LINQ queries, but not on LINQ queries
         [JsonPropertyName("activityId")]
         public string ActivityId { get; set; }
 
-        // Note: System.Text.Json attributes such as JsonPropertyName are currently applied on item CRUD operations and non-LINQ queries, but not on LINQ queries
         [JsonPropertyName("status")]
         public string Status { get; set; }
     }

--- a/Microsoft.Azure.Cosmos.Samples/Usage/SystemTextJson/SystemTextJson.csproj
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/SystemTextJson/SystemTextJson.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
     <PackageReference Include="System.Text.Json" Version="5.0.2" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="*" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.39.0" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\AppSettings.json">

--- a/Microsoft.Azure.Cosmos.Samples/Usage/SystemTextJson/SystemTextJson.csproj
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/SystemTextJson/SystemTextJson.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
     <PackageReference Include="System.Text.Json" Version="5.0.2" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.39.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="*" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\AppSettings.json">

--- a/Microsoft.Azure.Cosmos/src/Serializer/CosmosLinqSerializer.cs
+++ b/Microsoft.Azure.Cosmos/src/Serializer/CosmosLinqSerializer.cs
@@ -10,7 +10,8 @@ namespace Microsoft.Azure.Cosmos
     /// to be used by the CosmosClient for LINQ queries.
     /// </summary>
     /// <remarks>
-    /// https://github.com/Azure/azure-cosmos-dotnet-v3/blob/master/Microsoft.Azure.Cosmos.Samples/Usage/SystemTextJson/CosmosSystemTextJsonSerializer.cs
+    /// Refer to the <see href="https://github.com/Azure/azure-cosmos-dotnet-v3/blob/master/Microsoft.Azure.Cosmos.Samples/Usage/SystemTextJson/CosmosSystemTextJsonSerializer.cs">sample project</see> for a full implementation.
+
     /// </remarks>
     public abstract class CosmosLinqSerializer : CosmosSerializer
     {

--- a/Microsoft.Azure.Cosmos/src/Serializer/CosmosLinqSerializer.cs
+++ b/Microsoft.Azure.Cosmos/src/Serializer/CosmosLinqSerializer.cs
@@ -9,72 +9,9 @@ namespace Microsoft.Azure.Cosmos
     /// This abstract class can be implemented to allow a custom serializer (Non [Json.NET serializer](https://www.newtonsoft.com/json/help/html/Introduction.htm)'s) 
     /// to be used by the CosmosClient for LINQ queries.
     /// </summary>
-    /// <example>
-    /// This example implements the CosmosLinqSerializer contract.
-    /// This example custom serializer will honor System.Text.Json attributes.
-    /// <code language="c#">
-    /// <![CDATA[
-    /// class SystemTextJsonSerializer : CosmosLinqSerializer
-    /// {
-    ///    private readonly JsonObjectSerializer systemTextJsonSerializer;
-    ///
-    ///    public SystemTextJsonSerializer(JsonSerializerOptions jsonSerializerOptions)
-    ///    {
-    ///        this.systemTextJsonSerializer = new JsonObjectSerializer(jsonSerializerOptions);
-    ///    }
-    ///
-    ///    public override T FromStream<T>(Stream stream)
-    ///    {
-    ///        if (stream == null)
-    ///            throw new ArgumentNullException(nameof(stream));
-    ///
-    ///        using (stream)
-    ///        {
-    ///            if (stream.CanSeek && stream.Length == 0)
-    ///            {
-    ///                return default;
-    ///            }
-    ///
-    ///            if (typeof(Stream).IsAssignableFrom(typeof(T)))
-    ///            {
-    ///                return (T)(object)stream;
-    ///            }
-    ///
-    ///            return (T)this.systemTextJsonSerializer.Deserialize(stream, typeof(T), default);
-    ///        }
-    ///    }
-    ///
-    ///    public override Stream ToStream<T>(T input)
-    ///    {
-    ///        MemoryStream streamPayload = new MemoryStream();
-    ///        this.systemTextJsonSerializer.Serialize(streamPayload, input, input.GetType(), default);
-    ///        streamPayload.Position = 0;
-    ///        return streamPayload;
-    ///    }
-    ///
-    ///    public override string SerializeMemberName(MemberInfo memberInfo)
-    ///    {
-    ///        System.Text.Json.Serialization.JsonExtensionDataAttribute jsonExtensionDataAttribute =
-    ///             memberInfo.GetCustomAttribute<System.Text.Json.Serialization.JsonExtensionDataAttribute>(true);
-    ///        if (jsonExtensionDataAttribute != null)
-    ///        {
-    ///             return null;
-    ///        }
-    ///       
-    ///        JsonPropertyNameAttribute jsonPropertyNameAttribute = memberInfo.GetCustomAttribute<JsonPropertyNameAttribute>(true);
-    ///
-    ///        string memberName = !string.IsNullOrEmpty(jsonPropertyNameAttribute?.Name)
-    ///            ? jsonPropertyNameAttribute.Name
-    ///            : memberInfo.Name;
-    ///            
-    ///        // Users must add handling for any additional attributes here
-    ///
-    ///        return memberName;
-    ///    }
-    /// }
-    /// ]]>
-    /// </code>
-    /// </example>
+    /// <remarks>
+    /// https://github.com/Azure/azure-cosmos-dotnet-v3/blob/master/Microsoft.Azure.Cosmos.Samples/Usage/SystemTextJson/CosmosSystemTextJsonSerializer.cs
+    /// </remarks>
     public abstract class CosmosLinqSerializer : CosmosSerializer
     {
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Serializer/CosmosLinqSerializer.cs
+++ b/Microsoft.Azure.Cosmos/src/Serializer/CosmosLinqSerializer.cs
@@ -11,7 +11,6 @@ namespace Microsoft.Azure.Cosmos
     /// </summary>
     /// <remarks>
     /// Refer to the <see href="https://github.com/Azure/azure-cosmos-dotnet-v3/blob/master/Microsoft.Azure.Cosmos.Samples/Usage/SystemTextJson/CosmosSystemTextJsonSerializer.cs">sample project</see> for a full implementation.
-
     /// </remarks>
     public abstract class CosmosLinqSerializer : CosmosSerializer
     {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Linq/LinqTestsCommon.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Linq/LinqTestsCommon.cs
@@ -894,8 +894,8 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests
                 return this.jsonSerializerOptions.PropertyNamingPolicy.ConvertName(memberInfo.Name);
             }
 
-            // Do any custom conversions here
-            
+            // Do any additional handling of JsonSerializerOptions here.
+
             return memberInfo.Name;
         }
     }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Linq/LinqTestsCommon.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Linq/LinqTestsCommon.cs
@@ -837,10 +837,12 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests
     class SystemTextJsonLinqSerializer : CosmosLinqSerializer
     {
         private readonly JsonObjectSerializer systemTextJsonSerializer;
+        private readonly JsonSerializerOptions jsonSerializerOptions;
 
         public SystemTextJsonLinqSerializer(JsonSerializerOptions jsonSerializerOptions)
         {
             this.systemTextJsonSerializer = new JsonObjectSerializer(jsonSerializerOptions);
+            this.jsonSerializerOptions = jsonSerializerOptions;
         }
 
         public override T FromStream<T>(Stream stream)
@@ -882,12 +884,19 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests
             }
 
             JsonPropertyNameAttribute jsonPropertyNameAttribute = memberInfo.GetCustomAttribute<JsonPropertyNameAttribute>(true);
+            if (!string.IsNullOrEmpty(jsonPropertyNameAttribute?.Name))
+            {
+                return jsonPropertyNameAttribute.Name;
+            }
 
-            string memberName = !string.IsNullOrEmpty(jsonPropertyNameAttribute?.Name)
-                ? jsonPropertyNameAttribute.Name
-                : memberInfo.Name;
+            if (this.jsonSerializerOptions.PropertyNamingPolicy != null)
+            {
+                return this.jsonSerializerOptions.PropertyNamingPolicy.ConvertName(memberInfo.Name);
+            }
 
-            return memberName;
+            // Do any custom conversions here
+            
+            return memberInfo.Name;
         }
     }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Linq/CosmosLinqJsonConverterTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Linq/CosmosLinqJsonConverterTests.cs
@@ -198,7 +198,7 @@ namespace Microsoft.Azure.Cosmos.Linq
         {
             private readonly JsonObjectSerializer systemTextJsonSerializer;
 
-            public static readonly System.Text.Json.JsonSerializerOptions JsonOptions = new()
+            public readonly System.Text.Json.JsonSerializerOptions jsonSerializerOptions = new()
             {
                 DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
                 PropertyNameCaseInsensitive = true,
@@ -209,7 +209,7 @@ namespace Microsoft.Azure.Cosmos.Linq
 
             public TestCustomJsonLinqSerializer()
             {
-                this.systemTextJsonSerializer = new JsonObjectSerializer(JsonOptions);
+                this.systemTextJsonSerializer = new JsonObjectSerializer(this.jsonSerializerOptions);
             }
 
             public override T FromStream<T>(Stream stream)
@@ -249,12 +249,19 @@ namespace Microsoft.Azure.Cosmos.Linq
                 }
 
                 JsonPropertyNameAttribute jsonPropertyNameAttribute = memberInfo.GetCustomAttribute<JsonPropertyNameAttribute>(true);
+                if (!string.IsNullOrEmpty(jsonPropertyNameAttribute?.Name))
+                {
+                    return jsonPropertyNameAttribute.Name;
+                }
 
-                string memberName = jsonPropertyNameAttribute != null && !string.IsNullOrEmpty(jsonPropertyNameAttribute.Name)
-                    ? jsonPropertyNameAttribute.Name
-                    : memberInfo.Name;
+                if (this.jsonSerializerOptions.PropertyNamingPolicy != null)
+                {
+                    return this.jsonSerializerOptions.PropertyNamingPolicy.ConvertName(memberInfo.Name);
+                }
 
-                return memberName;
+                // Do any custom conversions here
+
+                return memberInfo.Name;
             }
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Linq/CosmosLinqJsonConverterTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Linq/CosmosLinqJsonConverterTests.cs
@@ -198,7 +198,7 @@ namespace Microsoft.Azure.Cosmos.Linq
         {
             private readonly JsonObjectSerializer systemTextJsonSerializer;
 
-            public readonly System.Text.Json.JsonSerializerOptions jsonSerializerOptions = new()
+            private readonly System.Text.Json.JsonSerializerOptions jsonSerializerOptions = new()
             {
                 DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
                 PropertyNameCaseInsensitive = true,
@@ -259,7 +259,7 @@ namespace Microsoft.Azure.Cosmos.Linq
                     return this.jsonSerializerOptions.PropertyNamingPolicy.ConvertName(memberInfo.Name);
                 }
 
-                // Do any custom conversions here
+                // Do any additional handling of JsonSerializerOptions here.
 
                 return memberInfo.Name;
             }


### PR DESCRIPTION
## Description

Adds usage of CosmosLinqSerializer in Samples and removes documentation for previous limitations.  Also updates STJ CosmosLinqSerializer implementation to cover more possible serializer options in SerializeMemberName.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues
