### PR TITLE
Hedging: Adds GA for DisableAvailabilityStrategy

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Routing/AvailabilityStrategy/AvailabilityStrategy.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/AvailabilityStrategy/AvailabilityStrategy.cs
@@ -21,7 +21,7 @@ namespace Microsoft.Azure.Cosmos
         ///  Used on a per request level to disable a client level AvailabilityStrategy
         /// </summary>
         /// <returns>something</returns>
-        internal static AvailabilityStrategy DisabledStrategy()
+        public static AvailabilityStrategy DisabledStrategy()
         {
             return new DisabledAvailabilityStrategy();
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetSDKAPI.json
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetSDKAPI.json
@@ -170,6 +170,11 @@
           "Type": "Method",
           "Attributes": [],
           "MethodInfo": "Microsoft.Azure.Cosmos.AvailabilityStrategy CrossRegionHedgingStrategy(System.TimeSpan, System.Nullable`1[System.TimeSpan]);IsAbstract:False;IsStatic:True;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "Microsoft.Azure.Cosmos.AvailabilityStrategy DisabledStrategy()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.AvailabilityStrategy DisabledStrategy();IsAbstract:False;IsStatic:True;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
         }
       },
       "NestedTypes": {}


### PR DESCRIPTION
# Pull Request Template

## Description

Makes `AvailabilityStrategy.DisableAvailabilityStrategy` public for GA consumption. This API is used to override the client level `AvailabilityStrategy`. 

## Type of change

Please delete options that are not relevant.

- [] New feature (non-breaking change which adds functionality)

## Closing issues

To automatically close an issue: closes #IssueNumber