### PR TITLE
[INTERNAL] CI: Fixes CI excluding performance and codecoverage jobs

### DIFF
--- a/azure-pipelines-rolling.yml
+++ b/azure-pipelines-rolling.yml
@@ -23,4 +23,6 @@ jobs:
     VmImage: $(VmImage)
     MultiRegionConnectionString: $(COSMOSDB_MULTI_REGION)
     IncludeEncryption: true
-    IncludePerformance: false
+    IncludePerformance: true
+    IncludeCoverage: true
+

--- a/azure-pipelines-rolling.yml
+++ b/azure-pipelines-rolling.yml
@@ -25,4 +25,6 @@ jobs:
     IncludeEncryption: true
     IncludePerformance: true
     IncludeCoverage: true
+    IncludeClientTelemetry: true
+
 

--- a/azure-pipelines-rolling.yml
+++ b/azure-pipelines-rolling.yml
@@ -25,6 +25,4 @@ jobs:
     IncludeEncryption: true
     IncludePerformance: true
     IncludeCoverage: true
-    IncludeClientTelemetry: true
-
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,6 +53,7 @@ jobs:
     MultiRegionConnectionString: $(COSMOSDB_MULTI_REGION)
     IncludePerformance: false
     IncludeCoverage: false
+    IncludeClientTelemetry: false
 
 - template:  templates/build-internal.yml
   parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -53,7 +53,6 @@ jobs:
     MultiRegionConnectionString: $(COSMOSDB_MULTI_REGION)
     IncludePerformance: false
     IncludeCoverage: false
-    IncludeClientTelemetry: false
 
 - template:  templates/build-internal.yml
   parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,6 +51,8 @@ jobs:
     Arguments: $(ReleaseArguments)
     VmImage: $(VmImage)
     MultiRegionConnectionString: $(COSMOSDB_MULTI_REGION)
+    IncludePerformance: false
+    IncludeCoverage: false
 
 - template:  templates/build-internal.yml
   parameters:

--- a/templates/build-test.yml
+++ b/templates/build-test.yml
@@ -5,16 +5,22 @@ parameters:
   Arguments: ''
   VmImage: '' # https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops
   OS: 'Windows'
-  EmulatorPipeline1Arguments: ' --filter "TestCategory!=Quarantine & TestCategory!=Functional & TestCategory!=ClientTelemetryRelease & TestCategory!=LongRunning & TestCategory!=MultiRegion & (TestCategory=ClientTelemetryEmulator|TestCategory=Query|TestCategory=ReadFeed|TestCategory=Batch|TestCategory=ChangeFeed)" --verbosity normal '
-  EmulatorPipeline2Arguments: ' --filter "TestCategory!=Quarantine & TestCategory!=Functional & TestCategory!=ClientTelemetryRelease & TestCategory!=ClientTelemetryEmulator & TestCategory!=Query & TestCategory!=ReadFeed & TestCategory!=Batch & TestCategory!=ChangeFeed & TestCategory!=LongRunning & TestCategory!=MultiRegion" --verbosity normal '
   EmulatorPipeline3Arguments: ' --filter "TestCategory=MultiRegion" --verbosity normal '
-  EmulatorPipeline1CategoryListName: ' Client Telemetry, Query, ChangeFeed, ReadFeed, Batch ' # Divided in 2 categories to run them in parallel and reduce the PR feedback time
   EmulatorPipeline2CategoryListName: ' Others '
   EmulatorPipeline3CategoryListName: ' MultiRegion '
   MultiRegionConnectionString : ''
   IncludeEncryption: true
   IncludePerformance: true
   IncludeCoverage: true
+  IncludeClientTelemetry: true
+  ${{ if eq( variables['IncludeClientTelemetry']], true) }}:
+    EmulatorPipeline1Arguments: ' --filter "TestCategory!=Quarantine & TestCategory!=Functional & TestCategory!=ClientTelemetryRelease & TestCategory!=LongRunning & TestCategory!=MultiRegion & (TestCategory=ClientTelemetryEmulator|TestCategory=Query|TestCategory=ReadFeed|TestCategory=Batch|TestCategory=ChangeFeed)" --verbosity normal '
+    EmulatorPipeline2Arguments: ' --filter "TestCategory!=Quarantine & TestCategory!=Functional & TestCategory!=ClientTelemetryRelease & TestCategory!=ClientTelemetryEmulator & TestCategory!=Query & TestCategory!=ReadFeed & TestCategory!=Batch & TestCategory!=ChangeFeed & TestCategory!=LongRunning & TestCategory!=MultiRegion" --verbosity normal '
+    EmulatorPipeline1CategoryListName: ' Client Telemetry, Query, ChangeFeed, ReadFeed, Batch ' # Divided in 2 categories to run them in parallel and reduce the PR feedback time
+  ${{ if eq( variables['IncludeClientTelemetry']], false) }}:
+    EmulatorPipeline1Arguments: ' --filter "TestCategory!=Quarantine & TestCategory!=Functional & TestCategory!=LongRunning & TestCategory!=MultiRegion & (TestCategory=Query|TestCategory=ReadFeed|TestCategory=Batch|TestCategory=ChangeFeed)" --verbosity normal '
+    EmulatorPipeline2Arguments: ' --filter "TestCategory!=Quarantine & TestCategory!=Functional & TestCategory!=Query & TestCategory!=ReadFeed & TestCategory!=Batch & TestCategory!=ChangeFeed & TestCategory!=LongRunning & TestCategory!=MultiRegion" --verbosity normal '
+    EmulatorPipeline1CategoryListName: ' Query, ChangeFeed, ReadFeed, Batch ' # Divided in 2 categories to run them in parallel and reduce the PR feedback time
 
 jobs:
 - job:

--- a/templates/build-test.yml
+++ b/templates/build-test.yml
@@ -38,20 +38,10 @@ jobs:
     inputs:
       command: test
       projects: 'Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/*.csproj'
-      arguments: ${{ parameters.Arguments }} --configuration Debug /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:CopyLocalLockFileAssemblies=true /p:OS=${{ parameters.OS }}
+      arguments: ${{ parameters.Arguments }} --configuration Debug /p:OS=${{ parameters.OS }}
       publishTestResults: true
       nugetConfigPath: NuGet.config
       testRunTitle: Microsoft.Azure.Cosmos.Tests
-  - script: |
-      dotnet tool install -g dotnet-reportgenerator-globaltool
-      reportgenerator -reports:$(Build.SourcesDirectory)/Microsoft.Azure.Cosmos/tests/**/coverage.cobertura.xml -targetdir:$(Build.SourcesDirectory)/CodeCoverage -reporttypes:HtmlInline_AzurePipelines;Cobertura
-    displayName: Create Code coverage report
-  - task: PublishCodeCoverageResults@2
-    displayName: 'Publish code coverage'
-    inputs:
-      codeCoverageTool: Cobertura
-      summaryFileLocation: '$(Build.SourcesDirectory)/CodeCoverage/Cobertura.xml'
-      reportDirectory: '$(Build.SourcesDirectory)/CodeCoverage'
       
 - job:
   displayName: PerformanceTests ${{ parameters.BuildConfiguration }}

--- a/templates/build-test.yml
+++ b/templates/build-test.yml
@@ -14,10 +14,11 @@ parameters:
   MultiRegionConnectionString : ''
   IncludeEncryption: true
   IncludePerformance: true
+  IncludeCoverage: true
 
 jobs:
 - job:
-  displayName: Tests Debug
+  displayName: Microsoft.Azure.Cosmos.Tests
   pool:
     name: 'OneES'
 
@@ -42,6 +43,45 @@ jobs:
       publishTestResults: true
       nugetConfigPath: NuGet.config
       testRunTitle: Microsoft.Azure.Cosmos.Tests
+
+
+jobs:
+- job:
+  displayName: Microsoft.Azure.Cosmos.Tests Coverage
+  condition: and(succeeded(), eq(${{ parameters.IncludeCoverage }}, true))
+  pool:
+    name: 'OneES'
+  steps:
+  - checkout: self  # self represents the repo where the initial Pipelines YAML file was found
+    clean: true  # if true, execute `execute git clean -ffdx && git reset --hard HEAD` before fetching
+
+  # Add this Command to Include the .NET 6 SDK
+  - task: UseDotNet@2
+    displayName: Use .NET 6.0
+    inputs:
+      packageType: 'sdk'
+      version: '6.x'
+      
+  - task: DotNetCoreCLI@2
+    displayName: Microsoft.Azure.Cosmos.Tests
+    condition: succeeded()
+    inputs:
+      command: test
+      projects: 'Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/*.csproj'
+      arguments: ${{ parameters.Arguments }} --configuration Debug /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura /p:CopyLocalLockFileAssemblies=true /p:OS=${{ parameters.OS }}
+      publishTestResults: true
+      nugetConfigPath: NuGet.config
+      testRunTitle: Microsoft.Azure.Cosmos.Tests
+  - script: |
+      dotnet tool install -g dotnet-reportgenerator-globaltool
+      reportgenerator -reports:$(Build.SourcesDirectory)/Microsoft.Azure.Cosmos/tests/**/coverage.cobertura.xml -targetdir:$(Build.SourcesDirectory)/CodeCoverage -reporttypes:HtmlInline_AzurePipelines;Cobertura
+    displayName: Create Code coverage report
+  - task: PublishCodeCoverageResults@2
+    displayName: 'Publish code coverage'
+    inputs:
+      codeCoverageTool: Cobertura
+      summaryFileLocation: '$(Build.SourcesDirectory)/CodeCoverage/Cobertura.xml'
+      reportDirectory: '$(Build.SourcesDirectory)/CodeCoverage'
       
 - job:
   displayName: PerformanceTests ${{ parameters.BuildConfiguration }}

--- a/templates/build-test.yml
+++ b/templates/build-test.yml
@@ -5,22 +5,16 @@ parameters:
   Arguments: ''
   VmImage: '' # https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops
   OS: 'Windows'
+  EmulatorPipeline1Arguments: ' --filter "TestCategory!=Quarantine & TestCategory!=Functional & TestCategory!=ClientTelemetryRelease & TestCategory!=LongRunning & TestCategory!=MultiRegion & (TestCategory=ClientTelemetryEmulator|TestCategory=Query|TestCategory=ReadFeed|TestCategory=Batch|TestCategory=ChangeFeed)" --verbosity normal '
+  EmulatorPipeline2Arguments: ' --filter "TestCategory!=Quarantine & TestCategory!=Functional & TestCategory!=ClientTelemetryRelease & TestCategory!=ClientTelemetryEmulator & TestCategory!=Query & TestCategory!=ReadFeed & TestCategory!=Batch & TestCategory!=ChangeFeed & TestCategory!=LongRunning & TestCategory!=MultiRegion" --verbosity normal '
   EmulatorPipeline3Arguments: ' --filter "TestCategory=MultiRegion" --verbosity normal '
+  EmulatorPipeline1CategoryListName: ' Client Telemetry, Query, ChangeFeed, ReadFeed, Batch ' # Divided in 2 categories to run them in parallel and reduce the PR feedback time
   EmulatorPipeline2CategoryListName: ' Others '
   EmulatorPipeline3CategoryListName: ' MultiRegion '
   MultiRegionConnectionString : ''
   IncludeEncryption: true
   IncludePerformance: true
   IncludeCoverage: true
-  IncludeClientTelemetry: true
-  ${{ if eq( variables['IncludeClientTelemetry']], true) }}:
-    EmulatorPipeline1Arguments: ' --filter "TestCategory!=Quarantine & TestCategory!=Functional & TestCategory!=ClientTelemetryRelease & TestCategory!=LongRunning & TestCategory!=MultiRegion & (TestCategory=ClientTelemetryEmulator|TestCategory=Query|TestCategory=ReadFeed|TestCategory=Batch|TestCategory=ChangeFeed)" --verbosity normal '
-    EmulatorPipeline2Arguments: ' --filter "TestCategory!=Quarantine & TestCategory!=Functional & TestCategory!=ClientTelemetryRelease & TestCategory!=ClientTelemetryEmulator & TestCategory!=Query & TestCategory!=ReadFeed & TestCategory!=Batch & TestCategory!=ChangeFeed & TestCategory!=LongRunning & TestCategory!=MultiRegion" --verbosity normal '
-    EmulatorPipeline1CategoryListName: ' Client Telemetry, Query, ChangeFeed, ReadFeed, Batch ' # Divided in 2 categories to run them in parallel and reduce the PR feedback time
-  ${{ if eq( variables['IncludeClientTelemetry']], false) }}:
-    EmulatorPipeline1Arguments: ' --filter "TestCategory!=Quarantine & TestCategory!=Functional & TestCategory!=LongRunning & TestCategory!=MultiRegion & (TestCategory=Query|TestCategory=ReadFeed|TestCategory=Batch|TestCategory=ChangeFeed)" --verbosity normal '
-    EmulatorPipeline2Arguments: ' --filter "TestCategory!=Quarantine & TestCategory!=Functional & TestCategory!=Query & TestCategory!=ReadFeed & TestCategory!=Batch & TestCategory!=ChangeFeed & TestCategory!=LongRunning & TestCategory!=MultiRegion" --verbosity normal '
-    EmulatorPipeline1CategoryListName: ' Query, ChangeFeed, ReadFeed, Batch ' # Divided in 2 categories to run them in parallel and reduce the PR feedback time
 
 jobs:
 - job:

--- a/templates/build-test.yml
+++ b/templates/build-test.yml
@@ -13,25 +13,14 @@ parameters:
   IncludePerformance: true
   IncludeCoverage: true
   IncludeClientTelemetry: true
-
-variables:
-- name: EmulatorPipeline1Arguments
   ${{ if eq( variables['IncludeClientTelemetry']], true) }}:
-    value: ' --filter "TestCategory!=Quarantine & TestCategory!=Functional & TestCategory!=ClientTelemetryRelease & TestCategory!=LongRunning & TestCategory!=MultiRegion & (TestCategory=ClientTelemetryEmulator|TestCategory=Query|TestCategory=ReadFeed|TestCategory=Batch|TestCategory=ChangeFeed)" --verbosity normal '
-  ${{ else }}:
-    value: ' --filter "TestCategory!=Quarantine & TestCategory!=Functional & TestCategory!=LongRunning & TestCategory!=MultiRegion & (TestCategory=Query|TestCategory=ReadFeed|TestCategory=Batch|TestCategory=ChangeFeed)" --verbosity normal '
-
-- name: EmulatorPipeline2Arguments
-  ${{ if eq( variables['IncludeClientTelemetry']], true) }}:
-    value: ' --filter "TestCategory!=Quarantine & TestCategory!=Functional & TestCategory!=ClientTelemetryRelease & TestCategory!=ClientTelemetryEmulator & TestCategory!=Query & TestCategory!=ReadFeed & TestCategory!=Batch & TestCategory!=ChangeFeed & TestCategory!=LongRunning & TestCategory!=MultiRegion" --verbosity normal '
-  ${{ else }}:
-    value: ' --filter "TestCategory!=Quarantine & TestCategory!=Functional & TestCategory!=Query & TestCategory!=ReadFeed & TestCategory!=Batch & TestCategory!=ChangeFeed & TestCategory!=LongRunning & TestCategory!=MultiRegion" --verbosity normal '
-
-- name: EmulatorPipeline1CategoryListName
-  ${{ if eq( variables['IncludeClientTelemetry']], true) }}:
-    value: ' Client Telemetry, Query, ChangeFeed, ReadFeed, Batch ' # Divided in 2 categories to run them in parallel and reduce the PR feedback time
-  ${{ else }}:
-    value: ' Query, ChangeFeed, ReadFeed, Batch ' # Divided in 2 categories to run them in parallel and reduce the PR feedback time
+    EmulatorPipeline1Arguments: ' --filter "TestCategory!=Quarantine & TestCategory!=Functional & TestCategory!=ClientTelemetryRelease & TestCategory!=LongRunning & TestCategory!=MultiRegion & (TestCategory=ClientTelemetryEmulator|TestCategory=Query|TestCategory=ReadFeed|TestCategory=Batch|TestCategory=ChangeFeed)" --verbosity normal '
+    EmulatorPipeline2Arguments: ' --filter "TestCategory!=Quarantine & TestCategory!=Functional & TestCategory!=ClientTelemetryRelease & TestCategory!=ClientTelemetryEmulator & TestCategory!=Query & TestCategory!=ReadFeed & TestCategory!=Batch & TestCategory!=ChangeFeed & TestCategory!=LongRunning & TestCategory!=MultiRegion" --verbosity normal '
+    EmulatorPipeline1CategoryListName: ' Client Telemetry, Query, ChangeFeed, ReadFeed, Batch ' # Divided in 2 categories to run them in parallel and reduce the PR feedback time
+  ${{ if eq( variables['IncludeClientTelemetry']], false) }}:
+    EmulatorPipeline1Arguments: ' --filter "TestCategory!=Quarantine & TestCategory!=Functional & TestCategory!=LongRunning & TestCategory!=MultiRegion & (TestCategory=Query|TestCategory=ReadFeed|TestCategory=Batch|TestCategory=ChangeFeed)" --verbosity normal '
+    EmulatorPipeline2Arguments: ' --filter "TestCategory!=Quarantine & TestCategory!=Functional & TestCategory!=Query & TestCategory!=ReadFeed & TestCategory!=Batch & TestCategory!=ChangeFeed & TestCategory!=LongRunning & TestCategory!=MultiRegion" --verbosity normal '
+    EmulatorPipeline1CategoryListName: ' Query, ChangeFeed, ReadFeed, Batch ' # Divided in 2 categories to run them in parallel and reduce the PR feedback time
 
 jobs:
 - job:

