### PR TITLE
[Internal] Binary Encoding: Fixes serializer for non-point operations. 

### DIFF
--- a/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
@@ -75,6 +75,7 @@ namespace Microsoft.Azure.Cosmos
         private Func<HttpClient> httpClientFactory;
         private string applicationName;
         private IFaultInjector faultInjector;
+        private bool isCustomSerializerProvided;
 
         /// <summary>
         /// Creates a new CosmosClientOptions
@@ -625,6 +626,7 @@ namespace Microsoft.Azure.Cosmos
                         $"{nameof(this.Serializer)} is not compatible with {nameof(this.SerializerOptions)} or {nameof(this.UseSystemTextJsonSerializerWithOptions)}. Only one can be set.  ");
                 }
 
+                this.isCustomSerializerProvided = true;
                 this.serializerInternal = value;
             }
         }
@@ -1083,6 +1085,11 @@ namespace Microsoft.Azure.Cosmos
             }
 
             return clientOptions;
+        }
+
+        internal bool IsCustomSerializerProvided()
+        {
+            return this.isCustomSerializerProvided;
         }
 
         private static T GetValueFromConnectionString<T>(string connectionString, string keyName, T defaultValue)

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
@@ -1288,7 +1288,7 @@ namespace Microsoft.Azure.Cosmos
 
         private JsonSerializationFormat? GetTargetResponseSerializationFormat()
         {
-            if (this.ClientContext.ClientOptions.Serializer is not CosmosJsonDotNetSerializer)
+            if (this.ClientContext.ClientOptions.IsCustomSerializerProvided())
             {
                 return JsonSerializationFormat.Text;
             }

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
@@ -848,7 +848,7 @@ namespace Microsoft.Azure.Cosmos
             Stream itemStream;
             using (trace.StartChild("ItemSerialize"))
             {
-                itemStream = this.ClientContext.SerializerCore.ToStream<T>(item);
+                itemStream = this.ClientContext.SerializerCore.ToStream<T>(item, isPointOperation: true);
             }
 
             // User specified PK value, no need to extract it

--- a/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Azure.Cosmos
                 operationType: OperationType.Read,
                 requestOptions: requestOptions,
                 trace: trace,
-                targetResponseSerializationFormat: default,
+                targetResponseSerializationFormat: this.GetTargetResponseSerializationFormat(),
                 cancellationToken: cancellationToken);
 
             return this.ClientContext.ResponseFactory.CreateItemResponse<T>(response);
@@ -249,7 +249,7 @@ namespace Microsoft.Azure.Cosmos
                 operationType: OperationType.Delete,
                 requestOptions: requestOptions,
                 trace: trace,
-                targetResponseSerializationFormat: default,
+                targetResponseSerializationFormat: this.GetTargetResponseSerializationFormat(),
                 cancellationToken: cancellationToken);
 
             return this.ClientContext.ResponseFactory.CreateItemResponse<T>(response);
@@ -861,7 +861,7 @@ namespace Microsoft.Azure.Cosmos
                         operationType,
                         requestOptions,
                         trace: trace,
-                        targetResponseSerializationFormat: default,
+                        targetResponseSerializationFormat: this.GetTargetResponseSerializationFormat(),
                         cancellationToken: cancellationToken);
             }
 
@@ -877,7 +877,7 @@ namespace Microsoft.Azure.Cosmos
                     operationType,
                     requestOptions,
                     trace: trace,
-                    targetResponseSerializationFormat: default,
+                    targetResponseSerializationFormat: this.GetTargetResponseSerializationFormat(),
                     cancellationToken: cancellationToken);
 
                 if (responseMessage.IsSuccessStatusCode)
@@ -1284,6 +1284,16 @@ namespace Microsoft.Azure.Cosmos
                 container: this,
                 changeFeedProcessor: changeFeedProcessor,
                 applyBuilderConfiguration: changeFeedProcessor.ApplyBuildConfiguration).WithChangeFeedMode(mode);
+        }
+
+        private JsonSerializationFormat? GetTargetResponseSerializationFormat()
+        {
+            if (this.ClientContext.ClientOptions.Serializer is not CosmosJsonDotNetSerializer)
+            {
+                return JsonSerializationFormat.Text;
+            }
+
+            return default;
         }
 
         private static JsonSerializationFormat GetTargetRequestSerializationFormat()

--- a/Microsoft.Azure.Cosmos/src/Serializer/CosmosSerializerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Serializer/CosmosSerializerCore.cs
@@ -82,8 +82,7 @@ namespace Microsoft.Azure.Cosmos
 
         internal T[] FromFeedStream<T>(Stream stream)
         {
-            CosmosSerializer serializer = this.GetSerializer<T>(
-                isBinaryEncodingEnabled: false);
+            CosmosSerializer serializer = this.GetSerializer<T>();
             return serializer.FromStream<T[]>(stream);
         }
 
@@ -127,7 +126,7 @@ namespace Microsoft.Azure.Cosmos
         }
 
         private CosmosSerializer GetSerializer<T>(
-            bool isBinaryEncodingEnabled)
+            bool isBinaryEncodingEnabled = false)
         {
             Type inputType = typeof(T);
             if (inputType == typeof(PatchSpec))

--- a/Microsoft.Azure.Cosmos/src/Serializer/CosmosSerializerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Serializer/CosmosSerializerCore.cs
@@ -120,7 +120,7 @@ namespace Microsoft.Azure.Cosmos
                 return this.customSerializer;
             }
 
-            return CosmosSerializerCore.propertiesSerializer;
+            return this.GetDefaultSerializer();
         }
 
         private CosmosSerializer GetSerializer<T>()
@@ -136,9 +136,7 @@ namespace Microsoft.Azure.Cosmos
 
             if (this.customSerializer == null)
             {
-                return this.isBinaryEncodingEnabled
-                    ? CosmosSerializerCore.binarySerializer
-                    : CosmosSerializerCore.propertiesSerializer;
+                return this.GetDefaultSerializer();
             }
 
             if (CosmosSerializerCore.IsInputTypeInternal(inputType))
@@ -166,6 +164,13 @@ namespace Microsoft.Azure.Cosmos
 #endif
 
             return this.customSerializer;
+        }
+
+        private CosmosSerializer GetDefaultSerializer()
+        {
+            return this.isBinaryEncodingEnabled
+                ? CosmosSerializerCore.binarySerializer
+                : CosmosSerializerCore.propertiesSerializer;
         }
 
         internal static bool IsInputTypeInternal(

--- a/Microsoft.Azure.Cosmos/src/Serializer/CosmosSerializerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Serializer/CosmosSerializerCore.cs
@@ -75,8 +75,7 @@ namespace Microsoft.Azure.Cosmos
 
         internal T FromStream<T>(Stream stream)
         {
-            CosmosSerializer serializer = this.GetSerializer<T>(
-                isBinaryEncodingEnabled: this.isBinaryEncodingEnabled);
+            CosmosSerializer serializer = this.GetSerializer<T>();
             return serializer.FromStream<T>(stream);
         }
 

--- a/Microsoft.Azure.Cosmos/src/Serializer/CosmosSerializerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Serializer/CosmosSerializerCore.cs
@@ -87,8 +87,7 @@ namespace Microsoft.Azure.Cosmos
 
         internal Stream ToStream<T>(T input)
         {
-            CosmosSerializer serializer = this.GetSerializer<T>(
-                isBinaryEncodingEnabled: this.isBinaryEncodingEnabled);
+            CosmosSerializer serializer = this.GetSerializer<T>();
             return serializer.ToStream<T>(input);
         }
 
@@ -124,8 +123,7 @@ namespace Microsoft.Azure.Cosmos
             return CosmosSerializerCore.propertiesSerializer;
         }
 
-        private CosmosSerializer GetSerializer<T>(
-            bool isBinaryEncodingEnabled = false)
+        private CosmosSerializer GetSerializer<T>()
         {
             Type inputType = typeof(T);
             if (inputType == typeof(PatchSpec))
@@ -138,7 +136,7 @@ namespace Microsoft.Azure.Cosmos
 
             if (this.customSerializer == null)
             {
-                return isBinaryEncodingEnabled
+                return this.isBinaryEncodingEnabled
                     ? CosmosSerializerCore.binarySerializer
                     : CosmosSerializerCore.propertiesSerializer;
             }

--- a/Microsoft.Azure.Cosmos/src/Serializer/CosmosSerializerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Serializer/CosmosSerializerCore.cs
@@ -85,9 +85,9 @@ namespace Microsoft.Azure.Cosmos
             return serializer.FromStream<T[]>(stream);
         }
 
