### PR TITLE
Query: Fixes (workaround) for query plan issue where placeholder index does not start at zero

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/HybridSearch/FullTextStatistics.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/HybridSearch/FullTextStatistics.cs
@@ -4,8 +4,6 @@
 
 namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.HybridSearch
 {
-    using System;
-    using System.Collections.Generic;
     using Microsoft.Azure.Cosmos.CosmosElements;
 
     internal sealed class FullTextStatistics
@@ -14,7 +12,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.HybridSearch
 
         public long TotalWordCount { get; }
 
-        public ReadOnlyMemory<long> HitCounts => this.hitCounts;
+        public System.ReadOnlyMemory<long> HitCounts => this.hitCounts;
 
         public FullTextStatistics(long totalWordCount, long[] hitCounts)
         {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/HybridSearchQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/HybridSearchQueryTests.cs
@@ -134,6 +134,11 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
                     FROM c
                     ORDER BY RANK RRF(FullTextScore(c.title, ['John']), FullTextScore(c.text, ['United States']), VectorDistance(c.vector, {SampleVector}))",
                     new List<List<int>>{new List<int>{ 21, 75, 37, 24, 26, 35, 49, 87, 55, 9 } }),
+                MakeSanityTest($@"
+                    SELECT TOP 10 c.index AS Index, c.title AS Title, c.text AS Text
+                    FROM c
+                    ORDER BY RANK RRF(VectorDistance(c.vector, {SampleVector}), FullTextScore(c.title, ['John']), FullTextScore(c.text, ['United States']))",
+                    new List<List<int>>{new List<int>{ 21, 75, 37, 24, 26, 35, 49, 87, 55, 9 } }),
             };
 
             foreach (SanityTestCase testCase in testCases)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/HybridSearchQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/HybridSearchQueryTests.cs
@@ -139,6 +139,11 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
                     FROM c
                     ORDER BY RANK RRF(VectorDistance(c.vector, {SampleVector}), FullTextScore(c.title, ['John']), FullTextScore(c.text, ['United States']))",
                     new List<List<int>>{new List<int>{ 21, 75, 37, 24, 26, 35, 49, 87, 55, 9 } }),
+                MakeSanityTest($@"
+                    SELECT TOP 10 c.index AS Index, c.title AS Title, c.text AS Text
+                    FROM c
+                    ORDER BY RANK RRF(VectorDistance(c.vector, {SampleVector}), FullTextScore(c.title, ['John']), VectorDistance(c.image, {SampleVector}), VectorDistance(c.backup_image, {SampleVector}), FullTextScore(c.text, ['United States']))",
+                    new List<List<int>>{new List<int>{ 21, 75, 37, 24, 26, 35, 49, 87, 55, 9 } }),
             };
 
             foreach (SanityTestCase testCase in testCases)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/NonStreamingOrderByQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/NonStreamingOrderByQueryTests.cs
@@ -305,6 +305,14 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                     skip: 7,
                     take: 10,
                     pageSize: 1),
+                MakeHybridSearchTest(
+                    leafPageCount: 0,
+                    backendPageSize: 10,
+                    requiresGlobalStatistics: true,
+                    skip: 0,
+                    take: 10,
+                    pageSize: 10,
+                    returnEmptyGlobalStatistics: true),
             };
 
             foreach (HybridSearchTest testCase in testCases)
@@ -347,7 +355,8 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                 PartitionedFeedMode.NonStreamingReversed,
                 componentCount: 2,
                 leafPageCount: testCase.LeafPageCount,
-                backendPageSize: testCase.BackendPageSize);
+                backendPageSize: testCase.BackendPageSize,
+                returnEmptyGlobalStatistics: testCase.ReturnEmptyGlobalStatistics);
 
             (IReadOnlyList<CosmosElement> results, double requestCharge) = await CreateAndRunHybridSearchQueryPipelineStage(
                 documentContainer: nonStreamingDocumentContainer,
@@ -618,9 +627,16 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
             }
         }
 
-        private static HybridSearchTest MakeHybridSearchTest(int leafPageCount, int backendPageSize, bool requiresGlobalStatistics, int? skip, int? take, int pageSize)
+        private static HybridSearchTest MakeHybridSearchTest(
+            int leafPageCount,
+            int backendPageSize,
+            bool requiresGlobalStatistics,
+            int? skip,
+            int? take,
+            int pageSize,
+            bool returnEmptyGlobalStatistics = false)
         {
-            return new HybridSearchTest(leafPageCount, backendPageSize, requiresGlobalStatistics, skip, take, pageSize);
+            return new HybridSearchTest(leafPageCount, backendPageSize, requiresGlobalStatistics, skip, take, pageSize, returnEmptyGlobalStatistics);
         }
 
         private class HybridSearchTest
@@ -637,7 +653,16 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
 
             public int PageSize { get; }
 
-            public HybridSearchTest(int leafPageCount, int backendPageSize, bool requiresGlobalStatistics, int? skip, int? take, int pageSize)
+            public bool ReturnEmptyGlobalStatistics { get; }
+
+            public HybridSearchTest(
+                int leafPageCount,
+                int backendPageSize,
+                bool requiresGlobalStatistics,
+                int? skip,
+                int? take,
+                int pageSize,
+                bool returnEmptyGlobalStatistics)
             {
                 this.LeafPageCount = leafPageCount;
                 this.BackendPageSize = backendPageSize;
@@ -645,6 +670,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                 this.Skip = skip;
                 this.Take = take;
                 this.PageSize = pageSize;
+                this.ReturnEmptyGlobalStatistics = returnEmptyGlobalStatistics;
             }
         }
 
@@ -1014,6 +1040,8 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
 
             private readonly double totalRequestCharge;
 
