### PR TITLE
ContainerProperties: Refactors Vector Embedding and Indexing Policy Interfaces to Mark Them as Public

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
-		<ClientOfficialVersion>3.40.0</ClientOfficialVersion>
-		<ClientPreviewVersion>3.41.0</ClientPreviewVersion>
+		<ClientOfficialVersion>3.39.1</ClientOfficialVersion>
+		<ClientPreviewVersion>3.40.0</ClientPreviewVersion>
 		<ClientPreviewSuffixVersion>preview.1</ClientPreviewSuffixVersion>
 		<DirectVersion>3.34.0</DirectVersion>
 		<EncryptionOfficialVersion>2.0.4</EncryptionOfficialVersion>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
-		<ClientOfficialVersion>3.39.1</ClientOfficialVersion>
-		<ClientPreviewVersion>3.40.0</ClientPreviewVersion>
+		<ClientOfficialVersion>3.40.0</ClientOfficialVersion>
+		<ClientPreviewVersion>3.41.0</ClientPreviewVersion>
 		<ClientPreviewSuffixVersion>preview.1</ClientPreviewSuffixVersion>
 		<DirectVersion>3.34.0</DirectVersion>
 		<EncryptionOfficialVersion>2.0.4</EncryptionOfficialVersion>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
 		<ClientOfficialVersion>3.39.1</ClientOfficialVersion>
 		<ClientPreviewVersion>3.40.0</ClientPreviewVersion>
 		<ClientPreviewSuffixVersion>preview.1</ClientPreviewSuffixVersion>
-		<DirectVersion>3.33.1</DirectVersion>
+		<DirectVersion>3.34.0</DirectVersion>
 		<EncryptionOfficialVersion>2.0.4</EncryptionOfficialVersion>
 		<EncryptionPreviewVersion>2.1.0</EncryptionPreviewVersion>
 		<EncryptionPreviewSuffixVersion>preview4</EncryptionPreviewSuffixVersion>

--- a/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryPlanRetriever.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryPlanRetriever.cs
@@ -28,7 +28,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
             | QueryFeatures.OrderBy
             | QueryFeatures.Top
             | QueryFeatures.NonValueAggregate
-            | QueryFeatures.DCount;
+            | QueryFeatures.DCount
+            | QueryFeatures.NonStreamingOrderBy;
 
         private static readonly string SupportedQueryFeaturesString = SupportedQueryFeatures.ToString();
 

--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/ContainerProperties.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/ContainerProperties.cs
@@ -306,7 +306,7 @@ namespace Microsoft.Azure.Cosmos
         /// </para>
         /// </remarks>
         [JsonIgnore]
-        internal VectorEmbeddingPolicy VectorEmbeddingPolicy
+        public VectorEmbeddingPolicy VectorEmbeddingPolicy
         {
             get => this.vectorEmbeddingPolicyInternal;
 

--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/DistanceFunction.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/DistanceFunction.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Azure.Cosmos
     /// Defines the distance function for a vector index specification in the Azure Cosmos DB service.
     /// </summary>
     /// <seealso cref="Embedding"/> for usage.
-    internal enum DistanceFunction
+    public enum DistanceFunction
     {
         /// <summary>
         /// Represents the euclidean distance function.

--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/Embedding.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/Embedding.cs
@@ -14,7 +14,7 @@ namespace Microsoft.Azure.Cosmos
     /// <summary>
     /// Represents the embedding settings for the vector index.
     /// </summary>
-    internal class Embedding : IEquatable<Embedding>
+    public class Embedding : IEquatable<Embedding>
     {
         /// <summary>
         /// Gets or sets a string containing the path of the vector index.

--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/IndexingPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/IndexingPolicy.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Azure.Cosmos
         /// ]
         /// ]]>
         /// </example>
-        internal Collection<VectorIndexPath> VectorIndexes
+        public Collection<VectorIndexPath> VectorIndexes
         {
             get => this.VectorIndexesInternal ??= new Collection<VectorIndexPath>();
             set => this.VectorIndexesInternal = value;

--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/VectorDataType.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/VectorDataType.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Azure.Cosmos
     /// <summary>
     /// Defines the target data type of a vector index specification in the Azure Cosmos DB service.
     /// </summary>
-    internal enum VectorDataType
+    public enum VectorDataType
     {
         /// <summary>
         /// Represent a float16 data type.

--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/VectorEmbeddingPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/VectorEmbeddingPolicy.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Azure.Cosmos
     /// Represents the vector embedding policy configuration for specifying the vector embeddings on documents in the collection in the Azure Cosmos DB service.
     /// </summary>
     /// <seealso cref="ContainerProperties"/>
-    internal sealed class VectorEmbeddingPolicy
+    public sealed class VectorEmbeddingPolicy
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="VectorEmbeddingPolicy"/> class.

--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/VectorIndexPath.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/VectorIndexPath.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Azure.Cosmos
     /// }
     /// ]]>
     /// </example>
-    internal sealed class VectorIndexPath
+    public sealed class VectorIndexPath
     {
         /// <summary>
         /// Gets or sets the full path in a document used for vector indexing.

--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/VectorIndexType.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/VectorIndexType.cs
@@ -8,7 +8,7 @@ namespace Microsoft.Azure.Cosmos
     /// <summary>
     /// Defines the target index type of an vector index path specification in the Azure Cosmos DB service.
     /// </summary>
-    internal enum VectorIndexType
+    public enum VectorIndexType
     {
         /// <summary>
         /// Represents a flat vector index type.


### PR DESCRIPTION
# Pull Request Template

## Description

The purpose of this PR is to mark the new `VectorEmbeddingPolicy` in `ContainerProperties` as a public interface and introducing new `VectorIndexes` in the `IndexingPolicy` to enable Vector Similarity Search in Cosmos DB.

Relevant PR for the vector similarity work: [4379](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/4379)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Closing issues

To automatically close an issue: closes #4364