### PR TITLE
[Internal] Binary Encoding: Refactors performance tests timeout period.

### DIFF
--- a/templates/build-test.yml
+++ b/templates/build-test.yml
@@ -137,7 +137,7 @@ jobs:
   condition: and(succeeded(), eq(${{ parameters.IncludePerformance }}, true))
   pool:
     name: 'OneES'
-  timeoutInMinutes: 70 
+  timeoutInMinutes: 80 
 
   steps:
   - checkout: self  # self represents the repo where the initial Pipelines YAML file was found

--- a/templates/build-test.yml
+++ b/templates/build-test.yml
@@ -137,7 +137,7 @@ jobs:
   condition: and(succeeded(), eq(${{ parameters.IncludePerformance }}, true))
   pool:
     name: 'OneES'
-  timeoutInMinutes: 80 
+  timeoutInMinutes: 120 
 
   steps:
   - checkout: self  # self represents the repo where the initial Pipelines YAML file was found


### PR DESCRIPTION
# Pull Request Template

## Description

Updating performance tests timeout period to 120 minutes as now all existing performance tests for point operations run with binary encoding flags enabled and disabled.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #IssueNumber