### PR TITLE
Open Telemetry Traces: Fixes filtering of event on 404/0 or similar non failure status codes

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/CosmosException.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/CosmosExceptions/CosmosException.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Azure.Cosmos
     using global::Azure.Core;
     using Microsoft.Azure.Cosmos.Diagnostics;
     using Microsoft.Azure.Cosmos.Telemetry;
+    using Microsoft.Azure.Cosmos.Telemetry.Diagnostics;
     using Microsoft.Azure.Cosmos.Tracing;
     using Microsoft.Azure.Documents;
 
@@ -296,7 +297,10 @@ namespace Microsoft.Azure.Cosmos
                 ClientTelemetryHelper.GetContactedRegions(exception.Diagnostics?.GetContactedRegions()));
             scope.AddAttribute(OpenTelemetryAttributeKeys.ExceptionMessage, exception.Message);
 
-            CosmosDbEventSource.RecordDiagnosticsForExceptions(exception.Diagnostics);
+            if (!DiagnosticsFilterHelper.IsSuccessfulResponse(exception.StatusCode, (int)exception.SubStatusCode))
+            {
+                CosmosDbEventSource.RecordDiagnosticsForExceptions(exception.Diagnostics);
+            }
         }
     }
 }


### PR DESCRIPTION
## Description
Added a check on Cosmos Exception to make sure events are generated only for the allowed status and substatuscode

## Type of change
- [] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #4735