--- a/templates/build-test.yml
+++ b/templates/build-test.yml
@@ -44,8 +44,6 @@ jobs:
       nugetConfigPath: NuGet.config
       testRunTitle: Microsoft.Azure.Cosmos.Tests
 
-
-jobs:
 - job:
   displayName: Microsoft.Azure.Cosmos.Tests Coverage
   condition: and(succeeded(), eq(${{ parameters.IncludeCoverage }}, true))
@@ -82,7 +80,7 @@ jobs:
       codeCoverageTool: Cobertura
       summaryFileLocation: '$(Build.SourcesDirectory)/CodeCoverage/Cobertura.xml'
       reportDirectory: '$(Build.SourcesDirectory)/CodeCoverage'
-      
+
 - job:
   displayName: PerformanceTests ${{ parameters.BuildConfiguration }}
   condition: and(succeeded(), eq(${{ parameters.IncludePerformance }}, true))

--- a/templates/build-test.yml
+++ b/templates/build-test.yml
@@ -38,7 +38,7 @@ jobs:
     inputs:
       command: test
       projects: 'Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/*.csproj'
-      arguments: ${{ parameters.Arguments }} --configuration Debug /p:OS=${{ parameters.OS }}
+      arguments: ${{ parameters.Arguments }} /p:OS=${{ parameters.OS }}
       publishTestResults: true
       nugetConfigPath: NuGet.config
       testRunTitle: Microsoft.Azure.Cosmos.Tests

--- a/templates/build-test.yml
+++ b/templates/build-test.yml
@@ -13,14 +13,25 @@ parameters:
   IncludePerformance: true
   IncludeCoverage: true
   IncludeClientTelemetry: true
+
+variables:
+- name: EmulatorPipeline1Arguments
   ${{ if eq( variables['IncludeClientTelemetry']], true) }}:
