### PR TITLE
[Internal] ClientRetryPolicy: Adds Code to Apply Partition Level Override When a Requested Cancellation Token Expires

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ClientRetryPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/ClientRetryPolicy.cs
@@ -141,8 +141,7 @@ namespace Microsoft.Azure.Cosmos
                     this.failoverRetryCount,
                     this.locationEndpoint?.ToString() ?? string.Empty);
 
-                if (this.isPartitionLevelFailoverEnabled
-                    && this.partitionKeyRangeLocationCache.IncrementRequestFailureCounterAndCheckIfPartitionCanFailover(
+                if (this.partitionKeyRangeLocationCache.IncrementRequestFailureCounterAndCheckIfPartitionCanFailover(
                         this.documentServiceRequest))
                 {
                     // In the event of a write operation getting timed out due to cancellation token expiration on region A,

--- a/Microsoft.Azure.Cosmos/src/ClientRetryPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/ClientRetryPolicy.cs
@@ -141,7 +141,9 @@ namespace Microsoft.Azure.Cosmos
                     this.failoverRetryCount,
                     this.locationEndpoint?.ToString() ?? string.Empty);
 
-                if (this.isPartitionLevelFailoverEnabled)
+                if (this.isPartitionLevelFailoverEnabled
+                    && this.partitionKeyRangeLocationCache.IncrementRequestFailureCounterAndCheckIfPartitionCanFailover(
+                        this.documentServiceRequest))
                 {
                     // In the event of a write operation getting timed out due to cancellation token expiration on region A,
                     // mark the partition as unavailable assuming that the partition has been failed over to region B, when

--- a/Microsoft.Azure.Cosmos/src/ClientRetryPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/ClientRetryPolicy.cs
@@ -150,8 +150,6 @@ namespace Microsoft.Azure.Cosmos
                     this.partitionKeyRangeLocationCache.TryMarkEndpointUnavailableForPartitionKeyRange(
                          this.documentServiceRequest);
                 }
-
-                return ShouldRetryResult.NoRetry();
             }
 
             return await this.throttlingRetry.ShouldRetryAsync(exception, cancellationToken);

--- a/Microsoft.Azure.Cosmos/src/ClientRetryPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/ClientRetryPolicy.cs
@@ -141,7 +141,7 @@ namespace Microsoft.Azure.Cosmos
                     this.failoverRetryCount,
                     this.locationEndpoint?.ToString() ?? string.Empty);
 
