### PR TITLE
[Internal] Binary Encoding: Add performance tests.

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/BinaryEncodingBenchmark.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/BinaryEncodingBenchmark.cs
@@ -1,0 +1,157 @@
+﻿namespace Microsoft.Azure.Cosmos.Performance.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Net;
+    using System.Threading.Tasks;
+    using BenchmarkDotNet.Attributes;
+    using BenchmarkDotNet.Configs;
+    using BenchmarkDotNet.Columns;
+    using BenchmarkDotNet.Exporters;
+    using BenchmarkDotNet.Jobs;
+    using Microsoft.Azure.Cosmos;
+    using Newtonsoft.Json.Linq;
+    using BenchmarkDotNet.Exporters.Csv;
+    using System.Linq;
+
+    [MemoryDiagnoser]
+    [BenchmarkCategory("NewGateBenchmark")]
+    [Config(typeof(CustomBenchmarkConfig))]
+    public class BinaryEncodingBenchmark
+    {
+        private readonly string accountEndpoint = ""; // Replace with Cosmos DB endpoint
+        private readonly string accountKey = ""; // Replace with Cosmos DB key
+        private CosmosClient client;
+        private Database database;
+        private Container container;
+
+        [GlobalSetup]
+        public async Task SetUp()
+        {
+            Console.WriteLine("Setting up the BinaryEncodingBenchmark");
+            CosmosClientOptions clientOptions = new CosmosClientOptions()
+            {
+                ConnectionMode = ConnectionMode.Direct,
+                ApplicationPreferredRegions = new List<string>() { "West US2" }
+            };
+
+            this.client = new CosmosClient(accountEndpoint: this.accountEndpoint, authKeyOrResourceToken: this.accountKey, clientOptions: clientOptions);
+            this.database = await this.client.CreateDatabaseIfNotExistsAsync("TestDatabase");
+
+            ContainerResponse containerResponse = await this.database.CreateContainerIfNotExistsAsync(
+                id: "BenchmarkContainer",
+                partitionKeyPath: "/id",
+                throughput: 10000);
+
+            this.container = containerResponse.Container;
+
+            if (containerResponse.StatusCode == HttpStatusCode.Created)
+            {
+                // Create fewer items to reduce workload and execution time
+                List<Task> tasks = new List<Task>();
+                for (int i = 0; i < 500; i++) 
+                {
+                    tasks.Add(this.container.CreateItemAsync(
+                        item: new JObject()
+                        {
+                        { "id", i.ToString() },
+                        { "name", Guid.NewGuid().ToString() },
+                        { "otherdata", Guid.NewGuid().ToString() },
+                        },
+                        partitionKey: new PartitionKey(i.ToString())));
+                }
+                await Task.WhenAll(tasks);
+            }
+        }
+
+        [GlobalCleanup]
+        public async Task CleanupAsync()
+        {
+            Console.WriteLine("Cleaning up the BinaryEncodingBenchmark, except for the database.");
+            this.client.Dispose();
+        }
+
+        [Benchmark]
+        public async Task ReadItemsAsync()
+        {
+            await Parallel.ForEachAsync(Enumerable.Range(0, 500), async (i, _) => await this.container.ReadItemAsync<JObject>(
+                    partitionKey: new PartitionKey(i.ToString()),
+                    id: i.ToString()));
+        }
+
+        [Benchmark]
+        public async Task QueryItemsAsync()
+        {
+            FeedIterator feedIterator = this.container.GetItemQueryStreamIterator(
+                "SELECT * FROM c",
+                requestOptions: new QueryRequestOptions()
+                {
+                    MaxConcurrency = 10, 
+                    MaxItemCount = 100, 
+                });
+
+            while (feedIterator.HasMoreResults)
+            {
+                using (ResponseMessage response = await feedIterator.ReadNextAsync())
+                {
+                    response.EnsureSuccessStatusCode();
+                }
+            }
+        }
+
+        [Benchmark]
+        public async Task UpsertItemsAsync()
+        {
+            await Parallel.ForEachAsync(Enumerable.Range(0, 500), async (i, _) =>
+            {
+                JObject updatedItem = new JObject()
+            {
+                { "id", i.ToString() },
+                { "name", $"UpdatedName_{i}" },
+                { "otherdata", $"UpdatedData_{Guid.NewGuid()}" }
+            };
+
+                await this.container.UpsertItemAsync(
+                    item: updatedItem,
+                    partitionKey: new PartitionKey(i.ToString()));
+            });
+        }
+
+        [Benchmark]
+        public async Task DeleteItemsAsync()
+        {
+            await Parallel.ForEachAsync(Enumerable.Range(0, 500), async (i, _) =>
+            {
+                try
+                {
+                    await this.container.DeleteItemAsync<JObject>(
+                        partitionKey: new PartitionKey(i.ToString()),
+                        id: i.ToString());
+                }
+                catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+                {
+                }
+            });
+        }
+
+        // Custom configuration 
+        private class CustomBenchmarkConfig : ManualConfig
+        {
+            public CustomBenchmarkConfig()
+            {
+                this.AddColumn(StatisticColumn.OperationsPerSecond);  // Show RPS
+                this.AddColumn(StatisticColumn.P95);
+
+              
+                this.AddJob(Job.Default
+                    .WithLaunchCount(1) 
+                    .WithWarmupCount(3) 
+                    .WithIterationCount(5) 
+                    .WithStrategy(BenchmarkDotNet.Engines.RunStrategy.Throughput));
+
+                this.AddExporter(HtmlExporter.Default);
+                this.AddExporter(CsvExporter.Default);
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request Template

## Description
Adding performance tests for binary encoding change PR https://github.com/Azure/azure-cosmos-dotnet-v3/pull/4652

## Benchmark Results Comparison

#### Processor: AMD EPYC 7763, 1 CPU, 16 logical and 8 physical cores  

---

## Comparison Table: Master vs. users/dkunda/4644_binary_encoding_for_point_ops

|           Method        |   Branch                               | IterationCount | LaunchCount | RunStrategy | WarmupCount |   Mean    |   Error  |  StdDev  |  Median  |    P95   |   Op/s  |   Gen0   | Allocated   |
|-------------------------|----------------------------------------|----------------|-------------|-------------|-------------|-----------:|---------:|---------:|----------:|----------:|---------:|----------:|-------------:|
| **ReadItemsAsync**      | Master                                 |              5 |           1 | Throughput  |           3 | 2,019.4 ms |  9.82 ms |  2.55 ms | 2,018.6 ms | 2,022.1 ms | 0.4952  | 1000.0000 | 22,901,176 B |
|                         | users/dkunda/4644_binary_encoding_for_point_ops |        5 |           1 | Throughput  |           3 | 2,032.0 ms | 42.52 ms | 11.04 ms | 2,035.8 ms | 2,043.0 ms | 0.4921  | 1000.0000 | 22,963,432 B |
| **QueryItemsAsync**     | Master                                 |              5 |           1 | Throughput  |           3 |   341.0 ms | 43.67 ms | 11.34 ms |   347.7 ms |   351.1 ms | 2.9325  |     -     |   539,136 B |
|                         | users/dkunda/4644_binary_encoding_for_point_ops |        5 |           1 | Throughput  |           3 |   321.8 ms | 20.31 ms |  3.14 ms |   323.1 ms |   323.7 ms | 3.1080  |     -     |   540,016 B |
| **UpsertItemsAsync**    | Master                                 |              5 |           1 | Throughput  |           3 | 2,307.6 ms | 21.35 ms |  3.30 ms | 2,309.1 ms | 2,309.4 ms | 0.4334  | 1000.0000 | 23,553,768 B |
|                         | users/dkunda/4644_binary_encoding_for_point_ops |        5 |           1 | Throughput  |           3 | 2,435.5 ms | 22.70 ms |  5.89 ms | 2,436.8 ms | 2,441.8 ms | 0.4106  | 1000.0000 | 23,856,208 B |
| **DeleteItemsAsync**    | Master                                 |              5 |           1 | Throughput  |           3 | 2,160.1 ms | 42.22 ms | 10.96 ms | 2,153.4 ms | 2,172.2 ms | 0.4629  | 1000.0000 | 22,111,528 B |
|                         | users/dkunda/4644_binary_encoding_for_point_ops |        5 |           1 | Throughput  |           3 | 2,300.2 ms | 77.18 ms | 20.04 ms | 2,290.1 ms | 2,326.7 ms | 0.4347  | 1000.0000 | 22,109,248 B |
| **QueryItemsAsync**     | Master (MediumRun)                     |             15 |           2 | Default     |          10 |   137.4 ms | 47.03 ms | 68.94 ms |   197.3 ms |   210.4 ms | 7.2775  |     -     |   344,008 B |
|                         | users/dkunda/4644_binary_encoding_for_point_ops (MediumRun) | 15 | 2 | Default  |          10 |   143.2 ms | 46.75 ms | 67.05 ms |   196.9 ms |   210.7 ms | 6.9816  |     -     |   354,936 B |
| **UpsertItemsAsync**    | Master (MediumRun)                     |             15 |           2 | Default     |          10 | 2,370.0 ms | 25.70 ms | 37.68 ms | 2,388.6 ms | 2,415.7 ms | 0.4219  | 1000.0000 | 23,579,448 B |
|                         | users/dkunda/4644_binary_encoding_for_point_ops (MediumRun) | 15 | 2 | Default  |          10 | 2,308.2 ms |  7.65 ms | 11.22 ms | 2,306.0 ms | 2,330.6 ms | 0.4332  | 1000.0000 | 23,844,400 B |
| **DeleteItemsAsync**    | Master (MediumRun)                     |             15 |           2 | Default     |          10 | 2,128.8 ms | 48.44 ms | 64.66 ms | 2,078.5 ms | 2,199.1 ms | 0.4698  | 1000.0000 | 22,119,016 B |
|                         | users/dkunda/4644_binary_encoding_for_point_ops (MediumRun) | 15 | 2 | Default  |          10 | 2,254.6 ms | 57.15 ms | 83.77 ms | 2,264.3 ms | 2,401.9 ms | 0.4435  | 1000.0000 | 22,026,672 B |

---



# Individual Benchmark Results


#### Processor: AMD EPYC 7763, 1 CPU, 16 logical and 8 physical cores  
#### Branch: Master
---

## Summary Table

|           Method        |        Job | IterationCount | LaunchCount | RunStrategy | WarmupCount |    Mean   |   Error |  StdDev |  Median  |   P95   |   Op/s  |   Gen0   | Allocated |
|-------------------------|------------|----------------|-------------|-------------|-------------|-----------:|--------:|--------:|----------:|---------:|---------:|----------:|----------:|
| **ReadItemsAsync**      | Job-NXGPKS |              5 |           1 | Throughput  |           3 | 2,019.4 ms |  9.82 ms |  2.55 ms | 2,018.6 ms | 2,022.1 ms | 0.4952 | 1000.0000 | 22,901,176 B |
| **QueryItemsAsync**     | Job-NXGPKS |              5 |           1 | Throughput  |           3 |   341.0 ms | 43.67 ms | 11.34 ms |   347.7 ms |   351.1 ms | 2.9325 |     -     |   539,136 B |
| **UpsertItemsAsync**    | Job-NXGPKS |              5 |           1 | Throughput  |           3 | 2,307.6 ms | 21.35 ms |  3.30 ms | 2,309.1 ms | 2,309.4 ms | 0.4334 | 1000.0000 | 23,553,768 B |
| **DeleteItemsAsync**    | Job-NXGPKS |              5 |           1 | Throughput  |           3 | 2,160.1 ms | 42.22 ms | 10.96 ms | 2,153.4 ms | 2,172.2 ms | 0.4629 | 1000.0000 | 22,111,528 B |
| **ReadItemsAsync**      | MediumRun  |             15 |           2 | Default     |          10 |      N/A   |     N/A  |     N/A  |      N/A   |     N/A   |     N/A  |     -     |        -   |
| **QueryItemsAsync**     | MediumRun  |             15 |           2 | Default     |          10 |   137.4 ms | 47.03 ms | 68.94 ms |   197.3 ms |   210.4 ms | 7.2775 |     -     |   344,008 B |
| **UpsertItemsAsync**    | MediumRun  |             15 |           2 | Default     |          10 | 2,370.0 ms | 25.70 ms | 37.68 ms | 2,388.6 ms | 2,415.7 ms | 0.4219 | 1000.0000 | 23,579,448 B |
| **DeleteItemsAsync**    | MediumRun  |             15 |           2 | Default     |          10 | 2,128.8 ms | 48.44 ms | 64.66 ms | 2,078.5 ms | 2,199.1 ms | 0.4698 | 1000.0000 | 22,119,016 B |

---

## Detailed Results

### **BinaryEncodingBenchmark.ReadItemsAsync**  
- **Job**: Job-NXGPKS  
- **Iteration Count**: 5  
- **Warmup Count**: 3  
- **Mean**: 2.019 s  
- **StdDev**: 0.003 s  
- **Confidence Interval (99.9%)**: [2.010 s; 2.029 s]  


---

### **BinaryEncodingBenchmark.QueryItemsAsync**  
- **Job**: Job-NXGPKS  
- **Iteration Count**: 5  
- **Warmup Count**: 3  
- **Mean**: 341.009 ms  
- **StdDev**: 11.340 ms  
- **Confidence Interval (99.9%)**: [297.343 ms; 384.675 ms]  


---

### **BinaryEncodingBenchmark.UpsertItemsAsync**  
- **Job**: Job-NXGPKS  
- **Iteration Count**: 5  
- **Warmup Count**: 3  
- **Mean**: 2.308 s  
- **StdDev**: 0.003 s  
- **Confidence Interval (99.9%)**: [2.286 s; 2.329 s]  


---

### **BinaryEncodingBenchmark.DeleteItemsAsync**  
- **Job**: Job-NXGPKS  
- **Iteration Count**: 5  
- **Warmup Count**: 3  
- **Mean**: 2.160 s  
- **StdDev**: 0.011 s  
- **Confidence Interval (99.9%)**: [2.118 s; 2.202 s]

---

## Branch:  users/dkunda/4644_binary_encoding_for_point_ops  

#### Processor: AMD EPYC 7763, 1 CPU, 16 logical and 8 physical cores  


---

## Summary Table

|           Method        |        Job | IterationCount | LaunchCount | RunStrategy | WarmupCount |    Mean   |   Error |  StdDev |  Median  |   P95   |   Op/s  |   Gen0   | Allocated |
|-------------------------|------------|----------------|-------------|-------------|-------------|-----------:|--------:|--------:|----------:|---------:|---------:|----------:|----------:|
| **ReadItemsAsync**      | Job-GBWISA |              5 |           1 | Throughput  |           3 | 2,032.0 ms | 42.52 ms | 11.04 ms | 2,035.8 ms | 2,043.0 ms | 0.4921 | 1000.0000 | 22,963,432 B |
| **QueryItemsAsync**     | Job-GBWISA |              5 |           1 | Throughput  |           3 |   321.8 ms | 20.31 ms |  3.14 ms |   323.1 ms |   323.7 ms | 3.1080 |     -     |   540,016 B |
| **UpsertItemsAsync**    | Job-GBWISA |              5 |           1 | Throughput  |           3 | 2,435.5 ms | 22.70 ms |  5.89 ms | 2,436.8 ms | 2,441.8 ms | 0.4106 | 1000.0000 | 23,856,208 B |
| **DeleteItemsAsync**    | Job-GBWISA |              5 |           1 | Throughput  |           3 | 2,300.2 ms | 77.18 ms | 20.04 ms | 2,290.1 ms | 2,326.7 ms | 0.4347 | 1000.0000 | 22,109,248 B |
| **ReadItemsAsync**      | MediumRun  |             15 |           2 | Default     |          10 |      N/A   |     N/A  |     N/A  |      N/A   |     N/A   |     N/A  |     -     |        -   |
| **QueryItemsAsync**     | MediumRun  |             15 |           2 | Default     |          10 |   143.2 ms | 46.75 ms | 67.05 ms |   196.9 ms |   210.7 ms | 6.9816 |     -     |   354,936 B |
| **UpsertItemsAsync**    | MediumRun  |             15 |           2 | Default     |          10 | 2,308.2 ms |  7.65 ms | 11.22 ms | 2,306.0 ms | 2,330.6 ms | 0.4332 | 1000.0000 | 23,844,400 B |
| **DeleteItemsAsync**    | MediumRun  |             15 |           2 | Default     |          10 | 2,254.6 ms | 57.15 ms | 83.77 ms | 2,264.3 ms | 2,401.9 ms | 0.4435 | 1000.0000 | 22,026,672 B |

---

## Detailed Results

### **BinaryEncodingBenchmark.ReadItemsAsync**
- **Job**: Job-GBWISA  
- **Iteration Count**: 5  
- **Warmup Count**: 3  
- **Mean**: 2.032 s  
- **StdDev**: 0.011 s  
- **Confidence Interval (99.9%)**: [1.989 s; 2.075 s]  


---

### **BinaryEncodingBenchmark.QueryItemsAsync**
- **Job**: Job-GBWISA  
- **Iteration Count**: 5  
- **Warmup Count**: 3  
- **Mean**: 321.753 ms  
- **StdDev**: 3.144 ms  
- **Confidence Interval (99.9%)**: [301.439 ms; 342.067 ms]  

---

### **BinaryEncodingBenchmark.UpsertItemsAsync**
- **Job**: Job-GBWISA  
- **Iteration Count**: 5  
- **Warmup Count**: 3  
- **Mean**: 2.435 s  
- **StdDev**: 0.006 s  
- **Confidence Interval (99.9%)**: [2.413 s; 2.458 s]  


---

### **BinaryEncodingBenchmark.DeleteItemsAsync**
- **Job**: Job-GBWISA  
- **Iteration Count**: 5  
- **Warmup Count**: 3  
- **Mean**: 2.300 s  
- **StdDev**: 0.020 s  
- **Confidence Interval (99.9%)**: [2.223 s; 2.377 s]  