### PR TITLE
ThroughputBucketing: Adds Throughput Bucket to RequestOptions and ClientOptions

### DIFF
--- a/Microsoft.Azure.Cosmos.sln
+++ b/Microsoft.Azure.Cosmos.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29123.88
+# Visual Studio Version 17
+VisualStudioVersion = 17.12.35514.174 d17.12
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.Cosmos", "Microsoft.Azure.Cosmos\src\Microsoft.Azure.Cosmos.csproj", "{36F6F6A8-CEC8-4261-9948-903495BC3C25}"
 EndProject
@@ -180,6 +180,18 @@ Global
 		{021DDC27-02EF-42C4-9A9E-AA600833C2EE}.Release|Any CPU.Build.0 = Release|Any CPU
 		{021DDC27-02EF-42C4-9A9E-AA600833C2EE}.Release|x64.ActiveCfg = Release|Any CPU
 		{021DDC27-02EF-42C4-9A9E-AA600833C2EE}.Release|x64.Build.0 = Release|Any CPU
+		{D744906A-1091-403F-B0B6-794DE045169A}.Cover|Any CPU.ActiveCfg = Debug|Any CPU
+		{D744906A-1091-403F-B0B6-794DE045169A}.Cover|Any CPU.Build.0 = Debug|Any CPU
+		{D744906A-1091-403F-B0B6-794DE045169A}.Cover|x64.ActiveCfg = Debug|Any CPU
+		{D744906A-1091-403F-B0B6-794DE045169A}.Cover|x64.Build.0 = Debug|Any CPU
+		{D744906A-1091-403F-B0B6-794DE045169A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D744906A-1091-403F-B0B6-794DE045169A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D744906A-1091-403F-B0B6-794DE045169A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D744906A-1091-403F-B0B6-794DE045169A}.Debug|x64.Build.0 = Debug|Any CPU
+		{D744906A-1091-403F-B0B6-794DE045169A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D744906A-1091-403F-B0B6-794DE045169A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D744906A-1091-403F-B0B6-794DE045169A}.Release|x64.ActiveCfg = Release|Any CPU
+		{D744906A-1091-403F-B0B6-794DE045169A}.Release|x64.Build.0 = Release|Any CPU
 		{CE4D6DA8-148D-4A98-943B-D8C2D532E1DC}.Cover|Any CPU.ActiveCfg = Debug|Any CPU
 		{CE4D6DA8-148D-4A98-943B-D8C2D532E1DC}.Cover|Any CPU.Build.0 = Debug|Any CPU
 		{CE4D6DA8-148D-4A98-943B-D8C2D532E1DC}.Cover|x64.ActiveCfg = Debug|Any CPU

--- a/Microsoft.Azure.Cosmos.sln
+++ b/Microsoft.Azure.Cosmos.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.12.35514.174 d17.12
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29123.88
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Azure.Cosmos", "Microsoft.Azure.Cosmos\src\Microsoft.Azure.Cosmos.csproj", "{36F6F6A8-CEC8-4261-9948-903495BC3C25}"
 EndProject
@@ -180,18 +180,6 @@ Global
 		{021DDC27-02EF-42C4-9A9E-AA600833C2EE}.Release|Any CPU.Build.0 = Release|Any CPU
 		{021DDC27-02EF-42C4-9A9E-AA600833C2EE}.Release|x64.ActiveCfg = Release|Any CPU
 		{021DDC27-02EF-42C4-9A9E-AA600833C2EE}.Release|x64.Build.0 = Release|Any CPU
-		{D744906A-1091-403F-B0B6-794DE045169A}.Cover|Any CPU.ActiveCfg = Debug|Any CPU
-		{D744906A-1091-403F-B0B6-794DE045169A}.Cover|Any CPU.Build.0 = Debug|Any CPU
-		{D744906A-1091-403F-B0B6-794DE045169A}.Cover|x64.ActiveCfg = Debug|Any CPU
-		{D744906A-1091-403F-B0B6-794DE045169A}.Cover|x64.Build.0 = Debug|Any CPU
-		{D744906A-1091-403F-B0B6-794DE045169A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{D744906A-1091-403F-B0B6-794DE045169A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D744906A-1091-403F-B0B6-794DE045169A}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{D744906A-1091-403F-B0B6-794DE045169A}.Debug|x64.Build.0 = Debug|Any CPU
-		{D744906A-1091-403F-B0B6-794DE045169A}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{D744906A-1091-403F-B0B6-794DE045169A}.Release|Any CPU.Build.0 = Release|Any CPU
-		{D744906A-1091-403F-B0B6-794DE045169A}.Release|x64.ActiveCfg = Release|Any CPU
-		{D744906A-1091-403F-B0B6-794DE045169A}.Release|x64.Build.0 = Release|Any CPU
 		{CE4D6DA8-148D-4A98-943B-D8C2D532E1DC}.Cover|Any CPU.ActiveCfg = Debug|Any CPU
 		{CE4D6DA8-148D-4A98-943B-D8C2D532E1DC}.Cover|Any CPU.Build.0 = Debug|Any CPU
 		{CE4D6DA8-148D-4A98-943B-D8C2D532E1DC}.Cover|x64.ActiveCfg = Debug|Any CPU

--- a/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
@@ -940,6 +940,16 @@ namespace Microsoft.Azure.Cosmos
             }
         }
 
+        /// <summary>
+        /// Sets the throughput bucket for requests created using cosmos client.
+        /// </summary>
+        /// <remarks>
+        /// If throughput bucket is also set at request level in <see cref="RequestOptions.ThroughputBucket"/>, that throughput bucket is used.
+        /// If <see cref="AllowBulkExecution"/> is set to true in CosmosClientOptions, throughput bucket set on the CosmosClient is used.
+        /// </remarks>
+        /// <seealso href="https://aka.ms/cosmsodb-bucketing"/>
+        public int? ThroughputBucket { get; set; }
+
         internal IChaosInterceptorFactory ChaosInterceptorFactory { get; set; }
 
         internal void SetSerializerIfNotConfigured(CosmosSerializer serializer)

--- a/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
@@ -945,7 +945,7 @@ namespace Microsoft.Azure.Cosmos
         /// </summary>
         /// <remarks>
         /// If throughput bucket is also set at request level in <see cref="RequestOptions.ThroughputBucket"/>, that throughput bucket is used.
-        /// If <see cref="AllowBulkExecution"/> is set to true in CosmosClientOptions, throughput bucket set on the CosmosClient is used.
+        /// If <see cref="AllowBulkExecution"/> is set to true in CosmosClientOptions, throughput bucket can only be set at client level.
         /// </remarks>
         /// <seealso href="https://aka.ms/cosmsodb-bucketing"/>
         public int? ThroughputBucket { get; set; }

--- a/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
@@ -948,7 +948,12 @@ namespace Microsoft.Azure.Cosmos
         /// If <see cref="AllowBulkExecution"/> is set to true in CosmosClientOptions, throughput bucket can only be set at client level.
         /// </remarks>
         /// <seealso href="https://aka.ms/cosmsodb-bucketing"/>
-        public int? ThroughputBucket { get; set; }
+#if PREVIEW
+        public
+#else
+        internal
+#endif
+        int? ThroughputBucket { get; set; }
 
         internal IChaosInterceptorFactory ChaosInterceptorFactory { get; set; }
 

--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -7093,6 +7093,12 @@ namespace Microsoft.Azure.Cosmos
             {
                 headers.Set(HttpConstants.HttpHeaders.PreserveFullContent, bool.TrueString);
             }
+
+            if (options.ThroughputBucket.HasValue)
+            {
+                headers.Set(HttpConstants.HttpHeaders.ThroughputBucket, options.ThroughputBucket.ToString());
+            }
+
             return headers;
         }
 

--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -7096,7 +7096,7 @@ namespace Microsoft.Azure.Cosmos
 
             if (options.ThroughputBucket.HasValue)
             {
-                headers.Set(HttpConstants.HttpHeaders.ThroughputBucket, options.ThroughputBucket.ToString());
+                headers.Set(HttpConstants.HttpHeaders.ThroughputBucket, options.ThroughputBucket?.ToString(CultureInfo.InvariantCulture));
             }
 
             return headers;

--- a/Microsoft.Azure.Cosmos/src/Fluent/CosmosClientBuilder.cs
+++ b/Microsoft.Azure.Cosmos/src/Fluent/CosmosClientBuilder.cs
@@ -818,7 +818,7 @@ namespace Microsoft.Azure.Cosmos.Fluent
 #else
         internal
 #endif
-        CosmosClientBuilder WithThroughputBucket(int? throughputBucket)
+        CosmosClientBuilder WithThroughputBucket(int throughputBucket)
         {
             this.clientOptions.ThroughputBucket = throughputBucket;
             return this;

--- a/Microsoft.Azure.Cosmos/src/Fluent/CosmosClientBuilder.cs
+++ b/Microsoft.Azure.Cosmos/src/Fluent/CosmosClientBuilder.cs
@@ -813,7 +813,12 @@ namespace Microsoft.Azure.Cosmos.Fluent
         /// <param name="throughputBucket">The desired throughput bucket for the client.</param>
         /// <returns>The current <see cref="CosmosClientBuilder"/>.</returns>
         /// <seealso href="https://aka.ms/cosmsodb-bucketing"/>
-        public CosmosClientBuilder WithThroughputBucket(int? throughputBucket)
+#if PREVIEW
+        public
+#else
+        internal
+#endif
+        CosmosClientBuilder WithThroughputBucket(int? throughputBucket)
         {
             this.clientOptions.ThroughputBucket = throughputBucket;
             return this;

--- a/Microsoft.Azure.Cosmos/src/Fluent/CosmosClientBuilder.cs
+++ b/Microsoft.Azure.Cosmos/src/Fluent/CosmosClientBuilder.cs
@@ -802,5 +802,21 @@ namespace Microsoft.Azure.Cosmos.Fluent
             this.clientOptions.CosmosClientTelemetryOptions = options;
             return this;
         }
+
+        /// <summary>
+        /// Sets the throughput bucket for requests created using cosmos client.
+        /// </summary>
+        /// <remarks>
+        /// If throughput bucket is also set at request level in <see cref="RequestOptions.ThroughputBucket"/>, that throughput bucket is used.
+        /// If <see cref="WithBulkExecution(bool)"/> is set to true, throughput bucket set on the CosmosClient is used.
+        /// </remarks>
+        /// <param name="throughputBucket">The desired throughput bucket for the client.</param>
+        /// <returns>The current <see cref="CosmosClientBuilder"/>.</returns>
+        /// <seealso href="https://aka.ms/cosmsodb-bucketing"/>
+        public CosmosClientBuilder WithThroughputBucket(int? throughputBucket)
+        {
+            this.clientOptions.ThroughputBucket = throughputBucket;
+            return this;
+        }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Fluent/CosmosClientBuilder.cs
+++ b/Microsoft.Azure.Cosmos/src/Fluent/CosmosClientBuilder.cs
@@ -808,7 +808,7 @@ namespace Microsoft.Azure.Cosmos.Fluent
         /// </summary>
         /// <remarks>
         /// If throughput bucket is also set at request level in <see cref="RequestOptions.ThroughputBucket"/>, that throughput bucket is used.
-        /// If <see cref="WithBulkExecution(bool)"/> is set to true, throughput bucket set on the CosmosClient is used.
+        /// If <see cref="WithBulkExecution(bool)"/> is set to true, throughput bucket can only be set at client level.
         /// </remarks>
         /// <param name="throughputBucket">The desired throughput bucket for the client.</param>
         /// <returns>The current <see cref="CosmosClientBuilder"/>.</returns>

--- a/Microsoft.Azure.Cosmos/src/Handler/ClientPipelineBuilder.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/ClientPipelineBuilder.cs
@@ -20,6 +20,7 @@ namespace Microsoft.Azure.Cosmos
         private readonly RequestHandler invalidPartitionExceptionRetryHandler;
         private readonly RequestHandler transportHandler;
         private readonly TelemetryHandler telemetryHandler;
+        private readonly int? requestedClientThroughputBucket;
 
         private IReadOnlyCollection<RequestHandler> customHandlers;
         private RequestHandler retryHandler;
@@ -29,11 +30,13 @@ namespace Microsoft.Azure.Cosmos
             ConsistencyLevel? requestedClientConsistencyLevel,
             PriorityLevel? requestedClientPriorityLevel,
             IReadOnlyCollection<RequestHandler> customHandlers,
-            TelemetryToServiceHelper telemetryToServiceHelper)
+            TelemetryToServiceHelper telemetryToServiceHelper,
+            int? requestedClientThroughputBucket)
         {
             this.client = client ?? throw new ArgumentNullException(nameof(client));
             this.requestedClientConsistencyLevel = requestedClientConsistencyLevel;
             this.requestedPriorityLevel = requestedClientPriorityLevel;
+            this.requestedClientThroughputBucket = requestedClientThroughputBucket;
             this.transportHandler = new TransportHandler(client);
             Debug.Assert(this.transportHandler.InnerHandler == null, nameof(this.transportHandler));
 
@@ -153,7 +156,8 @@ namespace Microsoft.Azure.Cosmos
             RequestInvokerHandler root = new RequestInvokerHandler(
                 this.client,
                 this.requestedClientConsistencyLevel,
-                this.requestedPriorityLevel);
+                this.requestedPriorityLevel,
+                this.requestedClientThroughputBucket);
 
             RequestHandler current = root;
             if (this.CustomHandlers != null && this.CustomHandlers.Any())

--- a/Microsoft.Azure.Cosmos/src/Handler/RequestInvokerHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/RequestInvokerHandler.cs
@@ -525,8 +525,15 @@ namespace Microsoft.Azure.Cosmos.Handlers
         {
             int? throughputBucket = this.RequestedClientThroughputBucket;
             RequestOptions promotedRequestOptions = requestMessage.RequestOptions;
+
             if (promotedRequestOptions?.ThroughputBucket.HasValue == true)
             {
+                if (this.client.ClientOptions.AllowBulkExecution)
+                {
+                    throw new ArgumentException($"{nameof(requestMessage.RequestOptions.ThroughputBucket)} cannot be set in " +
+                        $"{nameof(requestMessage.RequestOptions)} with {nameof(this.client.ClientOptions.AllowBulkExecution)} set to true. " +
+                        $"Set {nameof(this.client.ClientOptions.ThroughputBucket)} in {nameof(this.client.ClientOptions)} instead.");
+                }
                 throughputBucket = promotedRequestOptions.ThroughputBucket.Value;
             }
 

--- a/Microsoft.Azure.Cosmos/src/Handler/RequestInvokerHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/RequestInvokerHandler.cs
@@ -79,7 +79,7 @@ namespace Microsoft.Azure.Cosmos.Handlers
 
             await this.ValidateAndSetConsistencyLevelAsync(request);
             this.SetPriorityLevel(request);
-            this.SetThroughputBucket(request);
+            this.ValidateAndSetThroughputBucket(request);
 
             (bool isError, ResponseMessage errorResponse) = await this.EnsureValidClientAsync(request, request.Trace);
             if (isError)
@@ -521,7 +521,7 @@ namespace Microsoft.Azure.Cosmos.Handlers
         /// Set the ThroughputBucket in the request headers
         /// </summary>
         /// <param name="requestMessage"></param>
-        private void SetThroughputBucket(RequestMessage requestMessage)
+        private void ValidateAndSetThroughputBucket(RequestMessage requestMessage)
         {
             int? throughputBucket = this.RequestedClientThroughputBucket;
             RequestOptions promotedRequestOptions = requestMessage.RequestOptions;
@@ -531,8 +531,8 @@ namespace Microsoft.Azure.Cosmos.Handlers
                 if (this.client.ClientOptions.AllowBulkExecution)
                 {
                     throw new ArgumentException($"{nameof(requestMessage.RequestOptions.ThroughputBucket)} cannot be set in " +
-                        $"{nameof(requestMessage.RequestOptions)} with {nameof(this.client.ClientOptions.AllowBulkExecution)} set to true. " +
-                        $"Set {nameof(this.client.ClientOptions.ThroughputBucket)} in {nameof(this.client.ClientOptions)} instead.");
+                        $"{nameof(requestMessage.RequestOptions)} when {nameof(this.client.ClientOptions.AllowBulkExecution)} is set to true. " +
+                        $"Instead, set {nameof(this.client.ClientOptions.ThroughputBucket)} only in {nameof(this.client.ClientOptions)}.");
                 }
                 throughputBucket = promotedRequestOptions.ThroughputBucket.Value;
             }

--- a/Microsoft.Azure.Cosmos/src/RequestOptions/RequestOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/RequestOptions/RequestOptions.cs
@@ -112,7 +112,12 @@ namespace Microsoft.Azure.Cosmos
         /// <see cref="RequestOptions.ThroughputBucket"/> cannot be set in RequestOptions.
         /// </remarks>
         /// <seealso href="https://aka.ms/cosmsodb-bucketing"/>
