### PR TITLE
Query: Fixes non streaming order by to use flag from query plan

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/PipelineFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/PipelineFactory.cs
@@ -79,6 +79,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline
                         .Zip(queryInfo.OrderBy, (expression, sortOrder) => new OrderByColumn(expression, sortOrder)).ToList(),
                     queryPaginationOptions: queryPaginationOptions,
                     maxConcurrency: maxConcurrency,
+                    nonStreamingOrderBy: queryInfo.HasNonStreamingOrderBy,
                     continuationToken: continuationToken);
             }
             else

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Query/OrderByPipelineStageBenchmark.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Query/OrderByPipelineStageBenchmark.cs
@@ -44,16 +44,16 @@ namespace Microsoft.Azure.Cosmos.Performance.Tests.Query
         [Benchmark(Baseline = true)]
         public Task StreamingOrderByPipelineStage()
         {
-            return CreateAndRunPipeline(StreamingContainer);
+            return CreateAndRunPipeline(StreamingContainer, nonStreamingOrderBy: false);
         }
 
         [Benchmark]
         public Task NonStreamingOrderByPipelineStage()
         {
-            return CreateAndRunPipeline(NonStreamingContainer);
+            return CreateAndRunPipeline(NonStreamingContainer, nonStreamingOrderBy: true);
         }
 
-        private static async Task CreateAndRunPipeline(IDocumentContainer documentContainer)
+        private static async Task CreateAndRunPipeline(IDocumentContainer documentContainer, bool nonStreamingOrderBy)
         {
             IReadOnlyList<FeedRangeEpk> ranges = await documentContainer.GetFeedRangesAsync(
                 trace: NoOpTrace.Singleton,
@@ -67,6 +67,7 @@ namespace Microsoft.Azure.Cosmos.Performance.Tests.Query
                     orderByColumns: OrderByColumns,
                     queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: EndUserPageSize),
                     maxConcurrency: MaxConcurrency,
+                    nonStreamingOrderBy: nonStreamingOrderBy,
                     continuationToken: null);
 
             IQueryPipelineStage pipeline = pipelineStage.Result;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/NonStreamingOrderByQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/NonStreamingOrderByQueryTests.cs
@@ -228,14 +228,16 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                         ranges: ranges,
                         queryText: testCase.QueryText,
                         orderByColumns: testCase.OrderByColumns,
-                        pageSize: pageSize);
+                        pageSize: pageSize,
+                        nonStreamingOrderBy: true);
 
                     IReadOnlyList<CosmosElement> streamingResult = await CreateAndRunPipelineStage(
                         documentContainer: documentContainer,
                         ranges: ranges,
                         queryText: testCase.QueryText,
                         orderByColumns: testCase.OrderByColumns,
-                        pageSize: pageSize);
+                        pageSize: pageSize,
+                        nonStreamingOrderBy: false);
 
                     if (!streamingResult.SequenceEqual(nonStreamingResult))
                     {
@@ -255,7 +257,8 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
             IReadOnlyList<FeedRangeEpk> ranges,
             string queryText,
             IReadOnlyList<OrderByColumn> orderByColumns,
-            int pageSize)
+            int pageSize,
+            bool nonStreamingOrderBy)
         {
             TryCatch<IQueryPipelineStage> pipelineStage = OrderByCrossPartitionQueryPipelineStage.MonadicCreate(
                     documentContainer: documentContainer,
@@ -265,6 +268,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                     orderByColumns: orderByColumns,
                     queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: pageSize),
                     maxConcurrency: MaxConcurrency,
+                    nonStreamingOrderBy: nonStreamingOrderBy,
                     continuationToken: null);
 
             Assert.IsTrue(pipelineStage.Succeeded);
@@ -311,7 +315,8 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                         ranges: ranges,
                         queryText: testCase.QueryText,
                         orderByColumns: testCase.OrderByColumns,
-                        pageSize: pageSize);
+                        pageSize: pageSize,
+                        nonStreamingOrderBy: true);
 
                     DebugTraceHelpers.TraceStreamingPipelineStarting();
                     IReadOnlyList<CosmosElement> streamingResult = await CreateAndRunPipelineStage(
@@ -319,7 +324,8 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                         ranges: ranges,
                         queryText: testCase.QueryText,
                         orderByColumns: testCase.OrderByColumns,
-                        pageSize: pageSize);
+                        pageSize: pageSize,
+                        nonStreamingOrderBy: false);
 
                     if (!streamingResult.SequenceEqual(nonStreamingResult))
                     {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/OrderByCrossPartitionQueryPipelineStageTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/OrderByCrossPartitionQueryPipelineStageTests.cs
@@ -78,6 +78,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                 },
                 queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: 10),
                 maxConcurrency: 10,
+                nonStreamingOrderBy: false,
                 continuationToken: null);
             Assert.IsTrue(monadicCreate.Succeeded);
         }
@@ -98,6 +99,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                 },
                 queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: 10),
                 maxConcurrency: 10,
+                nonStreamingOrderBy: false,
                 continuationToken: CosmosObject.Create(new Dictionary<string, CosmosElement>()));
             Assert.IsTrue(monadicCreate.Failed);
             Assert.IsTrue(monadicCreate.InnerMostException is MalformedContinuationTokenException);
@@ -119,6 +121,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                 },
                 queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: 10),
                 maxConcurrency: 10,
+                nonStreamingOrderBy: false,
                 continuationToken: CosmosArray.Create(new List<CosmosElement>()));
             Assert.IsTrue(monadicCreate.Failed);
             Assert.IsTrue(monadicCreate.InnerMostException is MalformedContinuationTokenException);
@@ -140,6 +143,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                 },
                 queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: 10),
                 maxConcurrency: 10,
+                nonStreamingOrderBy: false,
                 continuationToken: CosmosArray.Create(new List<CosmosElement>() { CosmosString.Create("asdf") }));
             Assert.IsTrue(monadicCreate.Failed);
             Assert.IsTrue(monadicCreate.InnerMostException is MalformedContinuationTokenException);
@@ -176,6 +180,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                     },
                     queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: 10),
                     maxConcurrency: 10,
+                    nonStreamingOrderBy: false,
                     continuationToken: CosmosArray.Create(
                         new List<CosmosElement>()
                         {
@@ -220,6 +225,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                         },
                         queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: 10),
                         maxConcurrency: 10,
+                        nonStreamingOrderBy: false,
                         continuationToken: CosmosArray.Create(
                             new List<CosmosElement>()
                             {
@@ -279,6 +285,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                         },
                         queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: 10),
                         maxConcurrency: 10,
+                        nonStreamingOrderBy: false,
                         continuationToken: CosmosArray.Create(
                             new List<CosmosElement>()
                             {
@@ -321,6 +328,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                     },
                     queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: 10),
                     maxConcurrency: 10,
+                    nonStreamingOrderBy: false,
                     continuationToken: CosmosArray.Create(
                         new List<CosmosElement>()
                         {
@@ -362,6 +370,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                         },
                         queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: 10),
                         maxConcurrency: 10,
+                        nonStreamingOrderBy: false,
                         continuationToken: CosmosArray.Create(
                             new List<CosmosElement>()
                             {
@@ -417,6 +426,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                 },
                 queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: 1),
                 maxConcurrency: 0,
+                nonStreamingOrderBy: false,
                 continuationToken: CosmosElement.Parse(continuationToken));
             Assert.IsTrue(monadicCreate.Succeeded);
 
@@ -452,6 +462,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                 },
                 queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: 10),
                 maxConcurrency: 10,
+                nonStreamingOrderBy: false,
                 continuationToken: null);
             Assert.IsTrue(monadicCreate.Succeeded);
             IQueryPipelineStage queryPipelineStage = monadicCreate.Result;
@@ -501,6 +512,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                 },
                 queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: 10),
                 maxConcurrency: 10,
+                nonStreamingOrderBy: false,
                 continuationToken: null);
             Assert.IsTrue(monadicCreate.Succeeded);
             IQueryPipelineStage queryPipelineStage = monadicCreate.Result;
@@ -558,6 +570,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                     },
                     queryPaginationOptions: new QueryPaginationOptions(pageSizeHint: 10),
                     maxConcurrency: 10,
+                    nonStreamingOrderBy: false,
                     continuationToken: continuationToken);
                 monadicQueryPipelineStage.ThrowIfFailed();
                 IQueryPipelineStage queryPipelineStage = monadicQueryPipelineStage.Result;


### PR DESCRIPTION
## Description

The contract with the backend for non streaming order by has changed. The backend response will no longer have _streaming. Instead there is a new flag on the query plan to indicate the presence of a non streaming order by. This PR switches non streaming order by to use flag from query plan instead of _streaming in the backend response.

This PR does not do any code cleanup, since the SDK is required for integration testing of the backend. The cleanup PR will follow this change.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
