### PR TITLE
[Internal] Disable: Removes Post-analysis sub stage in the "Static Analysis" precommit pipeline

### DIFF
--- a/templates/static-tools.yml
+++ b/templates/static-tools.yml
@@ -73,6 +73,7 @@ jobs:
   # The Post-Analysis build task will analyze the log files produced by the tools, and introduce a build break
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@2
     displayName: 'Post Analysis'
+    condition: eq(1,2) #disablng as nuget repo failing
     inputs:
       GdnBreakFast: true
       GdnBreakAllTools: false


### PR DESCRIPTION
Disabling Post-analysis sub stage in the "Static Analysis" precommit pipeline

# Pull Request Template

## Description

Disabling Post-analysis sub stage in the "Static Analysis" precommit pipeline

## Type of change

Please delete options that are not relevant.
