### PR TITLE
[Internal] Query : Fixes response parsing error for ReadFeed by limiting binary format to query operations

### DIFF
--- a/Microsoft.Azure.Cosmos.Encryption/tests/EmulatorTests/MdeEncryptionTests.cs
+++ b/Microsoft.Azure.Cosmos.Encryption/tests/EmulatorTests/MdeEncryptionTests.cs
@@ -582,7 +582,6 @@ namespace Microsoft.Azure.Cosmos.Encryption.EmulatorTests
             TestDoc expectedDoc = new TestDoc(testDoc);
 
 #if SDKPROJECTREF
-            TODO: Re-enable when new SDK is referenced
             await MdeEncryptionTests.ValidateQueryResultsAsync(
                 MdeEncryptionTests.encryptionContainer,
                 query: null,

--- a/Microsoft.Azure.Cosmos.Encryption/tests/EmulatorTests/MdeEncryptionTests.cs
+++ b/Microsoft.Azure.Cosmos.Encryption/tests/EmulatorTests/MdeEncryptionTests.cs
@@ -581,10 +581,13 @@ namespace Microsoft.Azure.Cosmos.Encryption.EmulatorTests
 
             TestDoc expectedDoc = new TestDoc(testDoc);
 
+#if SDKPROJECTREF
+            TODO: Re-enable when new SDK is referenced
             await MdeEncryptionTests.ValidateQueryResultsAsync(
                 MdeEncryptionTests.encryptionContainer,
                 query: null,
                 expectedDocList: new List<TestDoc> { expectedDoc });
+#endif
 
             expectedDoc = new TestDoc(testDoc);
             await MdeEncryptionTests.ValidateQueryResultsAsync(

--- a/Microsoft.Azure.Cosmos.Encryption/tests/EmulatorTests/Microsoft.Azure.Cosmos.Encryption.EmulatorTests.csproj
+++ b/Microsoft.Azure.Cosmos.Encryption/tests/EmulatorTests/Microsoft.Azure.Cosmos.Encryption.EmulatorTests.csproj
@@ -68,4 +68,8 @@
   <PropertyGroup Condition=" '$(SdkProjectRef)' != 'True' AND '$(IsPreview)' == 'True' ">
     <DefineConstants>$(DefineConstants);ENCRYPTIONTESTPREVIEW</DefineConstants>
   </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(SdkProjectRef)' == 'True'">
+    <DefineConstants>$(DefineConstants);SDKPROJECTREF</DefineConstants>
+  </PropertyGroup>
 </Project>

--- a/Microsoft.Azure.Cosmos/src/Query/v2Query/DocumentQueryExecutionContextBase.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v2Query/DocumentQueryExecutionContextBase.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Azure.Cosmos.Query
     internal abstract class DocumentQueryExecutionContextBase : IDocumentQueryExecutionContext
     {
         // ISSUE-TODO-adityasa-2024/5/27 - Re-enable binary format. Currently encryption codepath is not able to handle binary response.
-        public static readonly string DefaultSupportedSerializationFormats = string.Join(",", SupportedSerializationFormats.JsonText);
+        public static readonly string DefaultSupportedSerializationFormats = SupportedSerializationFormats.JsonText.ToString();
 
         public readonly struct InitParams
         {

--- a/Microsoft.Azure.Cosmos/src/Query/v2Query/DocumentQueryExecutionContextBase.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v2Query/DocumentQueryExecutionContextBase.cs
@@ -32,8 +32,9 @@ namespace Microsoft.Azure.Cosmos.Query
 
     internal abstract class DocumentQueryExecutionContextBase : IDocumentQueryExecutionContext
     {
-        public static readonly string DefaultSupportedSerializationFormats = string.Join(",", SupportedSerializationFormats.JsonText, SupportedSerializationFormats.CosmosBinary);
-        
+        // ISSUE-TODO-adityasa-2024/5/27 - Re-enable binary format. Currently encryption codepath is not able to handle binary response.
+        public static readonly string DefaultSupportedSerializationFormats = string.Join(",", SupportedSerializationFormats.JsonText);
+
         public readonly struct InitParams
         {
             public IDocumentQueryClient Client { get; }

--- a/Microsoft.Azure.Cosmos/src/Query/v2Query/DocumentQueryExecutionContextBase.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v2Query/DocumentQueryExecutionContextBase.cs
@@ -32,9 +32,8 @@ namespace Microsoft.Azure.Cosmos.Query
 
     internal abstract class DocumentQueryExecutionContextBase : IDocumentQueryExecutionContext
     {
-        // ISSUE-TODO-adityasa-2024/5/27 - Re-enable binary format. Currently encryption codepath is not able to handle binary response.
-        public static readonly string DefaultSupportedSerializationFormats = SupportedSerializationFormats.JsonText.ToString();
-
+        public static readonly string DefaultSupportedSerializationFormats = string.Join(",", SupportedSerializationFormats.JsonText, SupportedSerializationFormats.CosmosBinary);
+        
         public readonly struct InitParams
         {
             public IDocumentQueryClient Client { get; }

--- a/Microsoft.Azure.Cosmos/src/RequestOptions/QueryRequestOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/RequestOptions/QueryRequestOptions.cs
@@ -237,8 +237,11 @@ namespace Microsoft.Azure.Cosmos
             {
                 request.Headers.Add(HttpConstants.HttpHeaders.ResponseContinuationTokenLimitInKB, this.ResponseContinuationTokenLimitInKb.ToString());
             }
-            
-            request.Headers.CosmosMessageHeaders.SupportedSerializationFormats = this.SupportedSerializationFormats?.ToString() ?? DocumentQueryExecutionContextBase.DefaultSupportedSerializationFormats;
+
+            if (request.OperationType == OperationType.Query)
+            {
+                request.Headers.CosmosMessageHeaders.SupportedSerializationFormats = this.SupportedSerializationFormats?.ToString() ?? DocumentQueryExecutionContextBase.DefaultSupportedSerializationFormats;
+            }
 
             if (this.StartId != null)
             {

--- a/Microsoft.Azure.Cosmos/src/RequestOptions/QueryRequestOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/RequestOptions/QueryRequestOptions.cs
@@ -238,6 +238,9 @@ namespace Microsoft.Azure.Cosmos
                 request.Headers.Add(HttpConstants.HttpHeaders.ResponseContinuationTokenLimitInKB, this.ResponseContinuationTokenLimitInKb.ToString());
             }
 
+            // All query APIs (GetItemQueryIterator, GetItemLinqQueryable and GetItemQueryStreamIterator) turn into ReadFeed operation if query text is null.
+            // In such a case, query pipelines are still involved (including QueryRequestOptions). In general backend only honors SupportedSerializationFormats
+            //  for OperationType Query but has a bug where it returns a binary response for ReadFeed API when partition key is also specified in the request.
             if (request.OperationType == OperationType.Query)
             {
                 request.Headers.CosmosMessageHeaders.SupportedSerializationFormats = this.SupportedSerializationFormats?.ToString() ?? DocumentQueryExecutionContextBase.DefaultSupportedSerializationFormats;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/HeadersValidationTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/HeadersValidationTests.cs
@@ -389,7 +389,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             INameValueCollection headers = new RequestNameValueCollection();
 
             headers.Add(HttpConstants.HttpHeaders.SupportedSerializationFormats, supportedSerializationFormats);
-            DocumentServiceResponse response;                   
+            DocumentServiceResponse response;
             if(sqlQuerySpec!=null)
             {
                 response = this.QueryRequest(client, collection.ResourceId, sqlQuerySpec, headers);
@@ -440,34 +440,28 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 expectedFormat: SupportedSerializationFormats.JsonText,
                 supportedSerializationFormats: "jsontext",
                 sqlQuerySpec: sqlQuerySpec);
-            /*
             this.SupportedSerializationFormatsPositiveCases(client, collection,
                 expectedFormat: SupportedSerializationFormats.CosmosBinary,
                 supportedSerializationFormats: "COSMOSBINARY",
                 sqlQuerySpec: sqlQuerySpec);
-            */
             this.SupportedSerializationFormatsPositiveCases(client, collection,
-                expectedFormat: SupportedSerializationFormats.JsonText,
+                expectedFormat: SupportedSerializationFormats.CosmosBinary,
                 supportedSerializationFormats: "JsonText, CosmosBinary",
                 sqlQuerySpec: sqlQuerySpec);
-            /*
             this.SupportedSerializationFormatsPositiveCases(client, collection,
                 expectedFormat: SupportedSerializationFormats.CosmosBinary,
                 supportedSerializationFormats: "CosmosBinary, HybridRow",
                 sqlQuerySpec: sqlQuerySpec);
-            */
-            this.SupportedSerializationFormatsPositiveCases(client, collection,
-                expectedFormat: SupportedSerializationFormats.JsonText,
-                supportedSerializationFormats: "JsonText, CosmosBinary, HybridRow",
-                sqlQuerySpec: sqlQuerySpec);
-            /*
             this.SupportedSerializationFormatsPositiveCases(client, collection,
                 expectedFormat: SupportedSerializationFormats.CosmosBinary,
                 supportedSerializationFormats: "JsonText, CosmosBinary, HybridRow",
                 sqlQuerySpec: sqlQuerySpec);
-            */
             this.SupportedSerializationFormatsPositiveCases(client, collection,
-                expectedFormat: SupportedSerializationFormats.JsonText,
+                expectedFormat: SupportedSerializationFormats.CosmosBinary,
+                supportedSerializationFormats: "JsonText, CosmosBinary, HybridRow",
+                sqlQuerySpec: sqlQuerySpec);
+            this.SupportedSerializationFormatsPositiveCases(client, collection,
+                expectedFormat: SupportedSerializationFormats.CosmosBinary,
                 supportedSerializationFormats: "JsonText, CosmosBinary, HybridRow",
                 sqlQuerySpec: sqlQuerySpec);
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/SupportedSerializationFormatsTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/SupportedSerializationFormatsTest.cs
@@ -1,14 +1,13 @@
 ﻿namespace Microsoft.Azure.Cosmos.Query
 {
-    using System;
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.EmulatorTests.Query;
-    using Microsoft.Azure.Cosmos.SDK.EmulatorTests.QueryOracle;
     using Microsoft.Azure.Documents;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Newtonsoft.Json.Linq;
 
     [TestClass]
     [TestCategory("Query")]
@@ -36,66 +35,89 @@
                 CollectionTypes.SinglePartition | CollectionTypes.MultiPartition,
                 inputDocuments,
                 this.TestSupportedSerializationFormatsHelper,
-                    "/id");
+                "/id");
         }
 
         private async Task TestSupportedSerializationFormatsHelper(Container container, IReadOnlyList<CosmosObject> documents)
         {
-            string[] expectedResults = new[] { "document_0", "document_1", "document_2", "document_3", "document_4", "document_5", "document_6", "document_7", "document_8", "document_9" };
-            string query = string.Format("SELECT c.name FROM c");
-            List<QueryRequestOptions> queryRequestOptionsList = new List<QueryRequestOptions>()
-            {
-                new QueryRequestOptions()
+            List<(Cosmos.PartitionKey?, string[]) > partitionKeyAndExpectedResults = new List<(Cosmos.PartitionKey? partitionKey, string[] documents)>
                 {
-                    SupportedSerializationFormats = SupportedSerializationFormats.CosmosBinary | SupportedSerializationFormats.HybridRow
-                },
-                new QueryRequestOptions()
-                {
-                    SupportedSerializationFormats = SupportedSerializationFormats.JsonText | SupportedSerializationFormats.CosmosBinary
-                },
-                new QueryRequestOptions()
-                {
-                    SupportedSerializationFormats = SupportedSerializationFormats.JsonText | SupportedSerializationFormats.HybridRow
-                },
-                new QueryRequestOptions()
-                {
-                    SupportedSerializationFormats = SupportedSerializationFormats.JsonText | SupportedSerializationFormats.CosmosBinary | SupportedSerializationFormats.HybridRow
-                },
-                new QueryRequestOptions()
-                {
-                    SupportedSerializationFormats = SupportedSerializationFormats.JsonText
-                },
-                new QueryRequestOptions()
-                {
-                    SupportedSerializationFormats = SupportedSerializationFormats.CosmosBinary
-                },
-                new QueryRequestOptions()
-                {
-                    SupportedSerializationFormats = SupportedSerializationFormats.CosmosBinary
-                },
-                new QueryRequestOptions()
-                {
-                    SupportedSerializationFormats = SupportedSerializationFormats.JsonText
-                }
-            };
+                    (
+                        partitionKey: null,
+                        documents: new[] { "document_0", "document_1", "document_2", "document_3", "document_4", "document_5", "document_6", "document_7", "document_8", "document_9" }
+                    ),
+                    (
+                        partitionKey: new Cosmos.PartitionKey("0"),
+                        documents: new[] { "document_0" }
+                    )
+                };
 
-            foreach (QueryRequestOptions requestOptions in queryRequestOptionsList)
-            {
-                List<CosmosElement> results = new List<CosmosElement>();
-                using (FeedIterator<CosmosElement> feedIterator = container.GetItemQueryIterator<CosmosElement>(new QueryDefinition(query), requestOptions: requestOptions))
+            foreach (string query in new string[]
                 {
-                    while (feedIterator.HasMoreResults)
+                    null,   // With null query, this turns into a ReadFeed API, for which SupportedSerializationFormats should be ignored.
+                    "SELECT * FROM c"
+                })
+            {
+                List<QueryRequestOptions> queryRequestOptionsList = new List<QueryRequestOptions>()
+                {
+                    new QueryRequestOptions()
                     {
-                        FeedResponse<CosmosElement> response = await feedIterator.ReadNextAsync();
-                        results.AddRange(response.ToList());
+                        SupportedSerializationFormats = SupportedSerializationFormats.CosmosBinary | SupportedSerializationFormats.HybridRow
+                    },
+                    new QueryRequestOptions()
+                    {
+                        SupportedSerializationFormats = SupportedSerializationFormats.JsonText | SupportedSerializationFormats.CosmosBinary
+                    },
+                    new QueryRequestOptions()
+                    {
+                        SupportedSerializationFormats = SupportedSerializationFormats.JsonText | SupportedSerializationFormats.HybridRow
+                    },
+                    new QueryRequestOptions()
+                    {
+                        SupportedSerializationFormats = SupportedSerializationFormats.JsonText | SupportedSerializationFormats.CosmosBinary | SupportedSerializationFormats.HybridRow
+                    },
+                    new QueryRequestOptions()
+                    {
+                        SupportedSerializationFormats = SupportedSerializationFormats.JsonText
+                    },
+                    new QueryRequestOptions()
+                    {
+                        SupportedSerializationFormats = SupportedSerializationFormats.CosmosBinary
+                    },
+                    new QueryRequestOptions()
+                    {
+                        SupportedSerializationFormats = SupportedSerializationFormats.CosmosBinary
+                    },
+                    new QueryRequestOptions()
+                    {
+                        SupportedSerializationFormats = SupportedSerializationFormats.JsonText
+                    }
+                };
+
+                foreach (QueryRequestOptions requestOptions in queryRequestOptionsList)
+                {
+                    QueryDefinition queryDefinition = query != null ? new QueryDefinition(query) : null;
+                    foreach ((Cosmos.PartitionKey? partitionKey, string[] expectedResults) in partitionKeyAndExpectedResults)
+                    {
+                        requestOptions.PartitionKey = partitionKey;
+
+                        List<JObject> queryResults = new List<JObject>();
+                        using (FeedIterator<JObject> feedIterator = container.GetItemQueryIterator<JObject>(queryDefinition, requestOptions: requestOptions))
+                        {
+                            while (feedIterator.HasMoreResults)
+                            {
+                                FeedResponse<JObject> response = await feedIterator.ReadNextAsync();
+                                queryResults.AddRange(response.ToList());
+                            }
+                        }
+
+                        string[] actualResults = queryResults
+                            .Select(doc => doc["name"].ToString())
+                            .ToArray();
+
+                        CollectionAssert.AreEquivalent(expectedResults, actualResults);
                     }
                 }
-
-                string[] actualResults = results
-                    .Select(doc => ((CosmosString)(doc as CosmosObject)["name"]).Value.ToString())
-                    .ToArray();
-
-                CollectionAssert.AreEquivalent(expectedResults, actualResults);
             }
         }
     }


### PR DESCRIPTION
# Pull Request Template

## Description

This change restricts use of SupportedSerializationFormats header to query scenarios only. Technically, this header is only used by QueryRequestOptions, however, the QueryRequestOptions (and therefore this header) also get invoked for ReadFeed. There is no direct API for ReadFeed, instead any of the query APIs (GetItemLinqQueryable, GetItemQueryIterator<T>, GetItemStreamQueryIterator) invoke ReadFeed operation (instead of Query operation) if supplied query (or QueryDefinition) is null.

ReadFeed API in the backend currently doesn't support this header and returns the response in text. However as it turns out, if this API is invoked with a specific partition key in the request options, backend honors the header. This is an issue, since SDK doesn't support handling of binary response in ReadFeed codepath.

As a result, when query APIs are invoked with query = null and a specific partition key, response cannot be parsed successfully. The issue is recently discovered after new emulator is published, which enabled binary encoding by default (when /EnablePreview flag is supplied). The issue was discovered in the form of test failures in the pipeline (which uses latest emulator with EnablePreview flag).
Currently following tests are failing:
EncryptionCreateItemAndQuery
ValidateSupportedSerializationFormatsRntbd
ValidateSupportedSerializationFormatsGateway

This change fixes following tests:
ValidateSupportedSerializationFormatsRntbd
ValidateSupportedSerializationFormatsGateway

The encryption project does not use the SDK code from master (by referencing project), but rather released SDK v3.35.4. The failing portion of the EncryptionCreateItemAndQuery test is made conditional, by only allowing to run when SDK project is referenced.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber