### PR TITLE
Benchmarking HashSet variations

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Benchmarks/ConcurrentDictionaryBenchmark.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Benchmarks/ConcurrentDictionaryBenchmark.cs
@@ -1,0 +1,101 @@
+﻿namespace Microsoft.Azure.Cosmos.Benchmarks
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Threading.Tasks;
+    using BenchmarkDotNet.Attributes;
+    using BenchmarkDotNet.Columns;
+    using BenchmarkDotNet.Configs;
+    using BenchmarkDotNet.Exporters.Csv;
+    using BenchmarkDotNet.Exporters;
+    using BenchmarkDotNet.Jobs;
+    using BenchmarkDotNet.Running;
+
+    [MemoryDiagnoser]
+    [Config(typeof(CustomBenchmarkConfig))]
+    public class ConcurrentDictionaryBenchmark
+    {
+        private ConcurrentDictionary<int, int> dictionary;
+
+        [Params(1000, 10000, 100000)]
+        public int ItemCount;
+
+        [Params(1, 10, 100)]
+        public int ReaderThreads;
+
+        [Params(1, 5, 10)]
+        public int WriterThreads;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            this.dictionary = new ConcurrentDictionary<int, int>();
+            for (int i = 0; i < this.ItemCount; i++)
+            {
+                this.dictionary[i] = i;
+            }
+        }
+
+        [Benchmark]
+        public void ReadFromDictionary()
+        {
+            Parallel.For(0, this.ReaderThreads, _ =>
+            {
+                for (int i = 0; i < this.ItemCount; i++)
+                {
+                    this.dictionary.TryGetValue(i, out _);
+                }
+            });
+        }
+        [Benchmark]
+        public void WriteToDictionary()
+        {
+            Parallel.For(0, this.WriterThreads, _ =>
+            {
+                for (int i = 0; i < this.ItemCount; i++)
+                {
+                    this.dictionary[i] = i + 1;
+                }
+            });
+        }
+
+        [Benchmark]
+        public void ReadAndWriteToDictionary()
+        {
+            Parallel.Invoke(
+                () => Parallel.For(0, this.ReaderThreads, _ =>
+                {
+                    for (int i = 0; i < this.ItemCount; i++)
+                    {
+                        this.dictionary.TryGetValue(i, out _);
+                    }
+                }),
+                () => Parallel.For(0, this.WriterThreads, _ =>
+                {
+                    for (int i = 0; i < this.ItemCount; i++)
+                    {
+                        this.dictionary[i] = i + 1;
+                    }
+                })
+            );
+        }
+        private class CustomBenchmarkConfig : ManualConfig
+        {
+            public CustomBenchmarkConfig()
+            {
+                this.AddColumn(StatisticColumn.OperationsPerSecond);  // Show RPS
+                this.AddColumn(StatisticColumn.P95);
+
+
+                this.AddJob(Job.Default
+                    .WithLaunchCount(1)
+                    .WithWarmupCount(3)
+                    .WithIterationCount(5)
+                    .WithStrategy(BenchmarkDotNet.Engines.RunStrategy.Throughput));
+
+                this.AddExporter(HtmlExporter.Default);
+                this.AddExporter(CsvExporter.Default);
+            }
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Benchmarks/ImmutableHashSetBenchmark.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Benchmarks/ImmutableHashSetBenchmark.cs
@@ -1,0 +1,107 @@
+﻿namespace Microsoft.Azure.Cosmos.Benchmarks
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.Threading.Tasks;
+    using BenchmarkDotNet.Attributes;
+    using BenchmarkDotNet.Columns;
+    using BenchmarkDotNet.Configs;
+    using BenchmarkDotNet.Exporters.Csv;
+    using BenchmarkDotNet.Exporters;
+    using BenchmarkDotNet.Jobs;
+    using BenchmarkDotNet.Running;
+    using System.Collections.Immutable;
+
+    [MemoryDiagnoser]
+    [Config(typeof(CustomBenchmarkConfig))]
+    public class ImmutableHashSetBenchmark
+    {
+        private ImmutableHashSet<int> hashSet;
+
+        [Params(1000, 10000, 100000)]
+        public int ItemCount;
+
+        [Params(1, 10, 100)]
+        public int ReaderThreads;
+
+        [Params(1, 5, 10)]
+        public int WriterThreads;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            ImmutableHashSet<int>.Builder builder = ImmutableHashSet.CreateBuilder<int>();
+            for (int i = 0; i < this.ItemCount; i++)
+            {
+                builder.Add(i);
+            }
+            this.hashSet = builder.ToImmutable();
+        }
+        [Benchmark]
+        public void ReadFromHashSet()
+        {
+            Parallel.For(0, this.ReaderThreads, _ =>
+            {
+                for (int i = 0; i < this.ItemCount; i++)
+                {
+                    this.hashSet.Contains(i);
+                }
+            });
+        }
+        [Benchmark]
+        public void WriteToHashSet()
+        {
+            Parallel.For(0, this.WriterThreads, _ =>
+            {
+                ImmutableHashSet<int> localHashSet = this.hashSet;
+                for (int i = 0; i < this.ItemCount; i++)
+                {
+                    localHashSet = localHashSet.Add(i + 1);
+                }
+                this.hashSet = localHashSet;
+            });
+        }
+
+        [Benchmark]
+        public void ReadAndWriteToHashSet()
+        {
+            Parallel.Invoke(
+                () => Parallel.For(0, this.ReaderThreads, _ =>
+                {
+                    for (int i = 0; i < this.ItemCount; i++)
+                    {
+                        this.hashSet.Contains(i);
+                    }
+                }),
+                () => Parallel.For(0, this.WriterThreads, _ =>
+                {
+                    ImmutableHashSet<int> localHashSet = this.hashSet;
+                    for (int i = 0; i < this.ItemCount; i++)
+                    {
+                        localHashSet = localHashSet.Add(i + 1);
+                    }
+                    this.hashSet = localHashSet;
+                })
+            );
+        }
+        private class CustomBenchmarkConfig : ManualConfig
+        {
+            public CustomBenchmarkConfig()
+            {
+                this.AddColumn(StatisticColumn.OperationsPerSecond);  // Show RPS
+                this.AddColumn(StatisticColumn.P95);
+
+
+                this.AddJob(Job.Default
+                    .WithLaunchCount(1)
+                    .WithWarmupCount(3)
+                    .WithIterationCount(5)
+                    .WithStrategy(BenchmarkDotNet.Engines.RunStrategy.Throughput));
+
+                this.AddExporter(HtmlExporter.Default);
+                this.AddExporter(CsvExporter.Default);
+            }
+        }
+
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Benchmarks/ThreadSafeHashSet.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Benchmarks/ThreadSafeHashSet.cs
@@ -1,0 +1,89 @@
+﻿namespace Microsoft.Azure.Cosmos.Benchmarks
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    internal class ThreadSafeHashSet<T>
+    {
+        private readonly HashSet<T> hashSet;
+        private readonly ReaderWriterLockSlim rwLock = new ReaderWriterLockSlim();
+
+        public ThreadSafeHashSet()
+        {
+            this.hashSet = new HashSet<T>();
+        }
+
+        public bool Add(T item)
+        {
+            this.rwLock.EnterWriteLock();
+            try
+            {
+                return this.hashSet.Add(item);
+            }
+            finally
+            {
+                this.rwLock.ExitWriteLock();
+            }
+        }
+
+        public bool Remove(T item)
+        {
+            this.rwLock.EnterWriteLock();
+            try
+            {
+                return this.hashSet.Remove(item);
+            }
+            finally
+            {
+                this.rwLock.ExitWriteLock();
+            }
+        }
+
+        public bool Contains(T item)
+        {
+            this.rwLock.EnterReadLock();
+            try
+            {
+                return this.hashSet.Contains(item);
+            }
+            finally
+            {
+                this.rwLock.ExitReadLock();
+            }
+        }
+
+        public void Clear()
+        {
+            this.rwLock.EnterWriteLock();
+            try
+            {
+                this.hashSet.Clear();
+            }
+            finally
+            {
+                this.rwLock.ExitWriteLock();
+            }
+        }
+
+        public int Count
+        {
+            get
+            {
+                this.rwLock.EnterReadLock();
+                try
+                {
+                    return this.hashSet.Count;
+                }
+                finally
+                {
+                    this.rwLock.ExitReadLock();
+                }
+            }
+        }
+
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Benchmarks/ThreadSafeHashSetBenchmark.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Benchmarks/ThreadSafeHashSetBenchmark.cs
@@ -1,0 +1,101 @@
+﻿namespace Microsoft.Azure.Cosmos.Benchmarks
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using BenchmarkDotNet.Attributes;
+    using BenchmarkDotNet.Columns;
+    using BenchmarkDotNet.Configs;
+    using BenchmarkDotNet.Exporters.Csv;
+    using BenchmarkDotNet.Exporters;
+    using BenchmarkDotNet.Jobs;
+
+    [MemoryDiagnoser]
+    [Config(typeof(CustomBenchmarkConfig))]
+    public class ThreadSafeHashSetBenchmark
+    {
+        private ThreadSafeHashSet<int> hashSet;
+
+        [Params(1000, 10000, 100000)]
+        public int ItemCount;
+
+        [Params(1, 10, 100)]
+        public int ReaderThreads;
+
+        [Params(1, 5, 10)]
+        public int WriterThreads;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            this.hashSet = new ThreadSafeHashSet<int>();
+            for (int i = 0; i < this.ItemCount; i++)
+            {
+                this.hashSet.Add(i);
+            }
+        }
+
+        [Benchmark]
+        public void ReadFromHashSet()
+        {
+            Parallel.For(0, this.ReaderThreads, _ =>
+            {
+                for (int i = 0; i < this.ItemCount; i++)
+                {
+                    this.hashSet.Contains(i);
+                }
+            });
+        }
+        [Benchmark]
+        public void WriteToHashSet()
+        {
+            Parallel.For(0, this.WriterThreads, _ =>
+            {
+                for (int i = 0; i < this.ItemCount; i++)
+                {
+                    this.hashSet.Add(i + this.ItemCount);
+                }
+            });
+        }
+
+        [Benchmark]
+        public void ReadAndWriteToHashSet()
+        {
+            Parallel.Invoke(
+                () => Parallel.For(0, this.ReaderThreads, _ =>
+                {
+                    for (int i = 0; i < this.ItemCount; i++)
+                    {
+                        this.hashSet.Contains(i);
+                    }
+                }),
+                () => Parallel.For(0, this.WriterThreads, _ =>
+                {
+                    for (int i = 0; i < this.ItemCount; i++)
+                    {
+                        this.hashSet.Add(i + this.ItemCount);
+                    }
+                })
+            );
+        }
+        private class CustomBenchmarkConfig : ManualConfig
+        {
+            public CustomBenchmarkConfig()
+            {
+                this.AddColumn(StatisticColumn.OperationsPerSecond);  // Show RPS
+                this.AddColumn(StatisticColumn.P95);
+
+                this.AddJob(Job.Default
+                    .WithLaunchCount(1)
+                    .WithWarmupCount(3)
+                    .WithIterationCount(5)
+                    .WithStrategy(BenchmarkDotNet.Engines.RunStrategy.Throughput));
+
+                this.AddExporter(HtmlExporter.Default);
+                this.AddExporter(CsvExporter.Default);
+            }
+        }
+    }
+}


### PR DESCRIPTION
 **ConcurrentDictionaryBenchmark Results**

BenchmarkDotNet=v0.13.5, OS=Windows 11 (10.0.22631.5039)
Intel Core Ultra 7 165H, 1 CPU, 22 logical and 16 physical cores
IterationCount=5  LaunchCount=1  RunStrategy=Throughput  WarmupCount=3 

| Method | ItemCount | ReaderThreads | WriterThreads | Mean | Error | StdDev | P95 | Op/s | Gen0 | Allocated |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| ReadAndWriteToDictionary | 1000 | 1   | 1   | 40.43 μs | 9.174 μs | 1.420 μs | 41.67 μs | 24,732.68 | 0.3052 | 3.74 KB |
| ReadAndWriteToDictionary | 1000 | 1   | 5   | 99.68 μs | 24.585 μs | 6.385 μs | 105.75 μs | 10,032.36 | 0.3662 | 4.7 KB |
| ReadAndWriteToDictionary | 1000 | 1   | 10  | 161.26 μs | 15.239 μs | 3.957 μs | 166.31 μs | 6,201.25 | 0.2441 | 5.75 KB |
| ReadAndWriteToDictionary | 1000 | 10  | 1   | 79.98 μs | 16.958 μs | 4.404 μs | 83.26 μs | 12,502.60 | 0.3662 | 4.78 KB |
| ReadAndWriteToDictionary | 1000 | 10  | 5   | 137.55 μs | 6.421 μs | 1.668 μs | 139.41 μs | 7,270.34 | 0.2441 | 5.5 KB |
| ReadAndWriteToDictionary | 1000 | 10  | 10  | 194.84 μs | 19.372 μs | 5.031 μs | 200.68 μs | 5,132.54 | 0.4883 | 6.61 KB |
| ReadAndWriteToDictionary | 1000 | 100 | 1   | 92.57 μs | 5.766 μs | 1.497 μs | 94.47 μs | 10,802.44 | 0.6104 | 7.48 KB |
| ReadAndWriteToDictionary | 1000 | 100 | 5   | 178.55 μs | 4.859 μs | 1.262 μs | 180.16 μs | 5,600.63 | 0.4883 | 8.09 KB |
| ReadAndWriteToDictionary | 1000 | 100 | 10  | 229.49 μs | 16.943 μs | 4.400 μs | 233.13 μs | 4,357.56 | 0.4883 | 8.33 KB |
| ReadAndWriteToDictionary | 10000 | 1   | 1   | 296.78 μs | 18.987 μs | 4.931 μs | 302.51 μs | 3,369.46 | \-  | 3.88 KB |
| ReadAndWriteToDictionary | 10000 | 1   | 5   | 679.78 μs | 43.136 μs | 11.202 μs | 692.78 μs | 1,471.06 | \-  | 4.76 KB |
| ReadAndWriteToDictionary | 10000 | 1   | 10  | 1,270.67 μs | 36.346 μs | 5.625 μs | 1,275.75 μs | 786.99 | \-  | 5.88 KB |
| ReadAndWriteToDictionary | 10000 | 10  | 1   | 276.86 μs | 7.594 μs | 1.972 μs | 278.72 μs | 3,611.88 | \-  | 5.68 KB |
| ReadAndWriteToDictionary | 10000 | 10  | 5   | 937.76 μs | 82.939 μs | 12.835 μs | 951.72 μs | 1,066.38 | \-  | 6.57 KB |
| ReadAndWriteToDictionary | 10000 | 10  | 10  | 1,314.60 μs | 44.055 μs | 11.441 μs | 1,328.55 μs | 760.69 | \-  | 7.49 KB |
| ReadAndWriteToDictionary | 10000 | 100 | 1   | 795.88 μs | 6.985 μs | 1.814 μs | 798.07 μs | 1,256.47 | \-  | 7.72 KB |
| ReadAndWriteToDictionary | 10000 | 100 | 5   | 1,216.06 μs | 67.714 μs | 17.585 μs | 1,234.39 μs | 822.33 | \-  | 8.08 KB |
| ReadAndWriteToDictionary | 10000 | 100 | 10  | 1,582.99 μs | 87.478 μs | 22.718 μs | 1,612.32 μs | 631.72 | \-  | 8.56 KB |
| ReadAndWriteToDictionary | 100000 | 1   | 1   | 2,318.89 μs | 384.226 μs | 59.459 μs | 2,384.74 μs | 431.24 | \-  | 3.88 KB |
| ReadAndWriteToDictionary | 100000 | 1   | 5   | 5,678.95 μs | 512.689 μs | 133.144 μs | 5,815.75 μs | 176.09 | \-  | 4.79 KB |
| ReadAndWriteToDictionary | 100000 | 1   | 10  | 9,463.39 μs | 1,321.968 μs | 204.576 μs | 9,663.25 μs | 105.67 | \-  | 5.83 KB |
| ReadAndWriteToDictionary | 100000 | 10  | 1   | 3,467.50 μs | 1,076.352 μs | 279.525 μs | 3,806.27 μs | 288.39 | \-  | 5.63 KB |
| ReadAndWriteToDictionary | 100000 | 10  | 5   | 6,714.29 μs | 471.737 μs | 122.509 μs | 6,870.40 μs | 148.94 | \-  | 6.56 KB |
| ReadAndWriteToDictionary | 100000 | 10  | 10  | 9,545.99 μs | 441.422 μs | 114.636 μs | 9,653.25 μs | 104.76 | \-  | 7.79 KB |
| ReadAndWriteToDictionary | 100000 | 100 | 1   | 6,363.17 μs | 138.384 μs | 21.415 μs | 6,374.79 μs | 157.15 | \-  | 7.67 KB |
| ReadAndWriteToDictionary | 100000 | 100 | 5   | 9,230.73 μs | 264.042 μs | 40.861 μs | 9,265.51 μs | 108.33 | \-  | 8.24 KB |
| ReadAndWriteToDictionary | 100000 | 100 | 10  | 14,228.71 μs | 585.084 μs | 151.945 μs | 14,406.85 μs | 70.28 | \-  | 8.68 KB |

