### PR TITLE
Direct Package Upgrade: Fixes Cosmos.Direct Package to 3.37.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
 		<ClientOfficialVersion>3.45.0</ClientOfficialVersion>
 		<ClientPreviewVersion>3.46.0</ClientPreviewVersion>
 		<ClientPreviewSuffixVersion>preview.0</ClientPreviewSuffixVersion>
-		<DirectVersion>3.36.1</DirectVersion>
+		<DirectVersion>3.37.0</DirectVersion>
 		<EncryptionOfficialVersion>2.0.4</EncryptionOfficialVersion>
 		<EncryptionPreviewVersion>2.1.0</EncryptionPreviewVersion>
 		<EncryptionPreviewSuffixVersion>preview4</EncryptionPreviewSuffixVersion>


### PR DESCRIPTION
# Pull Request Template

## Description
This PR is bumping up the Cosmos.Direct package version from 3.36.1 to 3.37.0, which includes new headers for Query Advisor

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber