### PR TITLE
[Internal] Thin Client Integration: Fixes rntbd headers for proxy request.

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ThinClientStoreClient.cs
+++ b/Microsoft.Azure.Cosmos/src/ThinClientStoreClient.cs
@@ -91,11 +91,6 @@ namespace Microsoft.Azure.Cosmos
             BufferProviderWrapper bufferProviderWrapper = this.bufferProviderWrapperPool.Get();
             try
             {
-                ContainerProperties collection = await clientCollectionCache.ResolveCollectionAsync(
-                     request,
-                     CancellationToken.None,
-                     NoOpTrace.Singleton);
-                request.ResourceId = collection.ResourceId;
                 requestMessage.Headers.TryAddWithoutValidation(
                     ThinClientConstants.ProxyOperationType,
                     request.OperationType.ToOperationTypeString());


### PR DESCRIPTION
# Pull Request Template

## Description

Update the logic for retrieving and setting RNTBD headers resourceId and collectionRid for proxy request. With the current implementation the request ends up throwing a 400 Bad Request error.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #5118