### PR TITLE
Query : Fixes ORDER BY query issue when partial partition key is specified with hierarchical partition

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CosmosQueryExecutionContextFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CosmosQueryExecutionContextFactory.cs
@@ -248,6 +248,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
                    inputParameters.InitialFeedRange,
                    trace);
 
+            Debug.Assert(targetRanges != null, $"{nameof(CosmosQueryExecutionContextFactory)} Assert!", "targetRanges != null");
+
             TryCatch<IQueryPipelineStage> tryCreatePipelineStage;
             Documents.PartitionKeyRange targetRange = await TryGetTargetRangeOptimisticDirectExecutionAsync(
                 inputParameters,

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CosmosQueryExecutionContextFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CosmosQueryExecutionContextFactory.cs
@@ -270,7 +270,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
             }
             else
             {
-                bool singleLogicalPartitionKeyQuery = inputParameters.PartitionKey.HasValue
+                bool singleLogicalPartitionKeyQuery = (inputParameters.PartitionKey.HasValue && targetRanges.Count == 1)
                     || ((partitionedQueryExecutionInfo.QueryRanges.Count == 1)
                     && partitionedQueryExecutionInfo.QueryRanges[0].IsSingleValue);
                 bool serverStreamingQuery = !partitionedQueryExecutionInfo.QueryInfo.HasAggregates

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BaselineTest/TestBaseline/SubpartitionTests.TestQueriesOnSplitContainer.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BaselineTest/TestBaseline/SubpartitionTests.TestQueriesOnSplitContainer.xml
@@ -57,4 +57,62 @@
 {"id":"2","value2":"97"}]]></Documents>
     </Output>
   </Result>
+  <Result>
+    <Input>
+      <Description>SELECT with ORDER BY without ODE</Description>
+      <Query><![CDATA[SELECT c.id, c.value2, c.intVal FROM c ORDER BY c.intVal]]></Query>
+      <ODE>False</ODE>
+    </Input>
+    <Output>
+      <Documents><![CDATA[{"id":"2","value2":"97","intVal":-47},
+{"id":"2","value2":"92","intVal":-42},
+{"id":"2","value2":"87","intVal":-37},
+{"id":"2","value2":"82","intVal":-32},
+{"id":"2","value2":"77","intVal":-27},
+{"id":"2","value2":"72","intVal":-22},
+{"id":"2","value2":"67","intVal":-17},
+{"id":"2","value2":"62","intVal":-12},
+{"id":"2","value2":"57","intVal":-7},
+{"id":"2","value2":"52","intVal":-2},
+{"id":"2","value2":"47","intVal":3},
+{"id":"2","value2":"42","intVal":8},
+{"id":"2","value2":"37","intVal":13},
+{"id":"2","value2":"32","intVal":18},
+{"id":"2","value2":"27","intVal":23},
+{"id":"2","value2":"22","intVal":28},
+{"id":"2","value2":"17","intVal":33},
+{"id":"2","value2":"12","intVal":38},
+{"id":"2","value2":"7","intVal":43},
+{"id":"2","value2":"2","intVal":48}]]></Documents>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>SELECT with ORDER BY without ODE</Description>
+      <Query><![CDATA[SELECT c.id, c.value2, c.intVal FROM c ORDER BY c.intVal]]></Query>
+      <ODE>True</ODE>
+    </Input>
+    <Output>
+      <Documents><![CDATA[{"id":"2","value2":"97","intVal":-47},
+{"id":"2","value2":"92","intVal":-42},
+{"id":"2","value2":"87","intVal":-37},
+{"id":"2","value2":"82","intVal":-32},
+{"id":"2","value2":"77","intVal":-27},
+{"id":"2","value2":"72","intVal":-22},
+{"id":"2","value2":"67","intVal":-17},
+{"id":"2","value2":"62","intVal":-12},
+{"id":"2","value2":"57","intVal":-7},
+{"id":"2","value2":"52","intVal":-2},
+{"id":"2","value2":"47","intVal":3},
+{"id":"2","value2":"42","intVal":8},
+{"id":"2","value2":"37","intVal":13},
+{"id":"2","value2":"32","intVal":18},
+{"id":"2","value2":"27","intVal":23},
+{"id":"2","value2":"22","intVal":28},
+{"id":"2","value2":"17","intVal":33},
+{"id":"2","value2":"12","intVal":38},
+{"id":"2","value2":"7","intVal":43},
+{"id":"2","value2":"2","intVal":48}]]></Documents>
+    </Output>
+  </Result>
 </Results>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BaselineTest/TestBaseline/SubpartitionTests.TestQueriesOnSplitContainer.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BaselineTest/TestBaseline/SubpartitionTests.TestQueriesOnSplitContainer.xml
@@ -59,9 +59,9 @@
   </Result>
   <Result>
     <Input>
-      <Description>SELECT with ORDER BY without ODE</Description>
+      <Description>SELECT ORDER BY with ODE</Description>
       <Query><![CDATA[SELECT c.id, c.value2, c.intVal FROM c ORDER BY c.intVal]]></Query>
-      <ODE>False</ODE>
+      <ODE>True</ODE>
     </Input>
     <Output>
       <Documents><![CDATA[{"id":"2","value2":"97","intVal":-47},
@@ -88,9 +88,9 @@
   </Result>
   <Result>
     <Input>
-      <Description>SELECT with ORDER BY without ODE</Description>
+      <Description>SELECT ORDER BY without ODE</Description>
       <Query><![CDATA[SELECT c.id, c.value2, c.intVal FROM c ORDER BY c.intVal]]></Query>
-      <ODE>True</ODE>
+      <ODE>False</ODE>
     </Input>
     <Output>
       <Documents><![CDATA[{"id":"2","value2":"97","intVal":-47},

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/SubpartitionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/SubpartitionTests.cs
@@ -37,8 +37,8 @@
                 {
                     new SubpartitionTestInput(description: "SELECT", query: @"SELECT c.id, c.value2 FROM c", ode: true),
                     new SubpartitionTestInput(description: "SELECT without ODE", query: @"SELECT c.id, c.value2 FROM c", ode: false),
-                    new SubpartitionTestInput(description: "SELECT with ORDER BY without ODE", query: @"SELECT c.id, c.value2, c.intVal FROM c ORDER BY c.intVal", ode: false, sortResults: false),
-                    new SubpartitionTestInput(description: "SELECT with ORDER BY without ODE", query: @"SELECT c.id, c.value2, c.intVal FROM c ORDER BY c.intVal", ode: true, sortResults: false),
+                    new SubpartitionTestInput(description: "SELECT ORDER BY with ODE", query: @"SELECT c.id, c.value2, c.intVal FROM c ORDER BY c.intVal", ode: true, sortResults: false),
+                    new SubpartitionTestInput(description: "SELECT ORDER BY without ODE", query: @"SELECT c.id, c.value2, c.intVal FROM c ORDER BY c.intVal", ode: false, sortResults: false),
                 };
 
             this.ExecuteTestSuite(inputs);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/SubpartitionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/SubpartitionTests.cs
@@ -35,9 +35,12 @@
         {
             List<SubpartitionTestInput> inputs = new List<SubpartitionTestInput>
                 {
-                    new SubpartitionTestInput("SELECT", query: @"SELECT c.id, c.value2 FROM c", ode: true),
-                    new SubpartitionTestInput("SELECT without ODE", query: @"SELECT c.id, c.value2 FROM c", ode: false),
+                    new SubpartitionTestInput(description: "SELECT", query: @"SELECT c.id, c.value2 FROM c", ode: true),
+                    new SubpartitionTestInput(description: "SELECT without ODE", query: @"SELECT c.id, c.value2 FROM c", ode: false),
+                    new SubpartitionTestInput(description: "SELECT with ORDER BY without ODE", query: @"SELECT c.id, c.value2, c.intVal FROM c ORDER BY c.intVal", ode: false, sortResults: false),
+                    new SubpartitionTestInput(description: "SELECT with ORDER BY without ODE", query: @"SELECT c.id, c.value2, c.intVal FROM c ORDER BY c.intVal", ode: true, sortResults: false),
                 };
+
             this.ExecuteTestSuite(inputs);
         }
 
@@ -65,16 +68,19 @@
 
         public override SubpartitionTestOutput ExecuteTest(SubpartitionTestInput input)
         {
-            IMonadicDocumentContainer monadicDocumentContainer = CreateSplitDocumentContainerAsync(DocumentCount).Result;
+            QueryRequestOptions queryRequestOptions = new QueryRequestOptions()
+            {
+                PartitionKey = new PartitionKeyBuilder().Add(SplitPartitionKey.ToString()).Build()
+            };
+
+            IMonadicDocumentContainer monadicDocumentContainer = CreateSplitDocumentContainerAsync(DocumentCount, queryRequestOptions).Result;
             DocumentContainer documentContainer = new DocumentContainer(monadicDocumentContainer);
+            TryCatch _ = monadicDocumentContainer.MonadicRefreshProviderAsync(NoOpTrace.Singleton, cancellationToken: default).Result;
+            List<FeedRangeEpk> containerRanges = documentContainer.GetFeedRangesAsync(NoOpTrace.Singleton, cancellationToken: default).Result;
 
             List<CosmosElement> documents = new List<CosmosElement>();
-            QueryRequestOptions queryRequestOptions = new QueryRequestOptions()
-                {
-                    PartitionKey = new PartitionKeyBuilder().Add(SplitPartitionKey.ToString()).Build()
-                };
             (CosmosQueryExecutionContextFactory.InputParameters inputParameters, CosmosQueryContextCore cosmosQueryContextCore) =
-                CreateInputParamsAndQueryContext(input, queryRequestOptions);
+                CreateInputParamsAndQueryContext(input, queryRequestOptions, containerRanges);
             IQueryPipelineStage queryPipelineStage = CosmosQueryExecutionContextFactory.Create(
                         documentContainer,
                         cosmosQueryContextCore,
@@ -92,10 +98,10 @@
                 documents.AddRange(tryGetPage.Result.Documents);
             }
 
-            return new SubpartitionTestOutput(documents);
+            return new SubpartitionTestOutput(documents, input.SortResults);
         }
 
-        private static Tuple<CosmosQueryExecutionContextFactory.InputParameters, CosmosQueryContextCore> CreateInputParamsAndQueryContext(SubpartitionTestInput input, QueryRequestOptions queryRequestOptions)
+        private static Tuple<CosmosQueryExecutionContextFactory.InputParameters, CosmosQueryContextCore> CreateInputParamsAndQueryContext(SubpartitionTestInput input, QueryRequestOptions queryRequestOptions, IReadOnlyList<FeedRangeEpk> containerRanges)
         {
             string query = input.Query;
             CosmosElement continuationToken = null;
@@ -134,10 +140,20 @@
                 isNonStreamingOrderByQueryFeatureDisabled: queryRequestOptions.IsNonStreamingOrderByQueryFeatureDisabled,
                 testInjections: queryRequestOptions.TestSettings);
 
+            List<PartitionKeyRange> targetPkRanges = new();
+            foreach (FeedRangeEpk feedRangeEpk in containerRanges)
+            {
+                targetPkRanges.Add(new PartitionKeyRange
+                {
+                    MinInclusive = feedRangeEpk.Range.Min,
+                    MaxExclusive = feedRangeEpk.Range.Max,
+                });
+            }
+
             string databaseId = "db1234";
             string resourceLink = $"dbs/{databaseId}/colls";
             CosmosQueryContextCore cosmosQueryContextCore = new CosmosQueryContextCore(
-                client: new TestCosmosQueryClient(queryPartitionProvider),
+                client: new TestCosmosQueryClient(queryPartitionProvider, targetPkRanges),
                 resourceTypeEnum: Documents.ResourceType.Document,
                 operationType: Documents.OperationType.Query,
                 resourceType: typeof(QueryResponseCore),
@@ -215,20 +231,20 @@
             return partitionKeyDefinition;
         }
 
-        private static async Task<IDocumentContainer> CreateSplitDocumentContainerAsync(int numItems)
+        private static async Task<IDocumentContainer> CreateSplitDocumentContainerAsync(int numItems, QueryRequestOptions queryRequestOptions)
         {
             PartitionKeyDefinition partitionKeyDefinition = CreatePartitionKeyDefinition();
-            InMemoryContainer inMemoryContainer = await CreateSplitInMemoryDocumentContainerAsync(numItems, partitionKeyDefinition);
+            InMemoryContainer inMemoryContainer = await CreateSplitInMemoryDocumentContainerAsync(numItems, partitionKeyDefinition, queryRequestOptions);
             DocumentContainer documentContainer = new DocumentContainer(inMemoryContainer);
             return documentContainer;
         }
 
-        private static async Task<InMemoryContainer> CreateSplitInMemoryDocumentContainerAsync(int numItems, PartitionKeyDefinition partitionKeyDefinition)
+        private static async Task<InMemoryContainer> CreateSplitInMemoryDocumentContainerAsync(int numItems, PartitionKeyDefinition partitionKeyDefinition, QueryRequestOptions queryRequestOptions = null)
         {
-            InMemoryContainer inMemoryContainer = new InMemoryContainer(partitionKeyDefinition, createSplitForMultiHashAtSecondlevel: true, resolvePartitionsBasedOnPrefix: true);
+            InMemoryContainer inMemoryContainer = new InMemoryContainer(partitionKeyDefinition, createSplitForMultiHashAtSecondlevel: true, resolvePartitionsBasedOnPrefix: true, queryRequestOptions: queryRequestOptions);
             for (int i = 0; i < numItems; i++)
             {
-                CosmosObject item = CosmosObject.Parse($"{{\"id\" : \"{i % 5}\", \"value1\" : \"{Guid.NewGuid()}\", \"value2\" : \"{i}\" }}");
+                CosmosObject item = CosmosObject.Parse($"{{\"id\" : \"{i % 5}\", \"value1\" : \"{Guid.NewGuid()}\", \"value2\" : \"{i}\", \"intVal\" : {(numItems/2) - i} }}");
                 while (true)
                 {
                     TryCatch<Record> monadicCreateRecord = await inMemoryContainer.MonadicCreateItemAsync(item, cancellationToken: default);
@@ -243,13 +259,16 @@
 
             return inMemoryContainer;
         }
+
         internal class TestCosmosQueryClient : CosmosQueryClient
         {
             private readonly QueryPartitionProvider queryPartitionProvider;
+            private readonly IReadOnlyList<PartitionKeyRange> targetPartitionKeyRanges;
 
-            public TestCosmosQueryClient(QueryPartitionProvider queryPartitionProvider)
+            public TestCosmosQueryClient(QueryPartitionProvider queryPartitionProvider, IEnumerable<PartitionKeyRange> targetPartitionKeyRanges)
             {
                 this.queryPartitionProvider = queryPartitionProvider;
+                this.targetPartitionKeyRanges = targetPartitionKeyRanges.ToList();
             }
 
             public override Action<IQueryable> OnExecuteScalarQueryCallback => throw new NotImplementedException();
@@ -322,14 +341,7 @@
 
             public override Task<List<PartitionKeyRange>> GetTargetPartitionKeyRangesAsync(string resourceLink, string collectionResourceId, IReadOnlyList<Documents.Routing.Range<string>> providedRanges, bool forceRefresh, ITrace trace)
             {
-                return Task.FromResult(new List<PartitionKeyRange>
-                    {
-                        new PartitionKeyRange()
-                        {
-                            MinInclusive = Documents.Routing.PartitionKeyInternal.MinimumInclusiveEffectivePartitionKey,
-                            MaxExclusive = Documents.Routing.PartitionKeyInternal.MaximumExclusiveEffectivePartitionKey
-                        }
-                    });
+                return Task.FromResult(this.targetPartitionKeyRanges.ToList());
             }
 
             public override Task<IReadOnlyList<PartitionKeyRange>> TryGetOverlappingRangesAsync(string collectionResourceId, Documents.Routing.Range<string> range, bool forceRefresh = false)
@@ -351,16 +363,19 @@
 
     public class SubpartitionTestInput : BaselineTestInput
     {
-        public SubpartitionTestInput(string description, string query, bool ode)
+        public SubpartitionTestInput(string description, string query, bool ode, bool sortResults = true)
             :base(description)
         {
             this.Query = query;
             this.ODE = ode;
+            this.SortResults = sortResults;
         }
 
         internal string Query { get; }
 
         internal bool ODE { get; }
+
+        internal bool SortResults { get; }
 
         public override void SerializeAsXml(XmlWriter xmlWriter)
         {
@@ -375,17 +390,25 @@
     public class SubpartitionTestOutput : BaselineTestOutput
     {
         private readonly List<CosmosElement> documents;
+        private readonly bool sortResults;
 
-        internal SubpartitionTestOutput(IReadOnlyList<CosmosElement> documents)
+        internal SubpartitionTestOutput(IReadOnlyList<CosmosElement> documents, bool sortResults)
         {
             this.documents = documents.ToList();
+            this.sortResults = sortResults;
         }
 
         public override void SerializeAsXml(XmlWriter xmlWriter)
         {
             xmlWriter.WriteStartElement("Documents");
-            string content = string.Join($",{Environment.NewLine}",
-                this.documents.Select(doc => doc.ToString()).OrderBy(serializedDoc => serializedDoc));
+
+            IEnumerable<string> lines = this.documents.Select(doc => doc.ToString());
+            if(this.sortResults)
+            {
+                lines = lines.OrderBy(serializedDoc => serializedDoc);
+            }
+
+            string content = string.Join($",{Environment.NewLine}", lines);
             xmlWriter.WriteCData(content);
             xmlWriter.WriteEndElement();
         }


### PR DESCRIPTION
# Pull Request Template

## Description

If partial partition key is specified during query execution and the container partition is split at the top level of the partition key, ORDER BY query results may be wrong. This happens because query is incorrectly treated as a streaming ORDER BY query, even though it spans across multiple physical partitions. The fix is to ensure cross-partition ORDER BY pipeline gets used, which applies global sort on results obtained from each backend partition (using k-way merge). Since the physical partitions are already resolved by the time this determination is made (they just happen to get ignored at the moment), the fix is straightforward and bulk of the change is test related.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #4472