### PR TITLE
Documentation: Fixes ReadItemAsync to show return ItemResponse<ToDoActivity> instead of ToDoActivity

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
@@ -443,7 +443,7 @@ namespace Microsoft.Azure.Cosmos
         ///     public string status {get; set;}
         /// }
         /// 
-        /// ToDoActivity toDoActivity = await this.container.ReadItemAsync<ToDoActivity>("id", new PartitionKey("partitionKey"));
+        /// ItemResponse<ToDoActivity> toDoActivity = await this.container.ReadItemAsync<ToDoActivity>("id", new PartitionKey("partitionKey"));
         /// 
         /// ]]>
         /// </code>
@@ -740,7 +740,7 @@ namespace Microsoft.Azure.Cosmos
         ///     public int frequency {get; set;}
         /// }
         /// 
-        /// ToDoActivity toDoActivity = await this.container.ReadItemAsync<ToDoActivity>("id", new PartitionKey("partitionKey"));
+        /// ItemResponse<ToDoActivity> toDoActivity = await this.container.ReadItemAsync<ToDoActivity>("id", new PartitionKey("partitionKey"));
         /// /* toDoActivity = {
         ///     "id" : "someId",
         ///     "status" : "someStatusPK",

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs
@@ -443,7 +443,20 @@ namespace Microsoft.Azure.Cosmos
         ///     public string status {get; set;}
         /// }
         /// 
+        /// Example 1: Reading Item with Full Response
+        ///
+        /// This example demonstrates how to read an item from the container and retrieve the full
+        /// response, including metadata such as request units (RU) consumed, along with the
+        /// `ToDoActivity` object.
+        ///
         /// ItemResponse<ToDoActivity> toDoActivity = await this.container.ReadItemAsync<ToDoActivity>("id", new PartitionKey("partitionKey"));
+        ///
+        /// Example 2: Reading Item with Implicit Casting
+        ///
+        /// This example shows how to read an item from the container and implicitly cast the
+        /// response directly to a `ToDoActivity` object, omitting the metadata in the `ItemResponse`.
+        ///
+        /// ToDoActivity toDoActivity = await this.container.ReadItemAsync<ToDoActivity>("id", new PartitionKey("partitionKey"));
         /// 
         /// ]]>
         /// </code>
@@ -740,7 +753,21 @@ namespace Microsoft.Azure.Cosmos
         ///     public int frequency {get; set;}
         /// }
         /// 
+        /// Example 1: Reading Item with Full Response
+        ///
+        /// This example demonstrates how to read an item from the container and retrieve the full
+        /// response, including metadata such as request units (RU) consumed, along with the
+        /// `ToDoActivity` object.
+        ///
         /// ItemResponse<ToDoActivity> toDoActivity = await this.container.ReadItemAsync<ToDoActivity>("id", new PartitionKey("partitionKey"));
+        ///
+        /// Example 2: Reading Item with Implicit Casting
+        ///
+        /// This example shows how to read an item from the container and implicitly cast the
+        /// response directly to a `ToDoActivity` object, omitting the metadata in the `ItemResponse`.
+        ///
+        /// ToDoActivity toDoActivity = await this.container.ReadItemAsync<ToDoActivity>("id", new PartitionKey("partitionKey"));
+        ///
         /// /* toDoActivity = {
         ///     "id" : "someId",
         ///     "status" : "someStatusPK",


### PR DESCRIPTION
# Pull Request Template

## Description

Documentation shows **ReadItemAsync** is returning type _ToDoActivity_ instead of _ItemResponse<ToDoActivity>_

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber