### PR TITLE
Direct Package Upgrade: Fixes `Cosmos.Direct` Package to `3.36.0`

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
 		<ClientOfficialVersion>3.43.0</ClientOfficialVersion>
 		<ClientPreviewVersion>3.44.0</ClientPreviewVersion>
 		<ClientPreviewSuffixVersion>preview.0</ClientPreviewSuffixVersion>
-		<DirectVersion>3.35.0</DirectVersion>
+		<DirectVersion>3.36.0</DirectVersion>
 		<EncryptionOfficialVersion>2.0.4</EncryptionOfficialVersion>
 		<EncryptionPreviewVersion>2.1.0</EncryptionPreviewVersion>
 		<EncryptionPreviewSuffixVersion>preview4</EncryptionPreviewSuffixVersion>


### PR DESCRIPTION
# Pull Request Template

## Description

This PR is bumping up the `Cosmos.Direct` package version from `3.35.0` to `3.36.0`, which includes the below changes:

- QuorumReader: Strong consistency with invalid (LSN -1) service responses: Adds the LSN verification to the path that `ReadsMultipleReplicas` and `ReadPrimary` involved in Strong/Bounded quorum to make sure that the responses are treated as errors and propagated above.
- Fixes an use case where `PartitionKey.None.GetHashCode()` throws `NullReferenceException`.
- `GoneAndRetryWithRequestRetryPolicy` - Refactors policy to throw `503` Service Unavailable when a `410` Gone Exception with Sub-Status code 1022 is Received.

### Understanding Gone Exception (Status Code: **410**) with Lease Not Found (Sub Status Code: **1022**).

**Background:** In general `410/1022` is used as a signal to indicate that a region is not part of the dynamic quorum - meaning in global strong with dynamic quorum all reads from the secondary region kicked out of the quorum will return `410/1022`.

- Today when a read region loses the read lease it returns `410/LeaseNotFound` - the client will then retry locally for up-to `60` seconds (for global strong) and up-to `30` seconds (for others) (catch-all 410 retry like for 410/0 or connectivity related 410) for any.
Instead the `410/LeaseNotFound(1022)` should be mapped immediately to a `503` to allow the cross-regional retry to happen as quickly as possible. Retrying in the next preferred region like usual for reads is acceptable. This has been taken care in the `Cosmos.Direct` release [`3.36.0`](https://www.nuget.org/packages/Microsoft.Azure.Cosmos.Direct/3.36.0) and this PR is upgrading the `Cosmos.Direct` version to `3.36.0` to reflect the change.


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Closing issues

To automatically close an issue: closes #4390