-        internal Stream ToStream<T>(T input, bool isPointOperation = false)
+        internal Stream ToStream<T>(T input, bool canUseBinaryEncodingForPointOperations = false)
         {
-            CosmosSerializer serializer = this.GetSerializer<T>(isPointOperation);
+            CosmosSerializer serializer = this.GetSerializer<T>(canUseBinaryEncodingForPointOperations);
             return serializer.ToStream<T>(input);
         }
 
@@ -124,7 +124,7 @@ namespace Microsoft.Azure.Cosmos
         }
 
         private CosmosSerializer GetSerializer<T>(
-            bool isPointOperation = false)
+            bool canUseBinaryEncodingForPointOperations = false)
         {
             Type inputType = typeof(T);
             if (inputType == typeof(PatchSpec))
@@ -142,7 +142,7 @@ namespace Microsoft.Azure.Cosmos
 
             if (this.customSerializer == null)
             {
-                return this.GetDefaultSerializer(isPointOperation);
+                return this.GetDefaultSerializer(canUseBinaryEncodingForPointOperations);
             }
 
             if (inputType == typeof(SqlQuerySpec))
@@ -168,9 +168,9 @@ namespace Microsoft.Azure.Cosmos
         }
 
         private CosmosSerializer GetDefaultSerializer(
-            bool isPointOperation = false)
+            bool canUseBinaryEncodingForPointOperations = false)
         {
-            return this.isBinaryEncodingEnabled && isPointOperation
+            return this.isBinaryEncodingEnabled && canUseBinaryEncodingForPointOperations
                 ? CosmosSerializerCore.binarySerializer
                 : CosmosSerializerCore.propertiesSerializer;
         }

--- a/Microsoft.Azure.Cosmos/src/Serializer/CosmosSerializerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Serializer/CosmosSerializerCore.cs
@@ -85,9 +85,9 @@ namespace Microsoft.Azure.Cosmos
             return serializer.FromStream<T[]>(stream);
         }
 
-        internal Stream ToStream<T>(T input)
+        internal Stream ToStream<T>(T input, bool isPointOperation = false)
         {
-            CosmosSerializer serializer = this.GetSerializer<T>();
+            CosmosSerializer serializer = this.GetSerializer<T>(isPointOperation);
             return serializer.ToStream<T>(input);
         }
 
@@ -123,7 +123,8 @@ namespace Microsoft.Azure.Cosmos
             return this.GetDefaultSerializer();
         }
 
-        private CosmosSerializer GetSerializer<T>()
+        private CosmosSerializer GetSerializer<T>(
+            bool isPointOperation = false)
         {
             Type inputType = typeof(T);
             if (inputType == typeof(PatchSpec))
@@ -134,14 +135,14 @@ namespace Microsoft.Azure.Cosmos
                 return this.patchOperationSerializer;
             }
 
-            if (this.customSerializer == null)
-            {
-                return this.GetDefaultSerializer();
-            }
-
             if (CosmosSerializerCore.IsInputTypeInternal(inputType))
             {
                 return CosmosSerializerCore.propertiesSerializer;
+            }
+
+            if (this.customSerializer == null)
+            {
+                return this.GetDefaultSerializer(isPointOperation);
             }
 
             if (inputType == typeof(SqlQuerySpec))
@@ -166,9 +167,10 @@ namespace Microsoft.Azure.Cosmos
             return this.customSerializer;
         }
 
