### PR TITLE
Enhancement: Configurable First Retry Timeout for HTTP Calls

### DIFF
--- a/Microsoft.Azure.Cosmos/src/HttpClient/HttpTimeoutPolicyControlPlaneRetriableHotPath.cs
+++ b/Microsoft.Azure.Cosmos/src/HttpClient/HttpTimeoutPolicyControlPlaneRetriableHotPath.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Azure.Cosmos
     using System.Collections.Generic;
     using System.Net.Http;
     using System.Text;
+    using Microsoft.Azure.Documents;
 
     internal sealed class HttpTimeoutPolicyControlPlaneRetriableHotPath : HttpTimeoutPolicy
     {
@@ -15,6 +16,12 @@ namespace Microsoft.Azure.Cosmos
         public bool shouldThrow503OnTimeout;
         private static readonly string Name = nameof(HttpTimeoutPolicyControlPlaneRetriableHotPath);
 
+        public const string HttpFirstRetryTimeoutValue = "AZURE_COSMOS_SDK_HTTP_FIRST_RETRY_TIMEOUT_VALUE_SECONDS";
+
+        /// <summary>
+        /// A read-only <see cref="TimeSpan"/> containing the default value of the first request timeout after which the request is retried.
+        /// </summary>
+        private const double firstRetryTimeoutDefault = 0.5;
         private HttpTimeoutPolicyControlPlaneRetriableHotPath(bool shouldThrow503OnTimeout)
         {
             this.shouldThrow503OnTimeout = shouldThrow503OnTimeout;
@@ -22,7 +29,9 @@ namespace Microsoft.Azure.Cosmos
 
         private readonly IReadOnlyList<(TimeSpan requestTimeout, TimeSpan delayForNextRequest)> TimeoutsAndDelays = new List<(TimeSpan requestTimeout, TimeSpan delayForNextRequest)>()
         {
-            (TimeSpan.FromSeconds(.5), TimeSpan.Zero),
+            (TimeSpan.FromSeconds(Helpers.GetEnvironmentVariable(
+                        name: HttpFirstRetryTimeoutValue,
+                        defaultValue: firstRetryTimeoutDefault)), TimeSpan.Zero),
             (TimeSpan.FromSeconds(5), TimeSpan.FromSeconds(1)),
             (TimeSpan.FromSeconds(65), TimeSpan.Zero),
         };


### PR DESCRIPTION
- Added support for configuring the first retry timeout in the HTTP retry stack via an environment variable.
- Default timeout remains 0.5 seconds, ensuring backward compatibility.
- This change enables customers to customize retry behavior based on their needs.

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Include samples if adding new API, and include relevant motivation and context. List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber