### PR TITLE
Query: Adds LINQ support for JsonObject

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Linq/BuiltinFunctions/BuiltinFunctionVisitor.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/BuiltinFunctions/BuiltinFunctionVisitor.cs
@@ -5,7 +5,6 @@
 namespace Microsoft.Azure.Cosmos.Linq
 {
     using System;
-    using System.Collections.Generic;
     using System.Globalization;
     using System.Linq.Expressions;
     using Microsoft.Azure.Cosmos;
@@ -97,7 +96,7 @@ namespace Microsoft.Azure.Cosmos.Linq
             }
 
             // Array functions
-            if (declaringType.IsEnumerable())
+            if (declaringType.IsEnumerable() || declaringType == typeof(System.Text.Json.Nodes.JsonNode))
             {
                 return ArrayBuiltinFunctions.Visit(methodCallExpression, context);
             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemLinqTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemLinqTests.cs
@@ -8,12 +8,14 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
     using Microsoft.Azure.Cosmos.Linq;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
     using System;
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
     using System.Linq;
     using System.Linq.Dynamic;
     using System.Linq.Expressions;
+    using System.Text.Json.Nodes;
     using System.Threading.Tasks;
 
     [TestClass]
@@ -947,6 +949,22 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                  .ToQueryDefinition();
 
             Assert.AreEqual(2, (await this.FetchResults<ToDoActivity>(queryDefinition)).Count);
+        }
+
+        [TestMethod]
+        public async Task LinqJsonObjectTest()
+        {
+            await ToDoActivity.CreateRandomItems(this.Container, pkCount: 2, perPKItemCount: 1, randomPartitionKey: true);
+
+            IOrderedQueryable<JObject> queryableJObject = this.Container.GetItemLinqQueryable<JObject>();
+            IQueryable<JObject> queryJObject = queryableJObject.Where(f => (string)f["id"] == "fooBar");
+            string queryTextJObject = queryJObject.ToString();
+
+            IOrderedQueryable<JsonObject> queryableJsonObject = this.Container.GetItemLinqQueryable<JsonObject>();
+            IQueryable<JsonObject> queryJsonObject = queryableJsonObject.Where(f => (string)f["id"] == "fooBar");
+            string queryTextJsonObject = queryJsonObject.ToString();
+
+            Assert.AreEqual(queryTextJObject, queryTextJsonObject);
         }
 
         private class NumberLinqItem


### PR DESCRIPTION
## Description

This PR adds support for performing basic LINQ queries using `JsonObject` from the `System.Json.Text` library.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Closing issues

To automatically close an issue: closes #3321
