### PR TITLE
[Internal] Thin Client Integration: Adds thinclient mode and performance tests.

### DIFF
--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -200,7 +200,7 @@ namespace Microsoft.Azure.Cosmos
         private event EventHandler<SendingRequestEventArgs> sendingRequest;
         private event EventHandler<ReceivedResponseEventArgs> receivedResponse;
         private Func<TransportClient, TransportClient> transportClientHandlerFactory;
-        private string liteClientTestEndpoint = "https://aavasthy-vmsstest.sql.cosmos.azure.com:10650";
+        private string liteClientTestEndpoint = "https://cdb-ms-stage-eastus2-fe2.eastus2.cloudapp.azure.com:10650";
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DocumentClient"/> class using the

--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -6577,6 +6577,13 @@ namespace Microsoft.Azure.Cosmos
                 return this.GatewayStoreModel;
             }
 
+            if (this.isLiteClientEnabled
+                && operationType == OperationType.Read
+                && resourceType == ResourceType.Database)
+            {
+                return this.GatewayStoreModel;
+            }
+
             if (operationType == OperationType.Create
                 || operationType == OperationType.Upsert)
             {
@@ -6618,7 +6625,7 @@ namespace Microsoft.Azure.Cosmos
             }
             else if (operationType == OperationType.Read)
             {
-                if (resourceType == ResourceType.Collection || resourceType == ResourceType.Database)
+                if (resourceType == ResourceType.Collection)
                 {
                     return this.GatewayStoreModel;
                 }

--- a/Microsoft.Azure.Cosmos/src/HttpClient/CosmosHttpClientCore.cs
+++ b/Microsoft.Azure.Cosmos/src/HttpClient/CosmosHttpClientCore.cs
@@ -441,7 +441,7 @@ namespace Microsoft.Azure.Cosmos
             return !timeoutEnumerator.MoveNext(); // No more retries are configured
         }
 
-        private async Task<HttpResponseMessage> ExecuteHttpHelperAsync(
+        public async Task<HttpResponseMessage> ExecuteHttpHelperAsync(
             HttpRequestMessage requestMessage,
             ResourceType resourceType,
             CancellationToken cancellationToken)

--- a/Microsoft.Azure.Cosmos/src/ProxyStoreClient.cs
+++ b/Microsoft.Azure.Cosmos/src/ProxyStoreClient.cs
@@ -1,0 +1,427 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Diagnostics.CodeAnalysis;
+    using System.IO;
+    using System.Net.Http;
+    using System.Net.Http.Headers;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Tracing.TraceData;
+    using Microsoft.Azure.Documents;
+    using Microsoft.Azure.Documents.Collections;
+    using Newtonsoft.Json;
+    using static Microsoft.Azure.Cosmos.ThinClientTransportSerializer;
+
+    internal class ProxyStoreClient : TransportClient
+    {
+        private readonly ICommunicationEventSource eventSource;
+        private readonly CosmosHttpClient httpClient;
+        private readonly Uri proxyEndpoint;
+        private readonly JsonSerializerSettings SerializerSettings;
+        private static readonly HttpMethod httpPatchMethod = new HttpMethod(HttpConstants.HttpMethods.Patch);
+        private readonly ObjectPool<BufferProviderWrapper> bufferProviderWrapperPool;
+        private readonly string globalDatabaseAccountName;
+
+        public ProxyStoreClient(
+            CosmosHttpClient httpClient,
+            ICommunicationEventSource eventSource,
+            Uri proxyEndpoint,
+            string globalDatabaseAccountName,
+            JsonSerializerSettings serializerSettings = null)
+        {
+            this.proxyEndpoint = proxyEndpoint;
+            this.httpClient = httpClient;
+            this.SerializerSettings = serializerSettings;
+            this.eventSource = eventSource;
+            this.globalDatabaseAccountName = globalDatabaseAccountName;
+            this.bufferProviderWrapperPool = new ObjectPool<BufferProviderWrapper>(() => new BufferProviderWrapper());
+        }
+
+        public async Task<DocumentServiceResponse> InvokeAsync(
+           DocumentServiceRequest request,
+           ResourceType resourceType,
+           Uri physicalAddress,
+           CancellationToken cancellationToken)
+        {
+            using (HttpResponseMessage responseMessage = await this.InvokeClientAsync(request, resourceType, physicalAddress, cancellationToken))
+            {
+                return await ProxyStoreClient.ParseResponseAsync(responseMessage, request.SerializerSettings ?? this.SerializerSettings, request);
+            }
+        }
+
+        public static bool IsFeedRequest(OperationType requestOperationType)
+        {
+            return requestOperationType == OperationType.Create ||
+                requestOperationType == OperationType.Upsert ||
+                requestOperationType == OperationType.ReadFeed ||
+                requestOperationType == OperationType.Query ||
+                requestOperationType == OperationType.SqlQuery ||
+                requestOperationType == OperationType.QueryPlan ||
+                requestOperationType == OperationType.Batch;
+        }
+
+        internal override async Task<StoreResponse> InvokeStoreAsync(Uri baseAddress, ResourceOperation resourceOperation, DocumentServiceRequest request)
+        {
+            Uri physicalAddress = ProxyStoreClient.IsFeedRequest(request.OperationType) ?
+                HttpTransportClient.GetResourceFeedUri(resourceOperation.resourceType, baseAddress, request) :
+                HttpTransportClient.GetResourceEntryUri(resourceOperation.resourceType, baseAddress, request);
+
+            using (HttpResponseMessage responseMessage = await this.InvokeClientAsync(request, resourceOperation.resourceType, physicalAddress, default))
+            {
+                return await HttpTransportClient.ProcessHttpResponse(request.ResourceAddress, string.Empty, responseMessage, physicalAddress, request);
+            }
+        }
+
+        [SuppressMessage("Microsoft.Reliability", "CA2000:DisposeObjectsBeforeLosingScope", Justification = "Disposable object returned by method")]
+        internal Task<HttpResponseMessage> SendHttpAsync(
+            Func<ValueTask<HttpRequestMessage>> requestMessage,
+            ResourceType resourceType,
+            HttpTimeoutPolicy timeoutPolicy,
+            IClientSideRequestStatistics clientSideRequestStatistics,
+            CancellationToken cancellationToken = default)
+        {
+            return this.httpClient.SendHttpAsync(
+                createRequestMessageAsync: requestMessage,
+                resourceType: resourceType,
+                timeoutPolicy: timeoutPolicy,
+                clientSideRequestStatistics: clientSideRequestStatistics,
+                cancellationToken: cancellationToken);
+        }
+
+        internal static async Task<DocumentServiceResponse> ParseResponseAsync(HttpResponseMessage responseMessage, JsonSerializerSettings serializerSettings = null, DocumentServiceRequest request = null)
+        {
+            using (responseMessage)
+            {
+                IClientSideRequestStatistics requestStatistics = request?.RequestContext?.ClientRequestStatistics;
+                if ((int)responseMessage.StatusCode < 400)
+                {
+                    INameValueCollection headers = ProxyStoreClient.ExtractResponseHeaders(responseMessage);
+                    Stream contentStream = await ProxyStoreClient.BufferContentIfAvailableAsync(responseMessage);
+                    return new DocumentServiceResponse(
+                        body: contentStream,
+                        headers: headers,
+                        statusCode: responseMessage.StatusCode,
+                        clientSideRequestStatistics: requestStatistics,
+                        serializerSettings: serializerSettings);
+                }
+                else if (request != null
+                    && request.IsValidStatusCodeForExceptionlessRetry((int)responseMessage.StatusCode))
+                {
+                    INameValueCollection headers = ProxyStoreClient.ExtractResponseHeaders(responseMessage);
+                    Stream contentStream = await ProxyStoreClient.BufferContentIfAvailableAsync(responseMessage);
+                    return new DocumentServiceResponse(
+                        body: contentStream,
+                        headers: headers,
+                        statusCode: responseMessage.StatusCode,
+                        clientSideRequestStatistics: requestStatistics,
+                        serializerSettings: serializerSettings);
+                }
+                else
+                {
+                    throw await ProxyStoreClient.CreateDocumentClientExceptionAsync(responseMessage, requestStatistics);
+                }
+            }
+        }
+
+        internal static INameValueCollection ExtractResponseHeaders(HttpResponseMessage responseMessage)
+        {
+            INameValueCollection headers = new HttpResponseHeadersWrapper(
+                responseMessage.Headers,
+                responseMessage.Content?.Headers);
+
+            return headers;
+        }
+
+        /// <summary>
+        /// Creating a new DocumentClientException using the Gateway response message.
+        /// </summary>
+        /// <param name="responseMessage"></param>
+        /// <param name="requestStatistics"></param>
+        internal static async Task<DocumentClientException> CreateDocumentClientExceptionAsync(
+            HttpResponseMessage responseMessage,
+            IClientSideRequestStatistics requestStatistics)
+        {
+            if (!PathsHelper.TryParsePathSegments(
+                resourceUrl: responseMessage.RequestMessage.RequestUri.LocalPath,
+                isFeed: out _,
+                resourcePath: out _,
+                resourceIdOrFullName: out string resourceIdOrFullName,
+                isNameBased: out _))
+            {
+                // if resourceLink is invalid - we will not set resourceAddress in exception.
+            }
+
+            // If service rejects the initial payload like header is to large it will return an HTML error instead of JSON.
+            if (string.Equals(responseMessage.Content?.Headers?.ContentType?.MediaType, "application/json", StringComparison.OrdinalIgnoreCase) &&
+                responseMessage.Content?.Headers.ContentLength > 0)
+            {
+                try
+                {
+                    Stream contentAsStream = await responseMessage.Content.ReadAsStreamAsync();
+                    Error error = JsonSerializable.LoadFrom<Error>(stream: contentAsStream);
+
+                    return new DocumentClientException(
+                        errorResource: error,
+                        responseHeaders: responseMessage.Headers,
+                        statusCode: responseMessage.StatusCode)
+                    {
+                        StatusDescription = responseMessage.ReasonPhrase,
+                        ResourceAddress = resourceIdOrFullName,
+                        RequestStatistics = requestStatistics
+                    };
+                }
+                catch
+                {
+                }
+            }
+
+            StringBuilder contextBuilder = new StringBuilder();
+            contextBuilder.AppendLine(await responseMessage.Content.ReadAsStringAsync());
+
+            HttpRequestMessage requestMessage = responseMessage.RequestMessage;
+
+            if (requestMessage != null)
+            {
+                contextBuilder.AppendLine($"RequestUri: {requestMessage.RequestUri};");
+                contextBuilder.AppendLine($"RequestMethod: {requestMessage.Method.Method};");
+
+                if (requestMessage.Headers != null)
+                {
+                    foreach (KeyValuePair<string, IEnumerable<string>> header in requestMessage.Headers)
+                    {
+                        contextBuilder.AppendLine($"Header: {header.Key} Length: {string.Join(",", header.Value).Length};");
+                    }
+                }
+            }
+
+            return new DocumentClientException(
+                message: contextBuilder.ToString(),
+                innerException: null,
+                responseHeaders: responseMessage.Headers,
+                statusCode: responseMessage.StatusCode,
+                requestUri: responseMessage.RequestMessage.RequestUri)
+            {
+                StatusDescription = responseMessage.ReasonPhrase,
+                ResourceAddress = resourceIdOrFullName,
+                RequestStatistics = requestStatistics
+            };
+        }
+
+        internal static bool IsAllowedRequestHeader(string headerName)
+        {
+            if (!headerName.StartsWith("x-ms", StringComparison.OrdinalIgnoreCase))
+            {
+#pragma warning disable IDE0066 // Convert switch statement to expression
+                switch (headerName)
+                {
+                    //Just flow the header which are settable at RequestMessage level and the one we care.
+                    case HttpConstants.HttpHeaders.Authorization:
+                    case HttpConstants.HttpHeaders.Accept:
+                    case HttpConstants.HttpHeaders.ContentType:
+                    case HttpConstants.HttpHeaders.Host:
+                    case HttpConstants.HttpHeaders.IfMatch:
+                    case HttpConstants.HttpHeaders.IfModifiedSince:
+                    case HttpConstants.HttpHeaders.IfNoneMatch:
+                    case HttpConstants.HttpHeaders.IfRange:
+                    case HttpConstants.HttpHeaders.IfUnmodifiedSince:
+                    case HttpConstants.HttpHeaders.UserAgent:
+                    case HttpConstants.HttpHeaders.Prefer:
+                    case HttpConstants.HttpHeaders.Query:
+                    case HttpConstants.HttpHeaders.A_IM:
+                        return true;
+
+                    default:
+                        return false;
+                }
+#pragma warning restore IDE0066 // Convert switch statement to expression
+            }
+            return true;
+        }
+
+        private static async Task<Stream> BufferContentIfAvailableAsync(HttpResponseMessage responseMessage)
+        {
+            if (responseMessage.Content == null)
+            {
+                return null;
+            }
+
+            MemoryStream bufferedStream = new MemoryStream();
+            await responseMessage.Content.CopyToAsync(bufferedStream);
+            bufferedStream.Position = 0;
+            return bufferedStream;
+        }
+
+        [SuppressMessage("Microsoft.Reliability", "CA2000:DisposeObjectsBeforeLosingScope", Justification = "Disposable object returned by method")]
+        private async ValueTask<HttpRequestMessage> PrepareRequestMessageAsync(
+            DocumentServiceRequest request,
+            Uri physicalAddress)
+        {
+            HttpMethod httpMethod = HttpMethod.Head;
+            if (request.OperationType == OperationType.Create ||
+                request.OperationType == OperationType.Upsert ||
+                request.OperationType == OperationType.Query ||
+                request.OperationType == OperationType.SqlQuery ||
+                request.OperationType == OperationType.Batch ||
+                request.OperationType == OperationType.ExecuteJavaScript ||
+                request.OperationType == OperationType.QueryPlan ||
+                (request.ResourceType == ResourceType.PartitionKey && request.OperationType == OperationType.Delete))
+            {
+                httpMethod = HttpMethod.Post;
+            }
+            else if (ChangeFeedHelper.IsChangeFeedWithQueryRequest(request.OperationType, request.Body != null))
+            {
+                // ChangeFeed with payload is a CF with query support and will
+                // be a query POST request.
+                httpMethod = HttpMethod.Post;
+            }
+            else if (request.OperationType == OperationType.Read
+                || request.OperationType == OperationType.ReadFeed)
+            {
+                httpMethod = HttpMethod.Get;
+            }
+            else if ((request.OperationType == OperationType.Replace)
+                || (request.OperationType == OperationType.CollectionTruncate))
+            {
+                httpMethod = HttpMethod.Put;
+            }
+            else if (request.OperationType == OperationType.Delete)
+            {
+                httpMethod = HttpMethod.Delete;
+            }
+            else if (request.OperationType == OperationType.Patch)
+            {
+                // There isn't support for PATCH method in .NetStandard 2.0
+                httpMethod = httpPatchMethod;
+            }
+            else
+            {
+                throw new NotImplementedException();
+            }
+
+            HttpRequestMessage requestMessage = new (httpMethod, physicalAddress)
+            {
+                Version = new Version(2, 0),
+            };
+
+            // The StreamContent created below will own and dispose its underlying stream, but we may need to reuse the stream on the 
+            // DocumentServiceRequest for future requests. Hence we need to clone without incurring copy cost, so that when
+            // HttpRequestMessage -> StreamContent -> MemoryStream all get disposed, the original stream will be left open.
+            if (request.Body != null)
+            {
+                await request.EnsureBufferedBodyAsync();
+                MemoryStream clonedStream = new MemoryStream();
+                // WriteTo doesn't use and update Position of source stream. No point in setting/restoring it.
+                request.CloneableBody.WriteTo(clonedStream);
+                clonedStream.Position = 0;
+
+                requestMessage.Content = new StreamContent(clonedStream);
+            }
+
+            if (request.Headers != null)
+            {
+                foreach (string key in request.Headers)
+                {
+                    if (GatewayStoreClient.IsAllowedRequestHeader(key))
+                    {
+                        if (key.Equals(HttpConstants.HttpHeaders.ContentType, StringComparison.OrdinalIgnoreCase))
+                        {
+                            requestMessage.Content.Headers.ContentType = new MediaTypeHeaderValue(request.Headers[key]);
+                        }
+                        else
+                        {
+                            requestMessage.Headers.TryAddWithoutValidation(key, request.Headers[key]);
+                        }
+                    }
+                }
+            }
+
+            if (request.Properties != null)
+            {
+                foreach (KeyValuePair<string, object> property in request.Properties)
+                {
+                    requestMessage.Properties.Add(property);
+                }
+            }
+
+            // add activityId
+            Guid activityId = System.Diagnostics.Trace.CorrelationManager.ActivityId;
+            Debug.Assert(activityId != Guid.Empty);
+            requestMessage.Headers.Add(HttpConstants.HttpHeaders.ActivityId, activityId.ToString());
+
+            string regionName = request?.RequestContext?.RegionName;
+            if (regionName != null)
+            {
+                requestMessage.Properties.Add(ClientSideRequestStatisticsTraceDatum.HttpRequestRegionNameProperty, regionName);
+            }
+
+            BufferProviderWrapper bufferProviderWrapper = this.bufferProviderWrapperPool.Get();
+            try
+            {
+                Stream contentStream = await ThinClientTransportSerializer.SerializeProxyRequestAsync(bufferProviderWrapper, this.globalDatabaseAccountName, requestMessage);
+
+                // force Http2, post and route to the thin client endpoint.
+                requestMessage.Content = new StreamContent(contentStream);
+                requestMessage.Content.Headers.ContentLength = contentStream.Length;
+                requestMessage.Headers.Clear();
+
+                // Force Http 2.0 on the request
+                // this.forceHttp20Action.Invoke(request);
+
+                requestMessage.RequestUri = this.proxyEndpoint;
+                requestMessage.Method = HttpMethod.Post;
+
+                return requestMessage;
+            }
+            finally
+            {
+                this.bufferProviderWrapperPool.Return(bufferProviderWrapper);
+            }
+        }
+
+        [SuppressMessage("Microsoft.Reliability", "CA2000:DisposeObjectsBeforeLosingScope", Justification = "Disposable object returned by method")]
+        private Task<HttpResponseMessage> InvokeClientAsync(
+           DocumentServiceRequest request,
+           ResourceType resourceType,
+           Uri physicalAddress,
+           CancellationToken cancellationToken)
+        {
+            return this.httpClient.SendHttpAsync(
+                () => this.PrepareRequestMessageAsync(request, physicalAddress),
+                resourceType,
+                HttpTimeoutPolicy.GetTimeoutPolicy(request),
+                request.RequestContext.ClientRequestStatistics,
+                cancellationToken);
+        }
+
+        public class ObjectPool<T>
+        {
+            private readonly ConcurrentBag<T> Objects;
+            private readonly Func<T> ObjectGenerator;
+
+            public ObjectPool(Func<T> objectGenerator)
+            {
+                this.ObjectGenerator = objectGenerator ?? throw new ArgumentNullException(nameof(objectGenerator));
+                this.Objects = new ConcurrentBag<T>();
+            }
+
+            public T Get()
+            {
+                return this.Objects.TryTake(out T item) ? item : this.ObjectGenerator();
+            }
+
+            public void Return(T item)
+            {
+                this.Objects.Add(item);
+            }
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/ThinClientHttpMessageHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/ThinClientHttpMessageHandler.cs
@@ -1,0 +1,95 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+/*namespace Microsoft.Azure.Cosmos
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.IO;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using System.Net.Http.Headers;
+    using System.Net.Security;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Common;
+    using Microsoft.Azure.Cosmos.Core.Trace;
+    using Microsoft.Azure.Cosmos.Routing;
+    using Microsoft.Azure.Cosmos.Tracing;
+    using Microsoft.Azure.Documents;
+    using Microsoft.Azure.Documents.Collections;
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// blabla
+    /// </summary>
+    internal class ThinClientHttpMessageHandler : DelegatingHandler
+    {
+        private readonly string accountName;
+        private readonly Uri gatewayEndpoint;
+        private readonly Uri thinClientEndpoint;
+        private readonly BufferProviderWrapper bufferProvider;
+        private readonly string customUserAgent;
+
+        public ThinClientHttpMessageHandler(Uri gatewayEndpoint, Uri thinClientEndpoint, string accountName)
+            : this(gatewayEndpoint, thinClientEndpoint, accountName, serverValidator: null)
+        {
+        }
+
+        public ThinClientHttpMessageHandler(Uri gatewayEndpoint, Uri thinClientEndpoint, string accountName, RemoteCertificateValidationCallback serverValidator, string customUserAgent = "")
+        {
+            this.gatewayEndpoint = gatewayEndpoint;
+            this.thinClientEndpoint = thinClientEndpoint;
+            this.accountName = accountName ?? throw new ArgumentNullException(nameof(accountName));
+            this.customUserAgent = customUserAgent;
+            this.bufferProvider = new();
+            SocketsHttpHandler clientHandler = new SocketsHttpHandler();
+            clientHandler.EnableMultipleHttp2Connections = true;
+            if (serverValidator != null)
+            {
+                clientHandler.SslOptions.RemoteCertificateValidationCallback = serverValidator;
+            }
+
+            this.InnerHandler = clientHandler;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            if (request.Headers.Contains(ProxyExtensions.RoutedViaProxy))
+            {
+                return this.SendViaProxyAsync(request, cancellationToken);
+            }
+            else
+            {
+                request.RequestUri = new Uri(this.gatewayEndpoint, request.RequestUri.PathAndQuery);
+                return base.SendAsync(request, cancellationToken);
+            }
+        }
+
+        private async Task<HttpResponseMessage> SendViaProxyAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Stream contentStream = await ThinClientTransportSerializer.SerializeProxyRequestAsync(this.bufferProvider, this.accountName, request);
+
+            // force Http2, post and route to the thin client endpoint.
+            request.Content = new StreamContent(contentStream);
+            request.Content.Headers.ContentLength = contentStream.Length;
+            request.Headers.Clear();
+
+            request.Version = new Version("2.0");
+            request.VersionPolicy = HttpVersionPolicy.RequestVersionExact;
+            request.RequestUri = this.thinClientEndpoint;
+            request.Method = HttpMethod.Post;
+
+            if (!string.IsNullOrEmpty(this.customUserAgent))
+            {
+                request.Headers.UserAgent.ParseAdd(this.customUserAgent);
+            }
+
+            using HttpResponseMessage responseMessage = await base.SendAsync(request, cancellationToken);
+            return await ProxyExtensions.ConvertProxyResponseAsync(responseMessage);
+        }
+    }
+}*/

--- a/Microsoft.Azure.Cosmos/src/ThinClientStoreModel.cs
+++ b/Microsoft.Azure.Cosmos/src/ThinClientStoreModel.cs
@@ -61,6 +61,8 @@ namespace Microsoft.Azure.Cosmos
 
         public virtual async Task<DocumentServiceResponse> ProcessMessageAsync(DocumentServiceRequest request, CancellationToken cancellationToken = default)
         {
+            DefaultTrace.TraceInformation("In {0}, OperationType: {1}, ResourceType: {2}", nameof(ThinClientStoreModel), request.OperationType, request.ResourceType);
+
             await ThinClientStoreModel.ApplySessionTokenAsync(
                 request,
                 this.defaultConsistencyLevel,

--- a/Microsoft.Azure.Cosmos/src/ThinClientStoreModel.cs
+++ b/Microsoft.Azure.Cosmos/src/ThinClientStoreModel.cs
@@ -1,0 +1,424 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using System.Net.Http.Headers;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Common;
+    using Microsoft.Azure.Cosmos.Core.Trace;
+    using Microsoft.Azure.Cosmos.Routing;
+    using Microsoft.Azure.Cosmos.Tracing;
+    using Microsoft.Azure.Documents;
+    using Microsoft.Azure.Documents.Collections;
+    using Newtonsoft.Json;
+
+    // Marking it as non-sealed in order to unit test it using Moq framework
+    internal class ThinClientStoreModel : IStoreModelExtension, IDisposable
+    {
+        private static readonly string sessionConsistencyAsString = ConsistencyLevel.Session.ToString();
+
+        private readonly GlobalEndpointManager endpointManager;
+        private readonly DocumentClientEventSource eventSource;
+        private readonly ISessionContainer sessionContainer;
+        private readonly ConsistencyLevel defaultConsistencyLevel;
+
+        private ProxyStoreClient proxyStoreClient;
+
+        // Caches to resolve the PartitionKeyRange from request. For Session Token Optimization.
+        private ClientCollectionCache clientCollectionCache;
+        private PartitionKeyRangeCache partitionKeyRangeCache;
+
+        public ThinClientStoreModel(
+            GlobalEndpointManager endpointManager,
+            ISessionContainer sessionContainer,
+            ConsistencyLevel defaultConsistencyLevel,
+            DocumentClientEventSource eventSource,
+            JsonSerializerSettings serializerSettings,
+            CosmosHttpClient httpClient,
+            Uri proxyEndpoint,
+            string globalDatabaseAccountName)
+        {
+            this.endpointManager = endpointManager;
+            this.sessionContainer = sessionContainer;
+            this.defaultConsistencyLevel = defaultConsistencyLevel;
+            this.eventSource = eventSource;
+            this.proxyStoreClient = new ProxyStoreClient(
+                httpClient,
+                this.eventSource,
+                proxyEndpoint,
+                globalDatabaseAccountName,
+                serializerSettings);
+        }
+
+        public virtual async Task<DocumentServiceResponse> ProcessMessageAsync(DocumentServiceRequest request, CancellationToken cancellationToken = default)
+        {
+            await ThinClientStoreModel.ApplySessionTokenAsync(
+                request,
+                this.defaultConsistencyLevel,
+                this.sessionContainer,
+                this.partitionKeyRangeCache,
+                this.clientCollectionCache,
+                this.endpointManager);
+
+            DocumentServiceResponse response;
+            try
+            {
+                Uri physicalAddress = ProxyStoreClient.IsFeedRequest(request.OperationType) ? this.GetFeedUri(request) : this.GetEntityUri(request);
+                // Collect region name only for document resources
+                if (request.ResourceType.Equals(ResourceType.Document) && this.endpointManager.TryGetLocationForGatewayDiagnostics(request.RequestContext.LocationEndpointToRoute, out string regionName))
+                {
+                    request.RequestContext.RegionName = regionName;
+                }
+                response = await this.proxyStoreClient.InvokeAsync(request, request.ResourceType, physicalAddress, cancellationToken);
+            }
+            catch (DocumentClientException exception)
+            {
+                if ((!ReplicatedResourceClient.IsMasterResource(request.ResourceType)) &&
+                    (exception.StatusCode == HttpStatusCode.PreconditionFailed || exception.StatusCode == HttpStatusCode.Conflict
+                    || (exception.StatusCode == HttpStatusCode.NotFound && exception.GetSubStatus() != SubStatusCodes.ReadSessionNotAvailable)))
+                {
+                    await this.CaptureSessionTokenAndHandleSplitAsync(exception.StatusCode, exception.GetSubStatus(), request, exception.Headers);
+                }
+
+                throw;
+            }
+
+            await this.CaptureSessionTokenAndHandleSplitAsync(response.StatusCode, response.SubStatusCode, request, response.Headers);
+            return response;
+        }
+
+        public void SetCaches(PartitionKeyRangeCache partitionKeyRangeCache, 
+                              ClientCollectionCache clientCollectionCache)
+        {
+            this.clientCollectionCache = clientCollectionCache;
+            this.partitionKeyRangeCache = partitionKeyRangeCache;
+        }
+
+        public void Dispose()
+        {
+            this.Dispose(true);
+        }
+
+        private async Task CaptureSessionTokenAndHandleSplitAsync(
+            HttpStatusCode? statusCode,
+            SubStatusCodes subStatusCode,
+            DocumentServiceRequest request,
+            INameValueCollection responseHeaders)
+        {
+            // Exceptionless can try to capture session token from CompleteResponse
+            if (request.IsValidStatusCodeForExceptionlessRetry((int)statusCode, subStatusCode))
+            {
+                // Not capturing on master resources
+                if (ReplicatedResourceClient.IsMasterResource(request.ResourceType))
+                {
+                    return;
+                }
+
+                // Only capturing on 409, 412, 404 && !1002
+                if (statusCode != HttpStatusCode.PreconditionFailed
+                    && statusCode != HttpStatusCode.Conflict
+                        && (statusCode != HttpStatusCode.NotFound || subStatusCode == SubStatusCodes.ReadSessionNotAvailable))
+                {
+                    return;
+                }
+            }
+
+            if (request.ResourceType == ResourceType.Collection && request.OperationType == OperationType.Delete)
+            {
+                string resourceId;
+
+                if (request.IsNameBased)
+                {
+                    resourceId = responseHeaders[HttpConstants.HttpHeaders.OwnerId];
+                }
+                else
+                {
+                    resourceId = request.ResourceId;
+                }
+
+                this.sessionContainer.ClearTokenByResourceId(resourceId);
+            }
+            else
+            {
+                this.sessionContainer.SetSessionToken(request, responseHeaders);
+                PartitionKeyRange detectedPartitionKeyRange = request.RequestContext.ResolvedPartitionKeyRange;
+                string partitionKeyRangeInResponse = responseHeaders[HttpConstants.HttpHeaders.PartitionKeyRangeId];
+                if (detectedPartitionKeyRange != null
+                    && !string.IsNullOrEmpty(partitionKeyRangeInResponse)
+                    && !string.IsNullOrEmpty(request.RequestContext.ResolvedCollectionRid)
+                    && !partitionKeyRangeInResponse.Equals(detectedPartitionKeyRange.Id, StringComparison.OrdinalIgnoreCase))
+                {
+                    // The request ended up being on a different partition unknown to the client, so we better refresh the caches
+                    await this.partitionKeyRangeCache.TryGetPartitionKeyRangeByIdAsync(
+                        request.RequestContext.ResolvedCollectionRid,
+                        partitionKeyRangeInResponse,
+                        NoOpTrace.Singleton,
+                        forceRefresh: true);
+                }
+            }
+        }
+
+        internal static async Task ApplySessionTokenAsync(
+            DocumentServiceRequest request,
+            ConsistencyLevel defaultConsistencyLevel,
+            ISessionContainer sessionContainer,
+            PartitionKeyRangeCache partitionKeyRangeCache,
+            CollectionCache clientCollectionCache,
+            IGlobalEndpointManager globalEndpointManager)
+        {
+            if (request.Headers == null)
+            {
+                Debug.Fail("DocumentServiceRequest does not have headers.");
+                return;
+            }
+
+            // Master resource operations don't require session token.
+            if (ThinClientStoreModel.IsMasterOperation(request.ResourceType, request.OperationType))
+            {
+                if (!string.IsNullOrEmpty(request.Headers[HttpConstants.HttpHeaders.SessionToken]))
+                {
+                    request.Headers.Remove(HttpConstants.HttpHeaders.SessionToken);
+                }
+
+                return;
+            }
+
+            if (!string.IsNullOrEmpty(request.Headers[HttpConstants.HttpHeaders.SessionToken]))
+            {
+                return; // User is explicitly controlling the session.
+            }
+
+            string requestConsistencyLevel = request.Headers[HttpConstants.HttpHeaders.ConsistencyLevel];
+            bool isReadOrBatchRequest = request.IsReadOnlyRequest || request.OperationType == OperationType.Batch;
+            bool requestHasConsistencySet = !string.IsNullOrEmpty(requestConsistencyLevel) && isReadOrBatchRequest; // Only read requests can have their consistency modified
+            
+            bool sessionConsistencyApplies =
+                (!requestHasConsistencySet && defaultConsistencyLevel == ConsistencyLevel.Session) ||
+                (requestHasConsistencySet
+                    && string.Equals(requestConsistencyLevel, ThinClientStoreModel.sessionConsistencyAsString, StringComparison.OrdinalIgnoreCase));
+
+            bool isMultiMasterEnabledForRequest = globalEndpointManager.CanUseMultipleWriteLocations(request);
+
+            if (!sessionConsistencyApplies
+                || (!isReadOrBatchRequest
+                    && !isMultiMasterEnabledForRequest))
+            {
+                return; // Only apply the session token in case of session consistency and the request is read only or read/write on multimaster
+            }
+
+            (bool isSuccess, string sessionToken) = await ThinClientStoreModel.TryResolveSessionTokenAsync(
+                request,
+                sessionContainer,
+                partitionKeyRangeCache,
+                clientCollectionCache);
+
+            if (isSuccess && !string.IsNullOrEmpty(sessionToken))
+            {
+                request.Headers[HttpConstants.HttpHeaders.SessionToken] = sessionToken;
+            }
+        }
+
+        internal static async Task<Tuple<bool, string>> TryResolveSessionTokenAsync(
+            DocumentServiceRequest request,
+            ISessionContainer sessionContainer,
+            PartitionKeyRangeCache partitionKeyRangeCache,
+            CollectionCache clientCollectionCache)
+        {
+            if (request == null)
+            {
+                throw new ArgumentNullException(nameof(request));
+            }
+
+            if (sessionContainer == null)
+            {
+                throw new ArgumentNullException(nameof(sessionContainer));
+            }
+
+            if (partitionKeyRangeCache == null)
+            {
+                throw new ArgumentNullException(nameof(partitionKeyRangeCache));
+            }
+
+            if (clientCollectionCache == null)
+            {
+                throw new ArgumentNullException(nameof(clientCollectionCache));
+            }
+
+            if (request.ResourceType.IsPartitioned())
+            {
+                (bool isSuccess, PartitionKeyRange partitionKeyRange) = await TryResolvePartitionKeyRangeAsync(
+                    request: request,
+                    sessionContainer: sessionContainer,
+                    partitionKeyRangeCache: partitionKeyRangeCache,
+                    clientCollectionCache: clientCollectionCache,
+                    refreshCache: false);
+
+                if (isSuccess && sessionContainer is SessionContainer gatewaySessionContainer)
+                {
+                    request.RequestContext.ResolvedPartitionKeyRange = partitionKeyRange;
+                    string localSessionToken = gatewaySessionContainer.ResolvePartitionLocalSessionTokenForGateway(request, partitionKeyRange.Id);
+                    if (!string.IsNullOrEmpty(localSessionToken))
+                    {
+                        return new Tuple<bool, string>(true, localSessionToken);
+                    }
+                }
+            }
+
+            return new Tuple<bool, string>(false, null);
+        }
+
+        private static async Task<Tuple<bool, PartitionKeyRange>> TryResolvePartitionKeyRangeAsync(
+            DocumentServiceRequest request,
+            ISessionContainer sessionContainer,
+            PartitionKeyRangeCache partitionKeyRangeCache,
+            CollectionCache clientCollectionCache,
+            bool refreshCache)
+        {
+            if (refreshCache)
+            {
+                request.ForceMasterRefresh = true;
+                request.ForceNameCacheRefresh = true;
+            }
+
+            PartitionKeyRange partitonKeyRange = null;
+            ContainerProperties collection = await clientCollectionCache.ResolveCollectionAsync(
+                request,
+                CancellationToken.None,
+                NoOpTrace.Singleton);
+
+            string partitionKeyString = request.Headers[HttpConstants.HttpHeaders.PartitionKey];
+            if (partitionKeyString != null)
+            {
+                CollectionRoutingMap collectionRoutingMap = await partitionKeyRangeCache.TryLookupAsync(
+                    collectionRid: collection.ResourceId,
+                    previousValue: null,
+                    request: request,
+                    NoOpTrace.Singleton);
+
+                if (refreshCache && collectionRoutingMap != null)
+                {
+                    collectionRoutingMap = await partitionKeyRangeCache.TryLookupAsync(
+                        collectionRid: collection.ResourceId,
+                        previousValue: collectionRoutingMap,
+                        request: request,
+                        NoOpTrace.Singleton);
+                }
+
+                if (collectionRoutingMap != null)
+                {
+                    partitonKeyRange = AddressResolver.TryResolveServerPartitionByPartitionKey(
+                        request: request,
+                        partitionKeyString: partitionKeyString,
+                        collectionCacheUptoDate: false,
+                        collection: collection,
+                        routingMap: collectionRoutingMap);
+                }
+            }
+            else if (request.PartitionKeyRangeIdentity != null)
+            {
+                PartitionKeyRangeIdentity partitionKeyRangeId = request.PartitionKeyRangeIdentity;
+                partitonKeyRange = await partitionKeyRangeCache.TryGetPartitionKeyRangeByIdAsync(
+                    collection.ResourceId,
+                    partitionKeyRangeId.PartitionKeyRangeId,
+                    NoOpTrace.Singleton,
+                    refreshCache);
+            }
+            else if (request.RequestContext.ResolvedPartitionKeyRange != null)
+            {
+                partitonKeyRange = request.RequestContext.ResolvedPartitionKeyRange;
+            }
+
+            if (partitonKeyRange == null)
+            {
+                if (refreshCache)
+                {
+                    return new Tuple<bool, PartitionKeyRange>(false, null);
+                }
+
+                // need to refresh cache. Maybe split happened.
+                return await ThinClientStoreModel.TryResolvePartitionKeyRangeAsync(
+                    request: request,
+                    sessionContainer: sessionContainer,
+                    partitionKeyRangeCache: partitionKeyRangeCache,
+                    clientCollectionCache: clientCollectionCache,
+                    refreshCache: true);
+            }
+
+            return new Tuple<bool, PartitionKeyRange>(true, partitonKeyRange);
+        }
+
+        // DEVNOTE: This can be replace with ReplicatedResourceClient.IsMasterOperation on next Direct sync
+        internal static bool IsMasterOperation(
+            ResourceType resourceType,
+            OperationType operationType)
+        {
+            // Stored procedures, trigger, and user defined functions CRUD operations are done on
+            // master so they do not require the session token. Stored procedures execute is not a master operation
+            return ReplicatedResourceClient.IsMasterResource(resourceType) ||
+                   ThinClientStoreModel.IsStoredProcedureCrudOperation(resourceType, operationType) ||
+                   resourceType == ResourceType.Trigger ||
+                   resourceType == ResourceType.UserDefinedFunction ||
+                   operationType == OperationType.QueryPlan;
+        }
+
+        internal static bool IsStoredProcedureCrudOperation(
+            ResourceType resourceType,
+            OperationType operationType)
+        {
+            return resourceType == ResourceType.StoredProcedure &&
+                   operationType != Documents.OperationType.ExecuteJavaScript;
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                if (this.proxyStoreClient != null)
+                {
+                    try
+                    {
+                        this.proxyStoreClient.Dispose();
+                    }
+                    catch (Exception exception)
+                    {
+                        DefaultTrace.TraceWarning("Exception {0} thrown during dispose of HttpClient, this could happen if there are inflight request during the dispose of client",
+                            exception);
+                    }
+
+                    this.proxyStoreClient = null;
+                }
+            }
+        }
+
+        private Uri GetEntityUri(DocumentServiceRequest entity)
+        {
+            string contentLocation = entity.Headers[HttpConstants.HttpHeaders.ContentLocation];
+
+            if (!string.IsNullOrEmpty(contentLocation))
+            {
+                return new Uri(this.endpointManager.ResolveServiceEndpoint(entity), new Uri(contentLocation).AbsolutePath);
+            }
+
+            return new Uri(this.endpointManager.ResolveServiceEndpoint(entity), PathsHelper.GeneratePath(entity.ResourceType, entity, false));
+        }
+
+        private Uri GetFeedUri(DocumentServiceRequest request)
+        {
+            return new Uri(this.endpointManager.ResolveServiceEndpoint(request), PathsHelper.GeneratePath(request.ResourceType, request, true));
+        }
+
+        public Task OpenConnectionsToAllReplicasAsync(string databaseName, string containerLinkUri, CancellationToken cancellationToken = default)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/ThinClientTransportSerializer.cs
+++ b/Microsoft.Azure.Cosmos/src/ThinClientTransportSerializer.cs
@@ -1,0 +1,282 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos
+{
+    using System;
+    using System.Buffers;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Documents;
+    using Microsoft.Azure.Documents.Collections;
+
+    /// <summary>
+    /// blabla
+    /// </summary>
+    internal static class ThinClientTransportSerializer
+    {
+        public const string RoutedViaProxy = "x-ms-thinclient-route-via-proxy";
+        public const string ProxyStartEpk = "x-ms-thinclient-range-min";
+        public const string ProxyEndEpk = "x-ms-thinclient-range-max";
+
+        public const string ProxyOperationType = "x-ms-thinclient-proxy-operation-type";
+        public const string ProxyResourceType = "x-ms-thinclient-proxy-resource-type";
+
+        private static readonly PartitionKeyDefinition HashV2SinglePath;
+
+        static ThinClientTransportSerializer()
+        {
+            HashV2SinglePath = new PartitionKeyDefinition
+            {
+                Kind = PartitionKind.Hash,
+                Version = Documents.PartitionKeyDefinitionVersion.V2,
+            };
+            HashV2SinglePath.Paths.Add("/id");
+        }
+
+        /// <summary>
+        /// Wrapper to expose a public bufferprovider for the RNTBD stack.
+        /// </summary>
+#pragma warning disable CA1034 // Nested types should not be visible
+        public sealed class BufferProviderWrapper
+#pragma warning restore CA1034 // Nested types should not be visible
+        {
+            internal BufferProvider Provider { get; set; } = new ();
+        }
+
+        /// <summary>
+        /// Serialize the Proxy request to the RNTBD protocol format.
+        /// Today this takes the HttprequestMessage and reconstructs the DSR.
+        /// If the SDK can push properties to the HttpRequestMessage then the handler above having
+        /// the DSR can allow us to push that directly to the serialization.
+        /// </summary>
+        public static async Task<Stream> SerializeProxyRequestAsync(
+            BufferProviderWrapper bufferProvider,
+            string accountName,
+            HttpRequestMessage requestMessage)
+        {
+            // Skip this and use the original DSR.
+            OperationType operationType = (OperationType)Enum.Parse(typeof(OperationType), requestMessage.Headers.GetValues(ProxyOperationType).First());
+            ResourceType resourceType = (ResourceType)Enum.Parse(typeof(ResourceType), requestMessage.Headers.GetValues(ProxyResourceType).First());
+
+            Guid activityId = Guid.Parse(requestMessage.Headers.GetValues(HttpConstants.HttpHeaders.ActivityId).First());
+
+            Stream requestStream = null;
+            if (requestMessage.Content != null)
+            {
+                requestStream = await requestMessage.Content.ReadAsStreamAsync();
+            }
+
+            RequestNameValueCollection dictionaryCollection = new RequestNameValueCollection();
+            foreach (KeyValuePair<string, IEnumerable<string>> header in requestMessage.Headers)
+            {
+                dictionaryCollection.Set(header.Key, string.Join(",", header.Value));
+            }
+
+            using DocumentServiceRequest request = new (operationType, resourceType, requestMessage.RequestUri.PathAndQuery,
+                                                requestStream, AuthorizationTokenType.PrimaryMasterKey,
+                                                dictionaryCollection);
+
+            if (operationType.IsPointOperation())
+            {
+                string partitionKey = request.Headers.Get(HttpConstants.HttpHeaders.PartitionKey);
+
+                if (string.IsNullOrEmpty(partitionKey))
+                {
+                    throw new InternalServerErrorException();
+                }
+
+                string epk = GetEffectivePartitionKeyHash(partitionKey);
+
+                request.Properties = new Dictionary<string, object>
+                {
+                    { "x-ms-effective-partition-key", HexStringUtility.HexStringToBytes(epk) }
+                };
+            }
+            else if (request.Headers[ProxyStartEpk] != null)
+            {
+                // Re-add EPK headers removed by RequestInvokerHandler through Properties
+                request.Properties = new Dictionary<string, object>
+                {
+                    { WFConstants.BackendHeaders.StartEpkHash, HexStringUtility.HexStringToBytes(request.Headers[ProxyStartEpk]) },
+                    { WFConstants.BackendHeaders.EndEpkHash, HexStringUtility.HexStringToBytes(request.Headers[ProxyEndEpk]) }
+                };
+
+                request.Headers.Add(HttpConstants.HttpHeaders.ReadFeedKeyType, RntbdConstants.RntdbReadFeedKeyType.EffectivePartitionKeyRange.ToString());
+                request.Headers.Add(HttpConstants.HttpHeaders.StartEpk, request.Headers[ProxyStartEpk]);
+                request.Headers.Add(HttpConstants.HttpHeaders.EndEpk, request.Headers[ProxyEndEpk]);
+            }
+
+            await request.EnsureBufferedBodyAsync();
+
+            using Documents.Rntbd.TransportSerialization.SerializedRequest serializedRequest =
+                Documents.Rntbd.TransportSerialization.BuildRequestForProxy(request,
+                new ResourceOperation(operationType, resourceType),
+                activityId,
+                bufferProvider.Provider,
+                accountName,
+                out _,
+                out _);
+
+            // TODO: consider using the SerializedRequest directly.
+            MemoryStream memoryStream = new MemoryStream(serializedRequest.RequestSize);
+            await serializedRequest.CopyToStreamAsync(memoryStream);
+            memoryStream.Position = 0;
+            return memoryStream;
+        }
+
+        public static string GetEffectivePartitionKeyHash(string partitionJson)
+        {
+            return Documents.PartitionKey.FromJsonString(partitionJson).InternalKey.GetEffectivePartitionKeyString(HashV2SinglePath);
+        }
+
+        /// <summary>
+        /// Deserialize the Proxy Response from the RNTBD protocol format to the Http format needed by the caller.
+        /// Today this takes the HttpResponseMessage and reconstructs the modified Http response.
+        /// </summary>
+        public static async Task<HttpResponseMessage> ConvertProxyResponseAsync(HttpResponseMessage responseMessage)
+        {
+            using Stream responseStream = await responseMessage.Content.ReadAsStreamAsync();
+
+            (StatusCodes status, byte[] metadata) = await ThinClientTransportSerializer.ReadHeaderAndMetadataAsync(responseStream);
+
+            if (responseMessage.StatusCode != (HttpStatusCode)status)
+            {
+                throw new InternalServerErrorException("Status code mismatch");
+            }
+
+            Rntbd.BytesDeserializer bytesDeserializer = new Rntbd.BytesDeserializer(metadata, metadata.Length);
+            if (!Documents.Rntbd.HeadersTransportSerialization.TryParseMandatoryResponseHeaders(ref bytesDeserializer, out bool payloadPresent, out _))
+            {
+                throw new InternalServerErrorException("Length mismatch");
+            }
+
+            MemoryStream bodyStream = null;
+            if (payloadPresent)
+            {
+                int length = await ThinClientTransportSerializer.ReadBodyLengthAsync(responseStream);
+                bodyStream = new MemoryStream(length);
+                await responseStream.CopyToAsync(bodyStream);
+                bodyStream.Position = 0;
+            }
+
+            // TODO(Perf): Clean this up.
+            bytesDeserializer = new Rntbd.BytesDeserializer(metadata, metadata.Length);
+            StoreResponse storeResponse = Documents.Rntbd.TransportSerialization.MakeStoreResponse(
+                status,
+                Guid.NewGuid(),
+                bodyStream,
+                HttpConstants.Versions.CurrentVersion,
+                ref bytesDeserializer);
+
+            HttpResponseMessage response = new HttpResponseMessage((HttpStatusCode)storeResponse.StatusCode);
+
+            if (bodyStream != null)
+            {
+                response.Content = new StreamContent(bodyStream);
+            }
+
+            foreach (string header in storeResponse.Headers.Keys())
+            {
+                if (header == HttpConstants.HttpHeaders.SessionToken)
+                {
+                    string newSessionToken = storeResponse.PartitionKeyRangeId + ":" + storeResponse.Headers.Get(header);
+                    response.Headers.TryAddWithoutValidation(header, newSessionToken);
+                }
+                else
+                {
+                    response.Headers.TryAddWithoutValidation(header, storeResponse.Headers.Get(header));
+                }
+            }
+
+            response.Headers.TryAddWithoutValidation(RoutedViaProxy, "1");
+            return response;
+        }
+
+        private static async Task<(StatusCodes, byte[] metadata)> ReadHeaderAndMetadataAsync(Stream stream)
+        {
+            byte[] header = ArrayPool<byte>.Shared.Rent(24);
+            const int headerLength = 24;
+            try
+            {
+                int headerRead = 0;
+                while (headerRead < headerLength)
+                {
+                    int read = 0;
+                    read = await stream.ReadAsync(header, headerRead, headerLength - headerRead);
+
+                    if (read == 0)
+                    {
+                        throw new DocumentClientException("Unexpected read empty bytes", HttpStatusCode.Gone, SubStatusCodes.Unknown);
+                    }
+
+                    headerRead += read;
+                }
+
+                uint totalLength = BitConverter.ToUInt32(header, 0);
+                StatusCodes status = (StatusCodes)BitConverter.ToUInt32(header, 4);
+
+                if (totalLength < headerLength)
+                {
+                    throw new InternalServerErrorException("Length mismatch");
+                }
+
+                int metadataLength = (int)totalLength - headerLength;
+                byte[] metadata = new byte[metadataLength];
+                int responseMetadataRead = 0;
+                while (responseMetadataRead < metadataLength)
+                {
+                    int read = 0;
+                    read = await stream.ReadAsync(metadata, responseMetadataRead, metadataLength - responseMetadataRead);
+
+                    if (read == 0)
+                    {
+                        throw new DocumentClientException("Unexpected read empty bytes", HttpStatusCode.Gone, SubStatusCodes.Unknown);
+                    }
+
+                    responseMetadataRead += read;
+                }
+
+                return (status, metadata);
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(header);
+            }
+        }
+
+        private static async Task<int> ReadBodyLengthAsync(Stream stream)
+        {
+            byte[] header = ArrayPool<byte>.Shared.Rent(4);
+            const int headerLength = 4;
+            try
+            {
+                int headerRead = 0;
+                while (headerRead < headerLength)
+                {
+                    int read = 0;
+                    read = await stream.ReadAsync(header, headerRead, headerLength - headerRead);
+
+                    if (read == 0)
+                    {
+                        throw new DocumentClientException("Unexpected read empty bytes", HttpStatusCode.Gone, SubStatusCodes.Unknown);
+                    }
+
+                    headerRead += read;
+                }
+
+                return BitConverter.ToInt32(header, 0);
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(header);
+            }
+
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/ThinClientTransportSerializer.cs
+++ b/Microsoft.Azure.Cosmos/src/ThinClientTransportSerializer.cs
@@ -174,7 +174,10 @@ namespace Microsoft.Azure.Cosmos
                 HttpConstants.Versions.CurrentVersion,
                 ref bytesDeserializer);
 
-            HttpResponseMessage response = new HttpResponseMessage((HttpStatusCode)storeResponse.StatusCode);
+            HttpResponseMessage response = new HttpResponseMessage((HttpStatusCode)storeResponse.StatusCode)
+            {
+                RequestMessage = responseMessage.RequestMessage
+            };
 
             if (bodyStream != null)
             {

--- a/Microsoft.Azure.Cosmos/src/Util/ConfigurationManager.cs
+++ b/Microsoft.Azure.Cosmos/src/Util/ConfigurationManager.cs
@@ -37,6 +37,16 @@ namespace Microsoft.Azure.Cosmos
         /// </summary>
         internal static readonly string DistributedQueryGatewayModeEnabled = "AZURE_COSMOS_DISTRIBUTED_QUERY_GATEWAY_ENABLED";
 
+        /// <summary>
+        /// Environment variable name to enable lite client mode.
+        /// </summary>
+        internal static readonly string LiteClientModeEnabled = "AZURE_COSMOS_LITE_CLIENT_ENABLED";
+
+        /// <summary>
+        /// Environment variable name to get lite client endpoint.
+        /// </summary>
+        internal static readonly string LiteClientEndpoint = "AZURE_COSMOS_LITE_CLIENT_ENDPOINT";
+
         public static T GetEnvironmentVariable<T>(string variable, T defaultValue)
         {
             string value = Environment.GetEnvironmentVariable(variable);
@@ -123,6 +133,40 @@ namespace Microsoft.Azure.Cosmos
             return ConfigurationManager
                     .GetEnvironmentVariable(
                         variable: DistributedQueryGatewayModeEnabled,
+                        defaultValue: defaultValue);
+        }
+
+        /// <summary>
+        /// Gets the boolean value of the partition level failover environment variable. Note that, partition level failover
+        /// is disabled by default for both preview and GA releases. The user can set the  respective environment variable
+        /// 'AZURE_COSMOS_PARTITION_LEVEL_FAILOVER_ENABLED' to override the value for both preview and GA. The method will
+        /// eventually be removed, once partition level failover is enabled by default for  both preview and GA.
+        /// </summary>
+        /// <param name="defaultValue">A boolean field containing the default value for partition level failover.</param>
+        /// <returns>A boolean flag indicating if partition level failover is enabled.</returns>
+        public static bool IsLiteClientEnabled(
+            bool defaultValue)
+        {
+            return ConfigurationManager
+                    .GetEnvironmentVariable(
+                        variable: ConfigurationManager.LiteClientModeEnabled,
+                        defaultValue: defaultValue);
+        }
+
+        /// <summary>
+        /// Gets the boolean value of the partition level failover environment variable. Note that, partition level failover
+        /// is disabled by default for both preview and GA releases. The user can set the  respective environment variable
+        /// 'AZURE_COSMOS_PARTITION_LEVEL_FAILOVER_ENABLED' to override the value for both preview and GA. The method will
+        /// eventually be removed, once partition level failover is enabled by default for  both preview and GA.
+        /// </summary>
+        /// <param name="defaultValue">A boolean field containing the default value for partition level failover.</param>
+        /// <returns>A boolean flag indicating if partition level failover is enabled.</returns>
+        public static string GetLiteClientEndpoint(
+            string defaultValue)
+        {
+            return ConfigurationManager
+                    .GetEnvironmentVariable(
+                        variable: ConfigurationManager.LiteClientEndpoint,
                         defaultValue: defaultValue);
         }
     }

--- a/Microsoft.Azure.Cosmos/src/Util/ConfigurationManager.cs
+++ b/Microsoft.Azure.Cosmos/src/Util/ConfigurationManager.cs
@@ -147,10 +147,8 @@ namespace Microsoft.Azure.Cosmos
         public static bool IsLiteClientEnabled(
             bool defaultValue)
         {
-            return ConfigurationManager
-                    .GetEnvironmentVariable(
-                        variable: ConfigurationManager.LiteClientModeEnabled,
-                        defaultValue: defaultValue);
+            Console.WriteLine(defaultValue);
+            return true;
         }
 
         /// <summary>
@@ -164,10 +162,8 @@ namespace Microsoft.Azure.Cosmos
         public static string GetLiteClientEndpoint(
             string defaultValue)
         {
-            return ConfigurationManager
-                    .GetEnvironmentVariable(
-                        variable: ConfigurationManager.LiteClientEndpoint,
-                        defaultValue: defaultValue);
+            Console.WriteLine(defaultValue);
+            return "https://cdb-ms-stage-eastus2-fe2.eastus2.cloudapp.azure.com:10650";
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Util/ConfigurationManager.cs
+++ b/Microsoft.Azure.Cosmos/src/Util/ConfigurationManager.cs
@@ -163,7 +163,7 @@ namespace Microsoft.Azure.Cosmos
             string defaultValue)
         {
             Console.WriteLine(defaultValue);
-            return "https://cdb-ms-stage-eastus2-fe2.eastus2.cloudapp.azure.com:10650";
+            return "https://cdb-ms-stage-eastus2-fe2-sql.eastus2.cloudapp.azure.com:10650";
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientCreateAndInitializeTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientCreateAndInitializeTest.cs
@@ -20,7 +20,7 @@
         private ContainerInternal Container = null;
         private const string PartitionKey = "/pk";
 
-        // [TestInitialize]
+        [TestInitialize]
         public async Task TestInitialize()
         {
             await this.TestInit();

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientCreateAndInitializeTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientCreateAndInitializeTest.cs
@@ -389,10 +389,10 @@
             };
 
             CosmosClient client = new CosmosClient(
-                "https://aavasthy-vmsstest.documents.azure.com:443/",
-                "key",
-                clientOptions
-            );
+                 "account",
+                 "key",
+                 clientOptions
+             );
 
             DatabaseResponse dbResponse = await client.CreateDatabaseIfNotExistsAsync(databaseName);
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientCreateAndInitializeTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientCreateAndInitializeTest.cs
@@ -20,7 +20,7 @@
         private ContainerInternal Container = null;
         private const string PartitionKey = "/pk";
 
-        [TestInitialize]
+        // [TestInitialize]
         public async Task TestInitialize()
         {
             await this.TestInit();

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Benchmarks/ThinClientIntegrationBenchmark.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Benchmarks/ThinClientIntegrationBenchmark.cs
@@ -299,36 +299,58 @@
         [Benchmark]
         public async Task DeleteItemAsync()
         {
-            int index = this.random.Next(this.deleteItems.Count);
-            if (index >= 0 && index < this.deleteItems.Count)
+            if (this.deleteItems.Count == 0)
             {
-                Comment comment = this.deleteItems[index];
-                this.deleteItems.Remove(comment);
+                Console.WriteLine("No items left to delete in DeleteItemAsync.");
+                return;
+            }
 
-                ItemResponse<Comment> itemResponse = await this.container.DeleteItemAsync<Comment>(comment.id, new PartitionKey(comment.pk));
+            int index = this.random.Next(this.deleteItems.Count);
+            Comment comment = this.deleteItems[index];
 
-                if (itemResponse.StatusCode == HttpStatusCode.NotFound)
-                {
-                    Console.WriteLine($"Error: Item {comment.id} was not deleted : " + itemResponse.StatusCode);
-                }
+            // Perform the deletion
+            ItemResponse<Comment> itemResponse = await this.container.DeleteItemAsync<Comment>(
+                comment.id,
+                new PartitionKey(comment.pk)
+            );
+
+            if (itemResponse.StatusCode == HttpStatusCode.NotFound)
+            {
+                Console.WriteLine($"Error: Item {comment.id} was not deleted.");
+            }
+            else
+            {
+                // Only remove from list if delete succeeded
+                this.deleteItems.RemoveAt(index);
             }
         }
 
         [Benchmark]
         public async Task DeleteItemStreamAsync()
         {
-            int index = this.random.Next(this.deleteStreamItems.Count);
-            if (index >= 0 && index < this.deleteItems.Count)
+            if (this.deleteStreamItems.Count == 0)
             {
-                Comment comment = this.deleteStreamItems[index];
-                this.deleteStreamItems.Remove(comment);
+                Console.WriteLine("No items left to delete in DeleteItemStreamAsync.");
+                return;
+            }
 
-                ResponseMessage itemResponse = await this.container.DeleteItemStreamAsync(comment.id, new PartitionKey(comment.pk));
+            int index = this.random.Next(this.deleteStreamItems.Count);
+            Comment comment = this.deleteStreamItems[index];
 
-                if (itemResponse.StatusCode == HttpStatusCode.NotFound)
-                {
-                    Console.WriteLine($"Error: Item {comment.id} was not deleted stream: " + itemResponse.StatusCode);
-                }
+            // Perform the deletion
+            ResponseMessage itemResponse = await this.container.DeleteItemStreamAsync(
+                comment.id,
+                new PartitionKey(comment.pk)
+            );
+
+            if (itemResponse.StatusCode == HttpStatusCode.NotFound)
+            {
+                Console.WriteLine($"Error: Item {comment.id} was not deleted stream.");
+            }
+            else
+            {
+                // Only remove from list if delete succeeded
+                this.deleteStreamItems.RemoveAt(index);
             }
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Benchmarks/ThinClientIntegrationBenchmark.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Benchmarks/ThinClientIntegrationBenchmark.cs
@@ -1,0 +1,398 @@
+﻿namespace Microsoft.Azure.Cosmos.Performance.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Net;
+    using System.Text;
+    using System.Threading.Tasks;
+    using BenchmarkDotNet.Attributes;
+    using BenchmarkDotNet.Configs;
+    using BenchmarkDotNet.Columns;
+    using BenchmarkDotNet.Exporters;
+    using BenchmarkDotNet.Exporters.Csv;
+    using BenchmarkDotNet.Jobs;
+    using Microsoft.Azure.Cosmos;
+    using Newtonsoft.Json;
+    using BenchmarkDotNet.Diagnosers;
+
+    [MemoryDiagnoser]
+    [BenchmarkCategory("NewGateBenchmark")]
+    [Config(typeof(CustomBenchmarkConfig))]
+    public class ThinClientIntegrationBenchmark
+    {
+        private readonly string databaseName = "MyTestDatabase";
+        private readonly string containerName = "MyTestContainer";
+        private readonly string partitionKeyPath = "/pk";
+        private readonly List<Comment> readItems = new();
+        private readonly List<Comment> upsertItems = new();
+        private readonly List<Comment> replaceItems = new();
+        private readonly List<Comment> deleteItems = new();
+        private readonly List<Comment> deleteStreamItems = new();
+        private readonly Random random = new();
+        private CosmosClient client;
+        private Database database;
+        private Container container;
+
+        [GlobalSetup(Targets = new[] { nameof(CreateItemAsync), nameof(CreateItemStreamAsync) })]
+        public async Task GlobalSetupCreate()
+        {
+            await this.InitializeDatabaseAndContainers();
+        }
+
+        [GlobalSetup(Targets = new[] { nameof(ReadItemAsync), nameof(ReadItemStreamAsync) })]
+        public async Task GlobalSetupRead()
+        {
+            await this.InitializeDatabaseAndContainers();
+            await this.InitializeContainerWithPreCreatedItemsAsync(0, 100, this.readItems); // Pre-create data for read operations
+            Console.WriteLine("Inserted documents for read benchmark.");
+        }
+
+        [GlobalSetup(Targets = new[] { nameof(UpsertItemAsync), nameof(UpsertItemStreamAsync) })]
+        public async Task GlobalSetupUpsert()
+        {
+            await this.InitializeDatabaseAndContainers();
+            await this.InitializeContainerWithPreCreatedItemsAsync(0, 100, this.upsertItems); // Pre-create data for upsert operations
+            Console.WriteLine("Inserted documents for upsert benchmark.");
+        }
+
+        [GlobalSetup(Targets = new[] { nameof(ReplaceItemAsync), nameof(ReplaceItemStreamAsync) })]
+        public async Task GlobalSetupReplace()
+        {
+            await this.InitializeDatabaseAndContainers();
+            await this.InitializeContainerWithPreCreatedItemsAsync(0, 100, this.replaceItems); // Pre-create data for replace operations
+            Console.WriteLine("Inserted documents for replace benchmark.");
+        }
+
+        [GlobalSetup(Targets = new[] { nameof(DeleteItemAsync) })]
+        public async Task GlobalSetupDelete()
+        {
+            await this.InitializeDatabaseAndContainers();
+            await this.InitializeContainerWithPreCreatedItemsAsync(0, 100, this.deleteItems); // Pre-create data for delete operations
+            Console.WriteLine("Inserted documents for delete benchmark.");
+        }
+
+        [GlobalSetup(Targets = new[] { nameof(DeleteItemStreamAsync) })]
+        public async Task GlobalSetupDeleteStream()
+        {
+            await this.InitializeDatabaseAndContainers();
+            await this.InitializeContainerWithPreCreatedItemsAsync(0, 100, this.deleteStreamItems); // Pre-create data for delete stream operations
+            Console.WriteLine("Inserted documents for delete stream benchmark.");
+        }
+
+        private async Task InitializeDatabaseAndContainers()
+        {
+            Console.WriteLine("Creating Database and Containers.");
+
+            CosmosClientOptions clientOptions = new CosmosClientOptions
+            {
+                ConnectionMode = ConnectionMode.Gateway
+            };
+
+            this.client = new CosmosClient(
+             "account",
+             "key",
+             clientOptions
+         );
+            this.database = await this.client.CreateDatabaseIfNotExistsAsync(this.databaseName);
+
+            ContainerResponse containerResponse = await this.database.CreateContainerIfNotExistsAsync(
+                id: this.containerName,
+                partitionKeyPath: this.partitionKeyPath,
+                throughput: 10000);
+
+            this.database = this.client.GetDatabase(this.databaseName);
+            this.container = containerResponse.Container;
+
+            Console.WriteLine("Successfully created Database and Containers with status: " + containerResponse.StatusCode);
+        }
+
+        private async Task InitializeContainerWithPreCreatedItemsAsync(int start, int count, List<Comment> items)
+        {
+            for (int i = start; i < count; i++)
+            {
+                Comment comment = this.GetRandomCommentItem();
+
+                ItemRequestOptions requestOptions = new ItemRequestOptions
+                {
+                };
+
+                ItemResponse<Comment> writeResponse = await this.container.CreateItemAsync<Comment>(
+                    item: comment,
+                    partitionKey: new PartitionKey(comment.pk),
+                    requestOptions: requestOptions
+                );
+
+                if (writeResponse.StatusCode == HttpStatusCode.Created)
+                {
+                    items.Add(comment);
+                }
+            }
+        }
+
+        [GlobalCleanup]
+        public async Task CleanupAsync()
+        {
+            Console.WriteLine("Cleaning up resources...");
+            await this.container.DeleteContainerAsync();
+            await this.database.DeleteAsync();
+            this.client.Dispose();
+        }
+
+        [Benchmark]
+        public async Task CreateItemAsync()
+        {
+            Comment comment = this.GetRandomCommentItem();
+
+            ItemRequestOptions requestOptions = new ItemRequestOptions
+            {
+            };
+
+            ItemResponse<Comment> itemResponse = await this.container.CreateItemAsync<Comment>(
+                item: comment,
+                partitionKey: new PartitionKey(comment.pk),
+                requestOptions: requestOptions
+            );
+
+            if (itemResponse.StatusCode != HttpStatusCode.Created)
+            {
+                Console.WriteLine($"Error: Item {comment.id} was not created.");
+            }
+        }
+
+        [Benchmark]
+        public async Task CreateItemStreamAsync()
+        {
+            Comment comment = this.GetRandomCommentItem();
+
+            using Stream stream = ToStream(comment);
+            ResponseMessage itemResponse = await this.container.CreateItemStreamAsync(stream, new PartitionKey(comment.pk));
+
+            if (itemResponse.StatusCode != HttpStatusCode.Created)
+            {
+                Console.WriteLine($"Error: Item {comment.id} was not created stream.");
+            }
+        }
+
+        [Benchmark]
+        public async Task ReadItemAsync()
+        {
+            int index = this.random.Next(this.readItems.Count);
+
+            Comment comment = this.readItems[index];
+
+            ItemRequestOptions requestOptions = new ItemRequestOptions
+            {
+            };
+
+            ItemResponse<Comment> itemResponse = await this.container.ReadItemAsync<Comment>(
+                id: comment.id,
+                partitionKey: new PartitionKey(comment.pk),
+                requestOptions: requestOptions
+                );
+
+            if (itemResponse.StatusCode != HttpStatusCode.OK)
+            {
+                Console.WriteLine($"Error: Item {comment.id} was not read.");
+            }
+        }
+
+        [Benchmark]
+        public async Task ReadItemStreamAsync()
+        {
+            int index = this.random.Next(this.readItems.Count);
+
+            Comment comment = this.readItems[index];
+
+            ItemRequestOptions requestOptions = new ItemRequestOptions
+            {
+            };
+
+            ResponseMessage itemResponse = await this.container.ReadItemStreamAsync(
+                id: comment.id,
+                partitionKey: new PartitionKey(comment.pk),
+                requestOptions: requestOptions
+                );
+
+            if (itemResponse.StatusCode != HttpStatusCode.OK)
+            {
+                Console.WriteLine($"Error: Item {comment.id} was not read stream.");
+            }
+        }
+
+        [Benchmark]
+        public async Task UpsertItemAsync()
+        {
+            int index = this.random.Next(this.upsertItems.Count);
+
+            Comment comment = this.upsertItems[index];
+            comment.Name = "UpdatedName";
+
+            ItemRequestOptions requestOptions = new ItemRequestOptions
+            {
+            };
+
+            ItemResponse<Comment> itemResponse = await this.container.UpsertItemAsync<Comment>(
+                item: comment,
+                partitionKey: new PartitionKey(comment.pk),
+                requestOptions: requestOptions
+                );
+
+            if (itemResponse.StatusCode != HttpStatusCode.OK)
+            {
+                Console.WriteLine($"Error: Item {comment.id} was not upserted.");
+            }
+        }
+
+        [Benchmark]
+        public async Task UpsertItemStreamAsync()
+        {
+            int index = this.random.Next(this.upsertItems.Count);
+
+            Comment comment = this.upsertItems[index];
+            comment.Name = "UpdatedNameStream";
+
+            using Stream stream = ToStream(comment);
+
+            ResponseMessage itemResponse = await this.container.UpsertItemStreamAsync(stream, new PartitionKey(comment.pk));
+
+            if (itemResponse.StatusCode != HttpStatusCode.OK)
+            {
+                Console.WriteLine($"Error: Item {comment.id} was not upserted stream.");
+            }
+        }
+
+        [Benchmark]
+        public async Task ReplaceItemAsync()
+        {
+            int index = this.random.Next(this.replaceItems.Count);
+
+            Comment comment = this.replaceItems[index];
+            comment.Name = "ReplacedName";
+
+            ItemResponse<Comment> itemResponse = await this.container.ReplaceItemAsync(comment, comment.id, new PartitionKey(comment.pk));
+
+            if (itemResponse.StatusCode != HttpStatusCode.OK)
+            {
+                Console.WriteLine($"Error: Item {comment.id} was not replaced.");
+            }
+        }
+
+        [Benchmark]
+        public async Task ReplaceItemStreamAsync()
+        {
+            int index = this.random.Next(this.replaceItems.Count);
+
+            Comment comment = this.replaceItems[index];
+            comment.Name = "ReplacedNameStream";
+
+            using Stream stream = ToStream(comment);
+            ResponseMessage itemResponse = await this.container.ReplaceItemStreamAsync(stream, comment.id, new PartitionKey(comment.pk));
+
+            if (itemResponse.StatusCode != HttpStatusCode.OK)
+            {
+                Console.WriteLine($"Error: Item {comment.id} was not replaced stream.");
+            }
+        }
+
+        [Benchmark]
+        public async Task DeleteItemAsync()
+        {
+            int index = this.random.Next(this.deleteItems.Count);
+            if (index >= 0 && index < this.deleteItems.Count)
+            {
+                Comment comment = this.deleteItems[index];
+                this.deleteItems.Remove(comment);
+
+                ItemResponse<Comment> itemResponse = await this.container.DeleteItemAsync<Comment>(comment.id, new PartitionKey(comment.pk));
+
+                if (itemResponse.StatusCode == HttpStatusCode.NotFound)
+                {
+                    Console.WriteLine($"Error: Item {comment.id} was not deleted : " + itemResponse.StatusCode);
+                }
+            }
+        }
+
+        [Benchmark]
+        public async Task DeleteItemStreamAsync()
+        {
+            int index = this.random.Next(this.deleteStreamItems.Count);
+            if (index >= 0 && index < this.deleteItems.Count)
+            {
+                Comment comment = this.deleteStreamItems[index];
+                this.deleteStreamItems.Remove(comment);
+
+                ResponseMessage itemResponse = await this.container.DeleteItemStreamAsync(comment.id, new PartitionKey(comment.pk));
+
+                if (itemResponse.StatusCode == HttpStatusCode.NotFound)
+                {
+                    Console.WriteLine($"Error: Item {comment.id} was not deleted stream: " + itemResponse.StatusCode);
+                }
+            }
+        }
+
+        private static Stream ToStream<T>(T input)
+        {
+            string json = JsonConvert.SerializeObject(input);
+            return new MemoryStream(Encoding.UTF8.GetBytes(json));
+        }
+
+        private class CustomBenchmarkConfig : ManualConfig
+        {
+            public CustomBenchmarkConfig()
+            {
+                this.AddColumn(StatisticColumn.OperationsPerSecond);
+                this.AddColumn(StatisticColumn.Q3);
+                this.AddColumn(StatisticColumn.P80);
+                this.AddColumn(StatisticColumn.P85);
+                this.AddColumn(StatisticColumn.P90);
+                this.AddColumn(StatisticColumn.P95);
+                this.AddColumn(StatisticColumn.P100);
+
+                this.AddDiagnoser(new IDiagnoser[] { MemoryDiagnoser.Default, ThreadingDiagnoser.Default });
+                this.AddColumnProvider(DefaultConfig.Instance.GetColumnProviders().ToArray());
+
+                // Minimal run to reduce time
+                this.AddJob(Job.ShortRun
+                    .WithStrategy(BenchmarkDotNet.Engines.RunStrategy.Throughput));
+
+                this.AddExporter(HtmlExporter.Default);
+                this.AddExporter(CsvExporter.Default);
+            }
+        }
+
+        public class Comment
+        {
+            public string id;
+            public string pk;
+            public string Name;
+            public string Email;
+            public string Body;
+
+            public Comment(
+                string id,
+                string pk,
+                string name,
+                string email,
+                string body)
+            {
+                this.id = id;
+                this.pk = pk;
+                this.Name = name;
+                this.Email = email;
+                this.Body = body;
+            }
+        }
+
+        private Comment GetRandomCommentItem()
+        {
+            return new(
+                Guid.NewGuid().ToString(),
+                Guid.NewGuid().ToString(),
+                this.random.Next().ToString(),
+                "dkunda@test.com",
+                "This document is intended for binary encoding perf testing.");
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request Template

## Description

This PR is an ongoing effort to integrate the thin client into the existing codebase. 
Performance test results when hitting stage endpoint:
VM: Standard F4s v2 (4 vcpus, 8 GiB memory)
Location: East US 2
Mode: Direct Mode
|                 Method | InvocationCount | UnrollFactor |              Mean |             Error |            StdDev |                  Q3 |                 P80 |                 P85 |                 P90 |                 P95 |                P100 |    Op/s | Completed Work Items | Lock Contentions | Allocated   |
|------------------------|-----------------|--------------|-------------------|-------------------|-------------------|---------------------|---------------------|---------------------|---------------------|---------------------|---------------------|---------|----------------------|------------------|-------------|
|        CreateItemAsync |         Default |           16 |   4.27 ms (4266 us) |   0.79 ms (790 us) |   0.04 ms (43 us) |   4.29 ms (4291 us) |   4.29 ms (4292 us) |   4.29 ms (4294 us) |   4.30 ms (4295 us) |   4.30 ms (4297 us) |   4.30 ms (4298 us) |   234.4 |               3.0000 |           0.0078 |   43.73 KB  |
|  CreateItemStreamAsync |         Default |           16 |   4.09 ms (4094 us) |   2.73 ms (2734 us) |   0.15 ms (150 us) |   4.17 ms (4170 us) |   4.18 ms (4184 us) |   4.20 ms (4199 us) |   4.21 ms (4213 us) |   4.23 ms (4228 us) |   4.24 ms (4242 us) |   244.2 |               3.0156 |                - |   32.24 KB  |
|          ReadItemAsync |         Default |           16 |   0.95 ms (948 us)  |   0.37 ms (365 us)  |   0.02 ms (20 us)  |   0.96 ms (958 us)  |   0.96 ms (960 us)  |   0.96 ms (962 us)  |   0.96 ms (964 us)  |   0.97 ms (966 us)  |   0.97 ms (968 us)  | 1,054.5 |               3.0000 |                - |   43.42 KB  |
|    ReadItemStreamAsync |         Default |           16 |   0.92 ms (915 us)  |   0.68 ms (684 us)  |   0.04 ms (38 us)  |   0.93 ms (929 us)  |   0.93 ms (934 us)  |   0.94 ms (940 us)  |   0.95 ms (946 us)  |   0.95 ms (952 us)  |   0.96 ms (958 us)  | 1,092.5 |               3.0039 |           0.0039 |   33.30 KB  |
|        UpsertItemAsync |         Default |           16 |   4.47 ms (4474 us) |   0.58 ms (579 us)  |   0.03 ms (32 us)  |   4.49 ms (4493 us) |   4.49 ms (4493 us) |   4.49 ms (4493 us) |   4.49 ms (4493 us) |   4.49 ms (4493 us) |   4.49 ms (4493 us) |   223.5 |               3.0156 |                - |   43.56 KB  |
|  UpsertItemStreamAsync |         Default |           16 |   4.54 ms (4540 us) |   0.50 ms (500 us)  |   0.03 ms (27 us)  |   4.55 ms (4550 us) |   4.55 ms (4554 us) |   4.56 ms (4559 us) |   4.56 ms (4563 us) |   4.57 ms (4567 us) |   4.57 ms (4572 us) |   220.2 |               3.0156 |                - |   32.30 KB  |
|       ReplaceItemAsync |         Default |           16 |   4.50 ms (4502 us) |   0.75 ms (754 us)  |   0.04 ms (41 us)  |   4.52 ms (4524 us) |   4.53 ms (4527 us) |   4.53 ms (4530 us) |   4.53 ms (4533 us) |   4.54 ms (4535 us) |   4.54 ms (4538 us) |   222.1 |               3.0156 |                - |   43.80 KB  |
| ReplaceItemStreamAsync |         Default |           16 |   4.13 ms (4127 us) |   1.47 ms (1472 us) |   0.08 ms (81 us)  |   4.17 ms (4169 us) |   4.18 ms (4176 us) |   4.18 ms (4183 us) |   4.19 ms (4189 us) |   4.20 ms (4196 us) |   4.20 ms (4202 us) |   242.3 |               3.0078 |                - |   32.46 KB  |
|        DeleteItemAsync |               1 |            1 |   4.58 ms (4578 us) |   3.68 ms (3679 us) |   0.20 ms (202 us) |   4.68 ms (4679 us) |   4.70 ms (4699 us) |   4.72 ms (4719 us) |   4.74 ms (4738 us) |   4.76 ms (4758 us) |   4.78 ms (4777 us) |   218.5 |               3.0000 |                - |   31.41 KB  |
|  DeleteItemStreamAsync |               1 |            1 |   4.08 ms (4080 us) |   4.91 ms (4908 us) |   0.27 ms (269 us) |   4.19 ms (4190 us) |   4.23 ms (4229 us) |   4.27 ms (4267 us) |   4.30 ms (4304 us) |   4.34 ms (4342 us) |   4.38 ms (4380 us) |   245.1 |               3.0000 |                - |   30.91 KB  |


VM: Standard F4s v2 (4 vcpus, 8 GiB memory)
Location: East US 2
Mode: Gateway mode with thinclient enabled

| Method                   | InvocationCount | UnrollFactor | Mean     | Error    | StdDev   | Q3      | P80     | P85     | P90     | P95     | P100    | Op/s  | Completed Work Items | Lock Contentions | Allocated  |
|--------------------------|-----------------|--------------|----------|----------|----------|---------|---------|---------|---------|---------|---------|-------|----------------------|------------------|------------|
| CreateItemAsync          | Default         | 16           | 4.734 ms | 1.7061 ms | 0.0935 ms | 4.781 ms | 4.790 ms | 4.799 ms | 4.808 ms | 4.818 ms | 4.827 ms | 211.3 | 2.0000              | -                | 43.93 KB   |
| CreateItemStreamAsync    | Default         | 16           | 5.054 ms | 2.7802 ms | 0.1524 ms | 5.119 ms | 5.139 ms | 5.160 ms | 5.181 ms | 5.201 ms | 5.222 ms | 197.9 | 2.0000              | -                | 32.48 KB   |
| ReadItemAsync            | Default         | 16           | 2.096 ms | 1.2775 ms | 0.0700 ms | 2.136 ms | 2.138 ms | 2.140 ms | 2.142 ms | 2.144 ms | 2.146 ms | 477.1 | 2.0000              | -                | 45.86 KB   |
| ReadItemStreamAsync      | Default         | 16           | 1.976 ms | 1.8893 ms | 0.1036 ms | 2.027 ms | 2.038 ms | 2.049 ms | 2.060 ms | 2.072 ms | 2.083 ms | 505.9 | 2.0039              | -                | 35.71 KB   |
| UpsertItemAsync          | Default         | 16           | 5.237 ms | 1.8037 ms | 0.0989 ms | 5.293 ms | 5.297 ms | 5.302 ms | 5.306 ms | 5.310 ms | 5.314 ms | 190.9 | 2.0000              | -                | 43.86 KB   |
| UpsertItemStreamAsync    | Default         | 16           | 5.391 ms | 3.2129 ms | 0.1761 ms | 5.447 ms | 5.476 ms | 5.505 ms | 5.535 ms | 5.564 ms | 5.594 ms | 185.5 | 2.0000              | -                | 32.47 KB   |
| ReplaceItemAsync         | Default         | 16           | 5.292 ms | 0.9327 ms | 0.0511 ms | 5.321 ms | 5.323 ms | 5.324 ms | 5.326 ms | 5.328 ms | 5.330 ms | 189.0 | 2.0000              | -                | 44.26 KB   |
| ReplaceItemStreamAsync   | Default         | 16           | 5.019 ms | 1.2404 ms | 0.0680 ms | 5.040 ms | 5.051 ms | 5.063 ms | 5.074 ms | 5.086 ms | 5.097 ms | 199.3 | 2.0000              | -                | 32.89 KB   |
| DeleteItemAsync          | 1               | 1            | 5.128 ms | 8.3417 ms | 0.4572 ms | 5.375 ms | 5.407 ms | 5.439 ms | 5.471 ms | 5.503 ms | 5.535 ms | 195.0 | 2.0000              | -                | 31.13 KB   |
| DeleteItemStreamAsync    | 1               | 1            | 4.944 ms | 8.1300 ms | 0.4456 ms | 5.193 ms | 5.216 ms | 5.238 ms | 5.260 ms | 5.283 ms | 5.305 ms | 202.3 | 2.0000              | -                | 30.66 KB   |

---


VM: Standard D16s v3 (16 vcpus, 64 GiB memory)
Location: East US 2
Mode: Gateway mode with thinclient enabled

Below are results for the performance tests when using thinclient mode in stage.
|                 Method            | InvocationCount | UnrollFactor |     Mean  |    Error  |    StdDev  |       Q3  |      P80  |      P85  |      P90  |      P95  |     P100  |  Op/s  | Completed Work Items | Lock Contentions | Allocated |
|------------------------------------|---------------- |--------------|----------:|----------:|-----------:|----------:|----------:|----------:|----------:|----------:|----------:|-------:|---------------------:|-----------------:|----------:|
|        CreateItemAsync            |         Default |           16 | 5.463 ms  | 3.323 ms  | 0.1821 ms  | 5.568 ms  | 5.572 ms  | 5.576 ms  | 5.580 ms  | 5.585 ms  | 5.589 ms  |  183.0 |               2.0000 |                - |  43.73 KB |
|  CreateItemStreamAsync            |         Default |           16 | 5.456 ms  | 2.080 ms  | 0.1140 ms  | 5.519 ms  | 5.526 ms  | 5.532 ms  | 5.539 ms  | 5.546 ms  | 5.553 ms  |  183.3 |               2.0000 |                - |  32.34 KB |
|          ReadItemAsync            |         Default |           16 | 2.214 ms  | 2.401 ms  | 0.1316 ms  | 2.281 ms  | 2.293 ms  | 2.306 ms  | 2.318 ms  | 2.330 ms  | 2.343 ms  |  451.7 |               2.0000 |                - |  45.71 KB |
|    ReadItemStreamAsync            |         Default |           16 | 2.040 ms  | 1.522 ms  | 0.0834 ms  | 2.088 ms  | 2.089 ms  | 2.091 ms  | 2.093 ms  | 2.095 ms  | 2.097 ms  |  490.3 |               2.0000 |                - |  35.61 KB |
|        UpsertItemAsync            |         Default |           16 | 6.058 ms  | 1.199 ms  | 0.0657 ms  | 6.095 ms  | 6.097 ms  | 6.099 ms  | 6.101 ms  | 6.103 ms  | 6.105 ms  |  165.1 |               2.0078 |                - |   43.8 KB |
|  UpsertItemStreamAsync            |         Default |           16 | 5.541 ms  | 3.061 ms  | 0.1678 ms  | 5.630 ms  | 5.643 ms  | 5.657 ms  | 5.670 ms  | 5.683 ms  | 5.696 ms  |  180.5 |               2.0000 |                - |   32.6 KB |
|       ReplaceItemAsync            |         Default |           16 | 6.029 ms  | 1.203 ms  | 0.0660 ms  | 6.049 ms  | 6.061 ms  | 6.072 ms  | 6.083 ms  | 6.094 ms  | 6.105 ms  |  165.9 |               2.0000 |                - |  44.38 KB |
| ReplaceItemStreamAsync            |         Default |           16 | 5.862 ms  | 1.105 ms  | 0.0606 ms  | 5.895 ms  | 5.899 ms  | 5.903 ms  | 5.907 ms  | 5.911 ms  | 5.915 ms  |  170.6 |               2.0000 |                - |  32.71 KB |
|        DeleteItemAsync            |               1 |            1 | 6.196 ms  | 2.730 ms  | 0.1496 ms  | 6.246 ms  | 6.270 ms  | 6.294 ms  | 6.319 ms  | 6.343 ms  | 6.368 ms  |  161.4 |               2.0000 |                - |     31 KB |
|  DeleteItemStreamAsync            |               1 |            1 | 5.757 ms  | 6.294 ms  | 0.3450 ms  | 5.915 ms  | 5.957 ms  | 5.999 ms  | 6.041 ms  | 6.082 ms  | 6.124 ms  |  173.7 |               2.0000 |                - |  30.54 KB |


<img width="807" alt="image" src="https://github.com/user-attachments/assets/f996b4fa-a289-4fa5-9264-35f81fbc376b">


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Closing issues

To automatically close an issue: closes #4927