**ImmutableHashSetBenchmark Results**
IterationCount=5  LaunchCount=1  RunStrategy=Throughput  
WarmupCount=3  

| Method | ItemCount | ReaderThreads | WriterThreads | Mean | Error | StdDev | P95 | Op/s | Gen0 | Allocated |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| ReadAndWriteToHashSet | 1000 | 1   | 1   | 48.70 μs | 5.484 μs | 1.424 μs | 50.14 μs | 20,534.37 | 0.3052 | 3.81 KB |
| ReadAndWriteToHashSet | 1000 | 1   | 5   | 90.13 μs | 14.382 μs | 3.735 μs | 94.55 μs | 11,095.34 | 0.3662 | 4.71 KB |
| ReadAndWriteToHashSet | 1000 | 1   | 10  | 117.78 μs | 40.976 μs | 10.641 μs | 126.49 μs | 8,490.77 | 0.2441 | 5.75 KB |
| ReadAndWriteToHashSet | 1000 | 10  | 1   | 109.31 μs | 11.399 μs | 2.960 μs | 112.62 μs | 9,148.46 | 0.3662 | 5.66 KB |
| ReadAndWriteToHashSet | 1000 | 10  | 5   | 128.12 μs | 8.516 μs | 2.212 μs | 130.25 μs | 7,805.19 | 0.4883 | 6.59 KB |
| ReadAndWriteToHashSet | 1000 | 10  | 10  | 117.98 μs | 9.433 μs | 2.450 μs | 121.16 μs | 8,476.07 | 0.6104 | 7.33 KB |
| ReadAndWriteToHashSet | 1000 | 100 | 1   | 576.34 μs | 16.446 μs | 4.271 μs | 580.40 μs | 1,735.09 | \-  | 7.87 KB |
| ReadAndWriteToHashSet | 1000 | 100 | 5   | 574.96 μs | 34.922 μs | 9.069 μs | 584.28 μs | 1,739.27 | \-  | 8.75 KB |
| ReadAndWriteToHashSet | 1000 | 100 | 10  | 564.81 μs | 12.291 μs | 3.192 μs | 568.84 μs | 1,770.51 | \-  | 9.52 KB |
| ReadAndWriteToHashSet | 10000 | 1   | 1   | 635.06 μs | 4.003 μs | 0.619 μs | 635.59 μs | 1,574.66 | \-  | 3.88 KB |
| ReadAndWriteToHashSet | 10000 | 1   | 5   | 781.02 μs | 50.745 μs | 13.178 μs | 793.64 μs | 1,280.37 | \-  | 4.73 KB |
| ReadAndWriteToHashSet | 10000 | 1   | 10  | 1,037.77 μs | 96.915 μs | 25.168 μs | 1,062.23 μs | 963.60 | \-  | 5.87 KB |
| ReadAndWriteToHashSet | 10000 | 10  | 1   | 908.92 μs | 20.397 μs | 5.297 μs | 911.57 μs | 1,100.21 | \-  | 5.77 KB |
| ReadAndWriteToHashSet | 10000 | 10  | 5   | 983.97 μs | 24.862 μs | 6.457 μs | 992.29 μs | 1,016.29 | \-  | 6.66 KB |
| ReadAndWriteToHashSet | 10000 | 10  | 10  | 1,112.46 μs | 55.681 μs | 14.460 μs | 1,130.22 μs | 898.91 | \-  | 7.62 KB |
| ReadAndWriteToHashSet | 10000 | 100 | 1   | 6,086.47 μs | 390.994 μs | 101.540 μs | 6,203.88 μs | 164.30 | \-  | 7.91 KB |
| ReadAndWriteToHashSet | 10000 | 100 | 5   | 6,225.84 μs | 148.688 μs | 23.010 μs | 6,247.23 μs | 160.62 | \-  | 8.78 KB |
| ReadAndWriteToHashSet | 10000 | 100 | 10  | 6,386.23 μs | 85.984 μs | 22.330 μs | 6,411.86 μs | 156.59 | \-  | 9.58 KB |
| ReadAndWriteToHashSet | 100000 | 1   | 1   | 6,271.70 μs | 1,743.174 μs | 452.697 μs | 6,828.85 μs | 159.45 | \-  | 3.85 KB |
| ReadAndWriteToHashSet | 100000 | 1   | 5   | 8,400.91 μs | 1,925.348 μs | 500.007 μs | 9,045.15 μs | 119.03 | \-  | 4.71 KB |
| ReadAndWriteToHashSet | 100000 | 1   | 10  | 11,359.08 μs | 447.126 μs | 116.117 μs | 11,508.04 μs | 88.04 | \-  | 5.84 KB |
| ReadAndWriteToHashSet | 100000 | 10  | 1   | 8,593.57 μs | 2,980.718 μs | 461.269 μs | 9,149.49 μs | 116.37 | \-  | 5.78 KB |
| ReadAndWriteToHashSet | 100000 | 10  | 5   | 9,439.35 μs | 265.273 μs | 68.890 μs | 9,517.73 μs | 105.94 | \-  | 6.73 KB |
| ReadAndWriteToHashSet | 100000 | 10  | 10  | 11,052.18 μs | 643.289 μs | 167.060 μs | 11,208.74 μs | 90.48 | \-  | 7.74 KB |
| ReadAndWriteToHashSet | 100000 | 100 | 1   | 60,123.48 μs | 3,443.986 μs | 532.961 μs | 60,486.23 μs | 16.63 | \-  | 8.31 KB |
| ReadAndWriteToHashSet | 100000 | 100 | 5   | 60,668.09 μs | 4,805.466 μs | 743.651 μs | 61,289.82 μs | 16.48 | \-  | 10.05 KB |
| ReadAndWriteToHashSet | 100000 | 100 | 10  | 66,121.39 μs | 3,127.867 μs | 812.297 μs | 66,993.65 μs | 15.12 | \-  | 10.16 KB |


**ThreadSafeHashSetBenchmark Results**
IterationCount=5  LaunchCount=1  RunStrategy=Throughput  WarmupCount=3 

| Method | ItemCount | ReaderThreads | WriterThreads | Mean | Error | StdDev | P95 | Op/s | Gen0 | Allocated |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| ReadAndWriteToHashSet | 1000 | 1   | 1   | 56.13 μs | 3.190 μs | 0.828 μs | 56.83 μs | 17,816.673 | 0.2441 | 3.82 KB |
| ReadAndWriteToHashSet | 1000 | 1   | 5   | 6,730.40 μs | 6,279.434 μs | 1,630.749 μs | 8,105.13 μs | 148.580 | \-  | 4.27 KB |
| ReadAndWriteToHashSet | 1000 | 1   | 10  | 10,334.32 μs | 7,462.748 μs | 1,938.052 μs | 12,394.70 μs | 96.765 | \-  | 4.99 KB |
| ReadAndWriteToHashSet | 1000 | 10  | 1   | 6,755.37 μs | 6,003.620 μs | 929.067 μs | 7,697.84 μs | 148.030 | \-  | 4.88 KB |
| ReadAndWriteToHashSet | 1000 | 10  | 5   | 17,007.18 μs | 11,868.973 μs | 1,836.737 μs | 18,978.69 μs | 58.799 | \-  | 5.34 KB |
| ReadAndWriteToHashSet | 1000 | 10  | 10  | 22,665.04 μs | 4,637.326 μs | 1,204.299 μs | 24,184.53 μs | 44.121 | \-  | 6.59 KB |
| ReadAndWriteToHashSet | 1000 | 100 | 1   | 50,684.58 μs | 4,314.944 μs | 667.742 μs | 51,192.93 μs | 19.730 | \-  | 8.72 KB |
| ReadAndWriteToHashSet | 1000 | 100 | 5   | 43,645.27 μs | 38,767.863 μs | 5,999.370 μs | 47,623.29 μs | 22.912 | \-  | 10.16 KB |
| ReadAndWriteToHashSet | 1000 | 100 | 10  | 50,298.50 μs | 19,821.100 μs | 5,147.477 μs | 56,042.02 μs | 19.881 | \-  | 11.17 KB |
| ReadAndWriteToHashSet | 10000 | 1   | 1   | 513.65 μs | 59.994 μs | 9.284 μs | 523.53 μs | 1,946.847 | \-  | 3.84 KB |
| ReadAndWriteToHashSet | 10000 | 1   | 5   | 14,287.94 μs | 3,226.084 μs | 837.804 μs | 15,361.24 μs | 69.989 | \-  | 4.68 KB |
| ReadAndWriteToHashSet | 10000 | 1   | 10  | 35,567.79 μs | 10,750.240 μs | 2,791.803 μs | 38,418.43 μs | 28.115 | \-  | 5.83 KB |
| ReadAndWriteToHashSet | 10000 | 10  | 1   | 44,973.70 μs | 8,411.882 μs | 1,301.748 μs | 46,499.41 μs | 22.235 | \-  | 5.72 KB |
| ReadAndWriteToHashSet | 10000 | 10  | 5   | 56,109.58 μs | 9,490.758 μs | 2,464.720 μs | 57,964.41 μs | 17.822 | \-  | 6.67 KB |
| ReadAndWriteToHashSet | 10000 | 10  | 10  | 63,436.34 μs | 53,736.531 μs | 13,955.206 μs | 80,914.90 μs | 15.764 | \-  | 7.63 KB |
| ReadAndWriteToHashSet | 10000 | 100 | 1   | 111,371.75 μs | 20,418.471 μs | 5,302.612 μs | 117,810.80 μs | 8.979 | \-  | 8.66 KB |
| ReadAndWriteToHashSet | 10000 | 100 | 5   | 87,408.71 μs | 41,171.581 μs | 10,692.129 μs | 99,996.95 μs | 11.441 | \-  | 10.59 KB |
| ReadAndWriteToHashSet | 10000 | 100 | 10  | 103,820.49 μs | 30,487.384 μs | 7,917.477 μs | 111,478.70 μs | 9.632 | \-  | 11.32 KB |
| ReadAndWriteToHashSet | 100000 | 1   | 1   | 4,907.58 μs | 1,317.584 μs | 342.172 μs | 5,284.25 μs | 203.767 | \-  | 3.82 KB |
| ReadAndWriteToHashSet | 100000 | 1   | 5   | 33,729.19 μs | 8,657.797 μs | 1,339.804 μs | 35,299.37 μs | 29.648 | \-  | 4.73 KB |
| ReadAndWriteToHashSet | 100000 | 1   | 10  | 77,993.57 μs | 43,992.222 μs | 11,424.640 μs | 88,124.74 μs | 12.822 | \-  | 5.97 KB |
| ReadAndWriteToHashSet | 100000 | 10  | 1   | 65,673.22 μs | 30,527.073 μs | 7,927.784 μs | 73,255.30 μs | 15.227 | \-  | 5.86 KB |
| ReadAndWriteToHashSet | 100000 | 10  | 5   | 91,535.99 μs | 35,158.478 μs | 9,130.545 μs | 101,892.99 μs | 10.925 | \-  | 7.15 KB |
| ReadAndWriteToHashSet | 100000 | 10  | 10  | 132,407.33 μs | 44,014.420 μs | 11,430.405 μs | 146,346.40 μs | 7.552 | \-  | 7.87 KB |
| ReadAndWriteToHashSet | 100000 | 100 | 1   | 520,740.96 μs | 182,731.335 μs | 47,454.747 μs | 561,901.32 μs | 1.920 | \-  | 13.88 KB |
| ReadAndWriteToHashSet | 100000 | 100 | 5   | 505,139.04 μs | 297,224.747 μs | 77,188.323 μs | 574,184.60 μs | 1.980 | \-  | 19.57 KB |
| ReadAndWriteToHashSet | 100000 | 100 | 10  | 643,822.64 μs | 226,100.553 μs | 58,717.596 μs | 701,481.18 μs | 1.553 | \-  | 20.53 KB |
