### PR TITLE
[Internal]Thin Client Integration: Adds containerId to ThinClient request.

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ThinClientStoreClient.cs
+++ b/Microsoft.Azure.Cosmos/src/ThinClientStoreClient.cs
@@ -6,13 +6,13 @@ namespace Microsoft.Azure.Cosmos
 {
     using System;
     using System.Collections.Concurrent;
-    using System.Diagnostics.CodeAnalysis;
     using System.IO;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Core.Trace;
     using Microsoft.Azure.Cosmos.Routing;
+    using Microsoft.Azure.Cosmos.Tracing;
     using Microsoft.Azure.Documents;
     using Newtonsoft.Json;
     using static Microsoft.Azure.Cosmos.ThinClientTransportSerializer;
@@ -91,6 +91,11 @@ namespace Microsoft.Azure.Cosmos
             BufferProviderWrapper bufferProviderWrapper = this.bufferProviderWrapperPool.Get();
             try
             {
+                ContainerProperties collection = await clientCollectionCache.ResolveCollectionAsync(
+                     request,
+                     CancellationToken.None,
+                     NoOpTrace.Singleton);
+                request.ResourceId = collection.ResourceId;
                 requestMessage.Headers.TryAddWithoutValidation(
                     ThinClientConstants.ProxyOperationType,
                     request.OperationType.ToOperationTypeString());


### PR DESCRIPTION
# Pull Request Template

## Description

Adding ResourceId as the proxy expects the ResourceId in the RNTBD headers otherwise the requests will start to fail.
By seting request.ResourceId = containerRid, TransportSerialization.cs will automatically add the ResourceID header.

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## Closing issues

To automatically close an issue: closes #5107