### PR TITLE
Direct Package: Adds upgrade to 3.37.10

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
 		<ClientOfficialVersion>3.47.0</ClientOfficialVersion>
 		<ClientPreviewVersion>3.48.0</ClientPreviewVersion>
 		<ClientPreviewSuffixVersion>preview.0</ClientPreviewSuffixVersion>
-		<DirectVersion>3.37.9</DirectVersion>
+		<DirectVersion>3.37.10</DirectVersion>
 		<FaultInjectionVersion>1.0.0</FaultInjectionVersion>
 		<FaultInjectionSuffixVersion>beta.0</FaultInjectionSuffixVersion>
 		<EncryptionOfficialVersion>2.0.4</EncryptionOfficialVersion>


### PR DESCRIPTION
- Direct package upgrade to 3.37.10
- Also contains an emulator test to verify connection management during aggressive timeouts.

Brings in the fix from Direct package:

https://msdata.visualstudio.com/CosmosDB/_git/CosmosDB/pullrequest/1574317?_a=files

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Include samples if adding new API, and include relevant motivation and context. List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber