### PR TITLE
Query: Adds an environment config to suppress sending NonStreamingOrderBy in the list of query features sent to the gateway

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CosmosQueryExecutionContextFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CosmosQueryExecutionContextFactory.cs
@@ -408,6 +408,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
                     inputParameters.ExecutionEnvironment,
                     inputParameters.ReturnResultsInDeterministicOrder,
                     inputParameters.EnableOptimisticDirectExecution,
+                    inputParameters.IsNonStreamingOrderByQueryFeatureDisabled,
                     inputParameters.TestInjections);
             }
 
@@ -593,6 +594,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
                     inputParameters.SqlQuerySpec,
                     cosmosQueryContext.ResourceLink,
                     inputParameters.PartitionKey,
+                    inputParameters.IsNonStreamingOrderByQueryFeatureDisabled,
                     trace,
                     cancellationToken);
             }
@@ -841,6 +843,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
                 ExecutionEnvironment? executionEnvironment,
                 bool? returnResultsInDeterministicOrder,
                 bool enableOptimisticDirectExecution,
+                bool isNonStreamingOrderByQueryFeatureDisabled,
                 TestInjections testInjections)
             {
                 this.SqlQuerySpec = sqlQuerySpec ?? throw new ArgumentNullException(nameof(sqlQuerySpec));
@@ -874,6 +877,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
                 this.ExecutionEnvironment = executionEnvironment.GetValueOrDefault(InputParameters.DefaultExecutionEnvironment);
                 this.ReturnResultsInDeterministicOrder = returnResultsInDeterministicOrder.GetValueOrDefault(InputParameters.DefaultReturnResultsInDeterministicOrder);
                 this.EnableOptimisticDirectExecution = enableOptimisticDirectExecution;
+                this.IsNonStreamingOrderByQueryFeatureDisabled = isNonStreamingOrderByQueryFeatureDisabled;
                 this.TestInjections = testInjections;
             }
 
@@ -890,6 +894,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
             public bool ReturnResultsInDeterministicOrder { get; }
             public TestInjections TestInjections { get; }
             public bool EnableOptimisticDirectExecution { get; }
+            public bool IsNonStreamingOrderByQueryFeatureDisabled { get; }
 
             public InputParameters WithContinuationToken(CosmosElement token)
             {
@@ -906,6 +911,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
                     this.ExecutionEnvironment,
                     this.ReturnResultsInDeterministicOrder,
                     this.EnableOptimisticDirectExecution,
+                    this.IsNonStreamingOrderByQueryFeatureDisabled,
                     this.TestInjections);
             }
         }

--- a/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryPlanRetriever.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryPlanRetriever.cs
@@ -28,9 +28,36 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
             | QueryFeatures.OrderBy
             | QueryFeatures.Top
             | QueryFeatures.NonValueAggregate
+            | QueryFeatures.DCount
+            | QueryFeatures.NonStreamingOrderBy;
+
+        private static readonly QueryFeatures LegacySupportedQueryFeatures =
+            QueryFeatures.Aggregate
+            | QueryFeatures.Distinct
+            | QueryFeatures.GroupBy
+            | QueryFeatures.MultipleOrderBy
+            | QueryFeatures.MultipleAggregates
+            | QueryFeatures.OffsetAndLimit
+            | QueryFeatures.OrderBy
+            | QueryFeatures.Top
+            | QueryFeatures.NonValueAggregate
             | QueryFeatures.DCount;
 
         private static readonly string SupportedQueryFeaturesString = SupportedQueryFeatures.ToString();
+
+        private static readonly string LegacySupportedQueryFeaturesString = LegacySupportedQueryFeatures.ToString();
+
+        private static string GetSupportedQueryFeaturesString(bool isNonStreamingOrderByQueryFeatureDisabled)
+        {
+            if (isNonStreamingOrderByQueryFeatureDisabled)
+            {
+                return LegacySupportedQueryFeaturesString;
+            }
+            else
+            {
+                return SupportedQueryFeaturesString;
+            }
+        }
 
         public static async Task<PartitionedQueryExecutionInfo> GetQueryPlanWithServiceInteropAsync(
             CosmosQueryClient queryClient,
@@ -95,6 +122,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
             SqlQuerySpec sqlQuerySpec,
             string resourceLink,
             PartitionKey? partitionKey,
+            bool isNonStreamingOrderByQueryFeatureDisabled,
             ITrace trace,
             CancellationToken cancellationToken = default)
         {
@@ -130,7 +158,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
                     OperationType.QueryPlan,
                     sqlQuerySpec,
                     partitionKey,
-                    QueryPlanRetriever.SupportedQueryFeaturesString,
+                    GetSupportedQueryFeaturesString(isNonStreamingOrderByQueryFeatureDisabled),
                     trace,
                     cancellationToken);
             }

--- a/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryPlanRetriever.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryPlanRetriever.cs
@@ -31,32 +31,19 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
             | QueryFeatures.DCount
             | QueryFeatures.NonStreamingOrderBy;
 
-        private static readonly QueryFeatures LegacySupportedQueryFeatures =
-            QueryFeatures.Aggregate
-            | QueryFeatures.Distinct
-            | QueryFeatures.GroupBy
-            | QueryFeatures.MultipleOrderBy
-            | QueryFeatures.MultipleAggregates
-            | QueryFeatures.OffsetAndLimit
-            | QueryFeatures.OrderBy
-            | QueryFeatures.Top
-            | QueryFeatures.NonValueAggregate
-            | QueryFeatures.DCount;
+        private static readonly QueryFeatures SupportedQueryFeaturesWithoutNonStreamingOrderBy =
+            SupportedQueryFeatures & (~QueryFeatures.NonStreamingOrderBy);
 
         private static readonly string SupportedQueryFeaturesString = SupportedQueryFeatures.ToString();
 
