### PR TITLE
Use static readonly arrays for separators

### DIFF
--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -113,6 +113,9 @@ namespace Microsoft.Azure.Cosmos
         private const bool DefaultEnableCpuMonitor = true;
         private const string DefaultInitTaskKey = "InitTaskKey";
 
+        private static readonly char[] resourceIdOrFullNameSeparators = new char[] { '/' };
+        private static readonly char[] resourceIdSeparators = new char[] { '/', '\\', '?', '#' };
+
         private readonly bool IsLocalQuorumConsistency = false;
         private readonly bool isReplicaAddressValidationEnabled;
 
@@ -2165,7 +2168,7 @@ namespace Microsoft.Azure.Cosmos
             string databaseLink = PathsHelper.GetDatabasePath(sourceDocumentCollectionLink);
             if (PathsHelper.TryParsePathSegments(databaseLink, out isFeed, out resourceTypeString, out resourceIdOrFullName, out isNameBased) && isNameBased && !isFeed)
             {
-                string[] segments = resourceIdOrFullName.Split(new char[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+                string[] segments = resourceIdOrFullName.Split(resourceIdOrFullNameSeparators, StringSplitOptions.RemoveEmptyEntries);
                 dbsId = segments[segments.Length - 1];
             }
             else
@@ -2176,7 +2179,7 @@ namespace Microsoft.Azure.Cosmos
             string sourceCollId;
             if (PathsHelper.TryParsePathSegments(sourceDocumentCollectionLink, out isFeed, out resourceTypeString, out resourceIdOrFullName, out isNameBased) && isNameBased && !isFeed)
             {
-                string[] segments = resourceIdOrFullName.Split(new char[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+                string[] segments = resourceIdOrFullName.Split(resourceIdOrFullNameSeparators, StringSplitOptions.RemoveEmptyEntries);
                 sourceCollId = segments[segments.Length - 1];
             }
             else
@@ -6811,7 +6814,7 @@ namespace Microsoft.Azure.Cosmos
         {
             if (!string.IsNullOrEmpty(resourceId))
             {
-                int match = resourceId.IndexOfAny(new char[] { '/', '\\', '?', '#' });
+                int match = resourceId.IndexOfAny(resourceIdSeparators);
                 if (match != -1)
                 {
                     throw new ArgumentException(string.Format(

--- a/Microsoft.Azure.Cosmos/src/Linq/ExpressionToSQL.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/ExpressionToSQL.cs
@@ -1525,7 +1525,7 @@ namespace Microsoft.Azure.Cosmos.Linq
         {
             return ExpressionToSql.VisitScalarExpression(
                 expression,
-                new ReadOnlyCollection<ParameterExpression>(new ParameterExpression[] { }),
+                new ReadOnlyCollection<ParameterExpression>(Array.Empty<ParameterExpression>()),
                 context);
         }
 

--- a/Microsoft.Azure.Cosmos/src/Routing/LocationHelper.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/LocationHelper.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Azure.Cosmos.Routing
     /// </summary>
     internal static class LocationHelper
     {
+        private static readonly char[] hostSeparators = new char[] { '.' };
+
         /// <summary>
         /// For example, for https://contoso.documents.azure.com:443/ and "West US", this will return https://contoso-westus.documents.azure.com:443/
         /// NOTE: This ONLY called by client first boot when the input endpoint is not available.
@@ -21,7 +23,7 @@ namespace Microsoft.Azure.Cosmos.Routing
             // Split the host into 2 parts seperated by '.'
             // For example, "contoso.documents.azure.com" is separated into "contoso" and "documents.azure.com"
             // If the host doesn't contains '.', this will return the host as is, as the only element
-            string[] hostParts = builder.Host.Split(new char[] { '.' }, 2);
+            string[] hostParts = builder.Host.Split(hostSeparators, 2);
 
             if (hostParts.Length != 0)
             {

--- a/Microsoft.Azure.Cosmos/src/Telemetry/Collector/TelemetryCollector.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/Collector/TelemetryCollector.cs
@@ -13,6 +13,8 @@ namespace Microsoft.Azure.Cosmos.Telemetry.Collector
 
     internal class TelemetryCollector : ITelemetryCollector
     {
+        private static readonly char[] pathSeparators = new char[] { '/' };
+
         private readonly ClientTelemetry clientTelemetry = null;
         private readonly ConnectionPolicy connectionPolicy = null;
 
@@ -69,7 +71,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry.Collector
 
         private static void GetDatabaseAndCollectionName(string path, out string databaseName, out string collectionName)
         {
-            string[] segments = path.Split(new char[] { '/' }, StringSplitOptions.RemoveEmptyEntries);
+            string[] segments = path.Split(pathSeparators, StringSplitOptions.RemoveEmptyEntries);
 
             PathsHelper.ParseDatabaseNameAndCollectionNameFromUrlSegments(segments, out databaseName, out collectionName);
         }


### PR DESCRIPTION
# Pull Request Template

## Description

Avoid allocating new arrays for separators when splitting strings.
Related code analysis warning https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1861.

## Type of change

Small performance-related change.