### PR TITLE
`ClientRetryPolicy`: Adds Cross Regional Retry Logic on `429/3092` and `410/1022`

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
 		<ClientOfficialVersion>3.43.0</ClientOfficialVersion>
 		<ClientPreviewVersion>3.44.0</ClientPreviewVersion>
 		<ClientPreviewSuffixVersion>preview.0</ClientPreviewSuffixVersion>
-		<DirectVersion>3.35.0</DirectVersion>
+		<DirectVersion>3.36.0</DirectVersion>
 		<EncryptionOfficialVersion>2.0.4</EncryptionOfficialVersion>
 		<EncryptionPreviewVersion>2.1.0</EncryptionPreviewVersion>
 		<EncryptionPreviewSuffixVersion>preview4</EncryptionPreviewSuffixVersion>

--- a/Microsoft.Azure.Cosmos/src/Batch/BatchAsyncContainerExecutor.cs
+++ b/Microsoft.Azure.Cosmos/src/Batch/BatchAsyncContainerExecutor.cs
@@ -92,7 +92,11 @@ namespace Microsoft.Azure.Cosmos
             ItemBatchOperationContext context = new ItemBatchOperationContext(
                 resolvedPartitionKeyRangeId,
                 trace,
-                BatchAsyncContainerExecutor.GetRetryPolicy(this.cosmosContainer, operation.OperationType, this.retryOptions));
+                BatchAsyncContainerExecutor.GetRetryPolicy(
+                    this.cosmosContainer,
+                    this.cosmosClientContext?.DocumentClient?.GlobalEndpointManager,
+                    operation.OperationType,
+                    this.retryOptions));
 
             if (itemRequestOptions != null && itemRequestOptions.AddRequestHeaders != null)
             {
@@ -159,6 +163,7 @@ namespace Microsoft.Azure.Cosmos
 
         private static IDocumentClientRetryPolicy GetRetryPolicy(
             ContainerInternal containerInternal,
+            GlobalEndpointManager endpointManager,
             OperationType operationType,
             RetryOptions retryOptions)
         {
@@ -167,6 +172,7 @@ namespace Microsoft.Azure.Cosmos
                operationType,
                new ResourceThrottleRetryPolicy(
                 retryOptions.MaxRetryAttemptsOnThrottledRequests,
+                endpointManager,
                 retryOptions.MaxRetryWaitTimeInSeconds));
         }
 

--- a/Microsoft.Azure.Cosmos/src/ClientRetryPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/ClientRetryPolicy.cs
@@ -48,6 +48,7 @@ namespace Microsoft.Azure.Cosmos
         {
             this.throttlingRetry = new ResourceThrottleRetryPolicy(
                 retryOptions.MaxRetryAttemptsOnThrottledRequests,
+                endpointManager: globalEndpointManager,
                 retryOptions.MaxRetryWaitTimeInSeconds);
 
             this.globalEndpointManager = globalEndpointManager;

--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -988,8 +988,9 @@ namespace Microsoft.Azure.Cosmos
             this.initializeTaskFactory = (_) => TaskHelper.InlineIfPossible<bool>(
                     () => this.GetInitializationTaskAsync(storeClientFactory: storeClientFactory),
                     new ResourceThrottleRetryPolicy(
-                        this.ConnectionPolicy.RetryOptions.MaxRetryAttemptsOnThrottledRequests,
-                        this.ConnectionPolicy.RetryOptions.MaxRetryWaitTimeInSeconds));
+                        maxAttemptCount: this.ConnectionPolicy.RetryOptions.MaxRetryAttemptsOnThrottledRequests,
+                        endpointManager: this.GlobalEndpointManager,
+                        maxWaitTimeInSeconds: this.ConnectionPolicy.RetryOptions.MaxRetryWaitTimeInSeconds));
 
             // Create the task to start the initialize task
             // Task will be awaited on in the EnsureValidClientAsync

--- a/Microsoft.Azure.Cosmos/src/MetadataRequestThrottleRetryPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/MetadataRequestThrottleRetryPolicy.cs
@@ -72,6 +72,7 @@ namespace Microsoft.Azure.Cosmos
 
             this.throttlingRetryPolicy = new ResourceThrottleRetryPolicy(
                 maxRetryAttemptsOnThrottledRequests,
+                this.globalEndpointManager,
                 maxRetryWaitTimeInSeconds);
 
             this.retryContext = new MetadataRetryContext

--- a/Microsoft.Azure.Cosmos/src/ResourceThrottleRetryPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/ResourceThrottleRetryPolicy.cs
@@ -109,14 +109,14 @@ namespace Microsoft.Azure.Cosmos
             if (this.isMultiMasterWriteRegion.HasValue
                 && this.isMultiMasterWriteRegion.Value
                 && subStatusCode != null
-                && subStatusCode == SubStatusCodes.AadTokenExpired)
+                && subStatusCode == SubStatusCodes.SystemResourceUnavailable)
             {
                 DefaultTrace.TraceError(
-                    "Operation will NOT be retried. Converting 429/3092 to 503. Current attempt {0} sub status code: {1}.",
-                    this.currentAttemptCount, SubStatusCodes.AadTokenExpired);
+                    "Operation will NOT be retried. Converting SystemResourceUnavailable (429/3092) to ServiceUnavailable (503). Current attempt {0} sub status code: {1}.",
+                    this.currentAttemptCount, SubStatusCodes.SystemResourceUnavailable);
 
                 ServiceUnavailableException exceptionToThrow = ServiceUnavailableException.Create(
-                    SubStatusCodes.AadTokenExpired,
+                    SubStatusCodes.SystemResourceUnavailable,
                     innerException: exception);
 
                 return Task.FromResult(

--- a/Microsoft.Azure.Cosmos/src/ResourceThrottleRetryPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/ResourceThrottleRetryPolicy.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Azure.Cosmos
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Core.Trace;
+    using Microsoft.Azure.Cosmos.Routing;
     using Microsoft.Azure.Documents;
 
     // Retry when we receive the throttling from server.
@@ -19,12 +20,15 @@ namespace Microsoft.Azure.Cosmos
         private readonly uint backoffDelayFactor;
         private readonly int maxAttemptCount;
         private readonly TimeSpan maxWaitTimeInMilliseconds;
+        private readonly IGlobalEndpointManager globalEndpointManager;
 
         private int currentAttemptCount;
         private TimeSpan cumulativeRetryDelay;
+        private bool? isMultiMasterWriteRegion;
 
         public ResourceThrottleRetryPolicy(
             int maxAttemptCount,
+            IGlobalEndpointManager endpointManager,
             int maxWaitTimeInSeconds = DefaultMaxWaitTimeInSeconds,
             uint backoffDelayFactor = 1)
         {
@@ -33,6 +37,7 @@ namespace Microsoft.Azure.Cosmos
                 throw new ArgumentException("maxWaitTimeInSeconds", "maxWaitTimeInSeconds must be less than " + (int.MaxValue / 1000));
             }
 
+            this.globalEndpointManager = endpointManager;
             this.maxAttemptCount = maxAttemptCount;
             this.backoffDelayFactor = backoffDelayFactor;
             this.maxWaitTimeInMilliseconds = TimeSpan.FromSeconds(maxWaitTimeInSeconds);
@@ -59,7 +64,9 @@ namespace Microsoft.Azure.Cosmos
                     return Task.FromResult(ShouldRetryResult.NoRetry());
                 }
 
-                return this.ShouldRetryInternalAsync(dce.RetryAfter);
+                return this.ShouldRetryInternalAsync(
+                    dce?.GetSubStatus(),
+                    dce?.RetryAfter);
             }
 
             DefaultTrace.TraceError(
@@ -88,11 +95,34 @@ namespace Microsoft.Azure.Cosmos
                 return Task.FromResult(ShouldRetryResult.NoRetry());
             }
 
-            return this.ShouldRetryInternalAsync(cosmosResponseMessage?.Headers.RetryAfter);
+            return this.ShouldRetryInternalAsync(
+                cosmosResponseMessage?.Headers.SubStatusCode,
+                cosmosResponseMessage?.Headers.RetryAfter,
+                cosmosResponseMessage?.CosmosException);
         }
 