-        private static readonly string LegacySupportedQueryFeaturesString = LegacySupportedQueryFeatures.ToString();
+        private static readonly string SupportedQueryFeaturesWithoutNonStreamingOrderByString =
+            SupportedQueryFeaturesWithoutNonStreamingOrderBy.ToString();
 
         private static string GetSupportedQueryFeaturesString(bool isNonStreamingOrderByQueryFeatureDisabled)
         {
-            if (isNonStreamingOrderByQueryFeatureDisabled)
-            {
-                return LegacySupportedQueryFeaturesString;
-            }
-            else
-            {
-                return SupportedQueryFeaturesString;
-            }
+            return isNonStreamingOrderByQueryFeatureDisabled ?
+                SupportedQueryFeaturesWithoutNonStreamingOrderByString :
+                SupportedQueryFeaturesString;
         }
 
         public static async Task<PartitionedQueryExecutionInfo> GetQueryPlanWithServiceInteropAsync(

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryIterator.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryIterator.cs
@@ -145,6 +145,7 @@ namespace Microsoft.Azure.Cosmos.Query
                 executionEnvironment: queryRequestOptions.ExecutionEnvironment,
                 returnResultsInDeterministicOrder: queryRequestOptions.ReturnResultsInDeterministicOrder,
                 enableOptimisticDirectExecution: queryRequestOptions.EnableOptimisticDirectExecution,
+                isNonStreamingOrderByQueryFeatureDisabled: queryRequestOptions.IsNonStreamingOrderByQueryFeatureDisabled,
                 testInjections: queryRequestOptions.TestSettings);
 
             return new QueryIterator(

--- a/Microsoft.Azure.Cosmos/src/RequestOptions/QueryRequestOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/RequestOptions/QueryRequestOptions.cs
@@ -52,6 +52,8 @@ namespace Microsoft.Azure.Cosmos
         /// </value>
         public bool EnableOptimisticDirectExecution { get; set; } = ConfigurationManager.IsOptimisticDirectExecutionEnabled(defaultValue: false);
 
+        internal bool IsNonStreamingOrderByQueryFeatureDisabled { get; set; } = ConfigurationManager.IsNonStreamingOrderByQueryFeatureDisabled(defaultValue: false);
+
         /// <summary>
         /// Gets or sets the maximum number of items that can be buffered client side during 
         /// parallel query execution in the Azure Cosmos DB service. 

--- a/Microsoft.Azure.Cosmos/src/RequestOptions/QueryRequestOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/RequestOptions/QueryRequestOptions.cs
@@ -52,8 +52,6 @@ namespace Microsoft.Azure.Cosmos
         /// </value>
         public bool EnableOptimisticDirectExecution { get; set; } = ConfigurationManager.IsOptimisticDirectExecutionEnabled(defaultValue: false);
 
-        internal bool IsNonStreamingOrderByQueryFeatureDisabled { get; set; } = ConfigurationManager.IsNonStreamingOrderByQueryFeatureDisabled(defaultValue: false);
-
         /// <summary>
         /// Gets or sets the maximum number of items that can be buffered client side during 
         /// parallel query execution in the Azure Cosmos DB service. 
@@ -192,6 +190,8 @@ namespace Microsoft.Azure.Cosmos
         internal TestInjections TestSettings { get; set; }
 
         internal FeedRange FeedRange { get; set; }
+
+        internal bool IsNonStreamingOrderByQueryFeatureDisabled { get; set; } = ConfigurationManager.IsNonStreamingOrderByQueryFeatureDisabled(defaultValue: false);
 
         /// <summary>
         /// Fill the CosmosRequestMessage headers with the set properties

--- a/Microsoft.Azure.Cosmos/src/Util/ConfigurationManager.cs
+++ b/Microsoft.Azure.Cosmos/src/Util/ConfigurationManager.cs
@@ -27,6 +27,11 @@ namespace Microsoft.Azure.Cosmos
         /// </summary>
         internal static readonly string OptimisticDirectExecutionEnabled = "AZURE_COSMOS_OPTIMISTIC_DIRECT_EXECUTION_ENABLED";
 
+        /// <summary>
+        /// Environment variable name to disable sending non streaming order by query feature falg to the gateway.
+        /// </summary>
+        internal static readonly string NonStreamingOrderByQueryFeatureDisabled = "AZURE_COSMOS_NON_STREAMING_ORDER_BY_FLAG_DISABLED";
+
         public static T GetEnvironmentVariable<T>(string variable, T defaultValue)
         {
             string value = Environment.GetEnvironmentVariable(variable);
@@ -87,6 +92,19 @@ namespace Microsoft.Azure.Cosmos
             return ConfigurationManager
                     .GetEnvironmentVariable(
                         variable: OptimisticDirectExecutionEnabled,
+                        defaultValue: defaultValue);
+        }
+
+        /// <summary>
+        /// Gets the boolean value indicating whether the non streaming order by query feature flag should be sent to the gateway
+        /// based on the environment variable override.
+        /// </summary>
+        public static bool IsNonStreamingOrderByQueryFeatureDisabled(
+            bool defaultValue)
+        {
+            return ConfigurationManager
+                    .GetEnvironmentVariable(
+                        variable: NonStreamingOrderByQueryFeatureDisabled,
                         defaultValue: defaultValue);
         }
     }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/NonStreamingOrderByQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/NonStreamingOrderByQueryTests.cs
@@ -83,6 +83,9 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
         [TestMethod]
         public async Task QueryFeatureFlagTests()
         {
+            using EnvironmentVariable nonStreamingOrderByDisabled = new EnvironmentVariable(
+                ConfigurationManager.NonStreamingOrderByQueryFeatureDisabled);
+
             static async Task ImplementationAsync(Container container, IReadOnlyList<CosmosObject> _)
             {
                 ContainerInlineCore containerCore = container as ContainerInlineCore;
@@ -330,6 +333,23 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
                 }
             }
 #pragma warning restore CS0162 // Unreachable code detected