-    EmulatorPipeline1Arguments: ' --filter "TestCategory!=Quarantine & TestCategory!=Functional & TestCategory!=ClientTelemetryRelease & TestCategory!=LongRunning & TestCategory!=MultiRegion & (TestCategory=ClientTelemetryEmulator|TestCategory=Query|TestCategory=ReadFeed|TestCategory=Batch|TestCategory=ChangeFeed)" --verbosity normal '
-    EmulatorPipeline2Arguments: ' --filter "TestCategory!=Quarantine & TestCategory!=Functional & TestCategory!=ClientTelemetryRelease & TestCategory!=ClientTelemetryEmulator & TestCategory!=Query & TestCategory!=ReadFeed & TestCategory!=Batch & TestCategory!=ChangeFeed & TestCategory!=LongRunning & TestCategory!=MultiRegion" --verbosity normal '
-    EmulatorPipeline1CategoryListName: ' Client Telemetry, Query, ChangeFeed, ReadFeed, Batch ' # Divided in 2 categories to run them in parallel and reduce the PR feedback time
-  ${{ if eq( variables['IncludeClientTelemetry']], false) }}:
-    EmulatorPipeline1Arguments: ' --filter "TestCategory!=Quarantine & TestCategory!=Functional & TestCategory!=LongRunning & TestCategory!=MultiRegion & (TestCategory=Query|TestCategory=ReadFeed|TestCategory=Batch|TestCategory=ChangeFeed)" --verbosity normal '
-    EmulatorPipeline2Arguments: ' --filter "TestCategory!=Quarantine & TestCategory!=Functional & TestCategory!=Query & TestCategory!=ReadFeed & TestCategory!=Batch & TestCategory!=ChangeFeed & TestCategory!=LongRunning & TestCategory!=MultiRegion" --verbosity normal '
-    EmulatorPipeline1CategoryListName: ' Query, ChangeFeed, ReadFeed, Batch ' # Divided in 2 categories to run them in parallel and reduce the PR feedback time
+    value: ' --filter "TestCategory!=Quarantine & TestCategory!=Functional & TestCategory!=ClientTelemetryRelease & TestCategory!=LongRunning & TestCategory!=MultiRegion & (TestCategory=ClientTelemetryEmulator|TestCategory=Query|TestCategory=ReadFeed|TestCategory=Batch|TestCategory=ChangeFeed)" --verbosity normal '
+  ${{ else }}:
+    value: ' --filter "TestCategory!=Quarantine & TestCategory!=Functional & TestCategory!=LongRunning & TestCategory!=MultiRegion & (TestCategory=Query|TestCategory=ReadFeed|TestCategory=Batch|TestCategory=ChangeFeed)" --verbosity normal '
+
+- name: EmulatorPipeline2Arguments
+  ${{ if eq( variables['IncludeClientTelemetry']], true) }}:
+    value: ' --filter "TestCategory!=Quarantine & TestCategory!=Functional & TestCategory!=ClientTelemetryRelease & TestCategory!=ClientTelemetryEmulator & TestCategory!=Query & TestCategory!=ReadFeed & TestCategory!=Batch & TestCategory!=ChangeFeed & TestCategory!=LongRunning & TestCategory!=MultiRegion" --verbosity normal '
+  ${{ else }}:
+    value: ' --filter "TestCategory!=Quarantine & TestCategory!=Functional & TestCategory!=Query & TestCategory!=ReadFeed & TestCategory!=Batch & TestCategory!=ChangeFeed & TestCategory!=LongRunning & TestCategory!=MultiRegion" --verbosity normal '
+
+- name: EmulatorPipeline1CategoryListName
+  ${{ if eq( variables['IncludeClientTelemetry']], true) }}:
+    value: ' Client Telemetry, Query, ChangeFeed, ReadFeed, Batch ' # Divided in 2 categories to run them in parallel and reduce the PR feedback time
+  ${{ else }}:
+    value: ' Query, ChangeFeed, ReadFeed, Batch ' # Divided in 2 categories to run them in parallel and reduce the PR feedback time
 
 jobs:
 - job:


### PR DESCRIPTION
[INTERNAL] CI: Fixes excluding performance and code coverage jobs from CI

Performance job: ~36Minutes
Code coverage debug build: 35Minutes
Tests with-out test coverage: 18Minutes

Changes: 
- CI pipeline: Excluded performance and Codecoverage
- Rolling: Will include performance and codecoverage (no change here same as earlier)

Overall long pole is still EmulatorTests but at-least will help us on concurrency.

https://cosmos-db-sdk-public.visualstudio.com/cosmos-db-sdk-public/_build/results?buildId=51336&view=results
<img width="992" alt="{9E642ED1-03D5-46B2-A082-B6E9688AEAE6}" src="https://github.com/user-attachments/assets/668e5ad4-66f5-498f-95b3-ee491336fa86">

https://cosmos-db-sdk-public.visualstudio.com/cosmos-db-sdk-public/_build/results?buildId=51339&view=results
<img width="1003" alt="{03411899-E041-4378-B2BB-511151E5095B}" src="https://github.com/user-attachments/assets/dde4ef2e-3ec7-4b23-9ca0-0dfdbf6066d0">