-        private Task<ShouldRetryResult> ShouldRetryInternalAsync(TimeSpan? retryAfter)
+        private Task<ShouldRetryResult> ShouldRetryInternalAsync(
+            SubStatusCodes? subStatusCode,
+            TimeSpan? retryAfter,
+            Exception exception = null)
         {
+            if (this.isMultiMasterWriteRegion.HasValue
+                && this.isMultiMasterWriteRegion.Value
+                && subStatusCode != null
+                && subStatusCode == SubStatusCodes.AadTokenExpired)
+            {
+                DefaultTrace.TraceError(
+                    "Operation will NOT be retried. Converting 429/3092 to 503. Current attempt {0} sub status code: {1}.",
+                    this.currentAttemptCount, SubStatusCodes.AadTokenExpired);
+
+                ServiceUnavailableException exceptionToThrow = ServiceUnavailableException.Create(
+                    SubStatusCodes.AadTokenExpired,
+                    innerException: exception);
+
+                return Task.FromResult(
+                    ShouldRetryResult.NoRetry(exceptionToThrow));
+            }
+
             TimeSpan retryDelay = TimeSpan.Zero;
             if (this.currentAttemptCount < this.maxAttemptCount &&
                 this.CheckIfRetryNeeded(retryAfter, out retryDelay))
@@ -133,6 +163,8 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="request">The request being sent to the service.</param>
         public void OnBeforeSendRequest(DocumentServiceRequest request)
         {
+            this.isMultiMasterWriteRegion = !request.IsReadOnlyRequest
+                && (this.globalEndpointManager?.CanUseMultipleWriteLocations(request) ?? false);
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Routing/LocationCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/LocationCache.cs
@@ -529,8 +529,9 @@ namespace Microsoft.Azure.Cosmos.Routing
 
         public bool CanUseMultipleWriteLocations(DocumentServiceRequest request)
         {
-            return this.CanUseMultipleWriteLocations() &&
-                (request.ResourceType == ResourceType.Document ||
+            return this.CanUseMultipleWriteLocations()
+                && this.locationInfo.AvailableWriteLocations.Count > 1
+                && (request.ResourceType == ResourceType.Document ||
                 (request.ResourceType == ResourceType.StoredProcedure && request.OperationType == Documents.OperationType.ExecuteJavaScript));
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchAsyncBatcherTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchAsyncBatcherTests.cs
@@ -23,6 +23,23 @@ namespace Microsoft.Azure.Cosmos.Tests
     {
         private static readonly Exception expectedException = new Exception();
         private static readonly BatchPartitionMetric metric = new BatchPartitionMetric();
+        private GlobalEndpointManager mockedEndpointManager;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            Mock<IDocumentClientInternal> mockedClient = new();
+
+            this.mockedEndpointManager = new(
+                mockedClient.Object,
+                new ConnectionPolicy());
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            this.mockedEndpointManager.Dispose();
+        }
 
         private ItemBatchOperation CreateItemBatchOperation(bool withContext = false)
         {
@@ -565,12 +582,12 @@ namespace Microsoft.Azure.Cosmos.Tests
             IDocumentClientRetryPolicy retryPolicy1 = new BulkExecutionRetryPolicy(
                 GetSplitEnabledContainer(),
                 OperationType.Read,
-                new ResourceThrottleRetryPolicy(1));
+                new ResourceThrottleRetryPolicy(1, this.mockedEndpointManager));
 
             IDocumentClientRetryPolicy retryPolicy2 = new BulkExecutionRetryPolicy(
                 GetSplitEnabledContainer(),
                 OperationType.Read,
-                new ResourceThrottleRetryPolicy(1));
+                new ResourceThrottleRetryPolicy(1, this.mockedEndpointManager));
 
             ItemBatchOperation operation1 = this.CreateItemBatchOperation();
             ItemBatchOperation operation2 = this.CreateItemBatchOperation();
@@ -594,12 +611,12 @@ namespace Microsoft.Azure.Cosmos.Tests
             IDocumentClientRetryPolicy retryPolicy1 = new BulkExecutionRetryPolicy(
                 GetSplitEnabledContainer(),
                 OperationType.Read,
-                new ResourceThrottleRetryPolicy(1));
+                new ResourceThrottleRetryPolicy(1, this.mockedEndpointManager));
 
             IDocumentClientRetryPolicy retryPolicy2 = new BulkExecutionRetryPolicy(
                 GetSplitEnabledContainer(),
                 OperationType.Read,
-                new ResourceThrottleRetryPolicy(1));
+                new ResourceThrottleRetryPolicy(1, this.mockedEndpointManager));
 
             ItemBatchOperation operation1 = this.CreateItemBatchOperation();
             ItemBatchOperation operation2 = this.CreateItemBatchOperation();
@@ -623,12 +640,12 @@ namespace Microsoft.Azure.Cosmos.Tests
             IDocumentClientRetryPolicy retryPolicy1 = new BulkExecutionRetryPolicy(
                 GetSplitEnabledContainer(),
                 OperationType.Read,
-                new ResourceThrottleRetryPolicy(1));
+                new ResourceThrottleRetryPolicy(1, this.mockedEndpointManager));
 
             IDocumentClientRetryPolicy retryPolicy2 = new BulkExecutionRetryPolicy(
                 GetSplitEnabledContainer(),
                 OperationType.Read,
-                new ResourceThrottleRetryPolicy(1));
+                new ResourceThrottleRetryPolicy(1, this.mockedEndpointManager));
 
             ItemBatchOperation operation1 = this.CreateItemBatchOperation();
             ItemBatchOperation operation2 = this.CreateItemBatchOperation();
