### PR TITLE
[Internal] Direct: Adds Direct stack 3.37.6 upgrade

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
 		<ClientOfficialVersion>3.46.1</ClientOfficialVersion>
 		<ClientPreviewVersion>3.47.0</ClientPreviewVersion>
 		<ClientPreviewSuffixVersion>preview.1</ClientPreviewSuffixVersion>
-		<DirectVersion>3.37.5</DirectVersion>
+		<DirectVersion>3.37.6</DirectVersion>
 		<FaultInjectionVersion>1.0.0</FaultInjectionVersion>
 		<FaultInjectionSuffixVersion>beta.0</FaultInjectionSuffixVersion>
 		<EncryptionOfficialVersion>2.0.4</EncryptionOfficialVersion>

--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -6652,17 +6652,6 @@ namespace Microsoft.Azure.Cosmos
 
         private void InitializeDirectConnectivity(IStoreClientFactory storeClientFactory)
         {
-            this.AddressResolver = new GlobalAddressResolver(
-                this.GlobalEndpointManager,
-                this.PartitionKeyRangeLocation,
-                this.ConnectionPolicy.ConnectionProtocol,
-                this,
-                this.collectionCache,
-                this.partitionKeyRangeCache,
-                this.accountServiceConfiguration,
-                this.ConnectionPolicy,
-                this.httpClient);
-
             // Check if we have a store client factory in input and if we do, do not initialize another store client
             // The purpose is to reuse store client factory across all document clients inside compute gateway
             if (storeClientFactory != null)
@@ -6704,7 +6693,6 @@ namespace Microsoft.Azure.Cosmos
                     sendHangDetectionTimeSeconds: this.rntbdSendHangDetectionTimeSeconds,
                     retryWithConfiguration: this.ConnectionPolicy.RetryOptions?.GetRetryWithConfiguration(),
                     enableTcpConnectionEndpointRediscovery: this.ConnectionPolicy.EnableTcpConnectionEndpointRediscovery,
-                    addressResolver: this.AddressResolver,
                     rntbdMaxConcurrentOpeningConnectionCount: this.rntbdMaxConcurrentOpeningConnectionCount,
                     remoteCertificateValidationCallback: this.remoteCertificateValidationCallback,
                     distributedTracingOptions: distributedTracingOptions,
@@ -6718,6 +6706,18 @@ namespace Microsoft.Azure.Cosmos
                 this.storeClientFactory = newClientFactory;
                 this.isStoreClientFactoryCreatedInternally = true;
             }
+
+            this.AddressResolver = new GlobalAddressResolver(
+                this.GlobalEndpointManager,
+                this.PartitionKeyRangeLocation,
+                this.ConnectionPolicy.ConnectionProtocol,
+                this,
+                this.collectionCache,
+                this.partitionKeyRangeCache,
+                this.accountServiceConfiguration,
+                this.ConnectionPolicy,
+                this.httpClient,
+                this.storeClientFactory.GetConnectionStateListener());
 
             this.CreateStoreModel(subscribeRntbdStatus: true);
         }

--- a/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
@@ -61,7 +61,6 @@ namespace Microsoft.Azure.Cosmos.Routing
         private bool validateUnknownReplicas;
         private IOpenConnectionsHandler openConnectionsHandler;
 