+            private readonly bool returnEmptyGlobalStatistics;
+
             private int statisticsQueryCount;
 
             private int queryCount;
@@ -1041,7 +1069,8 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                 PartitionedFeedMode feedMode,
                 int componentCount,
                 int leafPageCount,
-                int backendPageSize)
+                int backendPageSize,
+                bool returnEmptyGlobalStatistics)
             {
                 IReadOnlyList<IReadOnlyDictionary<FeedRange, IReadOnlyList<IReadOnlyList<CosmosElement>>>> pages = CreateHybridSearchPartitionedFeed(
                     componentCount,
@@ -1055,7 +1084,8 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                     streaming: !feedMode.HasFlag(PartitionedFeedMode.NonStreaming),
                     componentSelector: GetOrderByScoreKind,
                     isGlobalStatisticsQuery: IsGlobalStatisticsQuery,
-                    totalRequestCharge: 0);
+                    totalRequestCharge: 0,
+                    returnEmptyGlobalStatistics: returnEmptyGlobalStatistics);
             }
 
             public static MockDocumentContainer Create(IReadOnlyList<FeedRangeEpk> feedRanges, PartitionedFeedMode feedMode, DocumentCreationMode documentCreationMode)
@@ -1073,7 +1103,8 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                     streaming: !feedMode.HasFlag(PartitionedFeedMode.NonStreaming),
                     componentSelector: _ => 0,
                     isGlobalStatisticsQuery: _ => false,
-                    totalRequestCharge);
+                    totalRequestCharge,
+                    returnEmptyGlobalStatistics: false);
             }
 
             private MockDocumentContainer(
@@ -1081,13 +1112,15 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                 bool streaming,
                 Func<SqlQuerySpec, int> componentSelector,
                 Func<SqlQuerySpec, bool> isGlobalStatisticsQuery,
-                double totalRequestCharge)
+                double totalRequestCharge,
+                bool returnEmptyGlobalStatistics)
             {
                 this.pages = pages ?? throw new ArgumentNullException(nameof(pages));
                 this.streaming = streaming;
                 this.componentSelector = componentSelector;
                 this.isGlobalStatisticsQuery = isGlobalStatisticsQuery;
                 this.totalRequestCharge = totalRequestCharge;
+                this.returnEmptyGlobalStatistics = returnEmptyGlobalStatistics;
             }
 
             public Task<ChangeFeedPage> ChangeFeedAsync(FeedRangeState<ChangeFeedState> feedRangeState, ChangeFeedExecutionOptions changeFeedPaginationOptions, ITrace trace, CancellationToken cancellationToken)
@@ -1155,7 +1188,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                 if (this.isGlobalStatisticsQuery(sqlQuerySpec))
                 {
                     QueryPage globalStatisticsPage = new QueryPage(
-                        documents: new List<CosmosElement> { CreateHybridSearchGlobalStatistics() },
+                        documents: new List<CosmosElement> { this.returnEmptyGlobalStatistics ? CreateEmptyHybridSearchGlobalStatistics() : CreateHybridSearchGlobalStatistics() },
                         requestCharge: GlobalStatisticsQueryCharge,
                         activityId: ActivityId,
                         cosmosQueryExecutionInfo: null,
@@ -1172,7 +1205,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                 int componentIndex = this.componentSelector(sqlQuerySpec);
                 IReadOnlyList<IReadOnlyList<CosmosElement>> feedRangePages = this.pages[componentIndex][feedRangeState.FeedRange];
                 int index = feedRangeState.State == null ? 0 : int.Parse(((CosmosString)feedRangeState.State.Value).Value);
-                IReadOnlyList<CosmosElement> documents = feedRangePages[index];
+                IReadOnlyList<CosmosElement> documents = index < feedRangePages.Count ? feedRangePages[index] : Enumerable.Empty<CosmosElement>().ToList();
 
                 QueryState state = index < feedRangePages.Count - 1 ? new QueryState(CosmosString.Create((index + 1).ToString())) : null;
                 QueryPage queryPage = new QueryPage(
@@ -1377,6 +1410,38 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
             Swapped = 2,
 
             MultiItemSwapped = MultiItem | Swapped,
+        }
+
+        private static CosmosElement CreateEmptyHybridSearchGlobalStatistics()
+        {
+            List<CosmosElement> statistics = new List<CosmosElement>
+            {
+                CosmosObject.Create(new Dictionary<string, CosmosElement>
+                {
+                    [TotalWordCount] = CosmosNumber64.Create(0),
+                    [HitCounts] = CosmosArray.Create(new List<CosmosElement>
+                    {
+                        CosmosNumber64.Create(0),
+                        CosmosNumber64.Create(0),
+                    }),
+                }),
+                CosmosObject.Create(new Dictionary<string, CosmosElement>
+                {
+                    [TotalWordCount] = CosmosNumber64.Create(0),
+                    [HitCounts] = CosmosArray.Create(new List<CosmosElement>
+                    {
+                        CosmosNumber64.Create(0),
+                    }),
+                }),
+            };
+
+            CosmosObject globalStatistics = CosmosObject.Create(new Dictionary<string, CosmosElement>
+            {
+                [DocumentCountPropertyName] = CosmosNumber64.Create(0),
+                [FullTextStatistics] = CosmosArray.Create(statistics),
+            });
+
+            return globalStatistics;
         }
 
         private static CosmosElement CreateHybridSearchGlobalStatistics()


### PR DESCRIPTION
## Description

During query plan generation, we were using the loop index index over order by expressions as the index for placeholders within component queries. However, VectorDistance expressions do not require placeholders. As a result the output placeholder indexes may not always start at 0. The fix for this is currently in PR on the gateway.

We are putting this workaround in the SDK until the gateway fix is deployed.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
