### PR TITLE
Query: Fixes logic to determine whether to use distributed query by adding a check for gateway connection mode

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryIterator.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryIterator.cs
@@ -150,7 +150,7 @@ namespace Microsoft.Azure.Cosmos.Query
                 returnResultsInDeterministicOrder: queryRequestOptions.ReturnResultsInDeterministicOrder,
                 enableOptimisticDirectExecution: queryRequestOptions.EnableOptimisticDirectExecution,
                 isNonStreamingOrderByQueryFeatureDisabled: queryRequestOptions.IsNonStreamingOrderByQueryFeatureDisabled,
-                enableDistributedQueryGatewayMode: queryRequestOptions.EnableDistributedQueryGatewayMode,
+                enableDistributedQueryGatewayMode: queryRequestOptions.EnableDistributedQueryGatewayMode && (clientContext.ClientOptions?.ConnectionMode == ConnectionMode.Gateway),
                 testInjections: queryRequestOptions.TestSettings);
 
             return new QueryIterator(


### PR DESCRIPTION
## Description

This changes the logic for determining whether to use the distributed query dedicated gateway.

With this PR, we check both the **AZURE_COSMOS_DISTRIBUTED_QUERY_GATEWAY_ENABLED** environment variable **and** the connection mode to determine whether to use the distributed query dedicated gateway. If the environment variable is set to **True** **and** the connection mode is **gateway**, then we **will** use the dedicated gateway.  If the connection mode is **direct**, we should not use the distributed query dedicated gateway.


## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

