### PR TITLE
[Internal] Thin Client Integration: Adds Transport Serialization of RNTBD Payload

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Handler/HandlerConstants.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/HandlerConstants.cs
@@ -8,5 +8,12 @@ namespace Microsoft.Azure.Cosmos
         public const string StartEpkString = "x-ms-start-epk-string";
         public const string EndEpkString = "x-ms-end-epk-string";
         public const string ResourceUri = "x-ms-resource-uri";
+
+        public const string RoutedViaProxy = "x-ms-thinclient-route-via-proxy";
+        public const string ProxyStartEpk = "x-ms-thinclient-range-min";
+        public const string ProxyEndEpk = "x-ms-thinclient-range-max";
+
+        public const string ProxyOperationType = "x-ms-thinclient-proxy-operation-type";
+        public const string ProxyResourceType = "x-ms-thinclient-proxy-resource-type";
     }
 }

--- a/Microsoft.Azure.Cosmos/src/ThinClientTransportSerializer.cs
+++ b/Microsoft.Azure.Cosmos/src/ThinClientTransportSerializer.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Wrapper to expose a public bufferprovider for the RNTBD stack.
         /// </summary>
-        public sealed class BufferProviderWrapper
+        public class BufferProviderWrapper
         {
             internal BufferProvider Provider { get; set; } = new ();
         }

--- a/Microsoft.Azure.Cosmos/src/ThinClientTransportSerializer.cs
+++ b/Microsoft.Azure.Cosmos/src/ThinClientTransportSerializer.cs
@@ -1,0 +1,285 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos
+{
+    using System;
+    using System.Buffers;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Documents;
+    using Microsoft.Azure.Documents.Collections;
+
+    /// <summary>
+    /// blabla
+    /// </summary>
+    internal static class ThinClientTransportSerializer
+    {
+        public const string RoutedViaProxy = "x-ms-thinclient-route-via-proxy";
+        public const string ProxyStartEpk = "x-ms-thinclient-range-min";
+        public const string ProxyEndEpk = "x-ms-thinclient-range-max";
+
+        public const string ProxyOperationType = "x-ms-thinclient-proxy-operation-type";
+        public const string ProxyResourceType = "x-ms-thinclient-proxy-resource-type";
+
+        private static readonly PartitionKeyDefinition HashV2SinglePath;
+
+        static ThinClientTransportSerializer()
+        {
+            HashV2SinglePath = new PartitionKeyDefinition
+            {
+                Kind = PartitionKind.Hash,
+                Version = Documents.PartitionKeyDefinitionVersion.V2,
+            };
+            HashV2SinglePath.Paths.Add("/id");
+        }
+
+        /// <summary>
+        /// Wrapper to expose a public bufferprovider for the RNTBD stack.
+        /// </summary>
+#pragma warning disable CA1034 // Nested types should not be visible
+        public sealed class BufferProviderWrapper
+#pragma warning restore CA1034 // Nested types should not be visible
+        {
+            internal BufferProvider Provider { get; set; } = new ();
+        }
+
+        /// <summary>
+        /// Serialize the Proxy request to the RNTBD protocol format.
+        /// Today this takes the HttprequestMessage and reconstructs the DSR.
+        /// If the SDK can push properties to the HttpRequestMessage then the handler above having
+        /// the DSR can allow us to push that directly to the serialization.
+        /// </summary>
+        public static async Task<Stream> SerializeProxyRequestAsync(
+            BufferProviderWrapper bufferProvider,
+            string accountName,
+            HttpRequestMessage requestMessage)
+        {
+            // Skip this and use the original DSR.
+            OperationType operationType = (OperationType)Enum.Parse(typeof(OperationType), requestMessage.Headers.GetValues(ProxyOperationType).First());
+            ResourceType resourceType = (ResourceType)Enum.Parse(typeof(ResourceType), requestMessage.Headers.GetValues(ProxyResourceType).First());
+
+            Guid activityId = Guid.Parse(requestMessage.Headers.GetValues(HttpConstants.HttpHeaders.ActivityId).First());
+
+            Stream requestStream = null;
+            if (requestMessage.Content != null)
+            {
+                requestStream = await requestMessage.Content.ReadAsStreamAsync();
+            }
+
+            RequestNameValueCollection dictionaryCollection = new RequestNameValueCollection();
+            foreach (KeyValuePair<string, IEnumerable<string>> header in requestMessage.Headers)
+            {
+                dictionaryCollection.Set(header.Key, string.Join(",", header.Value));
+            }
+
+            using DocumentServiceRequest request = new (operationType, resourceType, requestMessage.RequestUri.PathAndQuery,
+                                                requestStream, AuthorizationTokenType.PrimaryMasterKey,
+                                                dictionaryCollection);
+
+            if (operationType.IsPointOperation())
+            {
+                string partitionKey = request.Headers.Get(HttpConstants.HttpHeaders.PartitionKey);
+
+                if (string.IsNullOrEmpty(partitionKey))
+                {
+                    throw new InternalServerErrorException();
+                }
+
+                string epk = GetEffectivePartitionKeyHash(partitionKey);
+
+                request.Properties = new Dictionary<string, object>
+                {
+                    { "x-ms-effective-partition-key", HexStringUtility.HexStringToBytes(epk) }
+                };
+            }
+            else if (request.Headers[ProxyStartEpk] != null)
+            {
+                // Re-add EPK headers removed by RequestInvokerHandler through Properties
+                request.Properties = new Dictionary<string, object>
+                {
+                    { WFConstants.BackendHeaders.StartEpkHash, HexStringUtility.HexStringToBytes(request.Headers[ProxyStartEpk]) },
+                    { WFConstants.BackendHeaders.EndEpkHash, HexStringUtility.HexStringToBytes(request.Headers[ProxyEndEpk]) }
+                };
+
+                request.Headers.Add(HttpConstants.HttpHeaders.ReadFeedKeyType, RntbdConstants.RntdbReadFeedKeyType.EffectivePartitionKeyRange.ToString());
+                request.Headers.Add(HttpConstants.HttpHeaders.StartEpk, request.Headers[ProxyStartEpk]);
+                request.Headers.Add(HttpConstants.HttpHeaders.EndEpk, request.Headers[ProxyEndEpk]);
+            }
+
+            await request.EnsureBufferedBodyAsync();
+
+            using Documents.Rntbd.TransportSerialization.SerializedRequest serializedRequest =
+                Documents.Rntbd.TransportSerialization.BuildRequestForProxy(request,
+                new ResourceOperation(operationType, resourceType),
+                activityId,
+                bufferProvider.Provider,
+                accountName,
+                out _,
+                out _);
+
+            // TODO: consider using the SerializedRequest directly.
+            MemoryStream memoryStream = new MemoryStream(serializedRequest.RequestSize);
+            await serializedRequest.CopyToStreamAsync(memoryStream);
+            memoryStream.Position = 0;
+            return memoryStream;
+        }
+
+        public static string GetEffectivePartitionKeyHash(string partitionJson)
+        {
+            return Documents.PartitionKey.FromJsonString(partitionJson).InternalKey.GetEffectivePartitionKeyString(HashV2SinglePath);
+        }
+
+        /// <summary>
+        /// Deserialize the Proxy Response from the RNTBD protocol format to the Http format needed by the caller.
+        /// Today this takes the HttpResponseMessage and reconstructs the modified Http response.
+        /// </summary>
+        public static async Task<HttpResponseMessage> ConvertProxyResponseAsync(HttpResponseMessage responseMessage)
+        {
+            using Stream responseStream = await responseMessage.Content.ReadAsStreamAsync();
+
+            (StatusCodes status, byte[] metadata) = await ThinClientTransportSerializer.ReadHeaderAndMetadataAsync(responseStream);
+
+            if (responseMessage.StatusCode != (HttpStatusCode)status)
+            {
+                throw new InternalServerErrorException("Status code mismatch");
+            }
+
+            Rntbd.BytesDeserializer bytesDeserializer = new Rntbd.BytesDeserializer(metadata, metadata.Length);
+            if (!Documents.Rntbd.HeadersTransportSerialization.TryParseMandatoryResponseHeaders(ref bytesDeserializer, out bool payloadPresent, out _))
+            {
+                throw new InternalServerErrorException("Length mismatch");
+            }
+
+            MemoryStream bodyStream = null;
+            if (payloadPresent)
+            {
+                int length = await ThinClientTransportSerializer.ReadBodyLengthAsync(responseStream);
+                bodyStream = new MemoryStream(length);
+                await responseStream.CopyToAsync(bodyStream);
+                bodyStream.Position = 0;
+            }
+
+            // TODO(Perf): Clean this up.
+            bytesDeserializer = new Rntbd.BytesDeserializer(metadata, metadata.Length);
+            StoreResponse storeResponse = Documents.Rntbd.TransportSerialization.MakeStoreResponse(
+                status,
+                Guid.NewGuid(),
+                bodyStream,
+                HttpConstants.Versions.CurrentVersion,
+                ref bytesDeserializer);
+
+            HttpResponseMessage response = new HttpResponseMessage((HttpStatusCode)storeResponse.StatusCode)
+            {
+                RequestMessage = responseMessage.RequestMessage
+            };
+
+            if (bodyStream != null)
+            {
+                response.Content = new StreamContent(bodyStream);
+            }
+
+            foreach (string header in storeResponse.Headers.Keys())
+            {
+                if (header == HttpConstants.HttpHeaders.SessionToken)
+                {
+                    string newSessionToken = storeResponse.PartitionKeyRangeId + ":" + storeResponse.Headers.Get(header);
+                    response.Headers.TryAddWithoutValidation(header, newSessionToken);
+                }
+                else
+                {
+                    response.Headers.TryAddWithoutValidation(header, storeResponse.Headers.Get(header));
+                }
+            }
+
+            response.Headers.TryAddWithoutValidation(RoutedViaProxy, "1");
+            return response;
+        }
+
+        private static async Task<(StatusCodes, byte[] metadata)> ReadHeaderAndMetadataAsync(Stream stream)
+        {
+            byte[] header = ArrayPool<byte>.Shared.Rent(24);
+            const int headerLength = 24;
+            try
+            {
+                int headerRead = 0;
+                while (headerRead < headerLength)
+                {
+                    int read = 0;
+                    read = await stream.ReadAsync(header, headerRead, headerLength - headerRead);
+
+                    if (read == 0)
+                    {
+                        throw new DocumentClientException("Unexpected read empty bytes", HttpStatusCode.Gone, SubStatusCodes.Unknown);
+                    }
+
+                    headerRead += read;
+                }
+
+                uint totalLength = BitConverter.ToUInt32(header, 0);
+                StatusCodes status = (StatusCodes)BitConverter.ToUInt32(header, 4);
+
+                if (totalLength < headerLength)
+                {
+                    throw new InternalServerErrorException("Length mismatch");
+                }
+
+                int metadataLength = (int)totalLength - headerLength;
+                byte[] metadata = new byte[metadataLength];
+                int responseMetadataRead = 0;
+                while (responseMetadataRead < metadataLength)
+                {
+                    int read = 0;
+                    read = await stream.ReadAsync(metadata, responseMetadataRead, metadataLength - responseMetadataRead);
+
+                    if (read == 0)
+                    {
+                        throw new DocumentClientException("Unexpected read empty bytes", HttpStatusCode.Gone, SubStatusCodes.Unknown);
+                    }
+
+                    responseMetadataRead += read;
+                }
+
+                return (status, metadata);
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(header);
+            }
+        }
+
+        private static async Task<int> ReadBodyLengthAsync(Stream stream)
+        {
+            byte[] header = ArrayPool<byte>.Shared.Rent(4);
+            const int headerLength = 4;
+            try
+            {
+                int headerRead = 0;
+                while (headerRead < headerLength)
+                {
+                    int read = 0;
+                    read = await stream.ReadAsync(header, headerRead, headerLength - headerRead);
+
+                    if (read == 0)
+                    {
+                        throw new DocumentClientException("Unexpected read empty bytes", HttpStatusCode.Gone, SubStatusCodes.Unknown);
+                    }
+
+                    headerRead += read;
+                }
+
+                return BitConverter.ToInt32(header, 0);
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(header);
+            }
+
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ThinClientTransportSerializerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ThinClientTransportSerializerTests.cs
@@ -15,157 +15,99 @@ namespace Microsoft.Azure.Cosmos.Tests
     using Microsoft.Azure.Cosmos;
     using Microsoft.Azure.Documents;
     using Microsoft.Azure.Documents.Collections;
-    using global::Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-    namespace Microsoft.Azure.Cosmos.Tests
+    [TestClass]
+    public class ThinClientTransportSerializerTests
     {
-        [TestClass]
-        public class ThinClientTransportSerializerTests
+        private readonly Mock<ThinClientTransportSerializer.BufferProviderWrapper> mockBufferProviderWrapper;
+        private readonly string testAccountName = "testAccount";
+        private readonly Uri testUri = new Uri("http://localhost/dbs/db1/colls/coll1/docs/doc1");
+
+        public ThinClientTransportSerializerTests()
         {
-            private readonly Mock<ThinClientTransportSerializer.BufferProviderWrapper> mockBufferProviderWrapper;
-            private readonly string testAccountName = "testAccount";
-            private readonly Uri testUri = new Uri("http://localhost/dbs/db1/colls/coll1/docs/doc1");
+            this.mockBufferProviderWrapper = new Mock<ThinClientTransportSerializer.BufferProviderWrapper>();
+        }
 
-            public ThinClientTransportSerializerTests()
-            {
-                this.mockBufferProviderWrapper = new Mock<ThinClientTransportSerializer.BufferProviderWrapper>();
-            }
+        [TestMethod]
+        public async Task SerializeProxyRequestAsync_ShouldSerializeRequest()
+        {
+            // Arrange
+            HttpRequestMessage requestMessage = new HttpRequestMessage(HttpMethod.Get, this.testUri);
+            requestMessage.Headers.Add(HandlerConstants.ProxyOperationType, "Read");
+            requestMessage.Headers.Add(HandlerConstants.ProxyResourceType, "Document");
+            requestMessage.Headers.Add(HttpConstants.HttpHeaders.ActivityId, Guid.NewGuid().ToString());
+            requestMessage.Headers.Add(HttpConstants.HttpHeaders.PartitionKey, "[\"testPartitionKey\"]");
 
-            [TestMethod]
-            public async Task SerializeProxyRequestAsync_ShouldSerializeRequest()
-            {
-                // Arrange
-                HttpRequestMessage requestMessage = new HttpRequestMessage(HttpMethod.Get, this.testUri);
-                requestMessage.Headers.Add(HandlerConstants.ProxyOperationType, "Read");
-                requestMessage.Headers.Add(HandlerConstants.ProxyResourceType, "Document");
-                requestMessage.Headers.Add(HttpConstants.HttpHeaders.ActivityId, Guid.NewGuid().ToString());
-                requestMessage.Headers.Add(HttpConstants.HttpHeaders.PartitionKey, "[\"testPartitionKey\"]");
+            // Act
+            Stream result = await ThinClientTransportSerializer.SerializeProxyRequestAsync(
+                this.mockBufferProviderWrapper.Object,
+                this.testAccountName,
+                requestMessage);
 
-                // Act
-                Stream result = await ThinClientTransportSerializer.SerializeProxyRequestAsync(
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.IsInstanceOfType(result, typeof(Stream));
+        }
+
+        [TestMethod]
+        public async Task SerializeProxyRequestAsync_ThrowsException_WhenPartitionKeyIsMissing()
+        {
+            // Arrange
+            HttpRequestMessage requestMessage = new HttpRequestMessage(HttpMethod.Get, this.testUri);
+            requestMessage.Headers.Add(HandlerConstants.ProxyOperationType, "Read");
+            requestMessage.Headers.Add(HandlerConstants.ProxyResourceType, "Document");
+            requestMessage.Headers.Add(HttpConstants.HttpHeaders.ActivityId, Guid.NewGuid().ToString());
+
+            // Act & Assert
+            await Assert.ThrowsExceptionAsync<InternalServerErrorException>(() =>
+                ThinClientTransportSerializer.SerializeProxyRequestAsync(
                     this.mockBufferProviderWrapper.Object,
                     this.testAccountName,
-                    requestMessage);
+                    requestMessage));
+        }
 
-                // Assert
-                Assert.IsNotNull(result);
-                Assert.IsInstanceOfType(result, typeof(Stream));
-            }
+        [TestMethod]
+        public async Task SerializeProxyRequestAsync_InvalidOperationType_ThrowsException()
+        {
+            // Arrange
+            HttpRequestMessage requestMessage = new HttpRequestMessage(HttpMethod.Get, this.testUri);
+            requestMessage.Headers.Add(HandlerConstants.ProxyOperationType, "InvalidOperation");
+            requestMessage.Headers.Add(HandlerConstants.ProxyResourceType, "Document");
+            requestMessage.Headers.Add(HttpConstants.HttpHeaders.ActivityId, Guid.NewGuid().ToString());
+            requestMessage.Headers.Add(HttpConstants.HttpHeaders.PartitionKey, "[\"testPartitionKey\"]");
 
-            [TestMethod]
-            public async Task SerializeProxyRequestAsync_ThrowsException_WhenPartitionKeyIsMissing()
-            {
-                // Arrange
-                HttpRequestMessage requestMessage = new HttpRequestMessage(HttpMethod.Get, this.testUri);
-                requestMessage.Headers.Add(HandlerConstants.ProxyOperationType, "Read");
-                requestMessage.Headers.Add(HandlerConstants.ProxyResourceType, "Document");
-                requestMessage.Headers.Add(HttpConstants.HttpHeaders.ActivityId, Guid.NewGuid().ToString());
-
-                // Act & Assert
-                await Assert.ThrowsExceptionAsync<InternalServerErrorException>(() =>
-                    ThinClientTransportSerializer.SerializeProxyRequestAsync(
-                        this.mockBufferProviderWrapper.Object,
-                        this.testAccountName,
-                        requestMessage));
-            }
-
-            [TestMethod]
-            public async Task SerializeProxyRequestAsync_InvalidOperationType_ThrowsException()
-            {
-                // Arrange
-                HttpRequestMessage requestMessage = new HttpRequestMessage(HttpMethod.Get, this.testUri);
-                requestMessage.Headers.Add(HandlerConstants.ProxyOperationType, "InvalidOperation");
-                requestMessage.Headers.Add(HandlerConstants.ProxyResourceType, "Document");
-                requestMessage.Headers.Add(HttpConstants.HttpHeaders.ActivityId, Guid.NewGuid().ToString());
-                requestMessage.Headers.Add(HttpConstants.HttpHeaders.PartitionKey, "[\"testPartitionKey\"]");
-
-                // Act & Assert
-                await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
-                    ThinClientTransportSerializer.SerializeProxyRequestAsync(
-                        this.mockBufferProviderWrapper.Object,
-                        this.testAccountName,
-                        requestMessage));
-            }
-
-            [TestMethod]
-            public async Task SerializeProxyRequestAsync_WithRequestBody_ShouldSerializeRequest()
-            {
-                // Arrange
-                HttpRequestMessage requestMessage = new HttpRequestMessage(HttpMethod.Post, this.testUri)
-                {
-                    Content = new StringContent("{ \"key\": \"value\" }")
-                };
-                requestMessage.Headers.Add(HandlerConstants.ProxyOperationType, "Create");
-                requestMessage.Headers.Add(HandlerConstants.ProxyResourceType, "Document");
-                requestMessage.Headers.Add(HttpConstants.HttpHeaders.ActivityId, Guid.NewGuid().ToString());
-                requestMessage.Headers.Add(HttpConstants.HttpHeaders.PartitionKey, "[\"testPartitionKey\"]");
-
-                // Act
-                Stream result = await ThinClientTransportSerializer.SerializeProxyRequestAsync(
+            // Act & Assert
+            await Assert.ThrowsExceptionAsync<ArgumentException>(() =>
+                ThinClientTransportSerializer.SerializeProxyRequestAsync(
                     this.mockBufferProviderWrapper.Object,
                     this.testAccountName,
-                    requestMessage);
+                    requestMessage));
+        }
 
-                // Assert
-                Assert.IsNotNull(result);
-                Assert.IsInstanceOfType(result, typeof(Stream));
-                Assert.IsTrue(result.Length > 0);
-            }
-
-            [TestMethod]
-            public async Task ConvertProxyResponseAsync_WithPayload_ShouldConvertResponse()
+        [TestMethod]
+        public async Task SerializeProxyRequestAsync_WithRequestBody_ShouldSerializeRequest()
+        {
+            // Arrange
+            HttpRequestMessage requestMessage = new HttpRequestMessage(HttpMethod.Post, this.testUri)
             {
-                // Arrange
-                MemoryStream content = new MemoryStream();
-                StreamWriter writer = new StreamWriter(content);
-                await writer.WriteAsync("payload content");
-                await writer.FlushAsync();
-                content.Position = 0;
+                Content = new StringContent("{ \"key\": \"value\" }")
+            };
+            requestMessage.Headers.Add(HandlerConstants.ProxyOperationType, "Create");
+            requestMessage.Headers.Add(HandlerConstants.ProxyResourceType, "Document");
+            requestMessage.Headers.Add(HttpConstants.HttpHeaders.ActivityId, Guid.NewGuid().ToString());
+            requestMessage.Headers.Add(HttpConstants.HttpHeaders.PartitionKey, "[\"testPartitionKey\"]");
 
-                HttpResponseMessage responseMessage = new HttpResponseMessage(HttpStatusCode.OK)
-                {
-                    Content = new StreamContent(content)
-                };
+            // Act
+            Stream result = await ThinClientTransportSerializer.SerializeProxyRequestAsync(
+                this.mockBufferProviderWrapper.Object,
+                this.testAccountName,
+                requestMessage);
 
-                // Act
-                HttpResponseMessage result = await ThinClientTransportSerializer.ConvertProxyResponseAsync(responseMessage);
-
-                // Assert
-                Assert.IsNotNull(result);
-                Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
-                Assert.AreEqual("payload content", await result.Content.ReadAsStringAsync());
-            }
-
-            [TestMethod]
-            public async Task ConvertProxyResponseAsync_ShouldConvertResponse()
-            {
-                // Arrange
-                HttpResponseMessage responseMessage = new HttpResponseMessage(HttpStatusCode.OK)
-                {
-                    Content = new StreamContent(new MemoryStream())
-                };
-
-                // Act
-                HttpResponseMessage result = await ThinClientTransportSerializer.ConvertProxyResponseAsync(responseMessage);
-
-                // Assert
-                Assert.IsNotNull(result);
-                Assert.AreEqual(responseMessage.StatusCode, result.StatusCode);
-            }
-
-            [TestMethod]
-            public async Task ConvertProxyResponseAsync_StatusCodeMismatch_ThrowsException()
-            {
-                // Arrange
-                HttpResponseMessage responseMessage = new HttpResponseMessage(HttpStatusCode.BadRequest)
-                {
-                    Content = new StreamContent(new MemoryStream())
-                };
-
-                // Act & Assert
-                await Assert.ThrowsExceptionAsync<InternalServerErrorException>(() =>
-                    ThinClientTransportSerializer.ConvertProxyResponseAsync(responseMessage));
-            }
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.IsInstanceOfType(result, typeof(Stream));
+            Assert.IsTrue(result.Length > 0);
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ThinClientTransportSerializerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ThinClientTransportSerializerTests.cs
@@ -1,0 +1,279 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos
+{
+    using System;
+    using System.Buffers;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Documents;
+    using Microsoft.Azure.Documents.Collections;
+
+    internal static class ThinClientTransportSerializer
+    {
+        public const string RoutedViaProxy = "x-ms-thinclient-route-via-proxy";
+        public const string ProxyStartEpk = "x-ms-thinclient-range-min";
+        public const string ProxyEndEpk = "x-ms-thinclient-range-max";
+
+        public const string ProxyOperationType = "x-ms-thinclient-proxy-operation-type";
+        public const string ProxyResourceType = "x-ms-thinclient-proxy-resource-type";
+
+        private static readonly PartitionKeyDefinition HashV2SinglePath;
+
+        static ThinClientTransportSerializer()
+        {
+            HashV2SinglePath = new PartitionKeyDefinition
+            {
+                Kind = PartitionKind.Hash,
+                Version = Documents.PartitionKeyDefinitionVersion.V2,
+            };
+            HashV2SinglePath.Paths.Add("/id");
+        }
+
+        /// <summary>
+        /// Wrapper to expose a public buffer provider for the RNTBD stack.
+        /// </summary>
+        public sealed class BufferProviderWrapper
+        {
+            internal BufferProvider Provider { get; set; } = new();
+        }
+
+        /// <summary>
+        /// Serialize the Proxy request to the RNTBD protocol format.
+        /// Today this takes the HttprequestMessage and reconstructs the DSR.
+        /// If the SDK can push properties to the HttpRequestMessage then the handler above having
+        /// the DSR can allow us to push that directly to the serialization.
+        /// </summary>
+        public static async Task<Stream> SerializeProxyRequestAsync(
+            BufferProviderWrapper bufferProvider,
+            string accountName,
+            HttpRequestMessage requestMessage)
+        {
+            OperationType operationType = Enum.Parse<OperationType>(requestMessage.Headers.GetValues(ProxyOperationType).First());
+            ResourceType resourceType = Enum.Parse<ResourceType>(requestMessage.Headers.GetValues(ProxyResourceType).First());
+
+            Guid activityId = Guid.Parse(requestMessage.Headers.GetValues(HttpConstants.HttpHeaders.ActivityId).First());
+
+            Stream requestStream = null;
+            if (requestMessage.Content != null)
+            {
+                requestStream = await requestMessage.Content.ReadAsStreamAsync();
+            }
+
+            RequestNameValueCollection dictionaryCollection = new();
+            foreach (KeyValuePair<string, IEnumerable<string>> header in requestMessage.Headers)
+            {
+                dictionaryCollection.Set(header.Key, string.Join(",", header.Value));
+            }
+
+            using DocumentServiceRequest request = new(
+                operationType,
+                resourceType,
+                requestMessage.RequestUri.PathAndQuery,
+                requestStream,
+                AuthorizationTokenType.PrimaryMasterKey,
+                dictionaryCollection);
+
+            if (operationType.IsPointOperation())
+            {
+                string partitionKey = request.Headers.Get(HttpConstants.HttpHeaders.PartitionKey);
+
+                if (string.IsNullOrEmpty(partitionKey))
+                {
+                    throw new InternalServerErrorException("Partition key is missing or empty.");
+                }
+
+                string epk = GetEffectivePartitionKeyHash(partitionKey);
+
+                request.Properties = new Dictionary<string, object>
+            {
+                { "x-ms-effective-partition-key", HexStringUtility.HexStringToBytes(epk) }
+            };
+            }
+            else if (request.Headers[ProxyStartEpk] != null)
+            {
+                // Re-add EPK headers removed by RequestInvokerHandler through Properties
+                request.Properties = new Dictionary<string, object>
+            {
+                { WFConstants.BackendHeaders.StartEpkHash, HexStringUtility.HexStringToBytes(request.Headers[ProxyStartEpk]) },
+                { WFConstants.BackendHeaders.EndEpkHash, HexStringUtility.HexStringToBytes(request.Headers[ProxyEndEpk]) }
+            };
+
+                request.Headers.Add(HttpConstants.HttpHeaders.ReadFeedKeyType, RntbdConstants.RntdbReadFeedKeyType.EffectivePartitionKeyRange.ToString());
+                request.Headers.Add(HttpConstants.HttpHeaders.StartEpk, request.Headers[ProxyStartEpk]);
+                request.Headers.Add(HttpConstants.HttpHeaders.EndEpk, request.Headers[ProxyEndEpk]);
+            }
+
+            await request.EnsureBufferedBodyAsync();
+
+            using Documents.Rntbd.TransportSerialization.SerializedRequest serializedRequest =
+                Documents.Rntbd.TransportSerialization.BuildRequestForProxy(
+                    request,
+                    new ResourceOperation(operationType, resourceType),
+                    activityId,
+                    bufferProvider.Provider,
+                    accountName,
+                    out _,
+                    out _);
+
+            MemoryStream memoryStream = new(serializedRequest.RequestSize);
+            await serializedRequest.CopyToStreamAsync(memoryStream);
+            memoryStream.Position = 0;
+            return memoryStream;
+        }
+
+        public static string GetEffectivePartitionKeyHash(string partitionJson)
+        {
+            return Documents.PartitionKey.FromJsonString(partitionJson).InternalKey.GetEffectivePartitionKeyString(HashV2SinglePath);
+        }
+
+        /// <summary>
+        /// Deserialize the Proxy Response from the RNTBD protocol format to the Http format needed by the caller.
+        /// Today this takes the HttpResponseMessage and reconstructs the modified Http response.
+        /// </summary>
+        public static async Task<HttpResponseMessage> ConvertProxyResponseAsync(HttpResponseMessage responseMessage)
+        {
+            using Stream responseStream = await responseMessage.Content.ReadAsStreamAsync();
+
+            (StatusCodes status, byte[] metadata) = await ReadHeaderAndMetadataAsync(responseStream);
+
+            if (responseMessage.StatusCode != (HttpStatusCode)status)
+            {
+                throw new InternalServerErrorException("Status code mismatch");
+            }
+
+            Rntbd.BytesDeserializer bytesDeserializer = new(metadata, metadata.Length);
+            if (!Documents.Rntbd.HeadersTransportSerialization.TryParseMandatoryResponseHeaders(ref bytesDeserializer, out bool payloadPresent, out _))
+            {
+                throw new InternalServerErrorException("Length mismatch");
+            }
+
+            MemoryStream bodyStream = null;
+            if (payloadPresent)
+            {
+                int length = await ReadBodyLengthAsync(responseStream);
+                bodyStream = new MemoryStream(length);
+                await responseStream.CopyToAsync(bodyStream);
+                bodyStream.Position = 0;
+            }
+
+            // TODO: Clean this up.
+            bytesDeserializer = new Rntbd.BytesDeserializer(metadata, metadata.Length);
+            StoreResponse storeResponse = Documents.Rntbd.TransportSerialization.MakeStoreResponse(
+                status,
+                Guid.NewGuid(),
+                bodyStream,
+                HttpConstants.Versions.CurrentVersion,
+                ref bytesDeserializer);
+
+            HttpResponseMessage response = new((HttpStatusCode)storeResponse.StatusCode)
+            {
+                RequestMessage = responseMessage.RequestMessage
+            };
+
+            if (bodyStream != null)
+            {
+                response.Content = new StreamContent(bodyStream);
+            }
+
+            foreach (string header in storeResponse.Headers.Keys())
+            {
+                if (header == HttpConstants.HttpHeaders.SessionToken)
+                {
+                    string newSessionToken = $"{storeResponse.PartitionKeyRangeId}:{storeResponse.Headers.Get(header)}";
+                    response.Headers.TryAddWithoutValidation(header, newSessionToken);
+                }
+                else
+                {
+                    response.Headers.TryAddWithoutValidation(header, storeResponse.Headers.Get(header));
+                }
+            }
+
+            response.Headers.TryAddWithoutValidation(RoutedViaProxy, "1");
+            return response;
+        }
+
+        private static async Task<(StatusCodes, byte[] metadata)> ReadHeaderAndMetadataAsync(Stream stream)
+        {
+            byte[] header = ArrayPool<byte>.Shared.Rent(24);
+            const int headerLength = 24;
+            try
+            {
+                int headerRead = 0;
+                while (headerRead < headerLength)
+                {
+                    int read = await stream.ReadAsync(header, headerRead, headerLength - headerRead);
+
+                    if (read == 0)
+                    {
+                        throw new DocumentClientException("Unexpected end of stream while reading header bytes", HttpStatusCode.Gone, SubStatusCodes.Unknown);
+                    }
+
+                    headerRead += read;
+                }
+
+                uint totalLength = BitConverter.ToUInt32(header, 0);
+                StatusCodes status = (StatusCodes)BitConverter.ToUInt32(header, 4);
+
+                if (totalLength < headerLength)
+                {
+                    throw new InternalServerErrorException("Header length mismatch");
+                }
+
+                int metadataLength = (int)totalLength - headerLength;
+                byte[] metadata = new byte[metadataLength];
+                int responseMetadataRead = 0;
+                while (responseMetadataRead < metadataLength)
+                {
+                    int read = await stream.ReadAsync(metadata, responseMetadataRead, metadataLength - responseMetadataRead);
+
+                    if (read == 0)
+                    {
+                        throw new DocumentClientException("Unexpected end of stream while reading metadata bytes", HttpStatusCode.Gone, SubStatusCodes.Unknown);
+                    }
+
+                    responseMetadataRead += read;
+                }
+
+                return (status, metadata);
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(header);
+            }
+        }
+
+        private static async Task<int> ReadBodyLengthAsync(Stream stream)
+        {
+            byte[] header = ArrayPool<byte>.Shared.Rent(4);
+            const int headerLength = 4;
+            try
+            {
+                int headerRead = 0;
+                while (headerRead < headerLength)
+                {
+                    int read = await stream.ReadAsync(header, headerRead, headerLength - headerRead);
+
+                    if (read == 0)
+                    {
+                        throw new DocumentClientException("Unexpected end of stream while reading body length", HttpStatusCode.Gone, SubStatusCodes.Unknown);
+                    }
+
+                    headerRead += read;
+                }
+
+                return BitConverter.ToInt32(header, 0);
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(header);
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request Template

## Description

The ThinClientTransportSerializer class provides methods for serializing and deserializing proxy requests and responses. It serializes HttpRequestMessage objects into RNTBD requests by extracting headers, operation types, resource types, and partition keys, and it deserializes RNTBD responses back into HttpResponseMessage objects, reconstructing headers and body content. This change also includes unit tests for the change.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Closing issues

To automatically close an issue: closes #4582