### PR TITLE
Query: Adds new Direct package version

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
 		<ClientOfficialVersion>3.40.0</ClientOfficialVersion>
 		<ClientPreviewVersion>3.41.0</ClientPreviewVersion>
 		<ClientPreviewSuffixVersion>preview.0</ClientPreviewSuffixVersion>
-		<DirectVersion>3.34.3</DirectVersion>
+		<DirectVersion>3.34.4</DirectVersion>
 		<EncryptionOfficialVersion>2.0.4</EncryptionOfficialVersion>
 		<EncryptionPreviewVersion>2.1.0</EncryptionPreviewVersion>
 		<EncryptionPreviewSuffixVersion>preview4</EncryptionPreviewSuffixVersion>


### PR DESCRIPTION
Upgrade Direct package version to 3.34.4

This upgrade contains the following changes:
Pull Request 1350393: Service interop change to utilize the vectorEmbeddings
Pull Request 1364446: Additional checks when parsing the vector embed policy
Pull Request 1359906: Baseline tests added for embedding and vector index parsing
Pull Request 1354385: FaultInjection: Refactors IChaosInterceptor to allow Gateway mode compatibility
Pull Request 1338135: Add in support for MakeList and MakeSet in QueryInfoExtractor