### PR TITLE
Fix IndexOutOfRangeException Observed in AddressEnumerator::MoveFailedReplicasToTheEnd()

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
@@ -456,7 +456,7 @@ namespace Microsoft.Azure.Cosmos.Routing
 
         private static void SetTransportAddressUrisToUnhealthy(
             PartitionAddressInformation stalePartitionAddressInformation,
-            Lazy<HashSet<TransportAddressUri>> failedEndpoints)
+            Lazy<ConcurrentDictionary<TransportAddressUri, bool>> failedEndpoints)
         {
             if (stalePartitionAddressInformation == null ||
                 failedEndpoints == null ||
@@ -473,7 +473,7 @@ namespace Microsoft.Azure.Cosmos.Routing
 
             foreach (TransportAddressUri failed in perProtocolPartitionAddressInformation)
             {
-                if (failedEndpoints.Value.Contains(failed))
+                if (failedEndpoints.Value.ContainsKey(failed))
                 {
                     failed.SetUnhealthy();
                 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GatewayAddressCacheTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GatewayAddressCacheTests.cs
@@ -1097,10 +1097,10 @@ namespace Microsoft.Azure.Cosmos
             Assert.AreEqual(0, addressInfo.AllAddresses.Count(x => x.PhysicalUri == newAddress));
 
             // Because force refresh is requested, an unhealthy replica is added to the failed endpoint so that it's status could be validted.
-            request.RequestContext.FailedEndpoints.Value.Add(
+            request.RequestContext.FailedEndpoints.Value.TryAdd(
                 new TransportAddressUri(
                     addressUri: new Uri(
-                        uriString: addressTobeMarkedUnhealthy)));
+                    uriString: addressTobeMarkedUnhealthy)), true);
 
             addressInfo = await cache.TryGetAddressesAsync(
                 request: request,
@@ -1250,10 +1250,10 @@ namespace Microsoft.Azure.Cosmos
             Assert.AreEqual(0, addressInfo.AllAddresses.Count(x => x.PhysicalUri == newAddress));
 
             // Because force refresh is requested, an unhealthy replica is added to the failed endpoint so that it's health status could be validted.
-            request.RequestContext.FailedEndpoints.Value.Add(
+            request.RequestContext.FailedEndpoints.Value.TryAdd(
                 new TransportAddressUri(
                     addressUri: new Uri(
-                        uriString: addressTobeMarkedUnhealthy)));
+                        uriString: addressTobeMarkedUnhealthy)), true);
 
             addressInfo = await cache.TryGetAddressesAsync(
                 request: request,
@@ -1554,10 +1554,10 @@ namespace Microsoft.Azure.Cosmos
             Assert.AreEqual(0, addressInfo.AllAddresses.Count(x => x.PhysicalUri == newAddress));
 
             // Because force refresh is requested, an unhealthy replica is added to the failed endpoint so that it's status could be validted.
-            request.RequestContext.FailedEndpoints.Value.Add(
+            request.RequestContext.FailedEndpoints.Value.TryAdd(
                 new TransportAddressUri(
                     addressUri: new Uri(
-                        uriString: addressTobeMarkedUnhealthy)));
+                        uriString: addressTobeMarkedUnhealthy)), true);
 
             addressInfo = await cache.TryGetAddressesAsync(
                 request: request,


### PR DESCRIPTION
due to a race condition between modifying and reading a shared variable FailedEndpoints which is instantiated in the DocumentServiceRequestContext class. multiple threads seems to be accessing it at the same time - one adding to it in the AddToFailedEndpoints() method in the DocumentServiceRequestContext and the other in the AddressEnumerator where it is trying to read an item in the GetEffectiveStatus() method which is called with in MoveFailedReplicasToTheEnd() and it results in an IndexOutOfRangeException . We need to move to a thread safe data structure.

- [] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #5046