### PR TITLE
[Internal] Flakey Tests: Fixes few Tests in `GatewayAddressCacheTests` 

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GatewayAddressCacheTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GatewayAddressCacheTests.cs
@@ -1408,13 +1408,19 @@ namespace Microsoft.Azure.Cosmos
                             serviceIdentity: this.serviceIdentity,
                             forceRefreshPartitionAddresses: false,
                             cancellationToken: CancellationToken.None)
-                         .ContinueWith(x => Interlocked.Increment(ref numberOfTasksCreated)));
+                         .ContinueWith(x =>
+                         {
+                            if(x.IsCompleted)
+                            {
+                                Interlocked.Increment(ref numberOfTasksCreated);
+                            }
+                         }));
                 }
 
                 // awaits for the parallel execution to finish.
                 await Task.WhenAll(openConnectionTasks);
 
-                // This assertion validates that the number of tasks created are same as the 500 * iterationIndex.
+                // This assertion validates that the number of tasks completed are same as the 500 * iterationIndex.
                 Assert.AreEqual(500 * iterationIndex, numberOfTasksCreated);
 
                 // Waits until a completion signal from the background task is received.

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GatewayAddressCacheTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GatewayAddressCacheTests.cs
@@ -1410,7 +1410,7 @@ namespace Microsoft.Azure.Cosmos
                             cancellationToken: CancellationToken.None)
                          .ContinueWith(x =>
                          {
-                            if(x.IsCompleted)
+                            if(x.IsCompletedSuccessfully)
                             {
                                 Interlocked.Increment(ref numberOfTasksCreated);
                             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GatewayAddressCacheTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GatewayAddressCacheTests.cs
@@ -1397,6 +1397,7 @@ namespace Microsoft.Azure.Cosmos
                                             fieldName: "lastUnhealthyTimestamp",
                                             delayInMinutes: -2 * iterationIndex);
 
+                int numberOfTasksCreated = 0;
                 for (int j = 0; j < 500 * iterationIndex; j++)
                 {
                     openConnectionTasks
@@ -1406,14 +1407,15 @@ namespace Microsoft.Azure.Cosmos
                             partitionKeyRangeIdentity: this.testPartitionKeyRangeIdentity,
                             serviceIdentity: this.serviceIdentity,
                             forceRefreshPartitionAddresses: false,
-                            cancellationToken: CancellationToken.None));
+                            cancellationToken: CancellationToken.None)
+                         .ContinueWith(x => Interlocked.Increment(ref numberOfTasksCreated)));
                 }
 
                 // awaits for the parallel execution to finish.
                 await Task.WhenAll(openConnectionTasks);
 
-                // This assertion validates that there are no extra tasks created in the thread pool.
-                Assert.AreEqual(0, ThreadPool.PendingWorkItemCount);
+                // This assertion validates that the number of tasks created are same as the 500 * iterationIndex.
+                Assert.AreEqual(500 * iterationIndex, numberOfTasksCreated);
 
                 // Waits until a completion signal from the background task is received.
                 GatewayAddressCacheTests.WaitForManualResetEventSignal(


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes the following test `TryGetAddressesAsync_WhenReplicaVlidationEnabledAndCSListenerMarksReplicaUnhealthyWithParallelInvocation_ShouldValidateUnhealthyReplicasOnce` in `GatewayAddressCacheTests`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #IssueNumber