### PR TITLE
[Internal] Pipelines: Adds rolling pipeline

### DIFF
--- a/azure-pipelines-rolling.yml
+++ b/azure-pipelines-rolling.yml
@@ -1,0 +1,26 @@
+# A pipeline with no CI trigger
+trigger: none
+
+pr: none
+
+schedules:
+- cron: "0 7,13,0,5 * * *" # cron syntax https://learn.microsoft.com/en-us/azure/devops/pipelines/process/scheduled-triggers?view=azure-devops&tabs=yaml#cron-syntax
+  displayName: Cosmos Rolling
+  branches:
+    include: 
+    - master
+  always: true # whether to always run the pipeline or only if there have been source code changes since the last run. The default is false
+
+variables:
+  ReleaseArguments: ' --filter "TestCategory!=Quarantine & TestCategory!=Functional" --verbosity normal '
+  VmImage: windows-latest # https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops
+
+jobs:
+- template:  templates/build-test.yml
+  parameters:
+    BuildConfiguration: Release
+    Arguments: $(ReleaseArguments)
+    VmImage: $(VmImage)
+    MultiRegionConnectionString: $(COSMOSDB_MULTI_REGION)
+    IncludeEncryption: true
+    IncludePerformance: false

--- a/templates/build-test.yml
+++ b/templates/build-test.yml
@@ -12,6 +12,8 @@ parameters:
   EmulatorPipeline2CategoryListName: ' Others '
   EmulatorPipeline3CategoryListName: ' MultiRegion '
   MultiRegionConnectionString : ''
+  IncludeEncryption: true
+  IncludePerformance: true
 
 jobs:
 - job:
@@ -53,6 +55,7 @@ jobs:
       
 - job:
   displayName: PerformanceTests ${{ parameters.BuildConfiguration }}
+  condition: and(succeeded(), eq(${{ parameters.IncludePerformance }}, true))
   pool:
     vmImage: ${{ parameters.VmImage }}
 
@@ -150,7 +153,7 @@ jobs:
 - job:
   displayName: Encryption EmulatorTests ${{ parameters.BuildConfiguration }}
   timeoutInMinutes: 90
-  condition: and(succeeded(), eq('${{ parameters.OS }}', 'Windows'))
+  condition: and(eq(${{ parameters.IncludeEncryption }}, true), and(succeeded(), eq('${{ parameters.OS }}', 'Windows')))
   pool:
     vmImage: ${{ parameters.VmImage }}
 
@@ -181,7 +184,7 @@ jobs:
 - job:
   displayName: Encryption.Custom EmulatorTests ${{ parameters.BuildConfiguration }}
   timeoutInMinutes: 90
-  condition: and(succeeded(), eq('${{ parameters.OS }}', 'Windows'))
+  condition: and(eq(${{ parameters.IncludeEncryption }}, true), and(succeeded(), eq('${{ parameters.OS }}', 'Windows')))
   pool:
     vmImage: ${{ parameters.VmImage }}
 


### PR DESCRIPTION
This PR adds the YML file for a pipeline to be executed 4 times a day, only from the content of `master`.

The pipeline will run at 7AM, 1PM, 12AM and 5AM UTC (which is ~ 12AM, 6AM, 5PM, 10PM PDT) and execute only the tests suites:

* Unit and Emulator tests for Microsoft.Azure.Cosmos
* Emulator tests for Microsoft.Azure.Cosmos.Encryption
* Emulator tests for Microsoft.Azure.Cosmos.Encryption.Custom