### PR TITLE
[Internal] Samples: Fixes OpenTelemetry sample package references

### DIFF
--- a/Microsoft.Azure.Cosmos.Samples/Usage/OpenTelemetry/OpenTelemetry.csproj
+++ b/Microsoft.Azure.Cosmos.Samples/Usage/OpenTelemetry/OpenTelemetry.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.9.0" />
+    <PackageReference Include="OpenTelemetry" Version="1.9.0" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 


### PR DESCRIPTION
# Pull Request Template

## Description

Current OpenTelemetry sample gives runtime error due to mismatched OpenTelemetry version. This is tracked in the Otel repo here: https://github.com/open-telemetry/opentelemetry-dotnet/issues/5741

There is no GA Azure Monitor Otel exporter version that uses OpenTelemetry 1.9.0, so we need to manually lift the version to avoid runtime errors.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
