### PR TITLE
[Internal] Thin Client Integration: Fixes config refresh and gateway mode check.

### DIFF
--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -1100,11 +1100,7 @@ namespace Microsoft.Azure.Cosmos
 
             gatewayStoreModel.SetCaches(this.partitionKeyRangeCache, this.collectionCache);
 
-            if (this.ConnectionPolicy.ConnectionMode == ConnectionMode.Gateway)
-            {
-                this.StoreModel = this.GatewayStoreModel;
-            }
-            else if (this.isThinClientEnabled)
+            if (this.isThinClientEnabled)
             {
                 ThinClientStoreModel thinClientStoreModel = new (
                     endpointManager: this.GlobalEndpointManager,
@@ -1118,6 +1114,10 @@ namespace Microsoft.Azure.Cosmos
                 thinClientStoreModel.SetCaches(this.partitionKeyRangeCache, this.collectionCache);
 
                 this.StoreModel = thinClientStoreModel;
+            }
+            else if (this.ConnectionPolicy.ConnectionMode == ConnectionMode.Gateway)
+            {
+                this.StoreModel = this.GatewayStoreModel;
             }
             else
             {

--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -1100,7 +1100,7 @@ namespace Microsoft.Azure.Cosmos
 
             gatewayStoreModel.SetCaches(this.partitionKeyRangeCache, this.collectionCache);
 
-            if (this.isThinClientEnabled)
+            if (this.ConnectionPolicy.ConnectionMode == ConnectionMode.Gateway && this.isThinClientEnabled)
             {
                 ThinClientStoreModel thinClientStoreModel = new (
                     endpointManager: this.GlobalEndpointManager,

--- a/Microsoft.Azure.Cosmos/src/Routing/GlobalEndpointManager.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GlobalEndpointManager.cs
@@ -554,6 +554,7 @@ namespace Microsoft.Azure.Cosmos.Routing
             {
                 return;
             }
+            GlobalEndpointManager.ParseThinClientLocationsFromAdditionalProperties(databaseAccount);
 
             this.locationCache.OnDatabaseAccountRead(databaseAccount);
 


### PR DESCRIPTION
# Pull Request Template

## Description
Fixing two issues found during testing:

- Fixing the issue of getting thinclient readable and writeable locations through `ParseThinClientLocationsFromAdditionalProperties`. Need this call at `GlobalEndpointManager`. `InitializeAccountPropertiesAndStartBackgroundRefresh()` stage as well otherwise the returned endpoint returned is a stale value.

- Fixing the thinclient mode check so that if thinclient flag is enabled then thinclient mode is be used during gateway mode and direct mode. 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #5116