### PR TITLE
HA: Fixes CrossRegion retry also on RequestTimeout from addressRefresh [DO-NOT-MERGE]

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ClientRetryPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/ClientRetryPolicy.cs
@@ -310,8 +310,9 @@ namespace Microsoft.Azure.Cosmos
             }
             
             // Received 503 due to client connect timeout or Gateway
+            // 408 retry: limit to document resource-type?
             if (statusCode == HttpStatusCode.ServiceUnavailable
-                || statusCode == HttpStatusCode.RequestTimeout) // Retry for even non-document resources?
+                || statusCode == HttpStatusCode.RequestTimeout) 
             {
                 return this.TryMarkEndpointUnavailableForPkRangeAndRetryOnServiceUnavailable(
                     shouldMarkEndpointUnavailableForPkRange: true);

--- a/Microsoft.Azure.Cosmos/src/ClientRetryPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/ClientRetryPolicy.cs
@@ -310,7 +310,8 @@ namespace Microsoft.Azure.Cosmos
             }
             
             // Received 503 due to client connect timeout or Gateway
-            if (statusCode == HttpStatusCode.ServiceUnavailable)
+            if (statusCode == HttpStatusCode.ServiceUnavailable
+                || statusCode == HttpStatusCode.RequestTimeout) // Retry for even non-document resources?
             {
                 return this.TryMarkEndpointUnavailableForPkRangeAndRetryOnServiceUnavailable(
                     shouldMarkEndpointUnavailableForPkRange: true);


### PR DESCRIPTION
# Pull Request Template

## Description

ClientRetryPolicy expects that RequestTimeouts gets converted to 503 by HA stack. 
In cases of AddressRefresh calls the AddressRefresh calls timeouts are not converted to 503 but original TaskCancellationException is thrown. 

Changes to HA stack will have higher impact radius, instead a generic is retry is added now to the ClientRetryPolicy.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber