### PR TITLE
[Internal] Query: Refactors ParallelCrossPartitionQueryPipelineStage to improve perf

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/Parallel/ParallelCrossPartitionQueryPipelineStage.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/Parallel/ParallelCrossPartitionQueryPipelineStage.cs
@@ -78,9 +78,6 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.Parallel
             }
             else
             {
-                Stopwatch sw = new ();
-                sw.Start();
-
                 // left most and any non null continuations
                 FeedRangeState<QueryState>[] feedRangeStates = crossPartitionState.Value.ToArray();
                 Array.Sort<FeedRangeState<QueryState>>(feedRangeStates, (x, y) => string.CompareOrdinal(((FeedRangeEpk)x.FeedRange).Range.Min, ((FeedRangeEpk)y.FeedRange).Range.Min));
@@ -114,9 +111,6 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.Parallel
                 CosmosArray cosmosElementParallelContinuationTokens = CosmosArray.Create(cosmosElementContinuationTokens);
 
                 queryState = new QueryState(cosmosElementParallelContinuationTokens);
-
-                sw.Stop();
-                Console.WriteLine(sw.Elapsed.ToString());
             }
 
             QueryPage crossPartitionQueryPage = new QueryPage(

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/Parallel/ParallelCrossPartitionQueryPipelineStage.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/Parallel/ParallelCrossPartitionQueryPipelineStage.cs
@@ -95,11 +95,12 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.Parallel
                 {
                     cancellationToken.ThrowIfCancellationRequested();
 
-                    if (feedRangeStates[i].State != null)
+                    FeedRangeState<QueryState> feedRangeState = feedRangeStates[i];
+                    if (feedRangeState.State != null)
                     {
                         ParallelContinuationToken parallelContinuationToken = new ParallelContinuationToken(
-                            token: feedRangeStates[i].State != null ? ((CosmosString)feedRangeStates[i].State.Value).Value : null,
-                            range: ((FeedRangeEpk)feedRangeStates[i].FeedRange).Range);
+                            token: feedRangeState.State != null ? ((CosmosString)feedRangeState.State.Value).Value : null,
+                            range: ((FeedRangeEpk)feedRangeState.FeedRange).Range);
 
                         activeParallelContinuationTokens.Add(parallelContinuationToken);
                     }

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/Parallel/ParallelCrossPartitionQueryPipelineStage.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/Parallel/ParallelCrossPartitionQueryPipelineStage.cs
@@ -6,7 +6,6 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.Parallel
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics;
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -1341,8 +1341,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         [TestMethod]
         public async Task ItemMultiplePartitionQuery()
         {
-            // 3000
-            IList<ToDoActivity> itemList = await ToDoActivity.CreateRandomItems(this.Container, 3000, randomPartitionKey: true);
+            IList<ToDoActivity> itemList = await ToDoActivity.CreateRandomItems(this.Container, 3, randomPartitionKey: true);
 
             ToDoActivity find = itemList.First();
             QueryDefinition sql = new QueryDefinition("select * from toDoActivity t where t.id = '" + find.id + "'");

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -1341,7 +1341,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         [TestMethod]
         public async Task ItemMultiplePartitionQuery()
         {
-            IList<ToDoActivity> itemList = await ToDoActivity.CreateRandomItems(this.Container, 3, randomPartitionKey: true);
+            // 3000
+            IList<ToDoActivity> itemList = await ToDoActivity.CreateRandomItems(this.Container, 3000, randomPartitionKey: true);
 
             ToDoActivity find = itemList.First();
             QueryDefinition sql = new QueryDefinition("select * from toDoActivity t where t.id = '" + find.id + "'");


### PR DESCRIPTION
## Description

Addresses identified performance issue in ParallelCrossPartitionQueryPipelineStage.

Testing of simple cross partition scenario showed up to 4x speedup for the modified code block. More details from internal performance team can be found in #3470.

## Type of change

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

closes #3470