### PR TITLE
Fix Proxy Response Mapping

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ThinClientTransportSerializer.cs
+++ b/Microsoft.Azure.Cosmos/src/ThinClientTransportSerializer.cs
@@ -174,7 +174,10 @@ namespace Microsoft.Azure.Cosmos
                 HttpConstants.Versions.CurrentVersion,
                 ref bytesDeserializer);
 
-            HttpResponseMessage response = new HttpResponseMessage((HttpStatusCode)storeResponse.StatusCode);
+            HttpResponseMessage response = new HttpResponseMessage((HttpStatusCode)storeResponse.StatusCode)
+            {
+                RequestMessage = responseMessage.RequestMessage
+            };
 
             if (bodyStream != null)
             {


### PR DESCRIPTION
# Pull Request Template

## Description

This is a fix for the bug [Fix Rntbd deserializer: Throwing exception when deserializing error responses](https://github.com/Azure/azure-cosmos-dotnet-v3/issues/4627) 

## Type of change

Adding HttpResponse Request parameter mapping ProxyResponse.

- [x] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #4627 