### PR TITLE
Documentation: Fixes changelog for AzureCosmosDisableNewtonsoftJsonCheck property name.

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Added
 - [4839](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/4839) Dependencies: Removes direct reference to the Newtonsoft.Json package, marks it as a private asset, and adds a build target to enforce explicit consumer references.
 
-> **NOTE**: This is a **breaking change**. Consumer applications must explicitly reference the Newtonsoft.Json package with a version >= 10.0.2 or opt-out of the check by setting `<DisableNewtonsoftJsonCheck>true</DisableNewtonsoftJsonCheck>` in their project file.
+> **NOTE**: This is a **breaking change**. Consumer applications must explicitly reference the Newtonsoft.Json package with a version >= 10.0.2 or opt-out of the check by setting `<AzureCosmosDisableNewtonsoftJsonCheck>true</AzureCosmosDisableNewtonsoftJsonCheck>` in their project file.
 
 - [4854](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/4854) Open Telemetry: Adds open telemetry based versioning.
 


### PR DESCRIPTION
# Pull Request Template

## Description

Fixed property name in changelog from DisableNewtonsoftJsonCheck to  AzureCosmosDisableNewtonsoftJsonCheck property name. This change provides the correct property name for disabling newtonsoft dependency build check.
Reference PR: https://github.com/Azure/azure-cosmos-dotnet-v3/pull/4839

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #4912