### PR TITLE
ChangeFeed: Adds MalformedContinuationToken SubstatusCode to exception

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/Core/ExceptionToCosmosException.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/ExceptionToCosmosException.cs
@@ -157,7 +157,10 @@ namespace Microsoft.Azure.Cosmos.Query.Core
             {
                 return CosmosExceptionFactory.CreateBadRequestException(
                     message: malformedChangeFeedContinuationTokenException.Message,
-                    headers: new Headers(),
+                    headers: new Headers()
+                    {
+                        SubStatusCode = Documents.SubStatusCodes.MalformedContinuationToken
+                    },
                     stackTrace: malformedChangeFeedContinuationTokenException.StackTrace,
                     innerException: malformedChangeFeedContinuationTokenException,
                     trace: trace);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -3321,6 +3321,23 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     cancellationToken: cancellationToken));
         }
 
+        [TestMethod]
+        public async Task MalformedChangeFeedContinuationTokenSubStatusCodeTest()
+        {
+            FeedIterator badIterator = this.Container.GetChangeFeedStreamIterator(
+                    ChangeFeedStartFrom.ContinuationToken("AMalformedContinuationToken"),
+                    ChangeFeedMode.Incremental,
+                    new ChangeFeedRequestOptions()
+                    {
+                        PageSizeHint = 100
+                    });
+
+            ResponseMessage response = await badIterator.ReadNextAsync();
+
+            Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
+            Assert.AreEqual(SubStatusCodes.MalformedContinuationToken, response.Headers.SubStatusCode);
+        }
+
         private static async Task GivenItemStreamAsyncWhenMissingMemberHandlingIsErrorThenExpectsCosmosExceptionTestAsync(
             Func<Container, string, string, CancellationToken, Task<ResponseMessage>> itemStreamAsync)
         {


### PR DESCRIPTION
# Pull Request Template

## Description

Added `MalformedContinuationToken` Substatus code to BadRequest (400:20007) to exception to clarify why there is a bad request. 

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)


## Closing issues

To automatically close an issue: closes #4366 