-                if (this.isPertitionLevelFailoverEnabled)
+                if (this.isPartitionLevelFailoverEnabled)
                 {
                     // In the event of a write operation getting timed out due to cancellation token expiration on region A,
                     // mark the partition as unavailable assuming that the partition has been failed over to region B, when

--- a/Microsoft.Azure.Cosmos/src/ClientRetryPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/ClientRetryPolicy.cs
@@ -144,9 +144,9 @@ namespace Microsoft.Azure.Cosmos
                 if (this.partitionKeyRangeLocationCache.IncrementRequestFailureCounterAndCheckIfPartitionCanFailover(
                         this.documentServiceRequest))
                 {
-                    // In the event of a write operation getting timed out due to cancellation token expiration on region A,
-                    // mark the partition as unavailable assuming that the partition has been failed over to region B, when
-                    // per partition automatic failover is enabled.
+                    // In the event of a (ppaf + write operation) or (ppcb + read or multi-master write operation) getting timed
+                    // out due to cancellation token expiration on region A, mark the partition as unavailable assuming that
+                    // the partition has been failed over to region B, when per partition automatic failover is enabled.
                     this.partitionKeyRangeLocationCache.TryMarkEndpointUnavailableForPartitionKeyRange(
                          this.documentServiceRequest);
                 }

--- a/Microsoft.Azure.Cosmos/src/Handler/AbstractRetryHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/AbstractRetryHandler.cs
@@ -67,11 +67,10 @@ namespace Microsoft.Azure.Cosmos.Handlers
         {
             while (true)
             {
-                cancellationToken.ThrowIfCancellationRequested();
                 ShouldRetryResult result;
-
                 try
                 {
+                    cancellationToken.ThrowIfCancellationRequested();
                     ResponseMessage cosmosResponseMessage = await callbackMethod();
                     if (cosmosResponseMessage.IsSuccessStatusCode)
                     {
@@ -91,6 +90,14 @@ namespace Microsoft.Azure.Cosmos.Handlers
                     {
                         // Today we don't translate request exceptions into status codes since this was an error before
                         // making the request. TODO: Figure out how to pipe this as a response instead of throwing?
+                        throw;
+                    }
+                }
+                catch (OperationCanceledException oce)
+                {
+                    result = await callShouldRetryException(oce, cancellationToken);
+                    if (!result.ShouldRetry)
+                    {
                         throw;
                     }
                 }

--- a/Microsoft.Azure.Cosmos/src/Handler/AbstractRetryHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/AbstractRetryHandler.cs
@@ -53,6 +53,10 @@ namespace Microsoft.Azure.Cosmos.Handlers
 
                 throw;
             }
+            catch (OperationCanceledException oce)
+            {
+                throw new CosmosOperationCanceledException(oce, request.Trace);
+            }
             finally
             {
                 request.OnBeforeSendRequestActions -= retryPolicyInstance.OnBeforeSendRequest;

--- a/Microsoft.Azure.Cosmos/src/Handler/AbstractRetryHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/AbstractRetryHandler.cs
@@ -53,10 +53,6 @@ namespace Microsoft.Azure.Cosmos.Handlers
 
                 throw;
             }
-            catch (OperationCanceledException oce)
-            {
-                throw new CosmosOperationCanceledException(oce, request.Trace);
-            }
             finally
             {
                 request.OnBeforeSendRequestActions -= retryPolicyInstance.OnBeforeSendRequest;

--- a/Microsoft.Azure.Cosmos/src/Routing/GlobalPartitionEndpointManagerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GlobalPartitionEndpointManagerCore.cs
@@ -213,11 +213,23 @@ namespace Microsoft.Azure.Cosmos.Routing
                 return false;
             }
 
-            PartitionKeyRangeFailoverInfo partionFailover = this.PartitionKeyRangeToLocationForReadAndWrite.Value.GetOrAdd(
-                partitionKeyRange,
-                (_) => new PartitionKeyRangeFailoverInfo(
-                    request.RequestContext.ResolvedCollectionRid,
-                    failedLocation));
+            PartitionKeyRangeFailoverInfo partionFailover;
+            if (this.IsRequestEligibleForPerPartitionAutomaticFailover(request))
+            {
+                partionFailover = this.PartitionKeyRangeToLocationForWrite.Value.GetOrAdd(
+                    partitionKeyRange,
+                    (_) => new PartitionKeyRangeFailoverInfo(
+                        request.RequestContext.ResolvedCollectionRid,
+                        failedLocation));
+            }
+            else
+            {
+                partionFailover = this.PartitionKeyRangeToLocationForReadAndWrite.Value.GetOrAdd(
+                    partitionKeyRange,
+                    (_) => new PartitionKeyRangeFailoverInfo(
+                        request.RequestContext.ResolvedCollectionRid,
+                        failedLocation));
+            }
 
             partionFailover.IncrementRequestFailureCounts(
                 isReadOnlyRequest: request.IsReadOnlyRequest,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ClientRetryPolicyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ClientRetryPolicyTests.cs
@@ -301,7 +301,7 @@
                 partitionKeyRangeLocationCache: this.partitionKeyRangeLocationCache,
                 retryOptions: new RetryOptions(),
                 enableEndpointDiscovery: enableEndpointDiscovery,
-                isPertitionLevelFailoverEnabled: enablePartitionLevelFailover);
+                isPartitionLevelFailoverEnabled: enablePartitionLevelFailover);
 
             CancellationToken cancellationToken = new();
             OperationCanceledException operationCancelledException = new(message: "Operation was cancelled due to cancellation token expiry.");


### PR DESCRIPTION
# Pull Request Template

## Description

**Background:**

During one of the backend drills, it was identified that when the following quorum loss condition is met, and the user provides a cancellation token, SDK honors the token, however doesn't apply the partition level fail over for the offending partition:

- Quorum loss injected with the quorum replicas (3 out of 4 replicas are down).
- The primary replica is specifically down.
- A cancellation token with 5 seconds of timeout value is provided.

**Observation:**

- SDK doesn't apply the partition level override and the subsequent write requests fails on the current faulty region/ partition.

**Fix:**

This PR is fixing the above behavior to apply partition level override, when a cancellation token gets expired. In order to avoid false positives, the cancellation token based failovers are currently based on certain thresholds, which could be overridden by setting the following environment variables: `AZURE_COSMOS_PPCB_CONSECUTIVE_FAILURE_COUNT_FOR_READS` and `AZURE_COSMOS_PPCB_CONSECUTIVE_FAILURE_COUNT_FOR_WRITES`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #5060