### PR TITLE
FeedRanges: Fixes GetFeedRangesAsync throwing DocumentClientException

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/FeedRange/FeedRangeTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/FeedRange/FeedRangeTests.cs
@@ -14,7 +14,6 @@ namespace Microsoft.Azure.Cosmos.Tests.FeedRange
     using Microsoft.Azure.Cosmos.Routing;
     using Moq;
     using Microsoft.Azure.Cosmos.Tracing;
-    using System.IO;
     using System.Net.Http;
     using System.Text;
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/FeedRange/FeedRangeTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/FeedRange/FeedRangeTests.cs
@@ -14,6 +14,9 @@ namespace Microsoft.Azure.Cosmos.Tests.FeedRange
     using Microsoft.Azure.Cosmos.Routing;
     using Moq;
     using Microsoft.Azure.Cosmos.Tracing;
+    using System.IO;
+    using System.Net.Http;
+    using System.Text;
 
     [TestClass]
     public class FeedRangeTests
@@ -219,6 +222,59 @@ namespace Microsoft.Azure.Cosmos.Tests.FeedRange
             FeedRangePartitionKeyRange feedRangePartitionKeyRangeDeserialized = Cosmos.FeedRange.FromJsonString(representation) as FeedRangePartitionKeyRange;
             Assert.IsNotNull(feedRangePartitionKeyRangeDeserialized);
             Assert.AreEqual(feedRangePartitionKeyRange.PartitionKeyRangeId, feedRangePartitionKeyRangeDeserialized.PartitionKeyRangeId);
+        }
+
+        /// <summary>
+        /// Upon failures in PartitionKeyRanges calls, the failure should be a CosmosException
+        /// </summary>
+        [TestMethod]
+        public async Task GetFeedRangesThrowsCosmosException()
+        {
+            Mock<IHttpHandler> mockHttpHandler = new Mock<IHttpHandler>();
+            Uri endpoint = MockSetupsHelper.SetupSingleRegionAccount(
+                "mockAccountInfo",
+                consistencyLevel: ConsistencyLevel.Session,
+                mockHttpHandler,
+                out string primaryRegionEndpoint);
+
+            string databaseName = "mockDbName";
+            string containerName = "mockContainerName";
+            string containerRid = "ccZ1ANCszwk=";
+            Documents.ResourceId cRid = Documents.ResourceId.Parse(containerRid);
+            MockSetupsHelper.SetupContainerProperties(
+                mockHttpHandler: mockHttpHandler,
+                regionEndpoint: primaryRegionEndpoint,
+                databaseName: databaseName,
+                containerName: containerName,
+                containerRid: containerRid);
+
+            // Return a 503 on PKRange call
+            bool invokedPkRanges = false;
+            Uri partitionKeyUri = new Uri($"{primaryRegionEndpoint}/dbs/{cRid.DatabaseId}/colls/{cRid.DocumentCollectionId}/pkranges");
+            mockHttpHandler.Setup(x => x.SendAsync(It.Is<HttpRequestMessage>(x => x.RequestUri == partitionKeyUri), It.IsAny<CancellationToken>()))
+              .Returns(() => Task.FromResult(new HttpResponseMessage()
+              {
+                  StatusCode = HttpStatusCode.ServiceUnavailable,
+                  Content = new StringContent("ServiceUnavailable")
+              }))
+              .Callback(() => invokedPkRanges = true);
+
+            CosmosClientOptions cosmosClientOptions = new CosmosClientOptions()
+            {
+                ConsistencyLevel = Cosmos.ConsistencyLevel.Session,
+                HttpClientFactory = () => new HttpClient(new HttpHandlerHelper(mockHttpHandler.Object)),
+            };
+
+            using (CosmosClient customClient = new CosmosClient(
+                   endpoint.ToString(),
+                   Convert.ToBase64String(Encoding.UTF8.GetBytes(Guid.NewGuid().ToString())),
+                   cosmosClientOptions))
+            {
+                Container container = customClient.GetContainer(databaseName, containerName);
+                CosmosException ex = await Assert.ThrowsExceptionAsync<CosmosException>(() => container.GetFeedRangesAsync(CancellationToken.None));
+                Assert.AreEqual(HttpStatusCode.ServiceUnavailable, ex.StatusCode);
+                Assert.IsTrue(invokedPkRanges);
+            }
         }
     }
 }


### PR DESCRIPTION
# Pull Request Template

## Description

`Container.GetFeedRangesAsync` performs a read on PartitionKeyRanges leveraging the `PartititonKeyRangeCache`. This translates into an HTTP operation to Gateway.

In cases where Gateway returns a failure (see linked issue), the `GatewayStoreClient` will fail creating a `DocumentClientException`.

In normal circumstances, `PartitionKeyRangeCache` is used within the scope of the Handler pipeline, on which any `DocumentClientException` is converted to `CosmosException`, but because this is a direct invocation, there is nothing doing the conversion and **`DocumentClientException` ends up being thrown to the user**.

## Solution

The proposed solution applies the conversion at the method level (`GetFeedRangesAsync`) to ensure the `DocumentClientException` is not received by the user.

An alternative that was evaluated was to apply the conversion within the `PartitionKeyRangeCache` but the problem is that this component is used within other components (such as the Direct Transport stack) where there are already contracts in-place that would expect `DocumentClientException`. Breaking this contract would be dangerous.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Closing issues

Closes #4528