+        }
+
+        private sealed class EnvironmentVariable : IDisposable
+        {
+            private readonly string name;
+            private readonly string value;
+
+            public EnvironmentVariable(string name)
+            {
+                this.name = name;
+                this.value = Environment.GetEnvironmentVariable(name);
+            }
+
+            public void Dispose()
+            {
+                Environment.SetEnvironmentVariable(this.name, this.value);
+            }
         }
 
         private sealed class SupportedQueryFeaturesValidator

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/NonStreamingOrderByQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/NonStreamingOrderByQueryTests.cs
@@ -4,9 +4,16 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Linq;
+    using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.CosmosElements;
+    using Microsoft.Azure.Cosmos.Query.Core.Monads;
+    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
+    using Microsoft.Azure.Cosmos.Query.Core.QueryPlan;
+    using Microsoft.Azure.Cosmos.Query.Core;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Microsoft.Azure.Cosmos.Query.Core.QueryClient;
+    using Microsoft.Azure.Cosmos.Query;
 
     [TestClass]
     [TestCategory("Query")]
@@ -71,6 +78,133 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
                 CollectionTypes.SinglePartition | CollectionTypes.MultiPartition,
                 Documents,
                 RunVectorDistanceTestsAsync);
+        }
+
+        [TestMethod]
+        public async Task QueryFeatureFlagTests()
+        {
+            static async Task ImplementationAsync(Container container, IReadOnlyList<CosmosObject> _)
+            {
+                ContainerInlineCore containerCore = container as ContainerInlineCore;
+
+                SupportedQueryFeaturesValidator validator = new SupportedQueryFeaturesValidator
+                {
+                    ExpectNonStreamingOrderBy = true
+                };
+
+                CosmosQueryClient cosmosQueryClient = new MockCosmosQueryClient(
+                    containerCore.ClientContext,
+                    containerCore,
+                    bypassQueryParsing: true,
+                    validator);
+
+                ContainerProperties containerProperties = await containerCore.GetCachedContainerPropertiesAsync(
+                    forceRefresh: false,
+                    Cosmos.Tracing.NoOpTrace.Singleton,
+                    cancellationToken: default);
+
+                IReadOnlyList<QueryFeaturesTest> testCases = new List<QueryFeaturesTest>
+                {
+                    MakeQueryFeaturesTest(
+                        environmentVariable: null,
+                        requestOption: null,
+                        expectNonStreamingOrderBy: true),
+                    MakeQueryFeaturesTest(
+                        environmentVariable: true,
+                        requestOption: null,
+                        expectNonStreamingOrderBy: false),
+                    MakeQueryFeaturesTest(
+                        environmentVariable: null,
+                        requestOption: true,
+                        expectNonStreamingOrderBy: false),
+                    MakeQueryFeaturesTest(
+                        environmentVariable: false,
+                        requestOption: null,
+                        expectNonStreamingOrderBy: true),
+                    MakeQueryFeaturesTest(
+                        environmentVariable: null,
+                        requestOption: false,
+                        expectNonStreamingOrderBy: true),
+                };
+
+                int validationCount = validator.InvocationCount;
+                foreach (QueryFeaturesTest testCase in testCases)
+                {
+                    if (testCase.EnvironmentVariable.HasValue)
+                    {
+                        Environment.SetEnvironmentVariable(
+                            ConfigurationManager.NonStreamingOrderByQueryFeatureDisabled,
+                            testCase.EnvironmentVariable.Value.ToString());
+                    }
+                    else
+                    {
+                        Environment.SetEnvironmentVariable(
+                            ConfigurationManager.NonStreamingOrderByQueryFeatureDisabled,
+                            null);
+                    }
+
+                    QueryRequestOptions requestOptions = new QueryRequestOptions
+                    {
+                        EnableOptimisticDirectExecution = false,
+                    };
+
+                    if (testCase.RequestOption.HasValue)
+                    {
+                        requestOptions.IsNonStreamingOrderByQueryFeatureDisabled = testCase.RequestOption.Value;
+                    }
+
+                    validator.ExpectNonStreamingOrderBy = testCase.ExpectNonStreamingOrderBy;
+                    ++validationCount;
+
+                    DebugTraceHelpers.TraceSupportedFeaturesTestCase(testCase);
+
+                    QueryIterator iterator = QueryIterator.Create(
+                        containerCore,
+                        cosmosQueryClient,
+                        containerCore.ClientContext,
+                        new SqlQuerySpec("SELECT * FROM c"),
+                        continuationToken: null,
+                        feedRangeInternal: FeedRangeEpk.FullRange,
+                        requestOptions,
+                        resourceLink: containerProperties.SelfLink,
+                        isContinuationExpected: true,
+                        allowNonValueAggregateQuery: true,
+                        partitionedQueryExecutionInfo: null,
+                        resourceType: Azure.Documents.ResourceType.Document);
+
+                    Assert.IsTrue(iterator.HasMoreResults);
+                    ResponseMessage responseMessage = await iterator.ReadNextAsync();
+                    Assert.AreEqual(System.Net.HttpStatusCode.OK, responseMessage.StatusCode);
+                    Assert.AreEqual(validationCount, validator.InvocationCount);
+                }
+            }
+
+            await this.CreateIngestQueryDeleteAsync(
+                ConnectionModes.Direct,
+                CollectionTypes.MultiPartition,
+                new List<string>(),
+                ImplementationAsync);
+        }
+
+        private static QueryFeaturesTest MakeQueryFeaturesTest(bool? environmentVariable, bool? requestOption, bool expectNonStreamingOrderBy)
+        {
+            return new QueryFeaturesTest(environmentVariable, requestOption, expectNonStreamingOrderBy);
+        }
+
+        private sealed class QueryFeaturesTest
+        {
+            public bool? EnvironmentVariable { get; }
+
+            public bool? RequestOption { get; }
+
+            public bool ExpectNonStreamingOrderBy { get; }
+
+            public QueryFeaturesTest(bool? environmentVariable, bool? requestOption, bool expectNonStreamingOrderBy)
+            {
+                this.EnvironmentVariable = environmentVariable;
+                this.RequestOption = requestOption;
+                this.ExpectNonStreamingOrderBy = expectNonStreamingOrderBy;
+            }
         }
 
         private static async Task RunVectorDistanceTestsAsync(Container container, IReadOnlyList<CosmosObject> _)