-
         public GatewayAddressCache(
             Uri serviceEndpoint,
             Protocol protocol,
@@ -502,8 +501,8 @@ namespace Microsoft.Azure.Cosmos.Routing
         {
             if (this.disposedValue)
             {
-                /// Will enable Listener to un-register in-case of un-graceful dispose
-                /// <see cref="ConnectionStateMuxListener.NotifyAsync(ServerKey, ConcurrentDictionary{Func{ServerKey, Task}, object})"/>
+                // Will enable Listener to un-register in-case of un-graceful dispose
+                // <see cref="ConnectionStateMuxListener.NotifyAsync(ServerKey, ConcurrentDictionary{Func{ServerKey, Task}, object})"/>
                 throw new ObjectDisposedException(nameof(GatewayAddressCache));
             }
 

--- a/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
@@ -53,12 +53,14 @@ namespace Microsoft.Azure.Cosmos.Routing
         private readonly SemaphoreSlim semaphore;
         private readonly CosmosHttpClient httpClient;
         private readonly bool isReplicaAddressValidationEnabled;
+        private readonly IConnectionStateListener connectionStateListener;
 
         private Tuple<PartitionKeyRangeIdentity, PartitionAddressInformation> masterPartitionAddressCache;
         private DateTime suboptimalMasterPartitionTimestamp;
         private bool disposedValue;
         private bool validateUnknownReplicas;
         private IOpenConnectionsHandler openConnectionsHandler;
+
 
         public GatewayAddressCache(
             Uri serviceEndpoint,
@@ -67,6 +69,7 @@ namespace Microsoft.Azure.Cosmos.Routing
             IServiceConfigurationReader serviceConfigReader,
             CosmosHttpClient httpClient,
             IOpenConnectionsHandler openConnectionsHandler,
+            IConnectionStateListener connectionStateListener,
             long suboptimalPartitionForceRefreshIntervalInSeconds = 600,
             bool enableTcpConnectionEndpointRediscovery = false,
             bool replicaAddressValidationEnabled = false)
@@ -81,6 +84,7 @@ namespace Microsoft.Azure.Cosmos.Routing
             this.serverPartitionAddressToPkRangeIdMap = new ConcurrentDictionary<ServerKey, HashSet<PartitionKeyRangeIdentity>>();
             this.suboptimalMasterPartitionTimestamp = DateTime.MaxValue;
             this.enableTcpConnectionEndpointRediscovery = enableTcpConnectionEndpointRediscovery;
+            this.connectionStateListener = connectionStateListener;
 
             this.suboptimalPartitionForceRefreshIntervalInSeconds = suboptimalPartitionForceRefreshIntervalInSeconds;
 
@@ -496,6 +500,13 @@ namespace Microsoft.Azure.Cosmos.Routing
         public async Task MarkAddressesToUnhealthyAsync(
             ServerKey serverKey)
         {
+            if (this.disposedValue)
+            {
+                /// Will enable Listener to un-register in-case of un-graceful dispose
+                /// <see cref="ConnectionStateMuxListener.NotifyAsync(ServerKey, ConcurrentDictionary{Func{ServerKey, Task}, object})"/>
+                throw new ObjectDisposedException(nameof(GatewayAddressCache));
+            }
+
             if (serverKey == null)
             {
                 throw new ArgumentNullException(nameof(serverKey));
@@ -538,6 +549,9 @@ namespace Microsoft.Azure.Cosmos.Routing
 
                         address.SetUnhealthy();
                     }
+
+                    // Update the health status
+                    this.CaptureTransportAddressUriHealthStates(addressInfo, transportAddresses);
                 }
             }
         }
@@ -828,9 +842,21 @@ namespace Microsoft.Azure.Cosmos.Routing
                        partitionKeyRangeIdentity.PartitionKeyRangeId,
                        addressInfo.PhysicalUri);
 
+                    HashSet<PartitionKeyRangeIdentity> createdValue = null;
+                    ServerKey serverKey = new ServerKey(new Uri(addressInfo.PhysicalUri));
                     HashSet<PartitionKeyRangeIdentity> pkRangeIdSet = this.serverPartitionAddressToPkRangeIdMap.GetOrAdd(
-                        new ServerKey(new Uri(addressInfo.PhysicalUri)),
-                        (_) => new HashSet<PartitionKeyRangeIdentity>());
+                        serverKey,
+                        (_) =>
+                        {
+                            createdValue = new HashSet<PartitionKeyRangeIdentity>();
+                            return createdValue;
+                        });
+
+                    if (object.ReferenceEquals(pkRangeIdSet, createdValue))
+                    {
+                        this.connectionStateListener.Register(serverKey, this.MarkAddressesToUnhealthyAsync);
+                    }
+
                     lock (pkRangeIdSet)
                     {
                         pkRangeIdSet.Add(partitionKeyRangeIdentity);
@@ -893,7 +919,7 @@ namespace Microsoft.Azure.Cosmos.Routing
 
         private static Protocol ProtocolFromString(string protocol)
         {
-            return (protocol.ToLowerInvariant()) switch
+            return protocol.ToLowerInvariant() switch
             {
                 RuntimeConstants.Protocols.HTTPS => Protocol.Https,
                 RuntimeConstants.Protocols.RNTBD => Protocol.Tcp,
@@ -903,7 +929,7 @@ namespace Microsoft.Azure.Cosmos.Routing
 
         private static string ProtocolString(Protocol protocol)
         {
-            return ((int)protocol) switch
+            return (int)protocol switch
             {
                 (int)Protocol.Https => RuntimeConstants.Protocols.HTTPS,
                 (int)Protocol.Tcp => RuntimeConstants.Protocols.RNTBD,
@@ -1071,11 +1097,18 @@ namespace Microsoft.Azure.Cosmos.Routing
         {
             if (this.disposedValue)
             {
+                DefaultTrace.TraceInformation("GatewayAddressCache is already disposed {0}", this.GetHashCode());
                 return;
             }
 
             if (disposing)
             {
+                // Unregister the server-key
+                foreach (ServerKey serverKey in this.serverPartitionAddressToPkRangeIdMap.Keys)
+                {
+                    this.connectionStateListener.UnRegister(serverKey, this.MarkAddressesToUnhealthyAsync);
+                }
+
                 this.serverPartitionAddressCache?.Dispose();
             }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ConnectionStateMuxListenerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ConnectionStateMuxListenerTests.cs
@@ -1,0 +1,276 @@
+﻿namespace Microsoft.Azure.Cosmos.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Net.Http;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Routing;
+    using Microsoft.Azure.Documents;
+    using Microsoft.Azure.Documents.Client;
+    using Microsoft.Azure.Documents.Rntbd;
+    using Microsoft.Azure.Documents.Routing;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+
+    [TestClass]
+    public class ConnectionStateMuxListenerTests
+    {
+        [Owner("kirankk")]
+        [TestMethod]
+        public void StoreClientFactoryV2Setup()
+        {
+            StoreClientFactory storeClientFactory = new StoreClientFactory(Protocol.Tcp,
+                requestTimeoutInSeconds: 10,
+                maxConcurrentConnectionOpenRequests: 10);
+            Assert.IsInstanceOfType(storeClientFactory.GetConnectionStateListener(), typeof(ConnectionStateMuxListener));
+
+        }
+
+        [Owner("kirankk")]
+        [TestMethod]
+        public async Task DisableEndpointRediscoveryAsync()
+        {
+            bool enableTcpConnectionEndpointRediscovery = false;
+            ConnectionStateMuxListener connectionStateMuxListener = new ConnectionStateMuxListener(enableTcpConnectionEndpointRediscovery);
+
+            ServerKey serverKey = new ServerKey(new Uri("http://localhost:8081/ep1"));
+            ServerKey calledBackServerKey = null;
+            connectionStateMuxListener.Register(serverKey,
+                async (sk) =>
+                {
+                    await Task.Yield();
+                    calledBackServerKey = sk;
+                });
+
+            await connectionStateMuxListener.OnConnectionEventAsync(ConnectionEvent.ReadEof, DateTime.Now, serverKey);
+
+            Assert.IsFalse(connectionStateMuxListener.enableTcpConnectionEndpointRediscovery);
+            Assert.IsFalse(connectionStateMuxListener.serverKeyEventHandlers.Any());
+            Assert.IsNull(calledBackServerKey);
+        }
+
+        [Owner("kirankk")]
+        [TestMethod]
+        public async Task RegisterUnregisterNotifyAsync()
+        {
+            bool enableTcpConnectionEndpointRediscovery = true;
+            ConnectionStateMuxListener connectionStateMuxListener = new ConnectionStateMuxListener(enableTcpConnectionEndpointRediscovery);
+
+            ServerKey serverKey = new ServerKey(new Uri("http://localhost:8081/ep1"));
+            ServerKey calledBackServerKey = null;
+            Func<ServerKey, Task> callback = async (sk) =>
+            {
+                await Task.Yield();
+                calledBackServerKey = sk;
+            };
+
+            // Register
+            connectionStateMuxListener.Register(serverKey, callback);
+            Assert.IsTrue(connectionStateMuxListener.enableTcpConnectionEndpointRediscovery);
+            Assert.AreEqual(1, connectionStateMuxListener.serverKeyEventHandlers.Count);
+            Assert.AreEqual(1, connectionStateMuxListener.serverKeyEventHandlers.First().Value.Count);
+
+            await connectionStateMuxListener.OnConnectionEventAsync(ConnectionEvent.ReadEof, DateTime.Now, serverKey);
+            Assert.AreEqual(serverKey, calledBackServerKey);
+
+            // Call with a different equivalent object
+            calledBackServerKey = null;
+            ServerKey serverKeyDuplicate = new ServerKey(new Uri("http://localhost:8081/ep1"));
+            await connectionStateMuxListener.OnConnectionEventAsync(ConnectionEvent.ReadEof, DateTime.Now, serverKeyDuplicate);
+
+            Assert.AreEqual(1, connectionStateMuxListener.serverKeyEventHandlers.Count);
+            Assert.AreEqual(serverKey, serverKeyDuplicate);
+
+            // UnRegister
+            calledBackServerKey = null;
+            connectionStateMuxListener.UnRegister(serverKey, callback);
+            await connectionStateMuxListener.OnConnectionEventAsync(ConnectionEvent.ReadEof, DateTime.Now, serverKey);
+
+            Assert.IsTrue(connectionStateMuxListener.enableTcpConnectionEndpointRediscovery);
+            Assert.AreEqual(0, connectionStateMuxListener.serverKeyEventHandlers.Count); // Unregiter will not remove entry fully
+            Assert.IsNull(calledBackServerKey);
+        }
+
+        [Owner("kirankk")]
+        [TestMethod]
+        public async Task DuplicateRegisterAndUnRegisterSingleCallbackAsync()
+        {
+            bool enableTcpConnectionEndpointRediscovery = true;
+            ConnectionStateMuxListener connectionStateMuxListener = new ConnectionStateMuxListener(enableTcpConnectionEndpointRediscovery);
+
+            ServerKey serverKey = new ServerKey(new Uri("http://localhost:8081/ep1"));
+            ServerKey calledBackServerKey = null;
+            int callCount = 0;
+            Func<ServerKey, Task> callback = async (sk) =>
+            {
+                await Task.Yield();
+                callCount++;
+                calledBackServerKey = sk;
+            };
+
+            // Register
+            connectionStateMuxListener.Register(serverKey, callback);
+            await connectionStateMuxListener.OnConnectionEventAsync(ConnectionEvent.ReadEof, DateTime.Now, serverKey);
+
+            Assert.IsTrue(connectionStateMuxListener.enableTcpConnectionEndpointRediscovery);
+            Assert.AreEqual(1, connectionStateMuxListener.serverKeyEventHandlers.Count);
+            Assert.AreEqual(serverKey, calledBackServerKey);
+            Assert.AreEqual(1, callCount);
+
+            // Re-register the name key and callback => also should get called only once
+            connectionStateMuxListener.Register(serverKey, callback);
+            calledBackServerKey = null;
+            await connectionStateMuxListener.OnConnectionEventAsync(ConnectionEvent.ReadEof, DateTime.Now, serverKey);
+
+            Assert.AreEqual(serverKey, calledBackServerKey);
+            Assert.AreEqual(2, callCount);
+
+            // UnRegister
+            calledBackServerKey = null;
+            connectionStateMuxListener.UnRegister(serverKey, callback);
+            await connectionStateMuxListener.OnConnectionEventAsync(ConnectionEvent.ReadEof, DateTime.Now, serverKey);
+
+            Assert.IsTrue(connectionStateMuxListener.enableTcpConnectionEndpointRediscovery);
+            Assert.AreEqual(0, connectionStateMuxListener.serverKeyEventHandlers.Count);
+            Assert.IsNull(calledBackServerKey);
+
+            // Double un-register
+            connectionStateMuxListener.UnRegister(serverKey, callback);
+            Assert.IsTrue(connectionStateMuxListener.enableTcpConnectionEndpointRediscovery);
+            Assert.AreEqual(0, connectionStateMuxListener.serverKeyEventHandlers.Count);
+        }
+
+        [Owner("kirankk")]
+        [TestMethod]
+        public async Task DuplicateRegisterAndUnRegisterDifferentCallbacksAsync()
+        {
+            bool enableTcpConnectionEndpointRediscovery = true;
+            ConnectionStateMuxListener connectionStateMuxListener = new ConnectionStateMuxListener(enableTcpConnectionEndpointRediscovery);
+
+            ServerKey serverKey = new ServerKey(new Uri("http://localhost:8081/ep1"));
+            int callCount = 0;
+            Func<ServerKey, Task> callback1 = async (sk) =>
+            {
+                await Task.Yield();
+                callCount++;
+            };
+            Func<ServerKey, Task> callback2 = async (sk) =>
+            {
+                await Task.Yield();
+                callCount++;
+            };
+
+            // Register
+            connectionStateMuxListener.Register(serverKey, callback1);
+            connectionStateMuxListener.Register(serverKey, callback2);
+            await connectionStateMuxListener.OnConnectionEventAsync(ConnectionEvent.ReadEof, DateTime.Now, serverKey);
+
+            Assert.IsTrue(connectionStateMuxListener.enableTcpConnectionEndpointRediscovery);
+            Assert.AreEqual(1, connectionStateMuxListener.serverKeyEventHandlers.Count);
+            Assert.AreEqual(2, connectionStateMuxListener.serverKeyEventHandlers.First().Value.Count);
+            Assert.AreEqual(2, callCount);
+
+            // UnRegister
+            connectionStateMuxListener.UnRegister(serverKey, callback1);
+            await connectionStateMuxListener.OnConnectionEventAsync(ConnectionEvent.ReadEof, DateTime.Now, serverKey);
+
+            Assert.IsTrue(connectionStateMuxListener.enableTcpConnectionEndpointRediscovery);
+            Assert.AreEqual(1, connectionStateMuxListener.serverKeyEventHandlers.Count);
+            Assert.AreEqual(3, callCount);
+
+            // Double un-register
+            connectionStateMuxListener.UnRegister(serverKey, callback2);
+            Assert.IsTrue(connectionStateMuxListener.enableTcpConnectionEndpointRediscovery);
+            Assert.AreEqual(0, connectionStateMuxListener.serverKeyEventHandlers.Count);
+        }
+
+        [Owner("kirankk")]
+        [TestMethod]
+        public void ArgumentCheck()
+        {
+            ConnectionStateMuxListener connectionStateMuxListener = new ConnectionStateMuxListener(true);
+
+            Assert.ThrowsException<ArgumentNullException>(() => connectionStateMuxListener.Register(null, null));
+            Assert.ThrowsException<ArgumentNullException>(() => connectionStateMuxListener.Register(new ServerKey(new Uri("http://localost:8081")), null));
+
+            Assert.ThrowsException<ArgumentNullException>(() => connectionStateMuxListener.UnRegister(null, null));
+            Assert.ThrowsException<ArgumentNullException>(() => connectionStateMuxListener.UnRegister(new ServerKey(new Uri("http://localost:8081")), null));
+        }
+
+        [Owner("kirankk")]
+        [TestMethod]
+        public async Task DynamicConcurrencyMuxListenerTestAsync()
+        {
+            ConnectionStateMuxListener connectionStateMuxListener = new ConnectionStateMuxListener(true);
+            Assert.AreEqual(Environment.ProcessorCount, connectionStateMuxListener.notificationConcurrency);
+            Assert.IsTrue(connectionStateMuxListener.enableTcpConnectionEndpointRediscovery);
+
+            int callbackCount = 0;
+            ServerKey serverKey = new ServerKey(new Uri("http://localhost:8081/"));
+            connectionStateMuxListener.Register(serverKey,
+                async (sk) =>
+                {
+                    callbackCount++;
+                    await Task.Yield();
+                });
+
+            await connectionStateMuxListener.OnConnectionEventAsync(ConnectionEvent.ReadEof, DateTime.Now, serverKey);
+            Assert.AreEqual(1, callbackCount);
+
+            connectionStateMuxListener.SetConnectionEventConcurrency(0);
+            Assert.AreEqual(0, connectionStateMuxListener.notificationConcurrency);
+            Assert.IsTrue(connectionStateMuxListener.enableTcpConnectionEndpointRediscovery);
+
+            callbackCount = 0;
+            await connectionStateMuxListener.OnConnectionEventAsync(ConnectionEvent.ReadEof, DateTime.Now, serverKey);
+            Assert.AreEqual(0, callbackCount);
+        }
+
+        [Owner("kirankk")]
+        [TestMethod]
+        public async Task NotificationsConcurrencyListenerTestAsync()
+        {
+            int concurrentToTest = 2;
+            int totalRequests = concurrentToTest * 2;
+            IConnectionStateListener connectionStateMuxListener = new ConnectionStateMuxListener(true);
+            connectionStateMuxListener.SetConnectionEventConcurrency(concurrentToTest);
+
+            SemaphoreSlim mainTaskSemsphore = new SemaphoreSlim(concurrentToTest);
+            ManualResetEvent manualResetEvent = new ManualResetEvent(false);
+
+            int callbackCount = 0;
+            ServerKey serverKey = new ServerKey(new Uri("http://localhost:8081/"));
+            connectionStateMuxListener.Register(serverKey,
+                async (sk) => {
+                    await mainTaskSemsphore.WaitAsync();
+
+                    lock (sk)
+                    {
+                        callbackCount++;
+                        if (callbackCount >= concurrentToTest)
+                        {
+                            manualResetEvent.Set();
+                        }
+                    }
+                });
+
+            Task[] allTasks = new Task[totalRequests];
+            for (int i = 0; i < totalRequests; i++)
+            {
+                allTasks[i] = connectionStateMuxListener.OnConnectionEventAsync(ConnectionEvent.ReadEof, DateTime.Now, serverKey);
+            }
+
+            manualResetEvent.WaitOne();
+            Assert.AreEqual(concurrentToTest, callbackCount);
+
+            mainTaskSemsphore.Release(concurrentToTest);
+            await Task.WhenAll(allTasks);
+            Assert.AreEqual(totalRequests, callbackCount);
+
+            mainTaskSemsphore.Release(concurrentToTest);
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GatewayAddressCacheTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GatewayAddressCacheTests.cs
@@ -85,6 +85,7 @@ namespace Microsoft.Azure.Cosmos
                 this.mockServiceConfigReader.Object,
                 MockCosmosUtil.CreateCosmosHttpClient(() => httpClient),
                 openConnectionsHandler: null,
+                 Mock.Of<IConnectionStateListener>(),
                 suboptimalPartitionForceRefreshIntervalInSeconds: 2);
 
             int initialAddressesCount = cache.TryGetAddressesAsync(
@@ -108,6 +109,42 @@ namespace Microsoft.Azure.Cosmos
             Assert.IsTrue(finalAddressCount == this.targetReplicaSetSize);
         }
 
+
+        [TestMethod]
+        public async Task TestGatewayAddressCacheAndConnectionStateListenerRegAndUnReg()
+        {
+            FakeMessageHandler messageHandler = new FakeMessageHandler();
+            HttpClient httpClient = new HttpClient(messageHandler)
+            {
+                Timeout = TimeSpan.FromSeconds(120)
+            };
+
+            Mock<IConnectionStateListener> connectionListenerMock = new Mock<IConnectionStateListener>();
+
+            GatewayAddressCache cache = new GatewayAddressCache(
+                new Uri(GatewayAddressCacheTests.DatabaseAccountApiEndpoint),
+                Documents.Client.Protocol.Tcp,
+                this.mockTokenProvider.Object,
+                this.mockServiceConfigReader.Object,
+                MockCosmosUtil.CreateCosmosHttpClient(() => httpClient),
+                openConnectionsHandler: null,
+                connectionListenerMock.Object,
+                suboptimalPartitionForceRefreshIntervalInSeconds: 2,
+                enableTcpConnectionEndpointRediscovery: true);
+
+            PartitionAddressInformation addresses = await cache.TryGetAddressesAsync(
+             DocumentServiceRequest.Create(OperationType.Invalid, ResourceType.Address, AuthorizationTokenType.Invalid),
+             this.testPartitionKeyRangeIdentity,
+             this.serviceIdentity,
+             false,
+             CancellationToken.None);
+
+            Mock.Get(connectionListenerMock.Object).Verify(x => x.Register(It.IsAny<ServerKey>(), It.IsAny<Func<ServerKey, Task>>()), Times.Exactly(3));
+            cache.Dispose();
+            Mock.Get(connectionListenerMock.Object).Verify(x => x.UnRegister(It.IsAny<ServerKey>(), It.IsAny<Func<ServerKey, Task>>()), Times.Exactly(3));
+
+        }
+
         [TestMethod]
         public async Task TestGatewayAddressCacheUpdateOnConnectionResetAsync()
         {
@@ -124,6 +161,7 @@ namespace Microsoft.Azure.Cosmos
                 this.mockServiceConfigReader.Object,
                 MockCosmosUtil.CreateCosmosHttpClient(() => httpClient),
                 openConnectionsHandler: null,
+                Mock.Of<IConnectionStateListener>(),
                 suboptimalPartitionForceRefreshIntervalInSeconds: 2,
                 enableTcpConnectionEndpointRediscovery: true);
 
@@ -133,7 +171,7 @@ namespace Microsoft.Azure.Cosmos
              this.serviceIdentity,
              false,
              CancellationToken.None);
-
+            
             Assert.IsNotNull(addresses.AllAddresses.Select(address => address.PhysicalUri == "https://blabla.com"));
 
             // Mark transport addresses to Unhealthy depcting a connection reset event.
@@ -191,6 +229,7 @@ namespace Microsoft.Azure.Cosmos
                 this.mockServiceConfigReader.Object,
                 MockCosmosUtil.CreateCosmosHttpClient(() => httpClient),
                 openConnectionsHandler: null,
+                Mock.Of<IConnectionStateListener>(),
                 suboptimalPartitionForceRefreshIntervalInSeconds: 2,
                 enableTcpConnectionEndpointRediscovery: true);
 
@@ -269,19 +308,20 @@ namespace Microsoft.Azure.Cosmos
                         RequestTimeout = TimeSpan.FromSeconds(10)
                     };
 
+                    IConnectionStateListener connectionStateListener = new ConnectionStateMuxListener(true);
                     GlobalAddressResolver globalAddressResolver = new GlobalAddressResolver(
                         endpointManager: globalEndpointManager,
-                        partitionKeyRangeLocationCache: partitionKeyRangeLocationCache,
-                        protocol: Documents.Client.Protocol.Tcp,
-                        tokenProvider: this.mockTokenProvider.Object,
-                        collectionCache: null,
-                        routingMapProvider: null,
-                        serviceConfigReader: this.mockServiceConfigReader.Object,
-                        connectionPolicy: connectionPolicy,
-                        httpClient: MockCosmosUtil.CreateCosmosHttpClient(() => new HttpClient(messageHandler)));
+                        null,
+                        Protocol.Tcp,
+                        this.mockTokenProvider.Object,
+                        null,
+                        null,
+                        this.mockServiceConfigReader.Object,
+                        connectionPolicy,
+                        httpClient: MockCosmosUtil.CreateCosmosHttpClient(() => new HttpClient(messageHandler)),
+                        connectionStateListener: connectionStateListener);
 
-                    ConnectionStateListener connectionStateListener = new ConnectionStateListener(globalAddressResolver);
-                    connectionStateListener.OnConnectionEvent(ConnectionEvent.ReadEof, DateTime.Now, new Documents.Rntbd.ServerKey(new Uri("https://endpoint.azure.com:4040/")));
+                    connectionStateListener.OnConnectionEventAsync(ConnectionEvent.ReadEof, DateTime.Now, new ServerKey(new Uri("https://endpoint.azure.com:4040/"))).Wait();
 
                 }, state: null);
             }