-        public int? ThroughputBucket { get; set; }
+#if PREVIEW
+        public
+#else
+        internal
+#endif
+        int? ThroughputBucket { get; set; }
 
         /// <summary>
         /// Fill the CosmosRequestMessage headers with the set properties

--- a/Microsoft.Azure.Cosmos/src/RequestOptions/RequestOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/RequestOptions/RequestOptions.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Azure.Cosmos
 {
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using Microsoft.Azure.Documents;
 
     /// <summary>
@@ -107,7 +108,8 @@ namespace Microsoft.Azure.Cosmos
         /// Gets or sets the throughput bucket for a request.
         /// </summary>
         /// <remarks>
-        /// If <see cref="CosmosClientOptions.AllowBulkExecution"/> is set to true on CosmosClient, throughput bucket set in RequestOptions is ignored.
+        /// If <see cref="CosmosClientOptions.AllowBulkExecution"/> is set to true on CosmosClient,
+        /// <see cref="RequestOptions.ThroughputBucket"/> cannot be set in RequestOptions.
         /// </remarks>
         /// <seealso href="https://aka.ms/cosmsodb-bucketing"/>
         public int? ThroughputBucket { get; set; }
@@ -143,7 +145,7 @@ namespace Microsoft.Azure.Cosmos
 
             if (this.ThroughputBucket.HasValue)
             {
-                request.Headers.Add(HttpConstants.HttpHeaders.ThroughputBucket, this.ThroughputBucket.ToString());
+                request.Headers.Add(HttpConstants.HttpHeaders.ThroughputBucket, this.ThroughputBucket?.ToString(CultureInfo.InvariantCulture));
             }
 
             this.AddRequestHeaders?.Invoke(request.Headers);

--- a/Microsoft.Azure.Cosmos/src/RequestOptions/RequestOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/RequestOptions/RequestOptions.cs
@@ -104,6 +104,15 @@ namespace Microsoft.Azure.Cosmos
         internal bool DisablePointOperationDiagnostics { get; set; }
 
         /// <summary>
+        /// Gets or sets the throughput bucket for a request.
+        /// </summary>
+        /// <remarks>
+        /// If <see cref="CosmosClientOptions.AllowBulkExecution"/> is set to true on CosmosClient, throughput bucket set in RequestOptions is ignored.
+        /// </remarks>
+        /// <seealso href="https://aka.ms/cosmsodb-bucketing"/>
+        public int? ThroughputBucket { get; set; }
+
+        /// <summary>
         /// Fill the CosmosRequestMessage headers with the set properties
         /// </summary>
         /// <param name="request">The <see cref="RequestMessage"/></param>
@@ -130,6 +139,11 @@ namespace Microsoft.Azure.Cosmos
             if (this.PriorityLevel.HasValue)
             {
                 request.Headers.Add(HttpConstants.HttpHeaders.PriorityLevel, this.PriorityLevel.ToString());
+            }
+
+            if (this.ThroughputBucket.HasValue)
+            {
+                request.Headers.Add(HttpConstants.HttpHeaders.ThroughputBucket, this.ThroughputBucket.ToString());
             }
 
             this.AddRequestHeaders?.Invoke(request.Headers);

--- a/Microsoft.Azure.Cosmos/src/Resource/ClientContextCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/ClientContextCore.cs
@@ -123,7 +123,8 @@ namespace Microsoft.Azure.Cosmos
                     clientOptions.ConsistencyLevel,
                     clientOptions.PriorityLevel,
                     clientOptions.CustomHandlers,
-                    telemetryToServiceHelper: documentClient.telemetryToServiceHelper);
+                    telemetryToServiceHelper: documentClient.telemetryToServiceHelper,
+                    clientOptions.ThroughputBucket);
 
                 requestInvokerHandler = clientPipelineBuilder.Build();
             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetPreviewSDKAPI.json
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetPreviewSDKAPI.json
@@ -494,10 +494,10 @@
           "Attributes": [],
           "MethodInfo": "Microsoft.Azure.Cosmos.Fluent.CosmosClientBuilder WithAvailabilityStrategy(Microsoft.Azure.Cosmos.AvailabilityStrategy);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
         },
-        "Microsoft.Azure.Cosmos.Fluent.CosmosClientBuilder WithThroughputBucket(System.Nullable`1[System.Int32])": {
+        "Microsoft.Azure.Cosmos.Fluent.CosmosClientBuilder WithThroughputBucket(Int32)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "Microsoft.Azure.Cosmos.Fluent.CosmosClientBuilder WithThroughputBucket(System.Nullable`1[System.Int32]);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+          "MethodInfo": "Microsoft.Azure.Cosmos.Fluent.CosmosClientBuilder WithThroughputBucket(Int32);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
         }
       },
       "NestedTypes": {}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetPreviewSDKAPI.json
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetPreviewSDKAPI.json
@@ -403,12 +403,31 @@
           ],
           "MethodInfo": "Microsoft.Azure.Cosmos.AvailabilityStrategy get_AvailabilityStrategy();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
         },
+        "System.Nullable`1[System.Int32] get_ThroughputBucket()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Nullable`1[System.Int32] get_ThroughputBucket();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "System.Nullable`1[System.Int32] ThroughputBucket": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": "System.Nullable`1[System.Int32] ThroughputBucket;CanRead:True;CanWrite:True;System.Nullable`1[System.Int32] get_ThroughputBucket();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;Void set_ThroughputBucket(System.Nullable`1[System.Int32]);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
         "Void set_AvailabilityStrategy(Microsoft.Azure.Cosmos.AvailabilityStrategy)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
           "Type": "Method",
           "Attributes": [
             "CompilerGeneratedAttribute"
           ],
           "MethodInfo": "Void set_AvailabilityStrategy(Microsoft.Azure.Cosmos.AvailabilityStrategy);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "Void set_ThroughputBucket(System.Nullable`1[System.Int32])[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_ThroughputBucket(System.Nullable`1[System.Int32]);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
         }
       },
       "NestedTypes": {}
@@ -474,6 +493,11 @@
           "Type": "Method",
           "Attributes": [],
           "MethodInfo": "Microsoft.Azure.Cosmos.Fluent.CosmosClientBuilder WithAvailabilityStrategy(Microsoft.Azure.Cosmos.AvailabilityStrategy);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "Microsoft.Azure.Cosmos.Fluent.CosmosClientBuilder WithThroughputBucket(System.Nullable`1[System.Int32])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Fluent.CosmosClientBuilder WithThroughputBucket(System.Nullable`1[System.Int32]);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
         }
       },
       "NestedTypes": {}
@@ -741,12 +765,31 @@
           ],
           "MethodInfo": "Microsoft.Azure.Cosmos.AvailabilityStrategy get_AvailabilityStrategy();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
         },
+        "System.Nullable`1[System.Int32] get_ThroughputBucket()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Nullable`1[System.Int32] get_ThroughputBucket();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "System.Nullable`1[System.Int32] ThroughputBucket": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": "System.Nullable`1[System.Int32] ThroughputBucket;CanRead:True;CanWrite:True;System.Nullable`1[System.Int32] get_ThroughputBucket();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;Void set_ThroughputBucket(System.Nullable`1[System.Int32]);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
         "Void set_AvailabilityStrategy(Microsoft.Azure.Cosmos.AvailabilityStrategy)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
           "Type": "Method",
           "Attributes": [
             "CompilerGeneratedAttribute"
           ],
           "MethodInfo": "Void set_AvailabilityStrategy(Microsoft.Azure.Cosmos.AvailabilityStrategy);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "Void set_ThroughputBucket(System.Nullable`1[System.Int32])[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_ThroughputBucket(System.Nullable`1[System.Int32]);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
         }
       },
       "NestedTypes": {}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
@@ -57,6 +57,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             IWebProxy webProxy = new TestWebProxy();
             Cosmos.ConsistencyLevel consistencyLevel = Cosmos.ConsistencyLevel.ConsistentPrefix;
             Cosmos.PriorityLevel priorityLevel = Cosmos.PriorityLevel.Low;
