### PR TITLE
[INTERNAL] CI: Fixes gates reliability issues

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Tracing/EndToEndTraceWriterBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Tracing/EndToEndTraceWriterBaselineTests.cs
@@ -65,6 +65,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Tracing
                         },
                         QueryTextMode = QueryTextMode.All
                     }));
+            await Util.DeleteAllDatabasesAsync(client);
 
             bulkClient = TestCommon.CreateCosmosClient(builder => builder
                 .WithBulkExecution(true)

--- a/azure-pipelines-rolling.yml
+++ b/azure-pipelines-rolling.yml
@@ -18,7 +18,7 @@ schedules:
   always: true # whether to always run the pipeline or only if there have been source code changes since the last run. The default is false
 
 variables:
-  ReleaseArguments: ' --filter "TestCategory!=Quarantine & TestCategory!=Functional" --verbosity normal '
+  ReleaseArguments: ' --filter "TestCategory!=Flaky & TestCategory!=Quarantine & TestCategory!=Functional" --verbosity normal '
   VmImage: windows-latest # https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops
 
 jobs:


### PR DESCRIPTION
- Rolling runs: Flaky ones are excluded (except some emulator issues remaining all failures are from them)
- EndToEndTraceWriterBaselineTests: Making them idempotent (retries are failing)