### PR TITLE
[Internal] Security: Fixes Azure.Identity dependency on Microsoft.Azure.Cosmos.Encryption.Custom

### DIFF
--- a/Microsoft.Azure.Cosmos.Encryption.Custom/src/Microsoft.Azure.Cosmos.Encryption.Custom.csproj
+++ b/Microsoft.Azure.Cosmos.Encryption.Custom/src/Microsoft.Azure.Cosmos.Encryption.Custom.csproj
@@ -35,7 +35,7 @@
   </ItemGroup>
 	
   <ItemGroup>
-     <PackageReference Include="Azure.Core" Version="1.35.0" />
+     <PackageReference Include="Azure.Core" Version="1.38.0" />
      <PackageReference Include="Azure.Identity" Version="1.11.0" />
      <PackageReference Include="Microsoft.Data.Encryption.Cryptography" Version="0.2.0-pre" />
      <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />     

--- a/Microsoft.Azure.Cosmos.Encryption.Custom/src/Microsoft.Azure.Cosmos.Encryption.Custom.csproj
+++ b/Microsoft.Azure.Cosmos.Encryption.Custom/src/Microsoft.Azure.Cosmos.Encryption.Custom.csproj
@@ -36,7 +36,7 @@
 	
   <ItemGroup>
      <PackageReference Include="Azure.Core" Version="1.35.0" />
-     <PackageReference Include="Azure.Identity" Version="1.10.2" />
+     <PackageReference Include="Azure.Identity" Version="1.11.0" />
      <PackageReference Include="Microsoft.Data.Encryption.Cryptography" Version="0.2.0-pre" />
      <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />     
   </ItemGroup>


### PR DESCRIPTION
There is a security vulnerability disclosed for Azure.Identity which was fixed in Azure.Identity 1.11.0.

This was reported by Dependabot: https://github.com/Azure/azure-cosmos-dotnet-v3/security/dependabot/32

This PR updates the `Azure.Identity` dependency to `1.11.0` and `Azure.Core` to `1.38.0` for the Microsoft.Azure.Cosmos.Encryption.Custom package