### PR TITLE
[Internal] Visibility: Adds new Portal Backend to Microsoft.Azure.Cosmos InternalsVisibleTo

### DIFF
--- a/Microsoft.Azure.Cosmos/src/AssemblyInfo.cs
+++ b/Microsoft.Azure.Cosmos/src/AssemblyInfo.cs
@@ -23,6 +23,8 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Microsoft.Azure.Cosmos.Table.Tests" + AssemblyKeys.TestPublicKey)]
 [assembly: InternalsVisibleTo("Microsoft.Azure.Cosmos.Performance.Tests" + AssemblyKeys.ProductPublicKey)]
 [assembly: InternalsVisibleTo("Microsoft.Azure.Cosmos.Performance.Tests" + AssemblyKeys.TestPublicKey)]
+[assembly: InternalsVisibleTo("Microsoft.Azure.Cosmos.Portal.Services.Backend" + AssemblyKeys.ProductPublicKey)]
+[assembly: InternalsVisibleTo("Microsoft.Azure.Cosmos.Portal.Services.Backend" + AssemblyKeys.TestPublicKey)]
 [assembly: InternalsVisibleTo("Microsoft.Azure.Cosmos.Tests" + AssemblyKeys.ProductPublicKey)]
 [assembly: InternalsVisibleTo("Microsoft.Azure.Cosmos.Tests" + AssemblyKeys.TestPublicKey)]
 [assembly: InternalsVisibleTo("Microsoft.Azure.Cosmos.EmulatorTests" + AssemblyKeys.ProductPublicKey)]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/ContractTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/ContractTests.cs
@@ -5,10 +5,11 @@ namespace Microsoft.Azure.Cosmos.Contracts
 {
     using System;
     using System.Linq;
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
     using System.Reflection;
-    using Microsoft.Azure.Documents;
+    using System.Runtime.CompilerServices;
     using System.Text;
+    using Microsoft.Azure.Documents;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     [TestClass]
     public class ContractTests
@@ -41,6 +42,49 @@ namespace Microsoft.Azure.Cosmos.Contracts
             int expected = 5;
 #endif
             ContractTests.NamespaceCountTest(typeof(CosmosClient), expected);
+        }
+
+        [TestMethod]
+        public void GenerateKeyAuthorizationSignatureContractTest()
+        {
+            Assembly clientAssembly = typeof(AuthorizationHelper).GetAssembly();
+            object[] internals = clientAssembly.GetCustomAttributes(typeof(InternalsVisibleToAttribute), false);
+            bool foundPortalBackend = internals.Cast<InternalsVisibleToAttribute>()
+                                  .Any(x => x.AssemblyName.Contains("Microsoft.Azure.Cosmos.Portal.Services.Backend"));
+
+            if (foundPortalBackend)
+            {
+                // Test GenerateKeyAuthorizationSignature method still exists
+                string[] generateKeyAuthorizationSignatureArgs = new string[] {
+                    "http://localhost.sql:8901/dbs/92dc837c73484349852a2c8f05777565/colls/ea9ebd7de6aa46d8bc0aa7e29b89236c",
+                    "dbs/92dc837c73484349852a2c8f05777565/colls/ea9ebd7de6aa46d8bc0aa7e29b89236c",
+                    "GET",
+                    "colls",
+                    "Tue, 21 Jul 2020 17:55:37 GMT",
+                    "" };
+                string key = "VGhpcyBpcyBhIHNhbXBsZSBzdHJpbmc=";
+                Documents.Collections.RequestNameValueCollection headers = new()
+                {
+                    { HttpConstants.HttpHeaders.XDate, generateKeyAuthorizationSignatureArgs[4] }
+                };
+
+                string keyAuthorizationSignature = AuthorizationHelper.GenerateKeyAuthorizationSignature(
+                    verb: generateKeyAuthorizationSignatureArgs[2],
+                    resourceId: generateKeyAuthorizationSignatureArgs[1],
+                    resourceType: generateKeyAuthorizationSignatureArgs[3],
+                    headers: headers,
+                    key: key);
+
+                AuthorizationHelper.ParseAuthorizationToken(keyAuthorizationSignature, out ReadOnlyMemory<char> typeOutput1, out ReadOnlyMemory<char> versionoutput1, out ReadOnlyMemory<char> tokenOutput1);
+                Assert.AreEqual("master", typeOutput1.ToString());
+                Assert.IsTrue(AuthorizationHelper.CheckPayloadUsingKey(
+                    tokenOutput1, 
+                    generateKeyAuthorizationSignatureArgs[2], 
+                    generateKeyAuthorizationSignatureArgs[1], 
+                    generateKeyAuthorizationSignatureArgs[3], 
+                    headers, 
+                    key));
+            }
         }
 
         private static void NamespaceCountTest(Type input, int expected)


### PR DESCRIPTION
# Pull Request Template

## Description

Portal team is migrating our backend to new infrastructure. As a part of this change the service will need access to `AuthorizationHelper`'s [GenerateKeyAuthorizationSignature](https://github.com/Azure/azure-cosmos-dotnet-v3/blob/18a677ace9998450f22598efe43cecb20dea079e/Microsoft.Azure.Cosmos/src/Authorization/AuthorizationHelper.cs#L108C30-L108C63). We are adding Portal Backend to `Microsoft.Azure.Cosmos`'s `InternalsVisibleTo`

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)