@@ -672,17 +689,17 @@ namespace Microsoft.Azure.Cosmos.Tests
             IDocumentClientRetryPolicy retryPolicy1 = new BulkExecutionRetryPolicy(
                 GetSplitEnabledContainer(),
                 OperationType.Read,
-                new ResourceThrottleRetryPolicy(1));
+                new ResourceThrottleRetryPolicy(1, this.mockedEndpointManager));
 
             IDocumentClientRetryPolicy retryPolicy2 = new BulkExecutionRetryPolicy(
                 GetSplitEnabledContainer(),
                 OperationType.Read,
-                new ResourceThrottleRetryPolicy(1));
+                new ResourceThrottleRetryPolicy(1, this.mockedEndpointManager));
 
             IDocumentClientRetryPolicy retryPolicy3 = new BulkExecutionRetryPolicy(
                 GetSplitEnabledContainer(),
                 OperationType.Create,
-                new ResourceThrottleRetryPolicy(1));
+                new ResourceThrottleRetryPolicy(1, this.mockedEndpointManager));
 
             ItemBatchOperation operation1 = this.CreateItemBatchOperation();
             ItemBatchOperation operation2 = this.CreateItemBatchOperation();
@@ -710,17 +727,17 @@ namespace Microsoft.Azure.Cosmos.Tests
             IDocumentClientRetryPolicy retryPolicy1 = new BulkExecutionRetryPolicy(
                 GetSplitEnabledContainer(),
                 OperationType.Read,
-                new ResourceThrottleRetryPolicy(1));
+                new ResourceThrottleRetryPolicy(1, this.mockedEndpointManager));
 
             IDocumentClientRetryPolicy retryPolicy2 = new BulkExecutionRetryPolicy(
                 GetSplitEnabledContainer(),
                 OperationType.Read,
-                new ResourceThrottleRetryPolicy(1));
+                new ResourceThrottleRetryPolicy(1, this.mockedEndpointManager));
 
             IDocumentClientRetryPolicy retryPolicy3 = new BulkExecutionRetryPolicy(
                 GetSplitEnabledContainer(),
                 OperationType.Create,
-                new ResourceThrottleRetryPolicy(1));
+                new ResourceThrottleRetryPolicy(1, this.mockedEndpointManager));
 
             ItemBatchOperation operation1 = this.CreateItemBatchOperation();
             ItemBatchOperation operation2 = this.CreateItemBatchOperation();

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchAsyncOperationContextTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchAsyncOperationContextTests.cs
@@ -18,13 +18,31 @@ namespace Microsoft.Azure.Cosmos.Tests
     [TestClass]
     public class BatchAsyncOperationContextTests
     {
+        private GlobalEndpointManager mockedEndpointManager;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            Mock<IDocumentClientInternal> mockedClient = new();
+
+            this.mockedEndpointManager = new(
+                mockedClient.Object,
+                new ConnectionPolicy());
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            this.mockedEndpointManager.Dispose();
+        }
+
         [TestMethod]
         public async Task TraceIsJoinedOnCompletionWithRetry()
         {
             IDocumentClientRetryPolicy retryPolicy = new BulkExecutionRetryPolicy(
                 Mock.Of<ContainerInternal>(),
                 OperationType.Read,
-                new ResourceThrottleRetryPolicy(1));
+                new ResourceThrottleRetryPolicy(1, this.mockedEndpointManager));
 
             Trace rootTrace = Trace.GetRootTrace(name: "RootTrace");
 
@@ -65,7 +83,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             IDocumentClientRetryPolicy retryPolicy = new BulkExecutionRetryPolicy(
                 Mock.Of<ContainerInternal>(),
                 OperationType.Read,
-                new ResourceThrottleRetryPolicy(1));
+                new ResourceThrottleRetryPolicy(1, this.mockedEndpointManager));
 
             Trace rootTrace = Trace.GetRootTrace(name: "RootTrace");
 
@@ -179,7 +197,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             IDocumentClientRetryPolicy retryPolicy = new BulkExecutionRetryPolicy(
                 Mock.Of<ContainerInternal>(),
                 OperationType.Read,
-                new ResourceThrottleRetryPolicy(1));
+                new ResourceThrottleRetryPolicy(1, this.mockedEndpointManager));
             TransactionalBatchOperationResult result = new TransactionalBatchOperationResult(HttpStatusCode.OK);
             ItemBatchOperation operation = new ItemBatchOperation(OperationType.Create, 0, Cosmos.PartitionKey.Null);
             operation.AttachContext(new ItemBatchOperationContext(string.Empty, NoOpTrace.Singleton, retryPolicy));
@@ -193,7 +211,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             IDocumentClientRetryPolicy retryPolicy = new BulkExecutionRetryPolicy(
                 Mock.Of<ContainerInternal>(),
                 OperationType.Read,
-                new ResourceThrottleRetryPolicy(1));
+                new ResourceThrottleRetryPolicy(1, this.mockedEndpointManager));
             TransactionalBatchOperationResult result = new TransactionalBatchOperationResult((HttpStatusCode)StatusCodes.TooManyRequests);
             ItemBatchOperation operation = new ItemBatchOperation(OperationType.Create, 0, Cosmos.PartitionKey.Null);
             operation.AttachContext(new ItemBatchOperationContext(string.Empty, NoOpTrace.Singleton, retryPolicy));
@@ -207,7 +225,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             IDocumentClientRetryPolicy retryPolicy = new BulkExecutionRetryPolicy(
                 Mock.Of<ContainerInternal>(),
                 OperationType.Read,
-                new ResourceThrottleRetryPolicy(1));
+                new ResourceThrottleRetryPolicy(1, this.mockedEndpointManager));
             TransactionalBatchOperationResult result = new TransactionalBatchOperationResult(HttpStatusCode.RequestEntityTooLarge) { SubStatusCode = (SubStatusCodes)3402 };
             ItemBatchOperation operation = new ItemBatchOperation(OperationType.Create, 0, Cosmos.PartitionKey.Null);
             operation.AttachContext(new ItemBatchOperationContext(string.Empty, NoOpTrace.Singleton, retryPolicy));
@@ -221,7 +239,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             IDocumentClientRetryPolicy retryPolicy = new BulkExecutionRetryPolicy(
                 Mock.Of<ContainerInternal>(),
                 OperationType.Create,
-                new ResourceThrottleRetryPolicy(1));
+                new ResourceThrottleRetryPolicy(1, this.mockedEndpointManager));
             TransactionalBatchOperationResult result = new TransactionalBatchOperationResult(HttpStatusCode.RequestEntityTooLarge);
             ItemBatchOperation operation = new ItemBatchOperation(OperationType.Create, 0, Cosmos.PartitionKey.Null);
             operation.AttachContext(new ItemBatchOperationContext(string.Empty, NoOpTrace.Singleton, retryPolicy));
@@ -235,7 +253,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             IDocumentClientRetryPolicy retryPolicy = new BulkExecutionRetryPolicy(
                 GetSplitEnabledContainer(),
                 OperationType.Read,
-                new ResourceThrottleRetryPolicy(1));
+                new ResourceThrottleRetryPolicy(1, this.mockedEndpointManager));
             TransactionalBatchOperationResult result = new TransactionalBatchOperationResult(HttpStatusCode.Gone) { SubStatusCode = SubStatusCodes.PartitionKeyRangeGone };
             ItemBatchOperation operation = new ItemBatchOperation(OperationType.Create, 0, Cosmos.PartitionKey.Null);
             operation.AttachContext(new ItemBatchOperationContext(string.Empty, NoOpTrace.Singleton, retryPolicy));
@@ -249,7 +267,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             IDocumentClientRetryPolicy retryPolicy = new BulkExecutionRetryPolicy(
                 GetSplitEnabledContainer(),
                 OperationType.Read,
-                new ResourceThrottleRetryPolicy(1));
+                new ResourceThrottleRetryPolicy(1, this.mockedEndpointManager));
             TransactionalBatchOperationResult result = new TransactionalBatchOperationResult(HttpStatusCode.Gone) { SubStatusCode = SubStatusCodes.CompletingSplit };
             ItemBatchOperation operation = new ItemBatchOperation(OperationType.Create, 0, Cosmos.PartitionKey.Null);
             operation.AttachContext(new ItemBatchOperationContext(string.Empty, NoOpTrace.Singleton, retryPolicy));
@@ -263,7 +281,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             IDocumentClientRetryPolicy retryPolicy = new BulkExecutionRetryPolicy(
                 GetSplitEnabledContainer(),
                 OperationType.Read,
-                new ResourceThrottleRetryPolicy(1));
+                new ResourceThrottleRetryPolicy(1, this.mockedEndpointManager));
             TransactionalBatchOperationResult result = new TransactionalBatchOperationResult(HttpStatusCode.Gone) { SubStatusCode = SubStatusCodes.CompletingPartitionMigration };
             ItemBatchOperation operation = new ItemBatchOperation(OperationType.Create, 0, Cosmos.PartitionKey.Null);
             operation.AttachContext(new ItemBatchOperationContext(string.Empty, NoOpTrace.Singleton, retryPolicy));

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ResourceThrottleRetryPolicyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ResourceThrottleRetryPolicyTests.cs
@@ -7,13 +7,10 @@ namespace Microsoft.Azure.Cosmos.Tests
     using System;
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
-    using System.Collections.Specialized;
     using System.Diagnostics;
     using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
-    using global::Azure.Core;
-    using Microsoft.Azure.Cosmos.Client.Tests;
     using Microsoft.Azure.Cosmos.Core.Trace;
     using Microsoft.Azure.Cosmos.Routing;
     using Microsoft.Azure.Documents;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ResourceThrottleRetryPolicyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ResourceThrottleRetryPolicyTests.cs
@@ -82,7 +82,8 @@ namespace Microsoft.Azure.Cosmos.Tests
         [TestMethod]
         [DataRow(true, DisplayName = "Validate retry policy with multi master write account.")]
         [DataRow(false, DisplayName = "Validate retry policy with single master write account.")]
-        public async Task ShouldRetryAsync_WhenResourceNotAvailableThrown_ShouldThrow503OnMultiMasterWrite(bool isMultiMasterAccount)
+        public async Task ShouldRetryAsync_WhenResourceNotAvailableThrown_ShouldThrow503OnMultiMasterWrite(
+            bool isMultiMasterAccount)
         {
             Documents.Collections.INameValueCollection requestHeaders = new Documents.Collections.DictionaryNameValueCollection();
 
@@ -105,9 +106,9 @@ namespace Microsoft.Azure.Cosmos.Tests
             policy.OnBeforeSendRequest(request);
 
             DocumentClientException dce = new (
-                "429 with 3092 occurred.",
+                "SystemResourceUnavailable: 429 with 3092 occurred.",
                 HttpStatusCode.TooManyRequests,
-                SubStatusCodes.AadTokenExpired);
+                SubStatusCodes.SystemResourceUnavailable);
 
             ShouldRetryResult shouldRetryResult = await policy.ShouldRetryAsync(dce, default);
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ResourceThrottleRetryPolicyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ResourceThrottleRetryPolicyTests.cs
@@ -6,14 +6,24 @@ namespace Microsoft.Azure.Cosmos.Tests
 {
     using System;
     using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using System.Collections.Specialized;
     using System.Diagnostics;
+    using System.Net;
+    using System.Threading;
     using System.Threading.Tasks;
+    using global::Azure.Core;
+    using Microsoft.Azure.Cosmos.Client.Tests;
     using Microsoft.Azure.Cosmos.Core.Trace;
+    using Microsoft.Azure.Cosmos.Routing;
+    using Microsoft.Azure.Documents;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
 
     [TestClass]
     public class ResourceThrottleRetryPolicyTests
     {
+        private static readonly Uri DefaultEndpoint = new ("https://default.documents.azure.com");
         private readonly List<TraceListener> existingListener = new List<TraceListener>();
         private SourceSwitch existingSourceSwitch;
 
@@ -44,8 +54,11 @@ namespace Microsoft.Azure.Cosmos.Tests
         [TestMethod]
         public async Task DoesNotSerializeExceptionOnTracingDisabled()
         {
+            Mock<IDocumentClientInternal> mockedClient = new();
+            GlobalEndpointManager endpointManager = new(mockedClient.Object, new ConnectionPolicy());
+
             // No listeners
-            ResourceThrottleRetryPolicy policy = new ResourceThrottleRetryPolicy(0);
+            ResourceThrottleRetryPolicy policy = new ResourceThrottleRetryPolicy(0, endpointManager);
             CustomException exception = new CustomException();
             await policy.ShouldRetryAsync(exception, default);
             Assert.AreEqual(0, exception.ToStringCount, "Exception was serialized");
@@ -54,13 +67,176 @@ namespace Microsoft.Azure.Cosmos.Tests
         [TestMethod]
         public async Task DoesSerializeExceptionOnTracingEnabled()
         {
+            Mock<IDocumentClientInternal> mockedClient = new();
+            GlobalEndpointManager endpointManager = new(mockedClient.Object, new ConnectionPolicy());
+
             // Let the default trace listener
             DefaultTrace.TraceSource.Switch = new SourceSwitch("ClientSwitch", "Error");
             DefaultTrace.TraceSource.Listeners.Add(new DefaultTraceListener());
-            ResourceThrottleRetryPolicy policy = new ResourceThrottleRetryPolicy(0);
+            ResourceThrottleRetryPolicy policy = new ResourceThrottleRetryPolicy(0, endpointManager);
             CustomException exception = new CustomException();
             await policy.ShouldRetryAsync(exception, default);
             Assert.AreEqual(1, exception.ToStringCount, "Exception was not serialized");
+        }
+
+        [TestMethod]
+        [DataRow(true, DisplayName = "Validate retry policy with multi master write account.")]
+        [DataRow(false, DisplayName = "Validate retry policy with single master write account.")]
+        public async Task ShouldRetryAsync_WhenResourceNotAvailableThrown_ShouldThrow503OnMultiMasterWrite(bool isMultiMasterAccount)
+        {
+            Documents.Collections.INameValueCollection requestHeaders = new Documents.Collections.DictionaryNameValueCollection();
+
+            GlobalEndpointManager endpointManager = await this.InitializeEndpointManager(
+                useMultipleWriteLocations: isMultiMasterAccount,
+                enableEndpointDiscovery: true,
+                isPreferredLocationsListEmpty: false,
+                enforceSingleMasterSingleWriteLocation: !isMultiMasterAccount);
+
+            ResourceThrottleRetryPolicy policy = new (0, endpointManager);
+
+            DocumentServiceRequest request = new(
+                OperationType.Create,
+                ResourceType.Document,
+                "dbs/db/colls/coll1/docs/doc1",
+                null,
+                AuthorizationTokenType.PrimaryMasterKey,
+                requestHeaders);
+
+            policy.OnBeforeSendRequest(request);
+
+            DocumentClientException dce = new (
+                "429 with 3092 occurred.",
+                HttpStatusCode.TooManyRequests,
+                SubStatusCodes.AadTokenExpired);
+
+            ShouldRetryResult shouldRetryResult = await policy.ShouldRetryAsync(dce, default);
+
+            if (isMultiMasterAccount)
+            {
+                Assert.IsFalse(shouldRetryResult.ShouldRetry);
+                Assert.IsNotNull(shouldRetryResult.ExceptionToThrow);
+                Assert.AreEqual(typeof(ServiceUnavailableException), shouldRetryResult.ExceptionToThrow.GetType());
+            }
+            else
+            {
+                Assert.IsFalse(shouldRetryResult.ShouldRetry);
+                Assert.IsNull(shouldRetryResult.ExceptionToThrow);
+            }
+        }
+
+        private async Task<GlobalEndpointManager> InitializeEndpointManager(
+            bool useMultipleWriteLocations,
+            bool enableEndpointDiscovery,
+            bool isPreferredLocationsListEmpty,
+            bool enforceSingleMasterSingleWriteLocation = false, // Some tests depend on the Initialize to create an account with multiple write locations, even when not multi master
+            ReadOnlyCollection<string> preferedRegionListOverride = null,
+            bool isExcludeRegionsTest = false)
+        {
+            ReadOnlyCollection<string> preferredLocations;
+            AccountProperties databaseAccount = ResourceThrottleRetryPolicyTests.CreateDatabaseAccount(
+                useMultipleWriteLocations,
+                enforceSingleMasterSingleWriteLocation,
+                isExcludeRegionsTest);
+
+            if (isPreferredLocationsListEmpty)
+            {
+                preferredLocations = new List<string>().AsReadOnly();
+            }
+            else
+            {
+                // Allow for override at the test method level if needed
+                preferredLocations = preferedRegionListOverride ?? new List<string>()
+                {
+                    "location1",
+                    "location2",
+                    "location3"
+                }.AsReadOnly();
+            }
+
+            Mock<IDocumentClientInternal> mockedClient = new Mock<IDocumentClientInternal>();
+            mockedClient.Setup(owner => owner.ServiceEndpoint).Returns(ResourceThrottleRetryPolicyTests.DefaultEndpoint);
+            mockedClient.Setup(owner => owner.GetDatabaseAccountInternalAsync(It.IsAny<Uri>(), It.IsAny<CancellationToken>())).ReturnsAsync(databaseAccount);
+
+            ConnectionPolicy connectionPolicy = new ConnectionPolicy()
+            {
+                EnableEndpointDiscovery = enableEndpointDiscovery,
+                UseMultipleWriteLocations = useMultipleWriteLocations,
+            };
+
+            foreach (string preferredLocation in preferredLocations)
+            {
+                connectionPolicy.PreferredLocations.Add(preferredLocation);
+            }
+
+            GlobalEndpointManager endpointManager = new GlobalEndpointManager(mockedClient.Object, connectionPolicy);
+            await endpointManager.RefreshLocationAsync(false);
+
+            return endpointManager;
+        }
+
+        private static AccountProperties CreateDatabaseAccount(
+            bool useMultipleWriteLocations,
+            bool enforceSingleMasterSingleWriteLocation,
+            bool isExcludeRegionsTest = false)
+        {
+            Uri Location1Endpoint = new ("https://location1.documents.azure.com");
+            Uri Location2Endpoint = new ("https://location2.documents.azure.com");
+            Uri Location3Endpoint = new ("https://location3.documents.azure.com");
+            Uri Location4Endpoint = new ("https://location4.documents.azure.com");
+
+            Collection<AccountRegion> writeLocations = isExcludeRegionsTest ?
+
+                new Collection<AccountRegion>()
+                {
+                    { new AccountRegion() { Name = "default", Endpoint = ResourceThrottleRetryPolicyTests.DefaultEndpoint.ToString() } },
+                    { new AccountRegion() { Name = "location1", Endpoint = Location1Endpoint.ToString() } },
+                    { new AccountRegion() { Name = "location2", Endpoint = Location2Endpoint.ToString() } },
+                    { new AccountRegion() { Name = "location3", Endpoint = Location3Endpoint.ToString() } },
+                } :
+                new Collection<AccountRegion>()
+                {
+                    { new AccountRegion() { Name = "location1", Endpoint = Location1Endpoint.ToString() } },
+                    { new AccountRegion() { Name = "location2", Endpoint = Location2Endpoint.ToString() } },
+                    { new AccountRegion() { Name = "location3", Endpoint = Location3Endpoint.ToString() } },
+                };
+
+            if (!useMultipleWriteLocations
+                && enforceSingleMasterSingleWriteLocation)
+            {
+                // Some pre-existing tests depend on the account having multiple write locations even on single master setup
+                // Newer tests can correctly define a single master account (single write region) without breaking existing tests
+                writeLocations = isExcludeRegionsTest ?
+                    new Collection<AccountRegion>()
+                    {
+                        { new AccountRegion() { Name = "default", Endpoint = ResourceThrottleRetryPolicyTests.DefaultEndpoint.ToString() } }
+                    } :
+                    new Collection<AccountRegion>()
+                    {
+                        { new AccountRegion() { Name = "location1", Endpoint = Location1Endpoint.ToString() } }
+                    };
+            }
+
+            AccountProperties databaseAccount = new ()
+            {
+                EnableMultipleWriteLocations = useMultipleWriteLocations,
+                ReadLocationsInternal = isExcludeRegionsTest ?
+                    new Collection<AccountRegion>()
+                    {
+                        { new AccountRegion() { Name = "default", Endpoint = ResourceThrottleRetryPolicyTests.DefaultEndpoint.ToString() } },
+                        { new AccountRegion() { Name = "location1", Endpoint = Location1Endpoint.ToString() } },
+                        { new AccountRegion() { Name = "location2", Endpoint = Location2Endpoint.ToString() } },
+                        { new AccountRegion() { Name = "location4", Endpoint = Location4Endpoint.ToString() } },
+                    } :
+                    new Collection<AccountRegion>()
+                    {
+                        { new AccountRegion() { Name = "location1", Endpoint = Location1Endpoint.ToString() } },
+                        { new AccountRegion() { Name = "location2", Endpoint = Location2Endpoint.ToString() } },
+                        { new AccountRegion() { Name = "location4", Endpoint = Location4Endpoint.ToString() } },
+                    },
+                WriteLocationsInternal = writeLocations
+            };
+
+            return databaseAccount;
         }
 
         private class CustomException : Exception


### PR DESCRIPTION
# Pull Request Template

## Description

This PR is covering two CRI scenarios in general:

- Gone Exception (Status Code: **410**) with Lease Not Found (Sub Status Code: **1022**).
- Request Throttled (Status Code: **429**) with System Resource Unavailable (Sub Status Code: **3092**).

The behavior changes are described below in detail:

**Background:** In general `410/1022` is used as a signal to indicate that a region is not part of the dynamic quorum - meaning in global strong with dynamic quorum all reads from the secondary region kicked out of the quorum will return `410/1022`.

- Today when a read region loses the read lease it returns `410/LeaseNotFound` - the client will then retry locally for up-to `60` seconds (for global strong) and up-to `30` seconds (for others) (catch-all 410 retry like for 410/0 or connectivity related 410) for any.
Instead the `410/LeaseNotFound(1022)` should be mapped immediately to a `503` to allow the cross-regional retry to happen as quickly as possible. Retrying in the next preferred region like usual for reads is acceptable. This has been taken care in the `Cosmos.Direct` release [`3.36.0`](https://www.nuget.org/packages/Microsoft.Azure.Cosmos.Direct/3.36.0) and this PR is upgrading the `Cosmos.Direct` version to `3.36.0` to reflect the change.

- For `429/3092 (Request Throttled/ SystemResourceUnavailable)`, we would only want to short-circuit this to retry cross-region quickly when we can actually retry cross region (not a write in single master) - and for reads only when it is returned from all replica in a region. The latter is extremely unlikely - so, I would probably compromise on a pragmatic approach and simply short-circuit by mapping `429/3092` to a 503 for write operations when multi-master is enabled (and there is >1 write regions).
That way we get the cross-region retry in the scenario where this is most critical. 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Closing issues

To automatically close an issue: closes #4656, #4390