### PR TITLE
Update ChangeFeedModeSwitchingCheck to have a default case for legacy lease document

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseManager.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseManager.cs
@@ -89,20 +89,20 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
             // AllVersionsAndDeletes does not exist. There should not be any legacy lease documents that are
             // AllVersionsAndDeletes. If the ChangeFeedProcessor's mode is not legacy, an exception should thrown.
             // If the ChangeFeedProcessor mode is not the mode in the lease document, an exception should be thrown.
+            string documentServiceLeaseMode = string.IsNullOrEmpty(documentServiceLease.Mode)
+                        ? ChangeFeedMode.LatestVersion
+                        : documentServiceLease.Mode;
 
             bool shouldThrowException = this.VerifyChangeFeedProcessorMode(
-                changeFeedMode:
-                    string.IsNullOrEmpty(documentServiceLease.Mode)
-                        ? ChangeFeedMode.LatestVersion
-                        : changeFeedLeaseOptionsMode,
-                leaseChangeFeedMode: documentServiceLease.Mode,
+                changeFeedMode: changeFeedLeaseOptionsMode,
+                leaseChangeFeedMode: documentServiceLeaseMode,
                 normalizedProcessorChangeFeedMode: out string normalizedProcessorChangeFeedMode);
 
             // If shouldThrowException is true, throw the exception.
 
             if (shouldThrowException)
             {
-                throw new ArgumentException(message: $"Switching {nameof(ChangeFeedMode)} {documentServiceLease.Mode} to {normalizedProcessorChangeFeedMode} is not allowed.");
+                throw new ArgumentException(message: $"Switching {nameof(ChangeFeedMode)} {documentServiceLeaseMode} to {normalizedProcessorChangeFeedMode} is not allowed.");
             }
         }
 


### PR DESCRIPTION

## Description

Fixes issue https://github.com/Azure/azure-cosmos-dotnet-v3/issues/4423

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #4423