### PR TITLE
[Internal] Binary Encoding: Fixes Serialization Gaps on Newtonsoft Reader/Writer for Transactional Batch

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Batch/TransactionalBatchOperationResult.cs
+++ b/Microsoft.Azure.Cosmos/src/Batch/TransactionalBatchOperationResult.cs
@@ -183,8 +183,14 @@ namespace Microsoft.Azure.Cosmos
                             return r;
                         }
 
-                        batchOperationResult.ResourceStream = new MemoryStream(
-                            buffer: resourceBody, index: 0, count: resourceBody.Length, writable: false, publiclyVisible: true);
+                        batchOperationResult.ResourceStream = new CloneableStream(
+                            internalStream: new MemoryStream(
+                                buffer: resourceBody,
+                                index: 0,
+                                count: resourceBody.Length,
+                                writable: false,
+                                publiclyVisible: true),
+                            allowUnsafeDataAccess: true);
                         break;
 
                     case "requestCharge":

--- a/Microsoft.Azure.Cosmos/src/Json/Interop/CosmosDBToNewtonsoftReader.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/Interop/CosmosDBToNewtonsoftReader.cs
@@ -182,7 +182,16 @@ namespace Microsoft.Azure.Cosmos.Json.Interop
         /// <returns>A <see cref="byte"/>[] or <c>null</c> if the next JSON token is null. This method will return <c>null</c> at the end of an array.</returns>
         public override byte[] ReadAsBytes()
         {
-            throw new NotImplementedException();
+            this.Read();
+            if (this.jsonReader.CurrentTokenType == JsonTokenType.Null || this.jsonReader.CurrentTokenType == JsonTokenType.EndArray)
+            {
+                return null;
+            }
+
+            string stringValue = this.jsonReader.GetStringValue();
+            byte[] byteArray = Convert.FromBase64String(stringValue);
+
+            return byteArray;
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Json/Interop/CosmosDBToNewtonsoftReader.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/Interop/CosmosDBToNewtonsoftReader.cs
@@ -183,15 +183,18 @@ namespace Microsoft.Azure.Cosmos.Json.Interop
         public override byte[] ReadAsBytes()
         {
             this.Read();
-            if (this.jsonReader.CurrentTokenType == JsonTokenType.Null || this.jsonReader.CurrentTokenType == JsonTokenType.EndArray)
+            if (this.jsonReader.CurrentTokenType == JsonTokenType.Null)
             {
                 return null;
             }
 
-            string stringValue = this.jsonReader.GetStringValue();
-            byte[] byteArray = Convert.FromBase64String(stringValue);
+            if (this.jsonReader.CurrentTokenType == JsonTokenType.EndArray)
+            {
+                return new byte[0];
+            }
 
-            return byteArray;
+            string stringValue = this.jsonReader.GetStringValue();
+            return Convert.FromBase64String(stringValue);
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Json/Interop/CosmosDBToNewtonsoftWriter.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/Interop/CosmosDBToNewtonsoftWriter.cs
@@ -331,7 +331,7 @@ namespace Microsoft.Azure.Cosmos.Json.Interop
         /// <param name="value">The <see cref="byte"/>[] value to write.</param>
         public override void WriteValue(byte[] value)
         {
-            throw new NotSupportedException("Can not write byte arrays");
+            this.WriteValue(Convert.ToBase64String(value));
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemIntegrationTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemIntegrationTests.cs
@@ -155,6 +155,14 @@
             bool isBinaryEncodingEnabled)
         {
             Environment.SetEnvironmentVariable(ConfigurationManager.BinaryEncodingEnabled, isBinaryEncodingEnabled.ToString());
+
+            Random random = new();
+            CosmosIntegrationTestObject testItem = new()
+            {
+                Id = $"smTestId{random.Next()}",
+                Pk = $"smpk{random.Next()}",
+            };
+
             try
             {
                 CosmosClientOptions cosmosClientOptions = new()
@@ -177,13 +185,6 @@
                 Container container = database.GetContainer(MultiRegionSetupHelpers.containerName);
 
                 // Create a transactional batch
-                Random random = new();
-                CosmosIntegrationTestObject testItem = new()
-                {
-                    Id = $"smTestId{random.Next()}",
-                    Pk = $"smpk{random.Next()}",
-                };
-
                 TransactionalBatch transactionalBatch = container.CreateTransactionalBatch(new PartitionKey(testItem.Pk));
 
                 transactionalBatch.CreateItem(
@@ -226,6 +227,10 @@
             finally
             {
                 Environment.SetEnvironmentVariable(ConfigurationManager.BinaryEncodingEnabled, null);
+
+                await this.container.DeleteItemAsync<CosmosIntegrationTestObject>(
+                    testItem.Id,
+                    new PartitionKey(testItem.Pk));
             }
         }
     }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemIntegrationTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemIntegrationTests.cs
@@ -145,5 +145,88 @@
                 fiClient.Dispose();
             }
         }
+
+        [TestMethod]
+        [Owner("dkunda")]
+        [TestCategory("MultiRegion")]
+        [DataRow(true, DisplayName = "Test scenario when binary encoding is enabled at client level.")]
+        [DataRow(false, DisplayName = "Test scenario when binary encoding is disabled at client level.")]
+        public async Task ExecuteTransactionalBatch_WhenBinaryEncodingEnabled_ShouldCompleteSuccessfully(
+            bool isBinaryEncodingEnabled)
+        {
+            Environment.SetEnvironmentVariable(ConfigurationManager.BinaryEncodingEnabled, isBinaryEncodingEnabled.ToString());
+            try
+            {
+                CosmosClientOptions cosmosClientOptions = new()
+                {
+                    ConsistencyLevel = ConsistencyLevel.Session,
+                    RequestTimeout = TimeSpan.FromSeconds(10),
+                    Serializer = new CosmosJsonDotNetSerializer(
+                        cosmosSerializerOptions: new CosmosSerializationOptions()
+                        {
+                            PropertyNamingPolicy = CosmosPropertyNamingPolicy.CamelCase
+                        },
+                        binaryEncodingEnabled: isBinaryEncodingEnabled)
+                };
+
+                using CosmosClient cosmosClient = new(
+                    connectionString: this.connectionString,
+                    clientOptions: cosmosClientOptions);
+
+                Database database = cosmosClient.GetDatabase(MultiRegionSetupHelpers.dbName);
+                Container container = database.GetContainer(MultiRegionSetupHelpers.containerName);
+
+                // Create a transactional batch
+                Random random = new();
+                CosmosIntegrationTestObject testItem = new()
+                {
+                    Id = $"smTestId{random.Next()}",
+                    Pk = $"smpk{random.Next()}",
+                };
+
+                TransactionalBatch transactionalBatch = container.CreateTransactionalBatch(new PartitionKey(testItem.Pk));
+
+                transactionalBatch.CreateItem(
+                    testItem,
+                    new TransactionalBatchItemRequestOptions
+                    {
+                        EnableContentResponseOnWrite = true,
+                    });
+
+                transactionalBatch.ReadItem(
+                    testItem.Id,
+                    new TransactionalBatchItemRequestOptions
+                    {
+                        EnableContentResponseOnWrite = true,
+                    });
+
+                // Execute the transactional batch
+                TransactionalBatchResponse transactionResponse = await transactionalBatch.ExecuteAsync(
+                    new TransactionalBatchRequestOptions
+                    {
+                    });
+
+                Assert.AreEqual(HttpStatusCode.OK, transactionResponse.StatusCode);
+                Assert.AreEqual(2, transactionResponse.Count);
+
+                TransactionalBatchOperationResult<CosmosIntegrationTestObject> createOperationResult = transactionResponse.GetOperationResultAtIndex<CosmosIntegrationTestObject>(0);
+                
+                Assert.IsNotNull(createOperationResult);
+                Assert.IsNotNull(createOperationResult.Resource);
+                Assert.AreEqual(testItem.Id, createOperationResult.Resource.Id);
+                Assert.AreEqual(testItem.Pk, createOperationResult.Resource.Pk);
+
+                TransactionalBatchOperationResult<CosmosIntegrationTestObject> readOperationResult = transactionResponse.GetOperationResultAtIndex<CosmosIntegrationTestObject>(1);
+                
+                Assert.IsNotNull(readOperationResult);
+                Assert.IsNotNull(readOperationResult.Resource);
+                Assert.AreEqual(testItem.Id, readOperationResult.Resource.Id);
+                Assert.AreEqual(testItem.Pk, readOperationResult.Resource.Pk);
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(ConfigurationManager.BinaryEncodingEnabled, null);
+            }
+        }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchSchemaTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Batch/BatchSchemaTests.cs
@@ -129,7 +129,9 @@ namespace Microsoft.Azure.Cosmos.Tests
                 new TransactionalBatchOperationResult(HttpStatusCode.Conflict),
                 new TransactionalBatchOperationResult(HttpStatusCode.OK)
                 {
-                    ResourceStream = new MemoryStream(new byte[] { 0x41, 0x42 }, index: 0, count: 2, writable: false, publiclyVisible: true),
+                    ResourceStream = new CloneableStream(
+                        internalStream: new MemoryStream(new byte[] { 0x41, 0x42 }, index: 0, count: 2, writable: false, publiclyVisible: true),
+                        allowUnsafeDataAccess: true),
                     RequestCharge = 2.5,
                     ETag = "1234",
                     RetryAfter = TimeSpan.FromMilliseconds(360)
@@ -250,7 +252,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                         return false;
                     }
 
-                    return ((MemoryStream)x).GetBuffer().SequenceEqual(((MemoryStream)y).GetBuffer());
+                    return ((CloneableStream)x).GetBuffer().SequenceEqual(((CloneableStream)y).GetBuffer());
                 }
 
                 return false;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Json/NewtonsoftInteropTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Json/NewtonsoftInteropTests.cs
@@ -156,9 +156,12 @@ namespace Microsoft.Azure.Cosmos.Tests.Json
 
         [TestMethod]
         [Owner("dkunda")]
-        public void ByteArrayTest()
+        [DataRow(null, DisplayName = "Case when the byte array is null.")]
+        [DataRow(new byte[] { }, DisplayName = "Case when the byte array is empty.")]
+        [DataRow(new byte[] { 1, 2, 3, 4, 5 }, DisplayName = "Case when the byte array has valid elements.")]
+        public void ByteArrayTest(
+            byte[] byteArray)
         {
-            byte[] byteArray = new byte[] { 1, 2, 3, 4, 5 };
             NewtonsoftInteropTests.VerifyNewtonsoftInterop<byte[]>(byteArray);
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Json/NewtonsoftInteropTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Json/NewtonsoftInteropTests.cs
@@ -155,6 +155,14 @@ namespace Microsoft.Azure.Cosmos.Tests.Json
         }
 
         [TestMethod]
+        [Owner("dkunda")]
+        public void ByteArrayTest()
+        {
+            byte[] byteArray = new byte[] { 1, 2, 3, 4, 5 };
+            NewtonsoftInteropTests.VerifyNewtonsoftInterop<byte[]>(byteArray);
+        }
+
+        [TestMethod]
         [Owner("brchon")]
         public void NestedArrayTest()
         {


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes the following:

- Fixes the serialization Gaps on `CosmosDBToNewtonsoftReader` and `CosmosDBToNewtonsoftWriter` for byte[] array read and write respectively.

- Wraps the transactional batch operation result output stream into a `CloneableStream` to de-serialize accurately, when binary encoding is enabled.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #5021