### PR TITLE
[Internal] Open Telemetry : Fixes preview pipeline test for open telemetry

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Metrics/OpenTelemetryMetricsTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Metrics/OpenTelemetryMetricsTest.cs
@@ -95,6 +95,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.Metrics
             {
                 await base.TestInit((builder) => builder.WithClientTelemetryOptions(new CosmosClientTelemetryOptions()
                 {
+                    DisableDistributedTracing = true,
                     IsClientMetricsEnabled = true
                 })
                 .WithConnectionModeDirect());
@@ -104,6 +105,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.Metrics
             {
                 await base.TestInit((builder) => builder.WithClientTelemetryOptions(new CosmosClientTelemetryOptions()
                 {
+                    DisableDistributedTracing = true,
                     IsClientMetricsEnabled = true
                 })
                 .WithConnectionModeGateway());
@@ -167,6 +169,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.Metrics
 
             await base.TestInit((builder) => builder.WithClientTelemetryOptions(new CosmosClientTelemetryOptions()
             {
+                DisableDistributedTracing = true,
                 IsClientMetricsEnabled = true,
                 OperationMetricsOptions = new OperationMetricsOptions()
                 {

--- a/templates/build-test.yml
+++ b/templates/build-test.yml
@@ -288,7 +288,7 @@ jobs:
     inputs:
       command: test
       projects: 'Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/*.csproj'
-      arguments: --filter "TestCategory=Flaky" --verbosity normal --configuration ${{ parameters.BuildConfiguration }} /p:OS=${{ parameters.OS }} -p:IsPreview=true;SdkProjectRef=true
+      arguments: --filter "TestCategory=Flaky" --verbosity normal --configuration ${{ parameters.BuildConfiguration }} /p:OS=${{ parameters.OS }}
       nugetConfigPath: NuGet.config
       publishTestResults: true
       testRunTitle: Microsoft.Azure.Cosmos.EmulatorTests

--- a/templates/build-test.yml
+++ b/templates/build-test.yml
@@ -288,7 +288,7 @@ jobs:
     inputs:
       command: test
       projects: 'Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/*.csproj'
-      arguments: --filter "TestCategory=Flaky" --verbosity normal --configuration ${{ parameters.BuildConfiguration }} /p:OS=${{ parameters.OS }}
+      arguments: --filter "TestCategory=Flaky" --verbosity normal --configuration ${{ parameters.BuildConfiguration }} /p:OS=${{ parameters.OS }} -p:IsPreview=true;SdkProjectRef=true
       nugetConfigPath: NuGet.config
       publishTestResults: true
       testRunTitle: Microsoft.Azure.Cosmos.EmulatorTests

--- a/templates/build-test.yml
+++ b/templates/build-test.yml
@@ -207,7 +207,7 @@ jobs:
     inputs:
       command: test
       projects: 'Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/*.csproj'
-      arguments: ${{ parameters.EmulatorPipeline1Arguments }} --configuration ${{ parameters.BuildConfiguration }} /p:OS=${{ parameters.OS }}
+      arguments: ${{ parameters.EmulatorPipeline1Arguments }} --configuration ${{ parameters.BuildConfiguration }} /p:OS=${{ parameters.OS }} -p:IsPreview=true;SdkProjectRef=true
       nugetConfigPath: NuGet.config
       publishTestResults: true
       testRunTitle: Microsoft.Azure.Cosmos.EmulatorTests
@@ -247,7 +247,7 @@ jobs:
     inputs:
       command: test
       projects: 'Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/*.csproj'
-      arguments: ${{ parameters.EmulatorPipeline2Arguments }} --configuration ${{ parameters.BuildConfiguration }} /p:OS=${{ parameters.OS }}
+      arguments: ${{ parameters.EmulatorPipeline2Arguments }} --configuration ${{ parameters.BuildConfiguration }} /p:OS=${{ parameters.OS }} -p:IsPreview=true;SdkProjectRef=true
       nugetConfigPath: NuGet.config
       publishTestResults: true
       testRunTitle: Microsoft.Azure.Cosmos.EmulatorTests
@@ -406,7 +406,7 @@ jobs:
     inputs:
       command: test
       projects: 'Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/*.csproj'
-      arguments: ${{ parameters.EmulatorPipeline3Arguments }} --configuration ${{ parameters.BuildConfiguration }} /p:OS=${{ parameters.OS }}
+      arguments: ${{ parameters.EmulatorPipeline3Arguments }} --configuration ${{ parameters.BuildConfiguration }} /p:OS=${{ parameters.OS }} -p:IsPreview=true;SdkProjectRef=true
       nugetConfigPath: NuGet.config
       publishTestResults: true
       testRunTitle: Microsoft.Azure.Cosmos.EmulatorTests
@@ -445,7 +445,7 @@ jobs:
     inputs:
       command: test
       projects: 'Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/*.csproj'
-      arguments: ${{ parameters.EmulatorPipeline4Arguments }} --configuration ${{ parameters.BuildConfiguration }} /p:OS=${{ parameters.OS }}
+      arguments: ${{ parameters.EmulatorPipeline4Arguments }} --configuration ${{ parameters.BuildConfiguration }} /p:OS=${{ parameters.OS }} -p:IsPreview=true;SdkProjectRef=true
       nugetConfigPath: NuGet.config
       publishTestResults: true
       testRunTitle: Microsoft.Azure.Cosmos.EmulatorTests

--- a/templates/build-test.yml
+++ b/templates/build-test.yml
@@ -207,7 +207,7 @@ jobs:
     inputs:
       command: test
       projects: 'Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/*.csproj'
-      arguments: ${{ parameters.EmulatorPipeline1Arguments }} --configuration ${{ parameters.BuildConfiguration }} /p:OS=${{ parameters.OS }} -p:IsPreview=true;SdkProjectRef=true
+      arguments: ${{ parameters.EmulatorPipeline1Arguments }} --configuration ${{ parameters.BuildConfiguration }} /p:OS=${{ parameters.OS }}
       nugetConfigPath: NuGet.config
       publishTestResults: true
       testRunTitle: Microsoft.Azure.Cosmos.EmulatorTests
@@ -247,7 +247,7 @@ jobs:
     inputs:
       command: test
       projects: 'Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/*.csproj'
-      arguments: ${{ parameters.EmulatorPipeline2Arguments }} --configuration ${{ parameters.BuildConfiguration }} /p:OS=${{ parameters.OS }} -p:IsPreview=true;SdkProjectRef=true
+      arguments: ${{ parameters.EmulatorPipeline2Arguments }} --configuration ${{ parameters.BuildConfiguration }} /p:OS=${{ parameters.OS }}
       nugetConfigPath: NuGet.config
       publishTestResults: true
       testRunTitle: Microsoft.Azure.Cosmos.EmulatorTests
@@ -406,7 +406,7 @@ jobs:
     inputs:
       command: test
       projects: 'Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/*.csproj'
-      arguments: ${{ parameters.EmulatorPipeline3Arguments }} --configuration ${{ parameters.BuildConfiguration }} /p:OS=${{ parameters.OS }} -p:IsPreview=true;SdkProjectRef=true
+      arguments: ${{ parameters.EmulatorPipeline3Arguments }} --configuration ${{ parameters.BuildConfiguration }} /p:OS=${{ parameters.OS }}
       nugetConfigPath: NuGet.config
       publishTestResults: true
       testRunTitle: Microsoft.Azure.Cosmos.EmulatorTests
@@ -445,7 +445,7 @@ jobs:
     inputs:
       command: test
       projects: 'Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/*.csproj'
-      arguments: ${{ parameters.EmulatorPipeline4Arguments }} --configuration ${{ parameters.BuildConfiguration }} /p:OS=${{ parameters.OS }} -p:IsPreview=true;SdkProjectRef=true
+      arguments: ${{ parameters.EmulatorPipeline4Arguments }} --configuration ${{ parameters.BuildConfiguration }} /p:OS=${{ parameters.OS }}
       nugetConfigPath: NuGet.config
       publishTestResults: true
       testRunTitle: Microsoft.Azure.Cosmos.EmulatorTests


### PR DESCRIPTION
## Description

As part of this PR, fixing test pipeline.

**Root Cause:** Metrics generation tests were designed to validate only metrics functionality with dimensions. However, with distributed tracing enabled by default in the preview package, the test began asserting traces generated by the distributed tracing feature.
**Resolution:** Disabled the distributed tracing feature in tests to ensure compatibility.

## Type of change

- [] Bug fix (non-breaking change which fixes an issue)
