### PR TITLE
CFP AVAD: Fixes issue where customers are allowed to use WithStartTime and WithStartFromBeginning with CFP AVAD.

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedProcessorBuilder.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedProcessorBuilder.cs
@@ -156,7 +156,7 @@ namespace Microsoft.Azure.Cosmos
         {
             if (this.changeFeedProcessorOptions.Mode == ChangeFeedMode.AllVersionsAndDeletes)
             {
-                throw new InvalidOperationException($"Using the 'WithStartTime' option with ChangeFeedProcessor is not supported with {ChangeFeedMode.AllVersionsAndDeletes} mode.");
+                throw new InvalidOperationException($"Using the '{nameof(WithStartTime)}' option with ChangeFeedProcessor is not supported with {ChangeFeedMode.AllVersionsAndDeletes} mode.");
             }
 
             if (startTime == null)

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedProcessorBuilder.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedProcessorBuilder.cs
@@ -134,7 +134,7 @@ namespace Microsoft.Azure.Cosmos
         {
             if (this.changeFeedProcessorOptions.Mode == ChangeFeedMode.AllVersionsAndDeletes)
             {
-                throw new InvalidOperationException($"Using the 'WithStartFromBeginning' option with ChangeFeedProcessor is not supported with {ChangeFeedMode.AllVersionsAndDeletes} mode.");
+                throw new InvalidOperationException($"Using the '{nameof(WithStartFromBeginning)}' option with ChangeFeedProcessor is not supported with {ChangeFeedMode.AllVersionsAndDeletes} mode.");
             }
 
             this.changeFeedProcessorOptions.StartFromBeginning = true;

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedProcessorBuilder.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedProcessorBuilder.cs
@@ -132,6 +132,11 @@ namespace Microsoft.Azure.Cosmos
         /// <returns>The instance of <see cref="ChangeFeedProcessorBuilder"/> to use.</returns>
         internal virtual ChangeFeedProcessorBuilder WithStartFromBeginning()
         {
+            if (this.changeFeedProcessorOptions.Mode == ChangeFeedMode.AllVersionsAndDeletes)
+            {
+                throw new InvalidOperationException($"Using the 'WithStartFromBeginning' option with ChangeFeedProcessor is not supported with {ChangeFeedMode.AllVersionsAndDeletes} mode.");
+            }
+
             this.changeFeedProcessorOptions.StartFromBeginning = true;
             return this;
         }
@@ -149,6 +154,11 @@ namespace Microsoft.Azure.Cosmos
         /// <returns>The instance of <see cref="ChangeFeedProcessorBuilder"/> to use.</returns>
         public ChangeFeedProcessorBuilder WithStartTime(DateTime startTime)
         {
+            if (this.changeFeedProcessorOptions.Mode == ChangeFeedMode.AllVersionsAndDeletes)
+            {
+                throw new InvalidOperationException($"Using the 'WithStartTime' option with ChangeFeedProcessor is not supported with {ChangeFeedMode.AllVersionsAndDeletes} mode.");
+            }
+
             if (startTime == null)
             {
                 throw new ArgumentNullException(nameof(startTime));

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/GetChangeFeedProcessorBuilderWithAllVersionsAndDeletesTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/GetChangeFeedProcessorBuilderWithAllVersionsAndDeletesTests.cs
@@ -588,5 +588,53 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
 
             return (ContainerInternal)response;
         }
+
+        [TestMethod]
+        [Owner("philipthomas-MSFT")]
+        [Description("Scenario: WithStartTime should throw an exception when used in AVAD mode.")]
+        public async Task WhenACFPInAVADModeUsesWithStartTimeExpectExceptionTestsAsync()
+        {
+            ContainerInternal monitoredContainer = await this.CreateMonitoredContainer(ChangeFeedMode.AllVersionsAndDeletes);
+
+            InvalidOperationException exception = Assert.ThrowsException<InvalidOperationException>(() =>
+            {
+                ChangeFeedProcessor processor = monitoredContainer
+                    .GetChangeFeedProcessorBuilderWithAllVersionsAndDeletes(
+                        processorName: "processor",
+                        onChangesDelegate: (ChangeFeedProcessorContext context, IReadOnlyCollection<ChangeFeedItem<dynamic>> docs, CancellationToken cancellationToken) => Task.CompletedTask)
+                    .WithStartTime(DateTime.Now)
+                    .WithInstanceName(Guid.NewGuid().ToString())
+                    .WithLeaseContainer(this.LeaseContainer)
+                    .Build();
+            });
+
+            Assert.AreEqual(
+                expected: "Using the 'WithStartTime' option with ChangeFeedProcessor is not supported with Microsoft.Azure.Cosmos.ChangeFeed.ChangeFeedModeFullFidelity mode.",
+                actual: exception.Message);
+        }
+
+        [TestMethod]
+        [Owner("philipthomas-MSFT")]
+        [Description("Scenario: WithStartFromBeginning should throw an exception when used in AVAD mode.")]
+        public async Task WhenACFPInAVADModeUsesWithStartFromBeginningExpectExceptionTestsAsync()
+        {
+            ContainerInternal monitoredContainer = await this.CreateMonitoredContainer(ChangeFeedMode.AllVersionsAndDeletes);
+
+            InvalidOperationException exception = Assert.ThrowsException<InvalidOperationException>(() =>
+            {
+                ChangeFeedProcessor processor = monitoredContainer
+                    .GetChangeFeedProcessorBuilderWithAllVersionsAndDeletes(
+                        processorName: "processor",
+                        onChangesDelegate: (ChangeFeedProcessorContext context, IReadOnlyCollection<ChangeFeedItem<dynamic>> docs, CancellationToken cancellationToken) => Task.CompletedTask)
+                    .WithStartFromBeginning()
+                    .WithInstanceName(Guid.NewGuid().ToString())
+                    .WithLeaseContainer(this.LeaseContainer)
+                    .Build();
+            });
+
+            Assert.AreEqual(
+                expected: "Using the 'WithStartFromBeginning' option with ChangeFeedProcessor is not supported with Microsoft.Azure.Cosmos.ChangeFeed.ChangeFeedModeFullFidelity mode.",
+                actual: exception.Message);
+        }
     }
 }


### PR DESCRIPTION
# Pull Request Template

Details contained at #4604 
## Description

Please include a summary of the change and which issue is fixed. Include samples if adding new API, and include relevant motivation and context. List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #4604 