-        private CosmosSerializer GetDefaultSerializer()
+        private CosmosSerializer GetDefaultSerializer(
+            bool isPointOperation = false)
         {
-            return this.isBinaryEncodingEnabled
+            return this.isBinaryEncodingEnabled && isPointOperation
                 ? CosmosSerializerCore.binarySerializer
                 : CosmosSerializerCore.propertiesSerializer;
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -3672,6 +3672,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
+        [DoNotParallelize]
         [DataRow(false, DisplayName = "CreateItemAsync - Binary encoding disabled.")]
         [DataRow(true, DisplayName = "CreateItemAsync - Binary encoding enabled.")]
         public async Task CreateItemAsyncTest(bool binaryEncodingEnabled)
@@ -3716,6 +3717,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
+        [DoNotParallelize]
         [DataRow(false, DisplayName = "UpsertItemAsync - Binary encoding disabled.")]
         [DataRow(true, DisplayName = "UpsertItemAsync - Binary encoding enabled.")]
         public async Task UpsertItemAsyncTest(bool binaryEncodingEnabled)
@@ -3771,6 +3773,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
+        [DoNotParallelize]
         [DataRow(false, DisplayName = "ReadItemAsync - Binary encoding disabled.")]
         [DataRow(true, DisplayName = "ReadItemAsync - Binary encoding enabled.")]
         public async Task ReadItemAsyncTest(bool binaryEncodingEnabled)
@@ -3815,6 +3818,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
+        [DoNotParallelize]
         [DataRow(false, DisplayName = "ReplaceItemAsync - Binary encoding disabled.")]
         [DataRow(true, DisplayName = "ReplaceItemAsync - Binary encoding enabled.")]
         public async Task ReplaceItemAsyncTest(bool binaryEncodingEnabled)
@@ -3865,6 +3869,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
+        [DoNotParallelize]
         [DataRow(false, DisplayName = "DeleteItemAsync - Binary encoding disabled.")]
         [DataRow(true, DisplayName = "DeleteItemAsync - Binary encoding enabled.")]
         public async Task DeleteItemAsyncTest(bool binaryEncodingEnabled)
@@ -3916,6 +3921,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
+        [DoNotParallelize]
         [DataRow(false, DisplayName = "QueryItemAsyncTest - Binary encoding disabled.")]
         [DataRow(true, DisplayName = "QueryItemAsyncTest - Binary encoding enabled.")]
         public async Task QueryItemAsyncTest(bool binaryEncodingEnabled)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -73,7 +73,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        [DoNotParallelize]
         [DataRow(false, DisplayName = "Test scenario when binary encoding is disabled at client level.")]
         [DataRow(true, DisplayName = "Test scenario when binary encoding is enabled at client level.")]
         public async Task CreateDropItemWithInvalidIdCharactersTest(bool binaryEncodingEnabledInClient)
@@ -141,7 +140,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        [DoNotParallelize]
         [DataRow(false, DisplayName = "Test scenario when binary encoding is disabled at client level.")]
         [DataRow(true, DisplayName = "Test scenario when binary encoding is enabled at client level.")]
         public async Task CreateDropItemTest(bool binaryEncodingEnabledInClient)
@@ -193,7 +191,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        [DoNotParallelize]
         [DataRow(false, DisplayName = "Test scenario when binary encoding is disabled at client level.")]
         [DataRow(true, DisplayName = "Test scenario when binary encoding is enabled at client level.")]
         public async Task ClientConsistencyTestAsync(bool binaryEncodingEnabledInClient)
@@ -235,7 +232,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        [DoNotParallelize]
         [DataRow(true, DisplayName = "Test scenario when binary encoding is enabled at client level.")]
         [DataRow(false, DisplayName = "Test scenario when binary encoding is disabled at client level.")]
         public async Task NegativeCreateItemTest(bool binaryEncodingEnabledInClient)
@@ -292,7 +288,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        [DoNotParallelize]
         [DataRow(true, DisplayName = "Test scenario when binary encoding is enabled at client level.")]
         [DataRow(false, DisplayName = "Test scenario when binary encoding is disabled at client level.")]
         public async Task NegativeCreateDropItemTest(bool binaryEncodingEnabledInClient)
@@ -318,7 +313,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        [DoNotParallelize]
         [DataRow(true, DisplayName = "Test scenario when binary encoding is enabled at client level.")]
         [DataRow(false, DisplayName = "Test scenario when binary encoding is disabled at client level.")]
         public async Task MemoryStreamBufferIsAccessibleOnResponse(bool binaryEncodingEnabledInClient)
@@ -360,7 +354,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        [DoNotParallelize]
         [DataRow(true, DisplayName = "Test scenario when binary encoding is enabled at client level.")]
         [DataRow(false, DisplayName = "Test scenario when binary encoding is disabled at client level.")]
         public async Task CustomSerilizerTest(bool binaryEncodingEnabledInClient)
@@ -421,7 +414,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        [DoNotParallelize]
         [DataRow(true, DisplayName = "Test scenario when binary encoding is enabled at client level.")]
         [DataRow(false, DisplayName = "Test scenario when binary encoding is disabled at client level.")]
         public async Task CreateDropItemUndefinedPartitionKeyTest(bool binaryEncodingEnabledInClient)
@@ -455,7 +447,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        [DoNotParallelize]
         [DataRow(true, DisplayName = "Test scenario when binary encoding is enabled at client level.")]
         [DataRow(false, DisplayName = "Test scenario when binary encoding is disabled at client level.")]
         public async Task CreateDropItemPartitionKeyNotInTypeTest(bool binaryEncodingEnabledInClient)
@@ -504,7 +495,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        [DoNotParallelize]
         [DataRow(true, DisplayName = "Test scenario when binary encoding is enabled at client level.")]
         [DataRow(false, DisplayName = "Test scenario when binary encoding is disabled at client level.")]
         public async Task CreateDropItemMultiPartPartitionKeyTest(bool binaryEncodingEnabledInClient)
@@ -574,7 +564,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        [DoNotParallelize]
         [DataRow(true, DisplayName = "Test scenario when binary encoding is enabled at client level.")]
         [DataRow(false, DisplayName = "Test scenario when binary encoding is disabled at client level.")]
         public async Task NonPartitionKeyLookupCacheTest(bool binaryEncodingEnabledInClient)
@@ -682,7 +671,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        [DoNotParallelize]
         [DataRow(true, true, DisplayName = "Test scenario when binary encoding is enabled at client level and expected stream response type is binary.")]
         [DataRow(true, false, DisplayName = "Test scenario when binary encoding is enabled at client level and expected stream response type is text.")]
         [DataRow(false, true, DisplayName = "Test scenario when binary encoding is disabled at client level and expected stream response type is binary.")]
@@ -783,7 +771,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        [DoNotParallelize]
         [DataRow(false, DisplayName = "Test scenario when binary encoding is disabled at client level.")]
         [DataRow(true, DisplayName = "Test scenario when binary encoding is enabled at client level.")]
         public async Task UpsertItemStreamTest(bool binaryEncodingEnabledInClient)
@@ -835,7 +822,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        [DoNotParallelize]
         [DataRow(false, DisplayName = "Test scenario when binary encoding is disabled at client level.")]
         [DataRow(true, DisplayName = "Test scenario when binary encoding is enabled at client level.")]
         public async Task UpsertItemTest(bool binaryEncodingEnabledInClient)
@@ -875,7 +861,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        [DoNotParallelize]
         [DataRow(false, DisplayName = "Test scenario when binary encoding is disabled at client level.")]
         [DataRow(true, DisplayName = "Test scenario when binary encoding is enabled at client level.")]
         public async Task ReplaceItemStreamTest(bool binaryEncodingEnabledInClient)
@@ -986,7 +971,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        [DoNotParallelize]
         [DataRow(true, DisplayName = "Test scenario when binary encoding is enabled at client level.")]
         [DataRow(false, DisplayName = "Test scenario when binary encoding is disabled at client level.")]
         public async Task PartitionKeyDeleteTest(bool binaryEncodingEnabledInClient)
@@ -1054,7 +1038,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        [DoNotParallelize]
         [DataRow(false, DisplayName = "Test scenario when binary encoding is disabled at client level.")]
         [DataRow(true, DisplayName = "Test scenario when binary encoding is enabled at client level.")]
         public async Task PartitionKeyDeleteTestForSubpartitionedContainer(bool binaryEncodingEnabledInClient)
@@ -2212,7 +2195,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        [DoNotParallelize]
         [DataRow(true, DisplayName = "Test scenario when binary encoding is enabled at client level.")]
         [DataRow(false, DisplayName = "Test scenario when binary encoding is disabled at client level.")]
         public async Task ItemRequestOptionAccessConditionTest(bool binaryEncodingEnabledInClient)
@@ -2277,7 +2259,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        [DoNotParallelize]
         [DataRow(true, DisplayName = "Test scenario when binary encoding is enabled at client level.")]
         [DataRow(false, DisplayName = "Test scenario when binary encoding is disabled at client level.")]
         public async Task ItemReplaceAsyncTest(bool binaryEncodingEnabledInClient)
@@ -3374,7 +3355,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        [DoNotParallelize]
         [DataRow(false, DisplayName = "Test scenario when binary encoding is disabled at client level.")]
         [DataRow(true, DisplayName = "Test scenario when binary encoding is enabled at client level.")]
         public async Task CustomPropertiesItemRequestOptionsTest(bool binaryEncodingEnabledInClient)
@@ -3432,7 +3412,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        [DoNotParallelize]
         [DataRow(false, DisplayName = "Test scenario when binary encoding is disabled at client level.")]
         [DataRow(true, DisplayName = "Test scenario when binary encoding is enabled at client level.")]
         public async Task RegionsContactedTest(bool binaryEncodingEnabledInClient)
@@ -3693,7 +3672,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        [DoNotParallelize]
         [DataRow(false, DisplayName = "CreateItemAsync - Binary encoding disabled.")]
         [DataRow(true, DisplayName = "CreateItemAsync - Binary encoding enabled.")]
         public async Task CreateItemAsyncTest(bool binaryEncodingEnabled)
@@ -3738,7 +3716,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        [DoNotParallelize]
         [DataRow(false, DisplayName = "UpsertItemAsync - Binary encoding disabled.")]
         [DataRow(true, DisplayName = "UpsertItemAsync - Binary encoding enabled.")]
         public async Task UpsertItemAsyncTest(bool binaryEncodingEnabled)
@@ -3794,7 +3771,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        [DoNotParallelize]
         [DataRow(false, DisplayName = "ReadItemAsync - Binary encoding disabled.")]
         [DataRow(true, DisplayName = "ReadItemAsync - Binary encoding enabled.")]
         public async Task ReadItemAsyncTest(bool binaryEncodingEnabled)
@@ -3839,7 +3815,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        [DoNotParallelize]
         [DataRow(false, DisplayName = "ReplaceItemAsync - Binary encoding disabled.")]
         [DataRow(true, DisplayName = "ReplaceItemAsync - Binary encoding enabled.")]
         public async Task ReplaceItemAsyncTest(bool binaryEncodingEnabled)
@@ -3890,7 +3865,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        [DoNotParallelize]
         [DataRow(false, DisplayName = "DeleteItemAsync - Binary encoding disabled.")]
         [DataRow(true, DisplayName = "DeleteItemAsync - Binary encoding enabled.")]
         public async Task DeleteItemAsyncTest(bool binaryEncodingEnabled)
@@ -3942,7 +3916,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        [DoNotParallelize]
         [DataRow(false, DisplayName = "QueryItemAsyncTest - Binary encoding disabled.")]
         [DataRow(true, DisplayName = "QueryItemAsyncTest - Binary encoding enabled.")]
         public async Task QueryItemAsyncTest(bool binaryEncodingEnabled)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -73,6 +73,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
+        [DoNotParallelize]
         [DataRow(false, DisplayName = "Test scenario when binary encoding is disabled at client level.")]
         [DataRow(true, DisplayName = "Test scenario when binary encoding is enabled at client level.")]
         public async Task CreateDropItemWithInvalidIdCharactersTest(bool binaryEncodingEnabledInClient)
@@ -140,6 +141,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
+        [DoNotParallelize]
         [DataRow(false, DisplayName = "Test scenario when binary encoding is disabled at client level.")]
         [DataRow(true, DisplayName = "Test scenario when binary encoding is enabled at client level.")]
         public async Task CreateDropItemTest(bool binaryEncodingEnabledInClient)
@@ -191,6 +193,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
+        [DoNotParallelize]
         [DataRow(false, DisplayName = "Test scenario when binary encoding is disabled at client level.")]
         [DataRow(true, DisplayName = "Test scenario when binary encoding is enabled at client level.")]
         public async Task ClientConsistencyTestAsync(bool binaryEncodingEnabledInClient)
@@ -232,6 +235,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
+        [DoNotParallelize]
         [DataRow(true, DisplayName = "Test scenario when binary encoding is enabled at client level.")]
         [DataRow(false, DisplayName = "Test scenario when binary encoding is disabled at client level.")]
         public async Task NegativeCreateItemTest(bool binaryEncodingEnabledInClient)
@@ -288,6 +292,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
+        [DoNotParallelize]
         [DataRow(true, DisplayName = "Test scenario when binary encoding is enabled at client level.")]
         [DataRow(false, DisplayName = "Test scenario when binary encoding is disabled at client level.")]
         public async Task NegativeCreateDropItemTest(bool binaryEncodingEnabledInClient)
@@ -313,6 +318,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
+        [DoNotParallelize]
         [DataRow(true, DisplayName = "Test scenario when binary encoding is enabled at client level.")]
         [DataRow(false, DisplayName = "Test scenario when binary encoding is disabled at client level.")]
         public async Task MemoryStreamBufferIsAccessibleOnResponse(bool binaryEncodingEnabledInClient)
@@ -354,6 +360,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
+        [DoNotParallelize]
         [DataRow(true, DisplayName = "Test scenario when binary encoding is enabled at client level.")]
         [DataRow(false, DisplayName = "Test scenario when binary encoding is disabled at client level.")]
         public async Task CustomSerilizerTest(bool binaryEncodingEnabledInClient)
@@ -414,6 +421,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
+        [DoNotParallelize]
         [DataRow(true, DisplayName = "Test scenario when binary encoding is enabled at client level.")]
         [DataRow(false, DisplayName = "Test scenario when binary encoding is disabled at client level.")]
         public async Task CreateDropItemUndefinedPartitionKeyTest(bool binaryEncodingEnabledInClient)
@@ -447,6 +455,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
+        [DoNotParallelize]
         [DataRow(true, DisplayName = "Test scenario when binary encoding is enabled at client level.")]
         [DataRow(false, DisplayName = "Test scenario when binary encoding is disabled at client level.")]
         public async Task CreateDropItemPartitionKeyNotInTypeTest(bool binaryEncodingEnabledInClient)
@@ -495,6 +504,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
+        [DoNotParallelize]
         [DataRow(true, DisplayName = "Test scenario when binary encoding is enabled at client level.")]
         [DataRow(false, DisplayName = "Test scenario when binary encoding is disabled at client level.")]
         public async Task CreateDropItemMultiPartPartitionKeyTest(bool binaryEncodingEnabledInClient)
@@ -564,6 +574,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
+        [DoNotParallelize]
         [DataRow(true, DisplayName = "Test scenario when binary encoding is enabled at client level.")]
         [DataRow(false, DisplayName = "Test scenario when binary encoding is disabled at client level.")]
         public async Task NonPartitionKeyLookupCacheTest(bool binaryEncodingEnabledInClient)
@@ -671,6 +682,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
+        [DoNotParallelize]
         [DataRow(true, true, DisplayName = "Test scenario when binary encoding is enabled at client level and expected stream response type is binary.")]
         [DataRow(true, false, DisplayName = "Test scenario when binary encoding is enabled at client level and expected stream response type is text.")]
         [DataRow(false, true, DisplayName = "Test scenario when binary encoding is disabled at client level and expected stream response type is binary.")]
@@ -771,6 +783,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
+        [DoNotParallelize]
         [DataRow(false, DisplayName = "Test scenario when binary encoding is disabled at client level.")]
         [DataRow(true, DisplayName = "Test scenario when binary encoding is enabled at client level.")]
         public async Task UpsertItemStreamTest(bool binaryEncodingEnabledInClient)
@@ -822,6 +835,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
+        [DoNotParallelize]
         [DataRow(false, DisplayName = "Test scenario when binary encoding is disabled at client level.")]
         [DataRow(true, DisplayName = "Test scenario when binary encoding is enabled at client level.")]
         public async Task UpsertItemTest(bool binaryEncodingEnabledInClient)
@@ -861,6 +875,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
+        [DoNotParallelize]
         [DataRow(false, DisplayName = "Test scenario when binary encoding is disabled at client level.")]
         [DataRow(true, DisplayName = "Test scenario when binary encoding is enabled at client level.")]
         public async Task ReplaceItemStreamTest(bool binaryEncodingEnabledInClient)
@@ -971,6 +986,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
+        [DoNotParallelize]
         [DataRow(true, DisplayName = "Test scenario when binary encoding is enabled at client level.")]
         [DataRow(false, DisplayName = "Test scenario when binary encoding is disabled at client level.")]
         public async Task PartitionKeyDeleteTest(bool binaryEncodingEnabledInClient)
@@ -1038,6 +1054,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
+        [DoNotParallelize]
         [DataRow(false, DisplayName = "Test scenario when binary encoding is disabled at client level.")]
         [DataRow(true, DisplayName = "Test scenario when binary encoding is enabled at client level.")]
         public async Task PartitionKeyDeleteTestForSubpartitionedContainer(bool binaryEncodingEnabledInClient)
@@ -2195,6 +2212,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
+        [DoNotParallelize]
         [DataRow(true, DisplayName = "Test scenario when binary encoding is enabled at client level.")]
         [DataRow(false, DisplayName = "Test scenario when binary encoding is disabled at client level.")]
         public async Task ItemRequestOptionAccessConditionTest(bool binaryEncodingEnabledInClient)
@@ -2259,6 +2277,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
+        [DoNotParallelize]
         [DataRow(true, DisplayName = "Test scenario when binary encoding is enabled at client level.")]
         [DataRow(false, DisplayName = "Test scenario when binary encoding is disabled at client level.")]
         public async Task ItemReplaceAsyncTest(bool binaryEncodingEnabledInClient)
@@ -3355,6 +3374,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
+        [DoNotParallelize]
         [DataRow(false, DisplayName = "Test scenario when binary encoding is disabled at client level.")]
         [DataRow(true, DisplayName = "Test scenario when binary encoding is enabled at client level.")]
         public async Task CustomPropertiesItemRequestOptionsTest(bool binaryEncodingEnabledInClient)
@@ -3412,6 +3432,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
+        [DoNotParallelize]
         [DataRow(false, DisplayName = "Test scenario when binary encoding is disabled at client level.")]
         [DataRow(true, DisplayName = "Test scenario when binary encoding is enabled at client level.")]
         public async Task RegionsContactedTest(bool binaryEncodingEnabledInClient)
@@ -3677,16 +3698,16 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         [DataRow(true, DisplayName = "CreateItemAsync - Binary encoding enabled.")]
         public async Task CreateItemAsyncTest(bool binaryEncodingEnabled)
         {
+            if (binaryEncodingEnabled)
+            {
+                Environment.SetEnvironmentVariable(ConfigurationManager.BinaryEncodingEnabled, "True");
+            }
+
             try
             {
-                if (binaryEncodingEnabled)
-                {
-                    Environment.SetEnvironmentVariable(ConfigurationManager.BinaryEncodingEnabled, "True");
-                }
-
                 // Create new client, db, container with binary serializer
                 (CosmosClient client, Cosmos.Database db, Container container) =
-                    await this.CreateTestResourcesAsync(binaryEncodingEnabled);
+                    await this.CreateTestResourcesAsync();
 
                 try
                 {
@@ -3722,15 +3743,15 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         [DataRow(true, DisplayName = "UpsertItemAsync - Binary encoding enabled.")]
         public async Task UpsertItemAsyncTest(bool binaryEncodingEnabled)
         {
+            if (binaryEncodingEnabled)
+            {
+                Environment.SetEnvironmentVariable(ConfigurationManager.BinaryEncodingEnabled, "True");
+            }
+
             try
             {
-                if (binaryEncodingEnabled)
-                {
-                    Environment.SetEnvironmentVariable(ConfigurationManager.BinaryEncodingEnabled, "True");
-                }
-
                 (CosmosClient client, Cosmos.Database db, Container container) =
-                    await this.CreateTestResourcesAsync(binaryEncodingEnabled);
+                    await this.CreateTestResourcesAsync();
 
                 try
                 {
@@ -3778,15 +3799,15 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         [DataRow(true, DisplayName = "ReadItemAsync - Binary encoding enabled.")]
         public async Task ReadItemAsyncTest(bool binaryEncodingEnabled)
         {
+            if (binaryEncodingEnabled)
+            {
+                Environment.SetEnvironmentVariable(ConfigurationManager.BinaryEncodingEnabled, "True");
+            }
+
             try
             {
-                if (binaryEncodingEnabled)
-                {
-                    Environment.SetEnvironmentVariable(ConfigurationManager.BinaryEncodingEnabled, "True");
-                }
-
                 (CosmosClient client, Cosmos.Database db, Container container) =
-                    await this.CreateTestResourcesAsync(binaryEncodingEnabled);
+                    await this.CreateTestResourcesAsync();
 
                 try
                 {
@@ -3823,15 +3844,15 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         [DataRow(true, DisplayName = "ReplaceItemAsync - Binary encoding enabled.")]
         public async Task ReplaceItemAsyncTest(bool binaryEncodingEnabled)
         {
+            if (binaryEncodingEnabled)
+            {
+                Environment.SetEnvironmentVariable(ConfigurationManager.BinaryEncodingEnabled, "True");
+            }
+
             try
             {
-                if (binaryEncodingEnabled)
-                {
-                    Environment.SetEnvironmentVariable(ConfigurationManager.BinaryEncodingEnabled, "True");
-                }
-
                 (CosmosClient client, Cosmos.Database db, Container container) =
-                    await this.CreateTestResourcesAsync(binaryEncodingEnabled);
+                    await this.CreateTestResourcesAsync();
 
                 try
                 {
@@ -3874,15 +3895,15 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         [DataRow(true, DisplayName = "DeleteItemAsync - Binary encoding enabled.")]
         public async Task DeleteItemAsyncTest(bool binaryEncodingEnabled)
         {
+            if (binaryEncodingEnabled)
+            {
+                Environment.SetEnvironmentVariable(ConfigurationManager.BinaryEncodingEnabled, "True");
+            }
+
             try
             {
-                if (binaryEncodingEnabled)
-                {
-                    Environment.SetEnvironmentVariable(ConfigurationManager.BinaryEncodingEnabled, "True");
-                }
-
                 (CosmosClient client, Cosmos.Database db, Container container) =
-                    await this.CreateTestResourcesAsync(binaryEncodingEnabled);
+                    await this.CreateTestResourcesAsync();
 
                 try
                 {
@@ -3926,15 +3947,15 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         [DataRow(true, DisplayName = "QueryItemAsyncTest - Binary encoding enabled.")]
         public async Task QueryItemAsyncTest(bool binaryEncodingEnabled)
         {
+            if (binaryEncodingEnabled)
+            {
+                Environment.SetEnvironmentVariable(ConfigurationManager.BinaryEncodingEnabled, "True");
+            }
+
             try
             {
-                if (binaryEncodingEnabled)
-                {
-                    Environment.SetEnvironmentVariable(ConfigurationManager.BinaryEncodingEnabled, "True");
-                }
-
                 (CosmosClient client, Cosmos.Database db, Container container) =
-                    await this.CreateTestResourcesAsync(binaryEncodingEnabled);
+                    await this.CreateTestResourcesAsync();
 
                 try
                 {
@@ -3973,14 +3994,12 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
         }
 
-        private async Task<(CosmosClient client, Cosmos.Database db, Container container)> CreateTestResourcesAsync(
-            bool binaryEncodingEnabled)
+        private async Task<(CosmosClient client, Cosmos.Database db, Container container)> CreateTestResourcesAsync()
         {
             CosmosClient client = TestCommon.CreateCosmosClient(
                 useCustomSeralizer: false,
                 validatePartitionKeyRangeCalls: false,
-                accountEndpointOverride: null,
-                binaryEncodingEnabled: binaryEncodingEnabled);
+                accountEndpointOverride: null);
 
             Cosmos.Database db = await client.CreateDatabaseAsync(Guid.NewGuid().ToString());
             Container container = await db.CreateContainerAsync(

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -3671,6 +3671,320 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.AreEqual(SubStatusCodes.MalformedContinuationToken, response.Headers.SubStatusCode);
         }
 
+        [TestMethod]
+        [DataRow(false, DisplayName = "CreateItemAsync - Binary encoding disabled.")]
+        [DataRow(true, DisplayName = "CreateItemAsync - Binary encoding enabled.")]
+        public async Task CreateItemAsyncTest(bool binaryEncodingEnabled)
+        {
+            try
+            {
+                if (binaryEncodingEnabled)
+                {
+                    Environment.SetEnvironmentVariable(ConfigurationManager.BinaryEncodingEnabled, "True");
+                }
+
+                // Create new client, db, container with binary serializer
+                (CosmosClient client, Cosmos.Database db, Container container) =
+                    await this.CreateTestResourcesAsync(binaryEncodingEnabled);
+
+                try
+                {
+                    ToDoActivity testItem = ToDoActivity.CreateRandomToDoActivity();
+
+                    ItemResponse<ToDoActivity> createResponse =
+                        await container.CreateItemAsync(testItem, new Cosmos.PartitionKey(testItem.pk));
+
+                    Assert.IsNotNull(createResponse);
+                    Assert.AreEqual(HttpStatusCode.Created, createResponse.StatusCode);
+                    Assert.IsNotNull(createResponse.Resource);
+                    Assert.AreEqual(testItem.id, createResponse.Resource.id);
+                    Assert.IsNotNull(createResponse.Diagnostics);
+
+                    Assert.IsTrue(createResponse.Diagnostics.GetClientElapsedTime() > TimeSpan.Zero);
+                    Assert.AreEqual(0, createResponse.Diagnostics.GetFailedRequestCount());
+                }
+                finally
+                {
+                    await db.DeleteAsync();
+                    client.Dispose();
+                }
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(ConfigurationManager.BinaryEncodingEnabled, null);
+            }
+        }
+
+        [TestMethod]
+        [DataRow(false, DisplayName = "UpsertItemAsync - Binary encoding disabled.")]
+        [DataRow(true, DisplayName = "UpsertItemAsync - Binary encoding enabled.")]
+        public async Task UpsertItemAsyncTest(bool binaryEncodingEnabled)
+        {
+            try
+            {
+                if (binaryEncodingEnabled)
+                {
+                    Environment.SetEnvironmentVariable(ConfigurationManager.BinaryEncodingEnabled, "True");
+                }
+
+                (CosmosClient client, Cosmos.Database db, Container container) =
+                    await this.CreateTestResourcesAsync(binaryEncodingEnabled);
+
+                try
+                {
+                    ToDoActivity testItem = ToDoActivity.CreateRandomToDoActivity();
+
+                    ItemResponse<ToDoActivity> createAsUpsertResponse =
+                        await container.UpsertItemAsync(testItem, new Cosmos.PartitionKey(testItem.pk));
+
+                    Assert.IsNotNull(createAsUpsertResponse);
+                    Assert.AreEqual(HttpStatusCode.Created, createAsUpsertResponse.StatusCode);
+                    Assert.IsNotNull(createAsUpsertResponse.Resource);
+                    Assert.AreEqual(testItem.id, createAsUpsertResponse.Resource.id);
+
+                    testItem.description = "Updated via Upsert";
+                    testItem.taskNum = 9999;
+
+                    ItemResponse<ToDoActivity> updateAsUpsertResponse =
+                        await container.UpsertItemAsync(testItem, new Cosmos.PartitionKey(testItem.pk));
+
+                    Assert.IsNotNull(updateAsUpsertResponse);
+                    Assert.AreEqual(HttpStatusCode.OK, updateAsUpsertResponse.StatusCode);
+                    Assert.IsNotNull(updateAsUpsertResponse.Resource);
+                    Assert.AreEqual(testItem.id, updateAsUpsertResponse.Resource.id);
+                    Assert.AreEqual(9999, updateAsUpsertResponse.Resource.taskNum);
+
+                    Assert.IsNotNull(updateAsUpsertResponse.Diagnostics);
+                    Assert.IsTrue(updateAsUpsertResponse.Diagnostics.GetClientElapsedTime() > TimeSpan.Zero);
+                    Assert.AreEqual(0, updateAsUpsertResponse.Diagnostics.GetFailedRequestCount());
+                }
+                finally
+                {
+                    await db.DeleteAsync();
+                    client.Dispose();
+                }
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(ConfigurationManager.BinaryEncodingEnabled, null);
+            }
+        }
+
+        [TestMethod]
+        [DataRow(false, DisplayName = "ReadItemAsync - Binary encoding disabled.")]
+        [DataRow(true, DisplayName = "ReadItemAsync - Binary encoding enabled.")]
+        public async Task ReadItemAsyncTest(bool binaryEncodingEnabled)
+        {
+            try
+            {
+                if (binaryEncodingEnabled)
+                {
+                    Environment.SetEnvironmentVariable(ConfigurationManager.BinaryEncodingEnabled, "True");
+                }
+
+                (CosmosClient client, Cosmos.Database db, Container container) =
+                    await this.CreateTestResourcesAsync(binaryEncodingEnabled);
+
+                try
+                {
+                    ToDoActivity testItem = ToDoActivity.CreateRandomToDoActivity();
+                    ItemResponse<ToDoActivity> createResponse =
+                        await container.CreateItemAsync(testItem, new Cosmos.PartitionKey(testItem.pk));
+                    Assert.AreEqual(HttpStatusCode.Created, createResponse.StatusCode);
+
+                    ItemResponse<ToDoActivity> readResponse =
+                        await container.ReadItemAsync<ToDoActivity>(testItem.id, new Cosmos.PartitionKey(testItem.pk));
+
+                    Assert.IsNotNull(readResponse);
+                    Assert.AreEqual(HttpStatusCode.OK, readResponse.StatusCode);
+                    Assert.IsNotNull(readResponse.Resource);
+                    Assert.AreEqual(testItem.id, readResponse.Resource.id);
+                    Assert.IsTrue(readResponse.Diagnostics.GetClientElapsedTime() > TimeSpan.Zero);
+                    Assert.AreEqual(0, readResponse.Diagnostics.GetFailedRequestCount());
+                }
+                finally
+                {
+                    await db.DeleteAsync();
+                    client.Dispose();
+                }
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(ConfigurationManager.BinaryEncodingEnabled, null);
+            }
+        }
+
+        [TestMethod]
+        [DataRow(false, DisplayName = "ReplaceItemAsync - Binary encoding disabled.")]
+        [DataRow(true, DisplayName = "ReplaceItemAsync - Binary encoding enabled.")]
+        public async Task ReplaceItemAsyncTest(bool binaryEncodingEnabled)
+        {
+            try
+            {
+                if (binaryEncodingEnabled)
+                {
+                    Environment.SetEnvironmentVariable(ConfigurationManager.BinaryEncodingEnabled, "True");
+                }
+
+                (CosmosClient client, Cosmos.Database db, Container container) =
+                    await this.CreateTestResourcesAsync(binaryEncodingEnabled);
+
+                try
+                {
+                    ToDoActivity testItem = ToDoActivity.CreateRandomToDoActivity();
+                    ItemResponse<ToDoActivity> createResponse =
+                        await container.CreateItemAsync(testItem, new Cosmos.PartitionKey(testItem.pk));
+                    Assert.AreEqual(HttpStatusCode.Created, createResponse.StatusCode);
+
+                    testItem.description = "Replaced description";
+                    testItem.taskNum = 1234;
+
+                    ItemResponse<ToDoActivity> replaceResponse =
+                        await container.ReplaceItemAsync(testItem, testItem.id, new Cosmos.PartitionKey(testItem.pk));
+
+                    Assert.IsNotNull(replaceResponse);
+                    Assert.AreEqual(HttpStatusCode.OK, replaceResponse.StatusCode);
+                    Assert.IsNotNull(replaceResponse.Resource);
+                    Assert.AreEqual(testItem.id, replaceResponse.Resource.id);
+                    Assert.AreEqual(1234, replaceResponse.Resource.taskNum);
+
+                    Assert.IsNotNull(replaceResponse.Diagnostics);
+                    Assert.IsTrue(replaceResponse.Diagnostics.GetClientElapsedTime() > TimeSpan.Zero);
+                    Assert.AreEqual(0, replaceResponse.Diagnostics.GetFailedRequestCount());
+                }
+                finally
+                {
+                    await db.DeleteAsync();
+                    client.Dispose();
+                }
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(ConfigurationManager.BinaryEncodingEnabled, null);
+            }
+        }
+
+        [TestMethod]
+        [DataRow(false, DisplayName = "DeleteItemAsync - Binary encoding disabled.")]
+        [DataRow(true, DisplayName = "DeleteItemAsync - Binary encoding enabled.")]
+        public async Task DeleteItemAsyncTest(bool binaryEncodingEnabled)
+        {
+            try
+            {
+                if (binaryEncodingEnabled)
+                {
+                    Environment.SetEnvironmentVariable(ConfigurationManager.BinaryEncodingEnabled, "True");
+                }
+
+                (CosmosClient client, Cosmos.Database db, Container container) =
+                    await this.CreateTestResourcesAsync(binaryEncodingEnabled);
+
+                try
+                {
+                    ToDoActivity testItem = ToDoActivity.CreateRandomToDoActivity();
+                    ItemResponse<ToDoActivity> createResponse =
+                        await container.CreateItemAsync(testItem, new Cosmos.PartitionKey(testItem.pk));
+                    Assert.AreEqual(HttpStatusCode.Created, createResponse.StatusCode);
+
+                    ItemResponse<ToDoActivity> deleteResponse =
+                        await container.DeleteItemAsync<ToDoActivity>(testItem.id, new Cosmos.PartitionKey(testItem.pk));
+
+                    Assert.IsNotNull(deleteResponse);
+                    Assert.AreEqual(HttpStatusCode.NoContent, deleteResponse.StatusCode);
+                    Assert.IsNotNull(deleteResponse.Diagnostics);
+                    Assert.IsTrue(deleteResponse.Diagnostics.GetClientElapsedTime() > TimeSpan.Zero);
+
+                    try
+                    {
+                        await container.ReadItemAsync<ToDoActivity>(testItem.id, new Cosmos.PartitionKey(testItem.pk));
+                        Assert.Fail("Read should have thrown a 404, as the item was deleted.");
+                    }
+                    catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+                    {
+                    }
+                }
+                finally
+                {
+                    await db.DeleteAsync();
+                    client.Dispose();
+                }
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(ConfigurationManager.BinaryEncodingEnabled, null);
+            }
+        }
+
+        [TestMethod]
+        [DataRow(false, DisplayName = "QueryItemAsyncTest - Binary encoding disabled.")]
+        [DataRow(true, DisplayName = "QueryItemAsyncTest - Binary encoding enabled.")]
+        public async Task QueryItemAsyncTest(bool binaryEncodingEnabled)
+        {
+            try
+            {
+                if (binaryEncodingEnabled)
+                {
+                    Environment.SetEnvironmentVariable(ConfigurationManager.BinaryEncodingEnabled, "True");
+                }
+
+                (CosmosClient client, Cosmos.Database db, Container container) =
+                    await this.CreateTestResourcesAsync(binaryEncodingEnabled);
+
+                try
+                {
+                    List<ToDoActivity> items = new List<ToDoActivity>();
+                    for (int i = 0; i < 5; i++)
+                    {
+                        ToDoActivity item = ToDoActivity.CreateRandomToDoActivity($"testPartition{i}");
+                        items.Add(item);
+                        await container.CreateItemAsync(item, new Cosmos.PartitionKey(item.pk));
+                    }
+
+                    QueryDefinition query = new QueryDefinition("SELECT * FROM c");
+                    FeedIterator<ToDoActivity> feedIterator = container.GetItemQueryIterator<ToDoActivity>(query);
+
+                    int totalCount = 0;
+                    while (feedIterator.HasMoreResults)
+                    {
+                        FeedResponse<ToDoActivity> page = await feedIterator.ReadNextAsync();
+                        totalCount += page.Count;
+                    }
+
+                    Assert.AreEqual(
+                        expected: items.Count,
+                        actual: totalCount,
+                        message: "All inserted items should be returned by the query!");
+                }
+                finally
+                {
+                    await db.DeleteAsync();
+                    client.Dispose();
+                }
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(ConfigurationManager.BinaryEncodingEnabled, null);
+            }
+        }
+
+        private async Task<(CosmosClient client, Cosmos.Database db, Container container)> CreateTestResourcesAsync(
+            bool binaryEncodingEnabled)
+        {
+            CosmosClient client = TestCommon.CreateCosmosClient(
+                useCustomSeralizer: false,
+                validatePartitionKeyRangeCalls: false,
+                accountEndpointOverride: null,
+                binaryEncodingEnabled: binaryEncodingEnabled);
+
+            Cosmos.Database db = await client.CreateDatabaseAsync(Guid.NewGuid().ToString());
+            Container container = await db.CreateContainerAsync(
+                id: Guid.NewGuid().ToString(),
+                partitionKeyPath: "/pk",
+                throughput: 4000);
+
+            return (client, db, container);
+        }
+
         private static async Task GivenItemStreamAsyncWhenMissingMemberHandlingIsErrorThenExpectsCosmosExceptionTestAsync(
             Func<Container, string, string, CancellationToken, Task<ResponseMessage>> itemStreamAsync)
         {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosReadManyItemsTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosReadManyItemsTests.cs
@@ -51,11 +51,18 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        [DataRow(true, DisplayName = "Validates Read Many scenario with advanced replica selection enabled.")]
-        [DataRow(false, DisplayName = "Validates Read Many scenario with advanced replica selection disabled.")]
+        [DataRow(true, true, DisplayName = "Validates Read Many scenario with advanced replica selection enabled.")]
+        [DataRow(true, false, DisplayName = "Validates Read Many scenario with advanced replica selection disabled.")]
+        [DataRow(false, true, DisplayName = "Validates Read Many scenario with advanced replica selection enabled.")]
+        [DataRow(false, false, DisplayName = "Validates Read Many scenario with advanced replica selection disabled.")]
         public async Task ReadManyTypedTestWithAdvancedReplicaSelection(
+            bool binaryEncodingEnabled,
             bool advancedReplicaSelectionEnabled)
         {
+            if (binaryEncodingEnabled)
+            {
+                Environment.SetEnvironmentVariable(ConfigurationManager.BinaryEncodingEnabled, "True");
+            }
             CosmosClientOptions clientOptions = new ()
             {
                 EnableAdvancedReplicaSelectionForTcp = advancedReplicaSelectionEnabled,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosReadManyItemsTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosReadManyItemsTests.cs
@@ -51,6 +51,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
+        [DoNotParallelize]
         [DataRow(true, true, DisplayName = "Validates Read Many scenario with advanced replica selection enabled.")]
         [DataRow(true, false, DisplayName = "Validates Read Many scenario with advanced replica selection disabled.")]
         [DataRow(false, true, DisplayName = "Validates Read Many scenario with advanced replica selection enabled.")]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosReadManyItemsTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosReadManyItemsTests.cs
@@ -51,7 +51,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        [DoNotParallelize]
         [DataRow(true, true, DisplayName = "Validates Read Many scenario with advanced replica selection enabled.")]
         [DataRow(true, false, DisplayName = "Validates Read Many scenario with advanced replica selection disabled.")]
         [DataRow(false, true, DisplayName = "Validates Read Many scenario with advanced replica selection enabled.")]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/TriggersTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/TriggersTests.cs
@@ -106,28 +106,37 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        [DataRow(TriggerOperation.Create)]
-        [DataRow(TriggerOperation.Upsert)]
-        public async Task ValidatePreTriggerTest(TriggerOperation triggerOperation)
+        [DataRow(TriggerOperation.Create, false, DisplayName = "TriggerOperation - Create with Binary encoding disabled.")]
+        [DataRow(TriggerOperation.Create, true, DisplayName = "TriggerOperation - Create with Binary encoding enabled.")]
+        [DataRow(TriggerOperation.Upsert, false, DisplayName = "TriggerOperation - Upsert with Binary encoding disabled.")]
+        [DataRow(TriggerOperation.Upsert, true, DisplayName = "TriggerOperation - Upsert with Binary encoding enabled.")]
+        public async Task ValidatePreTriggerTest(TriggerOperation triggerOperation, bool binaryEncodingEnabled)
         {
-            string triggerId = "SetJobNumber";
+            if (binaryEncodingEnabled)
+            {
+                Environment.SetEnvironmentVariable(ConfigurationManager.BinaryEncodingEnabled, "True");
+            }
 
-            // Prevent failures if previous test did not clean up correctly 
             try
             {
-                await this.scripts.DeleteTriggerAsync(triggerId);
-            }
-            catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
-            {
-                //swallow
-            }
+                string triggerId = "SetJobNumber";
 
-            TriggerProperties trigger = new TriggerProperties
-            {
-                Id = triggerId,
-                TriggerType = TriggerType.Pre,
-                TriggerOperation = triggerOperation,
-                Body = @"function setJobNumber() {
+                // Prevent failures if previous test did not clean up correctly 
+                try
+                {
+                    await this.scripts.DeleteTriggerAsync(triggerId);
+                }
+                catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+                {
+                    //swallow
+                }
+
+                TriggerProperties trigger = new TriggerProperties
+                {
+                    Id = triggerId,
+                    TriggerType = TriggerType.Pre,
+                    TriggerOperation = triggerOperation,
+                    Body = @"function setJobNumber() {
                     var context = getContext();
                     var request = context.getRequest();      
                     var containerManager = context.getCollection();
@@ -146,78 +155,83 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     // update the document that will be created
                     request.setBody(documentToCreate);
                     }",
-            };
+                };
 
-            TriggerProperties cosmosTrigger = await this.scripts.CreateTriggerAsync(trigger);
+                TriggerProperties cosmosTrigger = await this.scripts.CreateTriggerAsync(trigger);
 
-            Job value = new Job() { Id = Guid.NewGuid(), InvestigationKey = "investigation~1" };
+                Job value = new Job() { Id = Guid.NewGuid(), InvestigationKey = "investigation~1" };
 
-            Job item = null;
-            if (triggerOperation == TriggerOperation.Create)
-            {
-                // this should create the document successfully with jobnumber of 1
-                item = await this.container.CreateItemAsync<Job>(item: value, partitionKey: null, requestOptions: new ItemRequestOptions
+                Job item = null;
+                if (triggerOperation == TriggerOperation.Create)
                 {
-                    PreTriggers = new List<string> { triggerId }
-                });
-            }
-            else if(triggerOperation == TriggerOperation.Upsert)
-            {
-                // this should create the document successfully with jobnumber of 1
-                item = await this.container.UpsertItemAsync<Job>(item: value, partitionKey: null, requestOptions: new ItemRequestOptions
+                    // this should create the document successfully with jobnumber of 1
+                    item = await this.container.CreateItemAsync<Job>(item: value, partitionKey: null, requestOptions: new ItemRequestOptions
+                    {
+                        PreTriggers = new List<string> { triggerId }
+                    });
+                }
+                else if (triggerOperation == TriggerOperation.Upsert)
                 {
-                    PreTriggers = new List<string> { triggerId }
-                });
-            }
-          
-            Assert.AreEqual(value.Id, item.Id);
-            Assert.AreEqual(value.InvestigationKey, item.InvestigationKey);
-            Assert.AreEqual(1, item.JobNumber);
+                    // this should create the document successfully with jobnumber of 1
+                    item = await this.container.UpsertItemAsync<Job>(item: value, partitionKey: null, requestOptions: new ItemRequestOptions
+                    {
+                        PreTriggers = new List<string> { triggerId }
+                    });
+                }
 
-            List<Job> result = this.container.GetItemLinqQueryable<Job>(allowSynchronousQueryExecution: true).Where(x => x.InvestigationKey == "investigation~1").ToList();
-            Assert.IsNotNull(result);
-            Assert.AreEqual(1, result.Count);
-            Job jobFromLinq = result.First();
+                Assert.AreEqual(value.Id, item.Id);
+                Assert.AreEqual(value.InvestigationKey, item.InvestigationKey);
+                Assert.AreEqual(1, item.JobNumber);
 
-            Assert.AreEqual(value.Id, jobFromLinq.Id);
-            Assert.AreEqual(value.InvestigationKey, jobFromLinq.InvestigationKey);
-            Assert.AreEqual(1, jobFromLinq.JobNumber);
+                List<Job> result = this.container.GetItemLinqQueryable<Job>(allowSynchronousQueryExecution: true).Where(x => x.InvestigationKey == "investigation~1").ToList();
+                Assert.IsNotNull(result);
+                Assert.AreEqual(1, result.Count);
+                Job jobFromLinq = result.First();
 
-            value.Id = Guid.NewGuid();
+                Assert.AreEqual(value.Id, jobFromLinq.Id);
+                Assert.AreEqual(value.InvestigationKey, jobFromLinq.InvestigationKey);
+                Assert.AreEqual(1, jobFromLinq.JobNumber);
 
-            Job item2 = null;
-            if (triggerOperation == TriggerOperation.Create)
-            {
-                // this should create the document successfully with jobnumber of 2
-                item2 = await this.container.CreateItemAsync<Job>(item: value, partitionKey: null, requestOptions: new ItemRequestOptions
+                value.Id = Guid.NewGuid();
+
+                Job item2 = null;
+                if (triggerOperation == TriggerOperation.Create)
                 {
-                    PreTriggers = new List<string> { "SetJobNumber" }
-                });
-            }
-            else if (triggerOperation == TriggerOperation.Upsert)
-            {
-                // this should create the document successfully with jobnumber of 1
-                item2 = await this.container.UpsertItemAsync<Job>(item: value, partitionKey: null, requestOptions: new ItemRequestOptions
+                    // this should create the document successfully with jobnumber of 2
+                    item2 = await this.container.CreateItemAsync<Job>(item: value, partitionKey: null, requestOptions: new ItemRequestOptions
+                    {
+                        PreTriggers = new List<string> { "SetJobNumber" }
+                    });
+                }
+                else if (triggerOperation == TriggerOperation.Upsert)
                 {
-                    PreTriggers = new List<string> { "SetJobNumber" }
-                });
+                    // this should create the document successfully with jobnumber of 1
+                    item2 = await this.container.UpsertItemAsync<Job>(item: value, partitionKey: null, requestOptions: new ItemRequestOptions
+                    {
+                        PreTriggers = new List<string> { "SetJobNumber" }
+                    });
+                }
+
+                Assert.AreEqual(value.Id, item2.Id);
+                Assert.AreEqual(value.InvestigationKey, item2.InvestigationKey);
+                Assert.AreEqual(2, item2.JobNumber);
+
+                result = this.container.GetItemLinqQueryable<Job>(allowSynchronousQueryExecution: true).Where(x => x.InvestigationKey == "investigation~1").ToList();
+                Assert.IsNotNull(result);
+                Assert.AreEqual(2, result.Count);
+                jobFromLinq = result.First(x => x.JobNumber == 2);
+
+                Assert.AreEqual(value.Id, jobFromLinq.Id);
+                Assert.AreEqual(value.InvestigationKey, jobFromLinq.InvestigationKey);
+                Assert.AreEqual(2, jobFromLinq.JobNumber);
+
+                // Delete existing user defined functions.
+                await this.scripts.DeleteTriggerAsync(triggerId);
             }
-
-            Assert.AreEqual(value.Id, item2.Id);
-            Assert.AreEqual(value.InvestigationKey, item2.InvestigationKey);
-            Assert.AreEqual(2, item2.JobNumber);
-
-            result = this.container.GetItemLinqQueryable<Job>(allowSynchronousQueryExecution: true).Where(x => x.InvestigationKey == "investigation~1").ToList();
-            Assert.IsNotNull(result);
-            Assert.AreEqual(2, result.Count);
-            jobFromLinq = result.First(x => x.JobNumber == 2);
-
-            Assert.AreEqual(value.Id, jobFromLinq.Id);
-            Assert.AreEqual(value.InvestigationKey, jobFromLinq.InvestigationKey);
-            Assert.AreEqual(2, jobFromLinq.JobNumber);
-
-            // Delete existing user defined functions.
-            await this.scripts.DeleteTriggerAsync(triggerId);
+            finally
+            {
+                Environment.SetEnvironmentVariable(ConfigurationManager.BinaryEncodingEnabled, null);
+            }
         }
 
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/TestCommon.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/TestCommon.cs
@@ -81,8 +81,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         internal static CosmosClientBuilder GetDefaultConfiguration(
             bool useCustomSeralizer = true,
             bool validatePartitionKeyRangeCalls = false,
-            string accountEndpointOverride = null,
-            bool enableBinaryEncoding = false)
+            string accountEndpointOverride = null)
         {
             (string endpoint, string authKey) = TestCommon.GetAccountInfo();
             CosmosClientBuilder clientBuilder = new CosmosClientBuilder(
@@ -90,7 +89,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 authKeyOrResourceToken: authKey);
             if (useCustomSeralizer)
             {
-                clientBuilder.WithCustomSerializer(new CosmosJsonDotNetSerializer(enableBinaryEncoding));
+                clientBuilder.WithCustomSerializer(new CosmosJsonDotNetSerializer());
             }
 
             if (validatePartitionKeyRangeCalls)
@@ -105,10 +104,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Action<CosmosClientBuilder> customizeClientBuilder = null,
             bool useCustomSeralizer = true,
             bool validatePartitionKeyRangeCalls = false,
-            string accountEndpointOverride = null,
-            bool binaryEncodingEnabled = false)
+            string accountEndpointOverride = null)
         {
-            CosmosClientBuilder cosmosClientBuilder = GetDefaultConfiguration(useCustomSeralizer, validatePartitionKeyRangeCalls, accountEndpointOverride, binaryEncodingEnabled);
+            CosmosClientBuilder cosmosClientBuilder = GetDefaultConfiguration(useCustomSeralizer, validatePartitionKeyRangeCalls, accountEndpointOverride);
             customizeClientBuilder?.Invoke(cosmosClientBuilder);
 
             CosmosClient client = cosmosClientBuilder.Build();

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/TestCommon.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/TestCommon.cs
@@ -81,7 +81,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         internal static CosmosClientBuilder GetDefaultConfiguration(
             bool useCustomSeralizer = true,
             bool validatePartitionKeyRangeCalls = false,
-            string accountEndpointOverride = null)
+            string accountEndpointOverride = null,
+            bool enableBinaryEncoding = false)
         {
             (string endpoint, string authKey) = TestCommon.GetAccountInfo();
             CosmosClientBuilder clientBuilder = new CosmosClientBuilder(
@@ -89,7 +90,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 authKeyOrResourceToken: authKey);
             if (useCustomSeralizer)
             {
-                clientBuilder.WithCustomSerializer(new CosmosJsonDotNetSerializer());
+                clientBuilder.WithCustomSerializer(new CosmosJsonDotNetSerializer(enableBinaryEncoding));
             }
 
             if (validatePartitionKeyRangeCalls)
@@ -104,9 +105,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Action<CosmosClientBuilder> customizeClientBuilder = null,
             bool useCustomSeralizer = true,
             bool validatePartitionKeyRangeCalls = false,
-            string accountEndpointOverride = null)
+            string accountEndpointOverride = null,
+            bool binaryEncodingEnabled = false)
         {
-            CosmosClientBuilder cosmosClientBuilder = GetDefaultConfiguration(useCustomSeralizer, validatePartitionKeyRangeCalls, accountEndpointOverride);
+            CosmosClientBuilder cosmosClientBuilder = GetDefaultConfiguration(useCustomSeralizer, validatePartitionKeyRangeCalls, accountEndpointOverride, binaryEncodingEnabled);
             customizeClientBuilder?.Invoke(cosmosClientBuilder);
 
             CosmosClient client = cosmosClientBuilder.Build();


### PR DESCRIPTION
# Pull Request Template

## Description

In the current code, CosmosClient used a default version of CosmosJsonDotNetSerializer as a propertiesSerializer which used the ConfigurationManager.IsBinaryEncodingEnabled() to determine whether to use binary encoding during serialization and de-serialization.

This propertiesSerializer is hooked into multiple serializers to use as internal serializers and caused unexpected behaviors for APIs like ReadManyItems, ChangeFeed and caused a regression.
## Type of change

There are 3 parts of the change:

- As part of this change we are introducing a binary serializer. The default serializer will not just use `propertySerializer` but it will check if the binary encoding flag is enabled and accordingly assign the serializer.

- When a custom serializer is present, on the response path, no matter what we always return the stream as Text to the serializer. If the default serializer is used then we pass the binary stream in the serializer.

- During some local testing, I realized that `CreateItemAsync` with `PreTriggers` or `PostTriggers` doesn't work when binary encoding is enabled. This is because when triggers are present in the item request options the backend will pass the stream to the javascript engine, which does not support binary encoded content at the moment. For long term, since trigger operations won't be supported in the backend, avoiding the binary encoding in such cases, will be the ideal approach. Therefore, needed to skip using binary in such situation. For example, the below code will fail today (before the fix in the PR) if it's used with binary encoding:

```
ItemRequestOptions requestOptions = new ItemRequestOptions()
{
    PreTriggers = new List<string>() { triggerResponse.Resource.Id },
};

Comment comment = new Comment(
    Guid.NewGuid().ToString(),
    "pk",
    random.Next().ToString(),
    "dkunda@test.com", 
    "This document is intended for binary encoding.");

ItemResponse<Comment> writeResponse = await container.CreateItemAsync<Comment>(
    item: comment,
    partitionKey: new Cosmos.PartitionKey(comment.pk),
    requestOptions: requestOptions
);
```

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #5043