### PR TITLE
[Internal] FaultInjection: Fixes csproj so it will generate with a strong signed package name

### DIFF
--- a/Microsoft.Azure.Cosmos/FaultInjection/src/FaultInjection.csproj
+++ b/Microsoft.Azure.Cosmos/FaultInjection/src/FaultInjection.csproj
@@ -18,6 +18,23 @@
 		<SdkProjectRef>True</SdkProjectRef>
 		<ClientVersion>$(FaultInjectionVersion)</ClientVersion>
 		<VersionSuffix>$(FaultInjectionSuffixVersion)</VersionSuffix>
+		<Title>Microsoft Azure Cosmos DB Fault Injection library</Title>
+		<PackageId>Microsoft.Azure.Cosmos.FaultInjection</PackageId>
+		<PackageTags>microsoft;azure;cosmos;cosmosdb;documentdb;docdb;nosql;azureofficial;dotnetcore;netcore;netstandard</PackageTags>
+		<PackageReleaseNotes>The change log for this SDK is made available at https://github.com/Azure/azure-cosmos-dotnet-v3/blob/master/Microsoft.Azure.Cosmos/FaultInjection/changelog.md at the time of release.</PackageReleaseNotes>
+		<PackageProjectUrl>https://github.com/Azure/azure-cosmos-dotnet-v3/tree/master/Microsoft.Azure.Cosmos/FaultInjection</PackageProjectUrl>
+		<PublishRepositoryUrl Condition=" '$(ProjectRef)' != 'True' ">true</PublishRepositoryUrl>
+		<PackageIconUrl>http://go.microsoft.com/fwlink/?LinkID=288890</PackageIconUrl>
+		<PackageIcon>Icon.png</PackageIcon>
+		<PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+		<GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+		<GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+		<PlatformTarget>AnyCPU</PlatformTarget>
+		<ShippingScope>External</ShippingScope>
+		<SigningType>Product</SigningType>
+		<DebugType>portable</DebugType>
+		<IncludeSymbols>false</IncludeSymbols>
+		<IncludeSource>false</IncludeSource>
 	</PropertyGroup>
 
 	<ItemGroup Condition=" '$(SdkProjectRef)' != 'True' ">
@@ -39,9 +56,14 @@
 	  <PackageReference Include="System.Text.Json" Version="8.0.5" />
 	</ItemGroup>
 	
-	<PropertyGroup>
+	<PropertyGroup Condition=" '$(ProjectRef)' != 'True' ">
 		<SignAssembly>true</SignAssembly>
 		<DelaySign>true</DelaySign>
-		<AssemblyOriginatorKeyFile>..\..\..\testkey.snk</AssemblyOriginatorKeyFile>
+		<AssemblyOriginatorKeyFile>..\..\..\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
+	</PropertyGroup>
+
+	<PropertyGroup>
+		<DefineConstants Condition=" '$(SignAssembly)' == 'true' ">$(DefineConstants);SignAssembly</DefineConstants>
+		<DefineConstants Condition=" '$(DelaySign)' == 'true' ">$(DefineConstants);DelaySignKeys</DefineConstants>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
# Pull Request Template

## Description

When generating the package to publish to nuget currently the package has the following error
```
D:\a\_work\1\s\azure-sdk-build-tools\scripts\partition-by-strongname.ps1 : D:\a\_work\1\s\artifacts\temp\ContainerSigning\413018FAC2A26C5052D565C2510DF95BA666EB9BA502E69A99D0F762E02A0FFF\lib\net6.0\Microsoft.Azure.Cosmos.FaultInjection.dll-69c3241e6f0468ca with public key token 69c3241e6f0468ca is NOT strong name signed! (sn returned 1)
```

This should allow it to publish with the a strong named signed 

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
## Closing issues

To automatically close an issue: closes #IssueNumber