### PR TITLE
Query: Adds a new capability for non streaming order by in QueryFeatures

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryFeature.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryFeature.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
         OrderBy = 1 << 7,
         Top = 1 << 8,
         NonValueAggregate = 1 << 9,
-        DCount = 1 << 10
+        DCount = 1 << 10,
+        NonStreamingOrderBy = 1 << 11,
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryInfo.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryInfo.cs
@@ -107,6 +107,13 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
             set;
         }
 
+        [JsonProperty("hasNonStreamingOrderBy")]
+        public bool HasNonStreamingOrderBy
+        {
+            get;
+            set;
+        }
+
         public bool HasDCount => this.DCountInfo != null;
 
         public bool HasDistinct => this.DistinctType != DistinctQueryType.None;


### PR DESCRIPTION
Adds:
- [x] a new capability for non streaming order by in QueryFeatures
- [x] a new flag to QueryInfo that will be used by ServiceInterop to indicate non streaming order by queries

These will be used by the Compute gateway to fail queries that require non streaming order by but do not pass this capability

## Type of change

- [x] New feature (non-breaking change which adds functionality)
