### PR TITLE
Hedging: Fixes rare NullRefreneceException in Headers Clone

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Headers/Headers.cs
+++ b/Microsoft.Azure.Cosmos/src/Headers/Headers.cs
@@ -425,7 +425,8 @@ namespace Microsoft.Azure.Cosmos
             Headers clone = new Headers();
             foreach (string key in this.CosmosMessageHeaders.AllKeys())
             {
-                clone.Add(key, this.CosmosMessageHeaders.Get(key));
+                string value = this.CosmosMessageHeaders.Get(key);
+                if (value != null) clone.Add(key, this.CosmosMessageHeaders.Get(key));
             }
 
             return clone;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/HeadersTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/HeadersTests.cs
@@ -171,5 +171,86 @@ namespace Microsoft.Azure.Cosmos.Tests
             Assert.IsTrue(allKeys.Contains(HttpConstants.HttpHeaders.Continuation));
             Assert.IsTrue(allKeys.Contains(WFConstants.BackendHeaders.SubStatus));
         }
+
+        [TestMethod]
+        public void TestHeadersClone()
+        {
+            Headers Headers = new Headers();
+            Headers.CosmosMessageHeaders[Key] = Guid.NewGuid().ToString();
+            Headers.ContinuationToken = Guid.NewGuid().ToString();
+            Headers.CosmosMessageHeaders[HttpConstants.HttpHeaders.RetryAfterInMilliseconds] = "20";
+            Headers.Add(WFConstants.BackendHeaders.SubStatus, "1002");
+            Headers.PartitionKey = Guid.NewGuid().ToString();
+            string[] allKeys = Headers.AllKeys();
+            Assert.IsTrue(allKeys.Contains(Key));
+            Assert.IsTrue(allKeys.Contains(HttpConstants.HttpHeaders.PartitionKey));
+            Assert.IsTrue(allKeys.Contains(HttpConstants.HttpHeaders.RetryAfterInMilliseconds));
+            Assert.IsTrue(allKeys.Contains(HttpConstants.HttpHeaders.Continuation));
+            Assert.IsTrue(allKeys.Contains(WFConstants.BackendHeaders.SubStatus));
+
+            Headers clone = Headers.Clone();
+            Assert.IsNotNull(clone);
+            string[] keys = clone.AllKeys();
+            Assert.IsTrue(keys.Contains(Key));
+            Assert.IsTrue(keys.Contains(HttpConstants.HttpHeaders.PartitionKey));
+            Assert.IsTrue(keys.Contains(HttpConstants.HttpHeaders.RetryAfterInMilliseconds));
+            Assert.IsTrue(keys.Contains(HttpConstants.HttpHeaders.Continuation));
+            Assert.IsTrue(keys.Contains(WFConstants.BackendHeaders.SubStatus));
+            Assert.AreEqual(allKeys.Length, keys.Length);
+            Assert.AreEqual(
+                Headers.Get(HttpConstants.HttpHeaders.PartitionKey), 
+                clone.Get(HttpConstants.HttpHeaders.PartitionKey));
+            Assert.AreEqual(
+                Headers.Get(HttpConstants.HttpHeaders.RetryAfterInMilliseconds), 
+                clone.Get(HttpConstants.HttpHeaders.RetryAfterInMilliseconds));
+            Assert.AreEqual(
+                Headers.Get(HttpConstants.HttpHeaders.Continuation),
+                clone.Get(HttpConstants.HttpHeaders.Continuation));
+            Assert.AreEqual(
+                Headers.Get(WFConstants.BackendHeaders.SubStatus),
+                clone.Get(WFConstants.BackendHeaders.SubStatus));
+        }
+
+        [TestMethod]
+        public void TestNullHeadersClone()
+        {
+            Headers Headers = new Headers();
+            Headers.CosmosMessageHeaders[Key] = Guid.NewGuid().ToString();
+            Headers.ContinuationToken = Guid.NewGuid().ToString();
+            Headers.CosmosMessageHeaders[HttpConstants.HttpHeaders.RetryAfterInMilliseconds] = "20";
+            Headers.Add(WFConstants.BackendHeaders.SubStatus, "1002");
+            Headers.PartitionKey = "pk";
+
+            Headers.CosmosMessageHeaders["x-ms-documentdb-partitionkey"] = null;
+
+            string[] allKeys = Headers.AllKeys();
+            Assert.IsTrue(allKeys.Contains(Key));
+            Assert.IsFalse(allKeys.Contains(HttpConstants.HttpHeaders.PartitionKey));
+            Assert.IsTrue(allKeys.Contains(HttpConstants.HttpHeaders.RetryAfterInMilliseconds));
+            Assert.IsTrue(allKeys.Contains(HttpConstants.HttpHeaders.Continuation));
+            Assert.IsTrue(allKeys.Contains(WFConstants.BackendHeaders.SubStatus));
+
+            Headers clone = Headers.Clone();
+            Assert.IsNotNull(clone);
+            string[] keys = clone.AllKeys();
+            Assert.IsTrue(keys.Contains(Key));
+            Assert.IsFalse(keys.Contains(HttpConstants.HttpHeaders.PartitionKey));
+            Assert.IsTrue(keys.Contains(HttpConstants.HttpHeaders.RetryAfterInMilliseconds));
+            Assert.IsTrue(keys.Contains(HttpConstants.HttpHeaders.Continuation));
+            Assert.IsTrue(keys.Contains(WFConstants.BackendHeaders.SubStatus));
+            Assert.AreEqual(allKeys.Length, keys.Length);
+            Assert.AreEqual(
+                Headers.Get(HttpConstants.HttpHeaders.PartitionKey),
+                clone.Get(HttpConstants.HttpHeaders.PartitionKey));
+            Assert.AreEqual(
+                Headers.Get(HttpConstants.HttpHeaders.RetryAfterInMilliseconds),
+                clone.Get(HttpConstants.HttpHeaders.RetryAfterInMilliseconds));
+            Assert.AreEqual(
+                Headers.Get(HttpConstants.HttpHeaders.Continuation),
+                clone.Get(HttpConstants.HttpHeaders.Continuation));
+            Assert.AreEqual(
+                Headers.Get(WFConstants.BackendHeaders.SubStatus),
+                clone.Get(WFConstants.BackendHeaders.SubStatus));
+        }
     }
 }


### PR DESCRIPTION
# Pull Request Template

## Description

There is a rare case where a `NullReferenceException` can occur when cloning headers in the `Headers` class, in request hedging scenarions 

```
System.ArgumentNullException: Value cannot be null. (Parameter 'value')
at Microsoft.Azure.Cosmos.Headers.Clone()
at Microsoft.Azure.Cosmos.RequestMessage.Clone(ITrace newTrace, CloneableStream cloneContent)
at await Microsoft.Azure.Cosmos.CrossRegionHedgingAvailabilityStrategy.CloneAndSendAsync(?)
at await Microsoft.Azure.Cosmos.CrossRegionHedgingAvailabilityStrategy.ExecuteAvailabilityStrategyAsync(?)
at await Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler.SendAsync(?)
at await Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler.SendAsync(?)
at await Microsoft.Azure.Cosmos.ContainerCore.ProcessItemStreamAsync(?)
at await Microsoft.Azure.Cosmos.ContainerCore.ReadItemStreamAsync(?)
at await Microsoft.Azure.Cosmos.ClientContextCore.RunWithDiagnosticsHelperAsync(?)
at await Microsoft.Azure.Cosmos.ClientContextCore.OperationHelperWithRootTraceAsync(?)
```

This pull request introduces a null check in the `Clone` method of the `Headers` class and adds new unit tests to verify the cloning functionality, including handling of null values.

### Enhancements to `Headers` class cloning:

* [`Microsoft.Azure.Cosmos/src/Headers/Headers.cs`](diffhunk://#diff-5c443ec801ae9db0306b49e1a17c77f094bd5ca92cdcac522796fa1bb6e3d146L428-R429): Added a null check in the `Clone` method to ensure that headers with null values are not added to the cloned headers.

### New unit tests for `Headers` class:

* [`Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/HeadersTests.cs`](diffhunk://#diff-5ae5cca456d7aba9c11f827cdec9d056e34b62a711d2d34e1c0f22d0444a1a76R174-R254): Added `TestHeadersClone` to verify that all keys and values are correctly cloned.
* [`Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/HeadersTests.cs`](diffhunk://#diff-5ae5cca456d7aba9c11f827cdec9d056e34b62a711d2d34e1c0f22d0444a1a76R174-R254): Added `TestNullHeadersClone` to ensure that headers with null values are handled correctly during cloning.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #5093 