### PR TITLE
.NET9: Fixes WebAssembly or browser scenarios by conditionally setting the ConnectionLimit

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Routing/LocationCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/LocationCache.cs
@@ -859,8 +859,11 @@ namespace Microsoft.Azure.Cosmos.Routing
         private void SetServicePointConnectionLimit(Uri endpoint)
         {
 #if !NETSTANDARD16
-            ServicePointAccessor servicePoint = ServicePointAccessor.FindServicePoint(endpoint);
-            servicePoint.ConnectionLimit = this.connectionLimit;
+            if (ServicePointAccessor.IsSupported)
+            {
+                ServicePointAccessor servicePoint = ServicePointAccessor.FindServicePoint(endpoint);
+                servicePoint.ConnectionLimit = this.connectionLimit;
+            }
 #endif
         }
 

--- a/Microsoft.Azure.Cosmos/src/Util/ServicePointAccessor.cs
+++ b/Microsoft.Azure.Cosmos/src/Util/ServicePointAccessor.cs
@@ -1,4 +1,4 @@
-﻿//------------------------------------------------------------
+//------------------------------------------------------------
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 //------------------------------------------------------------
 
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.Cosmos
 
         private void TrySetConnectionLimit(int connectionLimit)
         {
-            if (ServicePointAccessor.IsSupportedd)
+            if (ServicePointAccessor.IsSupported)
             {
                 // Workaround for WebAssembly.
                 // WebAssembly currently throws a SynchronizationLockException and not a PlatformNotSupportedException.

--- a/Microsoft.Azure.Cosmos/src/Util/ServicePointAccessor.cs
+++ b/Microsoft.Azure.Cosmos/src/Util/ServicePointAccessor.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.Cosmos
     internal class ServicePointAccessor
     {
         // WebAssembly detection
-        private static readonly bool IsBrowser = RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER")) || RuntimeInformation.IsOSPlatform(OSPlatform.Create("WEBASSEMBLY"));
+        public static readonly bool IsSupported = RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER")) || RuntimeInformation.IsOSPlatform(OSPlatform.Create("WEBASSEMBLY"));
 
         private readonly ServicePoint servicePoint;
 
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.Cosmos
 
         private void TrySetConnectionLimit(int connectionLimit)
         {
-            if (ServicePointAccessor.IsBrowser)
+            if (ServicePointAccessor.IsSupportedd)
             {
                 // Workaround for WebAssembly.
                 // WebAssembly currently throws a SynchronizationLockException and not a PlatformNotSupportedException.

--- a/Microsoft.Azure.Cosmos/src/Util/ServicePointAccessor.cs
+++ b/Microsoft.Azure.Cosmos/src/Util/ServicePointAccessor.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.Cosmos
 
         private void TrySetConnectionLimit(int connectionLimit)
         {
-            if (ServicePointAccessor.IsSupported)
+            if (!ServicePointAccessor.IsSupported)
             {
                 // Workaround for WebAssembly.
                 // WebAssembly currently throws a SynchronizationLockException and not a PlatformNotSupportedException.

--- a/Microsoft.Azure.Cosmos/src/Util/ServicePointAccessor.cs
+++ b/Microsoft.Azure.Cosmos/src/Util/ServicePointAccessor.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.Cosmos
     internal class ServicePointAccessor
     {
         // WebAssembly detection
-        public static readonly bool IsSupported = RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER")) || RuntimeInformation.IsOSPlatform(OSPlatform.Create("WEBASSEMBLY"));
+        public static readonly bool IsSupported = !(RuntimeInformation.IsOSPlatform(OSPlatform.Create("BROWSER")) || RuntimeInformation.IsOSPlatform(OSPlatform.Create("WEBASSEMBLY")));
 
         private readonly ServicePoint servicePoint;
 


### PR DESCRIPTION
# Pull Request Template

## Description

Don't use ServicePoint at all on Browser.

in net9.0 all of [ServicePoint throws PlatformNotSupported](https://github.com/dotnet/runtime/issues/113174) so don't attempt to use it there.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

closes: #5029
