### PR TITLE
[Internal] 3.47.0: Fixes Perf test in release

### DIFF
--- a/templates/build-test.yml
+++ b/templates/build-test.yml
@@ -137,7 +137,7 @@ jobs:
   condition: and(succeeded(), eq(${{ parameters.IncludePerformance }}, true))
   pool:
     name: 'OneES'
-  timeoutInMinutes: 70 
+  timeoutInMinutes: 120 
 
   steps:
   - checkout: self  # self represents the repo where the initial Pipelines YAML file was found


### PR DESCRIPTION
Binary Encoding: Refactors performance tests timeout period. (#5009)

# Pull Request Template

## Description

Updating performance tests timeout period to 120 minutes as now all existing performance tests for point operations run with binary encoding flags enabled and disabled.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #IssueNumber

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Include samples if adding new API, and include relevant motivation and context. List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber