### PR TITLE
Added Compression Support in Always Encrypted

### DIFF
--- a/Microsoft.Azure.Cosmos.Encryption.Custom/src/CompressionOption.cs
+++ b/Microsoft.Azure.Cosmos.Encryption.Custom/src/CompressionOption.cs
@@ -1,0 +1,20 @@
+﻿namespace Microsoft.Azure.Cosmos.Encryption.Custom
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Text;
+
+    public class CompressionOption
+    {
+        public CompressionAlgorithm Algorithm { get; set; } = CompressionAlgorithm.None;
+
+        public List<string> PathsToCompress { get; set; } = new List<string>();
+    }
+
+    public enum CompressionAlgorithm
+    {
+        None,
+        Gzip,
+        Brotli
+    }
+}

--- a/Microsoft.Azure.Cosmos.Encryption.Custom/src/EncryptionOptions.cs
+++ b/Microsoft.Azure.Cosmos.Encryption.Custom/src/EncryptionOptions.cs
@@ -12,6 +12,14 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom
     public sealed class EncryptionOptions
     {
         /// <summary>
+        /// Initializes a new instance of the <see cref="EncryptionOptions"/> class.
+        /// </summary>
+        public EncryptionOptions()
+        {
+            this.CompressionOption = new CompressionOption();
+        }
+
+        /// <summary>
         /// Identifier of the data encryption key to be used for encrypting the data in the request payload.
         /// The data encryption key must be suitable for use with the <see cref="EncryptionAlgorithm"/> provided.
         /// </summary>
@@ -35,5 +43,7 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom
         /// Example of a path specification: /sensitive
         /// </summary>
         public IEnumerable<string> PathsToEncrypt { get; set; }
+
+        public CompressionOption CompressionOption { get; set; }
     }
 }

--- a/Microsoft.Azure.Cosmos.Encryption.Custom/src/EncryptionProperties.cs
+++ b/Microsoft.Azure.Cosmos.Encryption.Custom/src/EncryptionProperties.cs
@@ -1,8 +1,4 @@
-﻿//------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-//------------------------------------------------------------
-
-namespace Microsoft.Azure.Cosmos.Encryption.Custom
+﻿namespace Microsoft.Azure.Cosmos.Encryption.Custom
 {
     using System.Collections.Generic;
     using Newtonsoft.Json;
@@ -24,18 +20,22 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom
         [JsonProperty(PropertyName = Constants.EncryptedPaths)]
         public IEnumerable<string> EncryptedPaths { get; }
 
+        public CompressionOption CompressionOption { get; set; }
+
         public EncryptionProperties(
             int encryptionFormatVersion,
             string encryptionAlgorithm,
             string dataEncryptionKeyId,
             byte[] encryptedData,
-            IEnumerable<string> encryptedPaths)
+            IEnumerable<string> encryptedPaths,
+            CompressionOption compressionOption)
         {
             this.EncryptionFormatVersion = encryptionFormatVersion;
             this.EncryptionAlgorithm = encryptionAlgorithm;
             this.DataEncryptionKeyId = dataEncryptionKeyId;
             this.EncryptedData = encryptedData;
             this.EncryptedPaths = encryptedPaths;
+            this.CompressionOption = compressionOption;
         }
     }
 }

--- a/Microsoft.Azure.Cosmos.Encryption.Custom/src/Microsoft.Azure.Cosmos.Encryption.Custom.csproj
+++ b/Microsoft.Azure.Cosmos.Encryption.Custom/src/Microsoft.Azure.Cosmos.Encryption.Custom.csproj
@@ -37,7 +37,9 @@
   <ItemGroup>
      <PackageReference Include="Azure.Core" Version="1.38.0" />
      <PackageReference Include="Azure.Identity" Version="1.11.4" />
+     <PackageReference Include="BrotliSharpLib" Version="0.3.3" />
      <PackageReference Include="Microsoft.Data.Encryption.Cryptography" Version="0.2.0-pre" />
+     <PackageReference Include="System.IO.Compression" Version="4.3.0" />
      <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />     
   </ItemGroup>
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/settings.json
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/settings.json
@@ -1,7 +1,7 @@
 ﻿{
   "AppSettings": {
     "GatewayEndpoint": "https://127.0.0.1:8081/",
-    "ComputeGatewayEndpoint": "https://localhost:8081/",
+    "ComputeGatewayEndpoint": "https://localhost:8903/",
     "ComputeGatewayPort": "8903",
     "Location": "South Central US",
     "Location2": "West US",

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/settings.json
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/settings.json
@@ -1,7 +1,7 @@
 ﻿{
   "AppSettings": {
     "GatewayEndpoint": "https://127.0.0.1:8081/",
-    "ComputeGatewayEndpoint": "https://localhost:8903/",
+    "ComputeGatewayEndpoint": "https://localhost:8081/",
     "ComputeGatewayPort": "8903",
     "Location": "South Central US",
     "Location2": "West US",


### PR DESCRIPTION
# Pull Request Template

## Description

This pull request adds compression support in Always Encrypted in Azure Cosmos DB. Compression is applied before encryption to reduce storage requirements. After decryption, the data is decompressed to restore its original form. This enhancement aims to optimize storage efficiency and improve performance.

## Type of change

Please delete options that are not relevant.

- [] New feature (non-breaking change which adds functionality)

## Closing issues

To automatically close an issue: closes #IssueNumber