+            int throughputBucket = 3;
 
             CosmosClientBuilder cosmosClientBuilder = new CosmosClientBuilder(
                 accountEndpoint: endpoint,
@@ -88,6 +89,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             Assert.AreNotEqual(priorityLevel, clientOptions.PriorityLevel);
             Assert.IsFalse(clientOptions.EnablePartitionLevelFailover);
             Assert.IsFalse(clientOptions.EnableAdvancedReplicaSelectionForTcp.HasValue);
+            Assert.AreNotEqual(throughputBucket, clientOptions.ThroughputBucket);
 
             //Verify GetConnectionPolicy returns the correct values for default
             ConnectionPolicy policy = clientOptions.GetConnectionPolicy(clientId: 0);
@@ -122,7 +124,8 @@ namespace Microsoft.Azure.Cosmos.Tests
                 .WithBulkExecution(true)
                 .WithSerializerOptions(cosmosSerializerOptions)
                 .WithConsistencyLevel(consistencyLevel)
-                .WithPriorityLevel(priorityLevel);
+                .WithPriorityLevel(priorityLevel)
+                .WithThroughputBucket(throughputBucket);
 
             cosmosClient = cosmosClientBuilder.Build(new MockDocumentClient());
             clientOptions = cosmosClient.ClientOptions;
@@ -148,6 +151,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             Assert.AreEqual(priorityLevel, clientOptions.PriorityLevel);
             Assert.IsFalse(clientOptions.EnablePartitionLevelFailover);
             Assert.IsTrue(clientOptions.EnableAdvancedReplicaSelectionForTcp.HasValue && clientOptions.EnableAdvancedReplicaSelectionForTcp.Value);
+            Assert.AreEqual(throughputBucket, clientOptions.ThroughputBucket);
 
             //Verify GetConnectionPolicy returns the correct values
             policy = clientOptions.GetConnectionPolicy(clientId: 0);
@@ -227,7 +231,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         /// </summary>
         [TestMethod]
         [Owner("dkunda")]
-        [DataRow(true, DisplayName = "Validate that when enevironment variable is used to enable PPAF, the outcome of the test should be same.")]
+        [DataRow(true, DisplayName = "Validate that when environment variable is used to enable PPAF, the outcome of the test should be same.")]
         [DataRow(false, DisplayName = "Validate that when CosmosClientOptions is used to enable PPAF, the outcome of the test should be same.")]
         public void CosmosClientOptions_WhenPartitionLevelFailoverEnabledAndPreferredRegionsNotSet_ShouldThrowArgumentException(bool useEnvironmentVariable)
         {
@@ -254,6 +258,7 @@ namespace Microsoft.Azure.Cosmos.Tests
 
                 Cosmos.ConsistencyLevel consistencyLevel = Cosmos.ConsistencyLevel.ConsistentPrefix;
                 Cosmos.PriorityLevel priorityLevel = Cosmos.PriorityLevel.Low;
+                int throughputBucket = 3;
 
                 CosmosClientBuilder cosmosClientBuilder = new(
                     accountEndpoint: endpoint,
@@ -268,7 +273,8 @@ namespace Microsoft.Azure.Cosmos.Tests
                     .WithThrottlingRetryOptions(maxRetryWaitTime, maxRetryAttemptsOnThrottledRequests)
                     .WithSerializerOptions(cosmosSerializerOptions)
                     .WithConsistencyLevel(consistencyLevel)
-                    .WithPriorityLevel(priorityLevel);
+                    .WithPriorityLevel(priorityLevel)
+                    .WithThroughputBucket(throughputBucket);
 
                 if (!useEnvironmentVariable)
                 {
@@ -321,6 +327,7 @@ namespace Microsoft.Azure.Cosmos.Tests
 
                 Cosmos.ConsistencyLevel consistencyLevel = Cosmos.ConsistencyLevel.ConsistentPrefix;
                 Cosmos.PriorityLevel priorityLevel = Cosmos.PriorityLevel.Low;
+                int throughputBucket = 3;
                 CosmosClientBuilder cosmosClientBuilder = new(
                     accountEndpoint: endpoint,
                     authKeyOrResourceToken: key);
@@ -336,6 +343,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                     .WithConsistencyLevel(consistencyLevel)
                     .WithPriorityLevel(priorityLevel)
                     .WithPartitionLevelFailoverEnabled()
+                    .WithThroughputBucket(throughputBucket)
                     .WithApplicationPreferredRegions(
                         new List<string>()
                         {
@@ -424,6 +432,29 @@ namespace Microsoft.Azure.Cosmos.Tests
             };
 
             Assert.IsNull(cosmosClientOptionsNull.PriorityLevel);
+        }
+
+        [TestMethod]
+        public void VerifyThroughputBuckets()
+        {
+            List<int> throughputBuckets = Enumerable.Range(1, 5).ToList();
+
+            foreach (int throughputBucket in throughputBuckets)
+            {
+                CosmosClientOptions cosmosClientOptions = new CosmosClientOptions()
+                {
+                    ThroughputBucket = throughputBucket
+                };
+
+                Assert.AreEqual(throughputBucket, cosmosClientOptions.ThroughputBucket);
+            }
+
+            CosmosClientOptions cosmosClientOptionsNull = new CosmosClientOptions()
+            {
+                ThroughputBucket = null
+            };
+
+            Assert.IsNull(cosmosClientOptionsNull.ThroughputBucket);
         }
 
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/HandlerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/HandlerTests.cs
@@ -511,8 +511,8 @@ namespace Microsoft.Azure.Cosmos.Tests
             {
                 Console.WriteLine(ex.ToString());
                 Assert.AreEqual(typeof(ArgumentException), ex.GetType()) ;
-                Assert.AreEqual("ThroughputBucket cannot be set in RequestOptions with AllowBulkExecution set to true. " +
-                    "Set ThroughputBucket in ClientOptions instead.", ex.Message);
+                Assert.AreEqual("ThroughputBucket cannot be set in RequestOptions when AllowBulkExecution is set to true. " +
+                    "Instead, set ThroughputBucket only in ClientOptions.", ex.Message);
             }
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/HandlerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/HandlerTests.cs
@@ -126,7 +126,11 @@ namespace Microsoft.Azure.Cosmos.Tests
 
             CosmosClient client = MockCosmosUtil.CreateMockCosmosClient();
 
-            RequestInvokerHandler invoker = new RequestInvokerHandler(client, requestedClientConsistencyLevel: null, requestedClientPriorityLevel: null)
+            RequestInvokerHandler invoker = new RequestInvokerHandler(
+                client,
+                requestedClientConsistencyLevel: null,
+                requestedClientPriorityLevel: null,
+                requestedClientThroughputBucket: null)
             {
                 InnerHandler = testHandler
             };
@@ -176,7 +180,11 @@ namespace Microsoft.Azure.Cosmos.Tests
                         return TestHandler.ReturnSuccess();
                     });
 
-                    RequestInvokerHandler invoker = new RequestInvokerHandler(client, requestedClientConsistencyLevel: null, requestedClientPriorityLevel: null)
+                    RequestInvokerHandler invoker = new RequestInvokerHandler(
+                        client,
+                        requestedClientConsistencyLevel: null,
+                        requestedClientPriorityLevel: null,
+                        requestedClientThroughputBucket: null)
                     {
                         InnerHandler = testHandler
                     };
@@ -227,7 +235,11 @@ namespace Microsoft.Azure.Cosmos.Tests
 
                 using CosmosClient client = MockCosmosUtil.CreateMockCosmosClient();
 
-                RequestInvokerHandler invoker = new RequestInvokerHandler(client, requestedClientConsistencyLevel: null, requestedClientPriorityLevel: null)
+                RequestInvokerHandler invoker = new RequestInvokerHandler(
+                    client,
+                    requestedClientConsistencyLevel: null,
+                    requestedClientPriorityLevel: null,
+                    requestedClientThroughputBucket: null)
                 {
                     InnerHandler = testHandler
                 };
@@ -257,7 +269,11 @@ namespace Microsoft.Azure.Cosmos.Tests
 
             using CosmosClient client = MockCosmosUtil.CreateMockCosmosClient();
 
-            RequestInvokerHandler invoker = new RequestInvokerHandler(client, requestedClientConsistencyLevel: null, requestedClientPriorityLevel: null)
+            RequestInvokerHandler invoker = new RequestInvokerHandler(
+                client,
+                requestedClientConsistencyLevel: null,
+                requestedClientPriorityLevel: null,
+                requestedClientThroughputBucket: null)
             {
                 InnerHandler = testHandler
             };
@@ -285,7 +301,11 @@ namespace Microsoft.Azure.Cosmos.Tests
                     return TestHandler.ReturnSuccess();
                 });
 