@@ -173,6 +307,117 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
         {
             public string Id { get; set; }
             public string Word { get; set; }
+        }
+
+        private static class DebugTraceHelpers
+        {
+            private const bool Enabled = false;
+
+#pragma warning disable CS0162 // Unreachable code detected
+            public static void TraceSupportedFeaturesString(string supportedQueryFeatures)
+            {
+                if (Enabled)
+                {
+                    Trace.WriteLine($"Supported query features header: {supportedQueryFeatures}");
+                }
+            }
+
+            public static void TraceSupportedFeaturesTestCase(QueryFeaturesTest testCase)
+            {
+                if (Enabled)
+                {
+                    Trace.WriteLine($"EnvironmentVariable: {testCase.EnvironmentVariable}, RequestOption: {testCase.RequestOption}, ExpectNonStreamingOrderBy: {testCase.ExpectNonStreamingOrderBy}");
+                }
+            }
+#pragma warning restore CS0162 // Unreachable code detected
+        }
+
+        private sealed class SupportedQueryFeaturesValidator
+        {
+            public int InvocationCount { get; private set; }
+
+            public bool ExpectNonStreamingOrderBy { get; set;}
+
+            public void Validate(string supportedQueryFeatures)
+            {
+                DebugTraceHelpers.TraceSupportedFeaturesString(supportedQueryFeatures);
+                ++this.InvocationCount;
+                bool hasNonStreamingOrderBy = supportedQueryFeatures.Contains(QueryFeatures.NonStreamingOrderBy.ToString());
+                Assert.AreEqual(this.ExpectNonStreamingOrderBy, hasNonStreamingOrderBy);
+            }
+        }
+
+        private sealed class MockCosmosQueryClient : CosmosQueryClientCore
+        {
+            private readonly bool bypassQueryParsing;
+
+            private readonly SupportedQueryFeaturesValidator validator;
+
+            public MockCosmosQueryClient(
+                CosmosClientContext clientContext,
+                ContainerInternal cosmosContainerCore,
+                bool bypassQueryParsing,
+                SupportedQueryFeaturesValidator validateSupportedQueryFeatures)
+                : base(clientContext, cosmosContainerCore)
+            {
+                this.bypassQueryParsing = bypassQueryParsing;
+                this.validator = validateSupportedQueryFeatures;
+            }
+
+            public override bool BypassQueryParsing()
+            {
+                return this.bypassQueryParsing;
+            }
+
+            public override Task<PartitionedQueryExecutionInfo> ExecuteQueryPlanRequestAsync(
+                string resourceUri,
+                Documents.ResourceType resourceType,
+                Documents.OperationType operationType,
+                SqlQuerySpec sqlQuerySpec,
+                Cosmos.PartitionKey? partitionKey,
+                string supportedQueryFeatures,
+                Guid clientQueryCorrelationId,
+                Cosmos.Tracing.ITrace trace,
+                CancellationToken cancellationToken)
+            {
+                this.validator.Validate(supportedQueryFeatures);
+                return base.ExecuteQueryPlanRequestAsync(
+                    resourceUri,
+                    resourceType,
+                    operationType,
+                    sqlQuerySpec,
+                    partitionKey,
+                    supportedQueryFeatures,
+                    clientQueryCorrelationId,
+                    trace,
+                    cancellationToken);
+            }
+
+            public override Task<TryCatch<QueryPage>> ExecuteItemQueryAsync(
+                string resourceUri,
+                Documents.ResourceType resourceType,
+                Documents.OperationType operationType,
+                FeedRange feedRange,
+                QueryRequestOptions requestOptions,
+                AdditionalRequestHeaders additionalRequestHeaders,
+                SqlQuerySpec sqlQuerySpec,
+                string continuationToken,
+                int pageSize,
+                Cosmos.Tracing.ITrace trace,
+                CancellationToken cancellationToken)
+            {
+                QueryPage queryPage = new QueryPage(
+                    documents: new List<CosmosElement>(),
+                    requestCharge: 0,
+                    activityId: Guid.NewGuid().ToString(),
+                    cosmosQueryExecutionInfo: null,
+                    distributionPlanSpec: null,
+                    disallowContinuationTokenMessage: null,
+                    additionalHeaders: null,
+                    state: null,
+                    streaming: false);
+                return Task.FromResult(TryCatch<QueryPage>.FromResult(queryPage));
+            }
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OptimisticDirectExecutionQueryBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OptimisticDirectExecutionQueryBaselineTests.cs
@@ -1022,6 +1022,7 @@
                 executionEnvironment: null,
                 returnResultsInDeterministicOrder: null,
                 enableOptimisticDirectExecution: queryRequestOptions.EnableOptimisticDirectExecution,
+                isNonStreamingOrderByQueryFeatureDisabled: false,
                 testInjections: queryRequestOptions.TestSettings);
 
             List<PartitionKeyRange> targetPkRanges = new ();

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/FullPipelineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/FullPipelineTests.cs
@@ -343,6 +343,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                 executionEnvironment: null,
                 returnResultsInDeterministicOrder: null,
                 enableOptimisticDirectExecution: queryRequestOptions.EnableOptimisticDirectExecution,
+                isNonStreamingOrderByQueryFeatureDisabled: queryRequestOptions.IsNonStreamingOrderByQueryFeatureDisabled,
                 testInjections: queryRequestOptions.TestSettings);
 
             string databaseId = "db1234";

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/SubpartitionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/SubpartitionTests.cs
@@ -131,6 +131,7 @@
                 executionEnvironment: null,
                 returnResultsInDeterministicOrder: null,
                 enableOptimisticDirectExecution: queryRequestOptions.EnableOptimisticDirectExecution,
+                isNonStreamingOrderByQueryFeatureDisabled: queryRequestOptions.IsNonStreamingOrderByQueryFeatureDisabled,
                 testInjections: queryRequestOptions.TestSettings);
 
             string databaseId = "db1234";

--- a/templates/build-test.yml
+++ b/templates/build-test.yml
@@ -118,6 +118,8 @@ jobs:
       nugetConfigPath: NuGet.config
       publishTestResults: true
       testRunTitle: Microsoft.Azure.Cosmos.EmulatorTests
+    env: 
+      AZURE_COSMOS_NON_STREAMING_ORDER_BY_FLAG_DISABLED: true
 
 - job:
   displayName: EmulatorTests ${{ parameters.BuildConfiguration }} - ${{ parameters.EmulatorPipeline2CategoryListName }}
