### PR TITLE
[Internal] Flaky Test: Fixes Client Telemetry Flaky tests

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/InternalFriendsTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/InternalFriendsTest.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         {
             HttpClientHandlerHelper httpHandler = new HttpClientHandlerHelper
             {
-                ResponseIntercepter = async (response) =>
+                ResponseIntercepter = async (response, _) =>
                 {
                     string responseString = await response.Content.ReadAsStringAsync();
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/HttpHandlerHelper.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/HttpHandlerHelper.cs
@@ -44,8 +44,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             try
             {
                 httpResponse = await base.SendAsync(request, cancellationToken);
-
-                Console.WriteLine(request.RequestUri.AbsoluteUri + (httpResponse == null));
             }
             catch (Exception ex) {
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/HttpHandlerHelper.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/HttpHandlerHelper.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
         public Func<HttpRequestMessage, CancellationToken, Task<HttpResponseMessage>> RequestCallBack { get; set; }
 
-        public Func<HttpResponseMessage, Task<HttpResponseMessage>> ResponseIntercepter { get; set; }
+        public Func<HttpResponseMessage, HttpRequestMessage, Task<HttpResponseMessage>> ResponseIntercepter { get; set; }
 
         public Action<HttpRequestMessage, Exception> ExceptionIntercepter { get; set; }
 
@@ -34,7 +34,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     {
                         if (this.ResponseIntercepter != null)
                         {
-                            httpResponse = await this.ResponseIntercepter(httpResponse);
+                            httpResponse = await this.ResponseIntercepter(httpResponse, request);
                         }
                         return httpResponse;
                     }
@@ -44,6 +44,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             try
             {
                 httpResponse = await base.SendAsync(request, cancellationToken);
+
+                Console.WriteLine(request.RequestUri.AbsoluteUri + (httpResponse == null));
             }
             catch (Exception ex) {
 
@@ -58,7 +60,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
            
             if (this.ResponseIntercepter != null)
             {
-                httpResponse = await this.ResponseIntercepter(httpResponse);
+                httpResponse = await this.ResponseIntercepter(httpResponse, request);
             }
 
             return httpResponse;


### PR DESCRIPTION
## Description

Removing dependency on `Task.Delay()
`
## Type of change
- [] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #4731