### PR TITLE
[Internal] Binary Encoding: Adds unit tests with binary encoding enabled for CosmosBufferedStreamWrapper.

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosBufferedStreamWrapperTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosBufferedStreamWrapperTests.cs
@@ -5,8 +5,10 @@
 namespace Microsoft.Azure.Cosmos.Tests
 {
     using System;
+    using System.Collections.Generic;
     using System.IO;
     using System.Text;
+    using System.Text.Json;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Json;
     using Microsoft.Azure.Cosmos.Serializer;
@@ -28,38 +30,104 @@ namespace Microsoft.Azure.Cosmos.Tests
         [TestCleanup]
         public void Cleanup()
         {
+            // Delete the temporary file after each test
             JsonGenerator.DeleteJsonFile(TempFilePath);
         }
 
         [TestMethod]
-        public void TestReadComplexJsonFile()
+        public async Task TestStreamHandlingOfComplexJsonWithNestedObjects()
         {
-            // Read the generated JSON file
-            string jsonContent = File.ReadAllText(TempFilePath);
-
-            Assert.IsNotNull(jsonContent);
-            Assert.IsTrue(jsonContent.Contains("Id"));
-            Assert.IsTrue(jsonContent.Contains("Reference"));
-            Assert.IsTrue(jsonContent.Contains("CreatedOn"));
-            Assert.IsTrue(jsonContent.Contains("HexCode"));
-        }
-
-        [TestMethod]
-        public async Task TestStreamReadingFromJsonFile()
-        {
-            // Open the JSON file as a stream
             using FileStream fileStream = new FileStream(TempFilePath, FileMode.Open, FileAccess.Read);
             using CosmosBufferedStreamWrapper bufferedStream = new(await StreamExtension.AsClonableStreamAsync(fileStream), true);
 
-            byte[] buffer = new byte[fileStream.Length];
-            int bytesRead = bufferedStream.Read(buffer, 0, buffer.Length);
+            // Deserialize JSON from the stream
+            string jsonReadFromStream;
+            using (StreamReader reader = new(bufferedStream))
+            {
+                jsonReadFromStream = await reader.ReadToEndAsync();
+            }
 
-            Assert.AreEqual(fileStream.Length, bytesRead);
+            Assert.IsNotNull(jsonReadFromStream, "JSON read from the stream should not be null.");
 
-            string jsonContent = Encoding.UTF8.GetString(buffer);
-            Assert.IsNotNull(jsonContent);
-            Assert.IsTrue(jsonContent.Contains("NestedObject"));
-            Assert.IsTrue(jsonContent.Contains("ComplexArray"));
+            // Deserialize original and streamed JSON into objects
+            Dictionary<string, object> originalObject = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>>(await File.ReadAllTextAsync(TempFilePath));
+            Dictionary<string, object> streamedObject = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>>(jsonReadFromStream);
+
+            Assert.AreEqual(
+                System.Text.Json.JsonSerializer.Serialize(originalObject),
+                System.Text.Json.JsonSerializer.Serialize(streamedObject),
+                "Serialized JSON does not match after deserialization."
+            );
+        }
+
+        [TestMethod]
+        public async Task TestStreamHandlingOfComplexJsonWithUniformArraysAndHierarchy()
+        {
+            string originalJson = await File.ReadAllTextAsync(TempFilePath);
+
+            using FileStream fileStream = new FileStream(TempFilePath, FileMode.Open, FileAccess.Read);
+            using CosmosBufferedStreamWrapper bufferedStream = new(await StreamExtension.AsClonableStreamAsync(fileStream), true);
+
+            // Deserialize JSON from the stream
+            string jsonReadFromStream;
+            using (StreamReader reader = new(bufferedStream))
+            {
+                jsonReadFromStream = await reader.ReadToEndAsync();
+            }
+
+            Assert.IsNotNull(jsonReadFromStream, "JSON read from the stream should not be null.");
+
+            // Compare the normalized JSON for structural and content equality
+            Assert.AreEqual(
+                this.NormalizeJson(originalJson),
+                this.NormalizeJson(jsonReadFromStream),
+                "JSON does not match after processing through the wrapper."
+            );
+        }
+
+        [TestMethod]
+        public async Task TestStreamHandlingOfComplexJsonWithMixedDataAndRepeatingPatterns()
+        {
+            // Modify the utility-generated JSON for specific patterns
+            string originalJson = await File.ReadAllTextAsync(TempFilePath);
+
+            // Safely insert additional properties without breaking JSON syntax
+            Dictionary<string, object> jsonObject = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>>(originalJson);
+            jsonObject["Reference"] = "REF-1234";
+            jsonObject["HexCode"] = "#FF5733";
+
+            string updatedJson = System.Text.Json.JsonSerializer.Serialize(jsonObject, new JsonSerializerOptions { WriteIndented = true });
+
+            // Write the modified JSON to a new stream
+            using MemoryStream memoryStream = new(Encoding.UTF8.GetBytes(updatedJson));
+            using CosmosBufferedStreamWrapper bufferedStream = new(await StreamExtension.AsClonableStreamAsync(memoryStream), true);
+
+            // Deserialize JSON from the stream
+            string jsonReadFromStream;
+            using (StreamReader reader = new(bufferedStream))
+            {
+                jsonReadFromStream = await reader.ReadToEndAsync();
+            }
+
+            Assert.AreEqual(
+                this.NormalizeJson(updatedJson),
+                this.NormalizeJson(jsonReadFromStream),
+                "JSON with mixed data and repeating patterns does not match after processing."
+            );
+        }
+
+
+        /// <summary>
+        /// Normalizes JSON strings for consistent comparison.
+        /// </summary>
+        private string NormalizeJson(string json)
+        {
+            object jsonObject = System.Text.Json.JsonSerializer.Deserialize<object>(json);
+            return System.Text.Json.JsonSerializer.Serialize(jsonObject, new JsonSerializerOptions
+            {
+                WriteIndented = false,
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+            });
         }
 
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Utils/JsonGenerator.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Utils/JsonGenerator.cs
@@ -1,0 +1,159 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Tests.Utils
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Text.Json.Serialization;
+    using System.Text.Json;
+    using System.Threading.Tasks;
+    using System.IO;
+
+    internal class JsonGenerator
+    {
+        private static readonly Random RandomGenerator = new();
+
+        public static async Task<string> CreateComplexJsonFileAsync(string filePath)
+        {
+            Dictionary<string, object> jsonData = GenerateComplexJsonData();
+
+            // Write JSON to a file
+            await File.WriteAllTextAsync(filePath, JsonSerializer.Serialize(jsonData, new JsonSerializerOptions
+            {
+                WriteIndented = true,
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+            }));
+
+            return filePath;
+        }
+
+        public static void DeleteJsonFile(string filePath)
+        {
+            if (File.Exists(filePath))
+            {
+                File.Delete(filePath);
+            }
+        }
+
+        private static Dictionary<string, object> GenerateComplexJsonData()
+        {
+            return new Dictionary<string, object>
+            {
+                ["Id"] = Guid.NewGuid(),
+                ["Reference"] = GenerateReference(),
+                ["CreatedOn"] = DateTime.UtcNow.ToString("o"),
+                ["HexCode"] = GenerateHexColor(),
+                ["NumericSequence"] = GenerateRandomSequence(5, 100, 999),
+                ["Names"] = GenerateNames(5),
+                ["NestedObject"] = new
+                {
+                    Meta = "Metadata Info",
+                    Timestamps = GenerateDateRange(DateTime.UtcNow, -5, 5),
+                    DeepHierarchy = GenerateNestedHierarchy(4)
+                },
+                ["ComplexArray"] = GenerateComplexArray(6),
+                ["KeyValuePairs"] = GenerateKeyValuePairs(4),
+                ["MixedData"] = GenerateMixedDataArray()
+            };
+        }
+
+        private static string GenerateReference()
+        {
+            return $"REF-{Guid.NewGuid():N}"[..8];
+        }
+
+        private static string GenerateHexColor()
+        {
+            return $"#{RandomGenerator.Next(0x1000000):X6}";
+        }
+
+        private static int[] GenerateRandomSequence(int count, int min, int max)
+        {
+            int[] numbers = new int[count];
+            for (int i = 0; i < count; i++)
+            {
+                numbers[i] = RandomGenerator.Next(min, max);
+            }
+            return numbers;
+        }
+
+        private static string[] GenerateNames(int count)
+        {
+            string[] sampleNames = { "Alice", "Bob", "Charlie", "Diana", "Eve", "Frank", "Grace", "Heidi" };
+            string[] names = new string[count];
+            for (int i = 0; i < count; i++)
+            {
+                names[i] = sampleNames[RandomGenerator.Next(sampleNames.Length)];
+            }
+            return names;
+        }
+
+        private static DateTime[] GenerateDateRange(DateTime baseDate, int daysBefore, int daysAfter)
+        {
+            DateTime[] dates = new DateTime[daysBefore + daysAfter + 1];
+            for (int i = -daysBefore; i <= daysAfter; i++)
+            {
+                dates[i + daysBefore] = baseDate.AddDays(i);
+            }
+            return dates;
+        }
+
+        private static List<object> GenerateComplexArray(int count)
+        {
+            List<object> complexArray = new List<object>();
+            for (int i = 0; i < count; i++)
+            {
+                complexArray.Add(new
+                {
+                    Key = $"Key-{RandomGenerator.Next(1, 100)}",
+                    Value = RandomGenerator.NextDouble() * 1000,
+                    Timestamp = DateTime.UtcNow.AddMinutes(-RandomGenerator.Next(1, 100))
+                });
+            }
+            return complexArray;
+        }
+
+        private static Dictionary<string, object> GenerateNestedHierarchy(int levels)
+        {
+            if (levels <= 0) return null;
+
+            return new Dictionary<string, object>
+            {
+                ["Level"] = levels,
+                ["Description"] = $"Details at Level {levels}",
+                ["Next"] = GenerateNestedHierarchy(levels - 1),
+                ["Attributes"] = new
+                {
+                    Active = RandomGenerator.Next(0, 2) == 1,
+                    Priority = RandomGenerator.Next(1, 10)
+                }
+            };
+        }
+
+        private static Dictionary<string, string> GenerateKeyValuePairs(int count)
+        {
+            Dictionary<string, string> keyValuePairs = new Dictionary<string, string>();
+            for (int i = 0; i < count; i++)
+            {
+                keyValuePairs[$"Key{i}"] = $"Value{RandomGenerator.Next(100, 1000)}";
+            }
+            return keyValuePairs;
+        }
+
+        private static List<object> GenerateMixedDataArray()
+        {
+            return new List<object>
+            {
+                Guid.NewGuid(),
+                RandomGenerator.Next(1, 1000),
+                $"RandomString-{Guid.NewGuid():N}"[..12],
+                DateTime.UtcNow.ToString("o"),
+                new { NestedKey = "NestedValue", NestedId = Guid.NewGuid() }
+            };
+        }
+    }
+}


### PR DESCRIPTION
## Description

The tests for CosmosBufferedStreamWrapper ensure it correctly handles complex JSON with nested objects, arrays, GUIDs, and mixed data by testing serialization and deserialization. They check that the wrapper preserves JSON integrity, supports stream reading and resetting, and works reliably for various JSON scenarios.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)


## Closing issues

To automatically close an issue: closes #4719