### PR TITLE
ReadManyItemsAsync -> ReadManyTaskHelperAsync wraps forked IO task into Task.Run

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ReadManyQueryHelper.cs
+++ b/Microsoft.Azure.Cosmos/src/ReadManyQueryHelper.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Azure.Cosmos
     using System;
     using System.Collections;
     using System.Collections.Generic;
+    using System.Linq;
     using System.Net;
     using System.Text;
     using System.Threading;
@@ -84,42 +85,46 @@ namespace Microsoft.Azure.Cosmos
                                   CancellationToken cancellationToken)
         {
             SemaphoreSlim semaphore = new SemaphoreSlim(this.maxConcurrency, this.maxConcurrency);
-            List<Task<List<ResponseMessage>>> tasks = new List<Task<List<ResponseMessage>>>();
+
+            List<(KeyValuePair<PartitionKeyRange, List<(string, PartitionKey)>> entry, int startIndex)> rangeEntries =
+                new List<(KeyValuePair<PartitionKeyRange, List<(string, PartitionKey)>> entry, int startIndex)>();
 
             foreach (KeyValuePair<PartitionKeyRange, List<(string, PartitionKey)>> entry in partitionKeyRangeItemMap)
             {
                 // Fit MaxItemsPerQuery items in a single query to BE
                 for (int startIndex = 0; startIndex < entry.Value.Count; startIndex += this.maxItemsPerQuery)
                 {
-                    // Only allow 'maxConcurrency' number of queries at a time
-                    await semaphore.WaitAsync();
-
-                    ITrace childTrace = trace.StartChild("Execute query for a partitionkeyrange", TraceComponent.Query, TraceLevel.Info);
-                    int indexCopy = startIndex;
-                    tasks.Add(Task.Run(async () =>
-                    {
-                        try
-                        {
-                            QueryDefinition queryDefinition = ((this.partitionKeySelectors.Count == 1) && (this.partitionKeySelectors[0] == "[\"id\"]")) ?
-                                               this.CreateReadManyQueryDefinitionForId(entry.Value, indexCopy) :
-                                               this.CreateReadManyQueryDefinitionForOther(entry.Value, indexCopy);
-
-                            return await this.GenerateStreamResponsesForPartitionAsync(queryDefinition,
-                                                                       entry.Key,
-                                                                       readManyRequestOptions,
-                                                                       childTrace,
-                                                                       cancellationToken);
-                        }
-                        finally
-                        {
-                            semaphore.Release();
-                            childTrace.Dispose();
-                        }
-                    }));
+                    rangeEntries.Add((entry, startIndex));
                 }
             }
-            
-            return await Task.WhenAll(tasks);
+
+            IEnumerable<Task<List<ResponseMessage>>> tasks = rangeEntries.Select(async (entry, startIndex) =>
+            {
+                // Only allow 'maxConcurrency' number of queries at a time
+                await semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+
+                ITrace childTrace = trace.StartChild("Execute query for a partitionkeyrange", TraceComponent.Query, TraceLevel.Info);
+
+                try
+                {
+                    QueryDefinition queryDefinition = ((this.partitionKeySelectors.Count == 1) && (this.partitionKeySelectors[0] == "[\"id\"]")) ?
+                        this.CreateReadManyQueryDefinitionForId(entry.entry.Value, startIndex) :
+                        this.CreateReadManyQueryDefinitionForOther(entry.entry.Value, startIndex);
+
+                    return await this.GenerateStreamResponsesForPartitionAsync(queryDefinition,
+                        entry.entry.Key,
+                        readManyRequestOptions,
+                        childTrace,
+                        cancellationToken).ConfigureAwait(false);
+                }
+                finally
+                {
+                    semaphore.Release();
+                    childTrace.Dispose();
+                }
+            });
+
+            return await Task.WhenAll(tasks).ConfigureAwait(false);
         }
 
         private async Task<IDictionary<PartitionKeyRange, List<(string, PartitionKey)>>> CreatePartitionKeyRangeItemListMapAsync(


### PR DESCRIPTION
# Pull Request Template

## Description
`ReadManyTaskHelperAsync` uses `Task.Run` due to usage of `SemaphoreSlim` and rate limiting amount of parallel calls. `Task.Run` uses thread pool and schedules execution to background thread. Optimize solution not to use the thread pool.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #4527