-                RequestInvokerHandler invoker = new RequestInvokerHandler(client, requestedClientConsistencyLevel: client.ClientOptions.ConsistencyLevel, requestedClientPriorityLevel: null)
+                RequestInvokerHandler invoker = new RequestInvokerHandler(
+                    client,
+                    requestedClientConsistencyLevel: client.ClientOptions.ConsistencyLevel,
+                    requestedClientPriorityLevel: null,
+                    requestedClientThroughputBucket: null)
                 {
                     InnerHandler = testHandler
                 };
@@ -317,7 +337,11 @@ namespace Microsoft.Azure.Cosmos.Tests
                     return TestHandler.ReturnSuccess();
                 });
 
-                RequestInvokerHandler invoker = new RequestInvokerHandler(client, requestedClientConsistencyLevel: null, requestedClientPriorityLevel: client.ClientOptions.PriorityLevel)
+                RequestInvokerHandler invoker = new RequestInvokerHandler(
+                    client,
+                    requestedClientConsistencyLevel: null,
+                    requestedClientPriorityLevel: client.ClientOptions.PriorityLevel,
+                    requestedClientThroughputBucket: null)
                 {
                     InnerHandler = testHandler
                 };
@@ -349,7 +373,11 @@ namespace Microsoft.Azure.Cosmos.Tests
                 return TestHandler.ReturnSuccess();
             });
 
-            RequestInvokerHandler invoker = new RequestInvokerHandler(client, requestedClientConsistencyLevel: null, requestedClientPriorityLevel: client.ClientOptions.PriorityLevel)
+            RequestInvokerHandler invoker = new RequestInvokerHandler(
+                client,
+                requestedClientConsistencyLevel: null,
+                requestedClientPriorityLevel: client.ClientOptions.PriorityLevel,
+                requestedClientThroughputBucket: null)
             {
                 InnerHandler = testHandler
             };
@@ -369,6 +397,82 @@ namespace Microsoft.Azure.Cosmos.Tests
         }
 
         [TestMethod]
+        public async Task ThroughputBucketClientTest()
+        {
+            List<int> throughputBuckets = Enumerable.Range(1, 5).ToList();
+
+            foreach (int throughputBucket in throughputBuckets)
+            {
+                using CosmosClient client = MockCosmosUtil.CreateMockCosmosClient(
+                   accountConsistencyLevel: null,
+                   customizeClientBuilder: builder => builder.WithThroughputBucket(throughputBucket));
+
+                TestHandler testHandler = new TestHandler((request, cancellationToken) =>
+                {
+                    Assert.AreEqual(throughputBucket.ToString(), request.Headers[HttpConstants.HttpHeaders.ThroughputBucket]);
+                    return TestHandler.ReturnSuccess();
+                });
+
+                RequestInvokerHandler invoker = new RequestInvokerHandler(
+                    client: client,
+                    requestedClientConsistencyLevel: null,
+                    requestedClientPriorityLevel: null,
+                    requestedClientThroughputBucket: throughputBucket)
+                {
+                    InnerHandler = testHandler
+                };
+
+                RequestMessage requestMessage = new RequestMessage(HttpMethod.Get, new System.Uri("https://dummy.documents.azure.com:443/dbs"))
+                {
+                    ResourceType = ResourceType.Document
+                };
+                requestMessage.Headers.Add(HttpConstants.HttpHeaders.PartitionKey, "[]");
+                requestMessage.OperationType = OperationType.Read;
+
+                await invoker.SendAsync(requestMessage, new CancellationToken());
+            }
+        }
+
+        [TestMethod]
+        public async Task TestRequestThroughputBucketTakesPrecedence()
+        {
+            int clientBucket = 3;
+            int requestBucket = 5;
+
+            using CosmosClient client = MockCosmosUtil.CreateMockCosmosClient(
+               accountConsistencyLevel: null,
+               customizeClientBuilder: builder => builder.WithThroughputBucket(clientBucket));
+
+            TestHandler testHandler = new TestHandler((request, cancellationToken) =>
+            {
+                Assert.AreEqual(requestBucket.ToString(), request.Headers[HttpConstants.HttpHeaders.ThroughputBucket]);
+                return TestHandler.ReturnSuccess();
+            });
+
+            RequestInvokerHandler invoker = new RequestInvokerHandler(
+                client,
+                requestedClientConsistencyLevel: null,
+                requestedClientPriorityLevel: null,
+                requestedClientThroughputBucket: client.ClientOptions.ThroughputBucket)
+            {
+                InnerHandler = testHandler
+            };
+
+            RequestMessage requestMessage = new RequestMessage(HttpMethod.Get, new System.Uri("https://dummy.documents.azure.com:443/dbs"))
+            {
+                ResourceType = ResourceType.Document
+            };
+            requestMessage.Headers.Add(HttpConstants.HttpHeaders.PartitionKey, "[]");
+            requestMessage.OperationType = OperationType.Read;
+            requestMessage.RequestOptions = new RequestOptions
+            {
+                ThroughputBucket = requestBucket
+            };
+
+            await invoker.SendAsync(requestMessage, new CancellationToken());
+        }
+
+        [TestMethod]
         public async Task ConsistencyLevelClientAndRequestOption()
         {
             Cosmos.ConsistencyLevel requestOptionLevel = Cosmos.ConsistencyLevel.BoundedStaleness;
@@ -382,7 +486,11 @@ namespace Microsoft.Azure.Cosmos.Tests
                 return TestHandler.ReturnSuccess();
             });
 
-            RequestInvokerHandler invoker = new RequestInvokerHandler(client, requestedClientConsistencyLevel: null, requestedClientPriorityLevel: null)
+            RequestInvokerHandler invoker = new RequestInvokerHandler(
+                client,
+                requestedClientConsistencyLevel: null,
+                requestedClientPriorityLevel: null,
+                requestedClientThroughputBucket: null)
             {
                 InnerHandler = testHandler
             };
@@ -420,7 +528,11 @@ namespace Microsoft.Azure.Cosmos.Tests
 
             using CosmosClient client = MockCosmosUtil.CreateMockCosmosClient();
 
-            RequestInvokerHandler invoker = new RequestInvokerHandler(client, requestedClientConsistencyLevel: null, requestedClientPriorityLevel: null)
+            RequestInvokerHandler invoker = new RequestInvokerHandler(
+                client,
+                requestedClientConsistencyLevel: null,
+                requestedClientPriorityLevel: null,
+                requestedClientThroughputBucket: null)
             {
                 InnerHandler = testHandler
             };
@@ -609,10 +721,11 @@ namespace Microsoft.Azure.Cosmos.Tests
                 .Setup(container => container.GetPartitionKeyDefinitionAsync(cancellationToken))
                 .Returns(Task.FromResult(partitionKeyDefinition));
 
-            RequestInvokerHandler invoker = new(
-                client: client,
-                requestedClientConsistencyLevel: default,
-                requestedClientPriorityLevel: default);
+            RequestInvokerHandler invoker = new RequestInvokerHandler(
+                client,
+                requestedClientConsistencyLevel: null,
+                requestedClientPriorityLevel: null,
+                requestedClientThroughputBucket: null);
 
             Cosmos.FeedRange feedRange = await RequestInvokerHandler.ResolveFeedRangeBasedOnPrefixContainerAsync(
                 feedRange: inputFeedRange,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/RetryHandlerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/RetryHandlerTests.cs
@@ -34,7 +34,11 @@ namespace Microsoft.Azure.Cosmos.Tests
             });
 
             retryHandler.InnerHandler = testHandler;
-            RequestInvokerHandler invoker = new RequestInvokerHandler(client, requestedClientConsistencyLevel: null, requestedClientPriorityLevel: null)
+            RequestInvokerHandler invoker = new RequestInvokerHandler(
+                client,
+                requestedClientConsistencyLevel: null,
+                requestedClientPriorityLevel: null,
+                requestedClientThroughputBucket: null)
             {
                 InnerHandler = retryHandler
             };
@@ -67,7 +71,11 @@ namespace Microsoft.Azure.Cosmos.Tests
             });
 
             retryHandler.InnerHandler = testHandler;
-            RequestInvokerHandler invoker = new RequestInvokerHandler(client, requestedClientConsistencyLevel: null, requestedClientPriorityLevel: null)
+            RequestInvokerHandler invoker = new RequestInvokerHandler(
+                client,
+                requestedClientConsistencyLevel: null,
+                requestedClientPriorityLevel: null,
+                requestedClientThroughputBucket: null)
             {
                 InnerHandler = retryHandler
             };
@@ -100,7 +108,11 @@ namespace Microsoft.Azure.Cosmos.Tests
             });
 
             retryHandler.InnerHandler = testHandler;
-            RequestInvokerHandler invoker = new RequestInvokerHandler(client, requestedClientConsistencyLevel: null, requestedClientPriorityLevel: null)
+            RequestInvokerHandler invoker = new RequestInvokerHandler(
+                client,
+                requestedClientConsistencyLevel: null,
+                requestedClientPriorityLevel: null,
+                requestedClientThroughputBucket: null)
             {
                 InnerHandler = retryHandler
             };
@@ -145,7 +157,11 @@ namespace Microsoft.Azure.Cosmos.Tests
             });
 
             retryHandler.InnerHandler = testHandler;
-            RequestInvokerHandler invoker = new RequestInvokerHandler(client, requestedClientConsistencyLevel: null, requestedClientPriorityLevel: null)
+            RequestInvokerHandler invoker = new RequestInvokerHandler(
+                client,
+                requestedClientConsistencyLevel: null,
+                requestedClientPriorityLevel: null,
+                requestedClientThroughputBucket: null)
             {
                 InnerHandler = retryHandler
             };
@@ -204,7 +220,11 @@ namespace Microsoft.Azure.Cosmos.Tests
                 InnerHandler = testHandler
             };
 
-            RequestInvokerHandler invoker = new RequestInvokerHandler(client, requestedClientConsistencyLevel: null, requestedClientPriorityLevel: null)
+            RequestInvokerHandler invoker = new RequestInvokerHandler(
+                client,
+                requestedClientConsistencyLevel: null,
+                requestedClientPriorityLevel: null,
+                requestedClientThroughputBucket: null)
             {
                 InnerHandler = retryHandler
             };
@@ -236,7 +256,8 @@ namespace Microsoft.Azure.Cosmos.Tests
             RequestInvokerHandler invoker = new RequestInvokerHandler(
                 client,
                 requestedClientConsistencyLevel: null,
-                requestedClientPriorityLevel: null)
+                requestedClientPriorityLevel: null,
+                requestedClientThroughputBucket: null)
             {
                 InnerHandler = retryHandler
             };
@@ -269,7 +290,11 @@ namespace Microsoft.Azure.Cosmos.Tests
             });
 
             retryHandler.InnerHandler = testHandler;
-            RequestInvokerHandler invoker = new RequestInvokerHandler(client, requestedClientConsistencyLevel: null, requestedClientPriorityLevel: null)
+            RequestInvokerHandler invoker = new RequestInvokerHandler(
+                client,
+                requestedClientConsistencyLevel: null,
+                requestedClientPriorityLevel: null,
+                requestedClientThroughputBucket: null)
             {
                 InnerHandler = retryHandler
             };


### PR DESCRIPTION
## Description

This PR add ThroughputBucket in RequestOptions and ClientOptions to support Throughput Bucketing

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update