@@ -307,6 +347,7 @@ namespace Microsoft.Azure.Cosmos
                 this.mockServiceConfigReader.Object,
                 MockCosmosUtil.CreateCosmosHttpClient(() => httpClient),
                 openConnectionsHandler: null,
+                connectionStateListener: Mock.Of<IConnectionStateListener>(),
                 suboptimalPartitionForceRefreshIntervalInSeconds: 2,
                 enableTcpConnectionEndpointRediscovery: true);
 
@@ -367,6 +408,7 @@ namespace Microsoft.Azure.Cosmos
                 this.mockServiceConfigReader.Object,
                 MockCosmosUtil.CreateCosmosHttpClient(() => httpClient),
                 openConnectionsHandler: fakeOpenConnectionHandler,
+                connectionStateListener: Mock.Of<IConnectionStateListener>(),
                 suboptimalPartitionForceRefreshIntervalInSeconds: 2);
 
             // Act.
@@ -413,6 +455,7 @@ namespace Microsoft.Azure.Cosmos
                 this.mockServiceConfigReader.Object,
                 MockCosmosUtil.CreateCosmosHttpClient(() => httpClient),
                 openConnectionsHandler: fakeOpenConnectionHandler,
+                connectionStateListener: Mock.Of<IConnectionStateListener>(),
                 suboptimalPartitionForceRefreshIntervalInSeconds: 2);
 
             // Act.
@@ -462,6 +505,7 @@ namespace Microsoft.Azure.Cosmos
                 this.mockServiceConfigReader.Object,
                 MockCosmosUtil.CreateCosmosHttpClient(() => httpClient),
                 openConnectionsHandler: null,
+                connectionStateListener: Mock.Of<IConnectionStateListener>(),
                 suboptimalPartitionForceRefreshIntervalInSeconds: 2);
 
             // Act.
@@ -529,6 +573,7 @@ namespace Microsoft.Azure.Cosmos
                 this.mockServiceConfigReader.Object,
                 MockCosmosUtil.CreateCosmosHttpClient(() => httpClient),
                 openConnectionsHandler: fakeOpenConnectionHandler,
+                connectionStateListener: Mock.Of<IConnectionStateListener>(),
                 suboptimalPartitionForceRefreshIntervalInSeconds: 2);
 
             // Act.
@@ -611,6 +656,7 @@ namespace Microsoft.Azure.Cosmos
                 routingMapProvider: this.partitionKeyRangeCache.Object,
                 serviceConfigReader: this.mockServiceConfigReader.Object,
                 connectionPolicy: connectionPolicy,
+                connectionStateListener: Mock.Of<IConnectionStateListener>(),
                 httpClient: MockCosmosUtil.CreateCosmosHttpClient(() => new HttpClient(messageHandler)));
 
             globalAddressResolver.SetOpenConnectionsHandler(
@@ -689,6 +735,7 @@ namespace Microsoft.Azure.Cosmos
                 routingMapProvider: this.partitionKeyRangeCache.Object,
                 serviceConfigReader: this.mockServiceConfigReader.Object,
                 connectionPolicy: connectionPolicy,
+                connectionStateListener: Mock.Of<IConnectionStateListener>(),
                 httpClient: MockCosmosUtil.CreateCosmosHttpClient(() => new HttpClient(messageHandler)));
 
             globalAddressResolver.SetOpenConnectionsHandler(
@@ -778,6 +825,7 @@ namespace Microsoft.Azure.Cosmos
                 routingMapProvider: partitionKeyRangeCache.Object,
                 serviceConfigReader: this.mockServiceConfigReader.Object,
                 connectionPolicy: connectionPolicy,
+                connectionStateListener: Mock.Of<IConnectionStateListener>(),
                 httpClient: MockCosmosUtil.CreateCosmosHttpClient(() => new HttpClient(messageHandler)));
 
             globalAddressResolver.SetOpenConnectionsHandler(
@@ -854,6 +902,7 @@ namespace Microsoft.Azure.Cosmos
                 routingMapProvider: this.partitionKeyRangeCache.Object,
                 serviceConfigReader: this.mockServiceConfigReader.Object,
                 connectionPolicy: connectionPolicy,
+                connectionStateListener: Mock.Of<IConnectionStateListener>(),
                 httpClient: MockCosmosUtil.CreateCosmosHttpClient(() => new HttpClient(messageHandler)));
 
             globalAddressResolver.SetOpenConnectionsHandler(
@@ -939,6 +988,7 @@ namespace Microsoft.Azure.Cosmos
                 this.mockServiceConfigReader.Object,
                 mockHttpClient.Object,
                 openConnectionsHandler: fakeOpenConnectionHandler,
+                connectionStateListener: Mock.Of<IConnectionStateListener>(),
                 suboptimalPartitionForceRefreshIntervalInSeconds: 2);
 
             // Act.
@@ -1003,6 +1053,7 @@ namespace Microsoft.Azure.Cosmos
                 this.mockServiceConfigReader.Object,
                 MockCosmosUtil.CreateCosmosHttpClient(() => httpClient),
                 openConnectionsHandler: fakeOpenConnectionHandler,
+                connectionStateListener: Mock.Of<IConnectionStateListener>(),
                 suboptimalPartitionForceRefreshIntervalInSeconds: 2,
                 enableTcpConnectionEndpointRediscovery: true,
                 replicaAddressValidationEnabled: true);
@@ -1148,6 +1199,7 @@ namespace Microsoft.Azure.Cosmos
                 this.mockServiceConfigReader.Object,
                 MockCosmosUtil.CreateCosmosHttpClient(() => httpClient),
                 openConnectionsHandler: fakeOpenConnectionHandler,
+                connectionStateListener: Mock.Of<IConnectionStateListener>(),
                 suboptimalPartitionForceRefreshIntervalInSeconds: 2,
                 enableTcpConnectionEndpointRediscovery: true,
                 replicaAddressValidationEnabled: true);
@@ -1365,6 +1417,7 @@ namespace Microsoft.Azure.Cosmos
                 this.mockServiceConfigReader.Object,
                 MockCosmosUtil.CreateCosmosHttpClient(() => httpClient),
                 openConnectionsHandler: fakeOpenConnectionHandler,
+                connectionStateListener: Mock.Of<IConnectionStateListener>(),
                 suboptimalPartitionForceRefreshIntervalInSeconds: 2,
                 enableTcpConnectionEndpointRediscovery: true,
                 replicaAddressValidationEnabled: true);
@@ -1481,6 +1534,7 @@ namespace Microsoft.Azure.Cosmos
                 this.mockServiceConfigReader.Object,
                 MockCosmosUtil.CreateCosmosHttpClient(() => httpClient),
                 openConnectionsHandler: fakeOpenConnectionHandler,
+                connectionStateListener: Mock.Of<IConnectionStateListener>(),
                 suboptimalPartitionForceRefreshIntervalInSeconds: 2,
                 enableTcpConnectionEndpointRediscovery: true);
 


### PR DESCRIPTION
# Pull Request Template

## Description

This PR is for upgrading Direct stack version 3.37.6 the V3 codebase with 3.37.6. 

It contains two changes,
 
https://msdata.visualstudio.com/CosmosDB/_git/CosmosDB/pullrequest/1505615

 : QuorumReader: Fixes bug with BoundedStaleness

https://msdata.visualstudio.com/CosmosDB/_git/CosmosDB/pullrequest/1529101

 ConnectionStateListener multiplexing: support multiple CosmosClients (Sharing StoreClient)

It also brings in a dependent change done in OSS codebase 

https://msdata.visualstudio.com/CosmosDB/_git/CosmosSdkOSSClone/pullrequest/1532400?_a=files&path=/Microsoft.Azure.Cosmos/src/DocumentClient.cs


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