@@ -149,6 +151,8 @@ jobs:
       nugetConfigPath: NuGet.config
       publishTestResults: true
       testRunTitle: Microsoft.Azure.Cosmos.EmulatorTests
+    env: 
+      AZURE_COSMOS_NON_STREAMING_ORDER_BY_FLAG_DISABLED: true
 
 - job:
   displayName: Encryption EmulatorTests ${{ parameters.BuildConfiguration }}
@@ -180,6 +184,8 @@ jobs:
       nugetConfigPath: NuGet.config
       publishTestResults: true
       testRunTitle: Microsoft.Azure.Cosmos.Encryption.EmulatorTests
+    env: 
+      AZURE_COSMOS_NON_STREAMING_ORDER_BY_FLAG_DISABLED: true
 
 - job:
   displayName: Encryption.Custom EmulatorTests ${{ parameters.BuildConfiguration }}
@@ -211,6 +217,8 @@ jobs:
       nugetConfigPath: NuGet.config
       publishTestResults: true
       testRunTitle: Microsoft.Azure.Cosmos.Encryption.Custom.EmulatorTests
+    env: 
+      AZURE_COSMOS_NON_STREAMING_ORDER_BY_FLAG_DISABLED: true
 
 - job:
   displayName: EmulatorTests ${{ parameters.BuildConfiguration }} - ${{ parameters.EmulatorPipeline3CategoryListName }}
@@ -242,3 +250,4 @@ jobs:
       testRunTitle: Microsoft.Azure.Cosmos.EmulatorTests
     env: 
       COSMOSDB_MULTI_REGION: ${{ parameters.MultiRegionConnectionString }}
+      AZURE_COSMOS_NON_STREAMING_ORDER_BY_FLAG_DISABLED: true


### PR DESCRIPTION
## Description

In order to retrieve a query plan for non streaming order by queries, the sdk must send NonStreamingOrderBy in the list of supported query features to the gateway. However, older gateways will not recognize this new value, causing the query plan request to fail with a 400. To mitigate this edge case, we add a check for an environment variable `AZURE_COSMOS_NON_STREAMING_ORDER_BY_FLAG_DISABLED`, which when set to `True`  will suppress sending NonStreamingOrderBy in the list of supported query features.

A note about the naming
It is named as `DISABLED` by design for two reasons:
 - Since we decided to have this functionality enabled by default, if the environment variable is set, then the functionality would be disabled. This is reflected in the name of the environment variable.
- The convention is always to have `false` be the default for boolean flags. (Since C# will auto initialize to false for members.) If we name the flag as `ENABLED`, the default value would have to be `true`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
