### PR TITLE
[Internal] Fixes `GlobalEndpointManagerTest` Flakey Tests

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GlobalEndpointManagerTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GlobalEndpointManagerTest.cs
@@ -93,8 +93,8 @@ namespace Microsoft.Azure.Cosmos
 
                 Assert.IsTrue(getAccountInfoCount > 0, "Callback is not working. There should be at least one call in this time frame.");
                 getAccountInfoCount = 0;
-                Thread.Sleep(TimeSpan.FromSeconds(3));
-                Assert.AreEqual(0, getAccountInfoCount, "There should be no more account calls after the GlobalEndpointManager is disposed");
+                await Task.Delay(TimeSpan.FromSeconds(5));
+                Assert.IsTrue(getAccountInfoCount <= 1, "There should be at most 1 call to refresh tied to the background refresh happening while Dispose cancels the internal CancellationToken");
             }
             finally
             {


### PR DESCRIPTION
# Pull Request Template

## Description

See this bug [3142251](https://dev.azure.com/msdata/CosmosDB/_workitems/edit/3142251/?view=edit)  for detailed description about the failure. It is an expected and known behavior that the refresh loop can run at-most once, even after disposing the `GlobalEndpointManager`. Thus the assertation was updated to check `getAccountInfoCount <= 1`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #IssueNumber