### PR TITLE
Dependencies: Fixes Pinning System.Net.Http and System.Text.RegularExpressions to latest patched versions

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
+++ b/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
@@ -119,6 +119,8 @@
 		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.0.0" />
 		<PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" Version="16.0.102" PrivateAssets="All" />
 		<PackageReference Include="Newtonsoft.Json" Version="10.0.2" NoWarn="NU1903" />
+		<PackageReference Include="System.Net.Http" Version="4.3.4" />
+		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
 		<PackageReference Include="StyleCop.Analyzers" Version="1.1.118" PrivateAssets="All" />
 
 		<!--Direct Dependencies-->


### PR DESCRIPTION
# Pull Request Template

## Description
Create a new project with the latest .NET 9.0 preview SDK which includes NuGet audit for security vulnerabilities. Add a reference to <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.43.0"/> and restore the project.

**Expected behavior**
No warnings when restoring.

**Actual behavior**
The following warnings occur:
```
    C:\scratch\azureCosmos\azureCosmos.csproj : warning NU1903: Package 'Newtonsoft.Json' 10.0.2 has a known high severity vulnerability, https://github.com/advisories/GHSA-5crp-9r3c-p9vr
    C:\scratch\azureCosmos\azureCosmos.csproj : warning NU1903: Package 'System.Net.Http' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-7jgj-8wvc-jh57
    C:\scratch\azureCosmos\azureCosmos.csproj : warning NU1903: Package 'System.Text.RegularExpressions' 4.3.0 has a known high severity vulnerability, https://github.com/advisories/GHSA-cmhx-cq75-c4mj
```

'System.Text.RegularExpressions' seems like a transitive dependency through 'Newtonsoft.Json'
Unsure of source of System.Net.Http dependency (we do use HttpClient but not explicitly listed in package spec.

'Newtonsoft.Json' 10.0.2 vulnerability is address through a code fix, unfortunately upgrading to the suggested version is a breaking change.

Except 'Newtonsoft.Json' we can at-least fix others as new dependencies directly to override.


## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Related issue
ref: #4674 
