### PR TITLE
[Internal] Engineering: Fixes Nuget generation and copy process

### DIFF
--- a/templates/nuget-pack.yml
+++ b/templates/nuget-pack.yml
@@ -61,7 +61,7 @@ jobs:
         BuildDropPath: '$(Build.ArtifactStagingDirectory)/bin/AnyCPU/$(BuildConfiguration)/Microsoft.Azure.Cosmos'
 
     - ${{ if ne(parameters.BlobVersion, '') }}:
-      - task: AzureFileCopy@5
+      - task: AzureFileCopy@6
         displayName: 'Copy Artifacts to Azure SDK Release blob storage'
         condition: succeeded()
         inputs:


### PR DESCRIPTION
AzCopy needs to be updated to 6 to work with the new security workflows.

Reference: https://github.com/microsoft/azure-pipelines-tasks/pull/19650