### PR TITLE
Query: Adds an environment variable for disabling the hybrid search query plan optimization

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CosmosQueryExecutionContextFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CosmosQueryExecutionContextFactory.cs
@@ -584,7 +584,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
                     inputParameters.SqlQuerySpec,
                     cosmosQueryContext.ResourceLink,
                     inputParameters.PartitionKey,
-                    inputParameters.IsNonStreamingOrderByQueryFeatureDisabled,
+                    inputParameters.IsHybridSearchQueryPlanOptimizationDisabled,
                     trace,
                     cancellationToken);
             }
@@ -601,6 +601,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
                     inputParameters.PartitionKey != null,
                     containerQueryProperties.GeospatialType,
                     cosmosQueryContext.UseSystemPrefix,
+                    inputParameters.IsHybridSearchQueryPlanOptimizationDisabled,
                     trace,
                     cancellationToken);
             }
@@ -832,7 +833,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
                 PartitionedQueryExecutionInfo partitionedQueryExecutionInfo,
                 bool returnResultsInDeterministicOrder,
                 bool enableOptimisticDirectExecution,
-                bool isNonStreamingOrderByQueryFeatureDisabled,
+                bool isHybridSearchQueryPlanOptimizationDisabled,
                 bool enableDistributedQueryGatewayMode,
                 TestInjections testInjections)
             {
@@ -847,7 +848,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
                 this.PartitionedQueryExecutionInfo = partitionedQueryExecutionInfo;
                 this.ReturnResultsInDeterministicOrder = returnResultsInDeterministicOrder;
                 this.EnableOptimisticDirectExecution = enableOptimisticDirectExecution;
-                this.IsNonStreamingOrderByQueryFeatureDisabled = isNonStreamingOrderByQueryFeatureDisabled;
+                this.IsHybridSearchQueryPlanOptimizationDisabled = isHybridSearchQueryPlanOptimizationDisabled;
                 this.EnableDistributedQueryGatewayMode = enableDistributedQueryGatewayMode;
                 this.TestInjections = testInjections;
             }
@@ -864,7 +865,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
                 PartitionedQueryExecutionInfo partitionedQueryExecutionInfo,
                 bool? returnResultsInDeterministicOrder,
                 bool enableOptimisticDirectExecution,
-                bool isNonStreamingOrderByQueryFeatureDisabled,
+                bool isHybridSearchQueryPlanOptimizationDisabled,
                 bool enableDistributedQueryGatewayMode,
                 TestInjections testInjections)
             {
@@ -903,7 +904,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
                     partitionedQueryExecutionInfo: partitionedQueryExecutionInfo,
                     returnResultsInDeterministicOrder: returnResultsInDeterministicOrder.GetValueOrDefault(InputParameters.DefaultReturnResultsInDeterministicOrder),
                     enableOptimisticDirectExecution: enableOptimisticDirectExecution,
-                    isNonStreamingOrderByQueryFeatureDisabled: isNonStreamingOrderByQueryFeatureDisabled,
+                    isHybridSearchQueryPlanOptimizationDisabled: isHybridSearchQueryPlanOptimizationDisabled,
                     enableDistributedQueryGatewayMode: enableDistributedQueryGatewayMode,
                     testInjections: testInjections);
             }
@@ -920,7 +921,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
             public bool ReturnResultsInDeterministicOrder { get; }
             public TestInjections TestInjections { get; }
             public bool EnableOptimisticDirectExecution { get; }
-            public bool IsNonStreamingOrderByQueryFeatureDisabled { get; }
+            public bool IsHybridSearchQueryPlanOptimizationDisabled { get; }
             public bool EnableDistributedQueryGatewayMode { get; }
 
             public InputParameters WithContinuationToken(CosmosElement token)
@@ -937,7 +938,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.ExecutionContext
                     this.PartitionedQueryExecutionInfo,
                     this.ReturnResultsInDeterministicOrder,
                     this.EnableOptimisticDirectExecution,
-                    this.IsNonStreamingOrderByQueryFeatureDisabled,
+                    this.IsHybridSearchQueryPlanOptimizationDisabled,
                     this.EnableDistributedQueryGatewayMode,
                     this.TestInjections);
             }

--- a/Microsoft.Azure.Cosmos/src/Query/Core/QueryClient/CosmosQueryClient.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/QueryClient/CosmosQueryClient.cs
@@ -48,6 +48,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryClient
             bool hasLogicalPartitionKey,
             bool allowDCount,
             bool useSystemPrefix,
+            bool isHybridSearchQueryPlanOptimizationDisabled,
             Cosmos.GeospatialType geospatialType,
             CancellationToken cancellationToken);
 

--- a/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryPartitionProvider.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryPartitionProvider.cs
@@ -127,6 +127,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
             bool hasLogicalPartitionKey,
             bool allowDCount,
             bool useSystemPrefix,
+            bool hybridSearchSkipOrderByRewrite,
             GeospatialType geospatialType)
         {
             TryCatch<PartitionedQueryExecutionInfoInternal> tryGetInternalQueryInfo = this.TryGetPartitionedQueryExecutionInfoInternal(
@@ -139,6 +140,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
                 hasLogicalPartitionKey: hasLogicalPartitionKey,
                 allowDCount: allowDCount,
                 useSystemPrefix: useSystemPrefix,
+                hybridSearchSkipOrderByRewrite: hybridSearchSkipOrderByRewrite,
                 geospatialType: geospatialType);
 
             if (!tryGetInternalQueryInfo.Succeeded)
@@ -190,6 +192,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
             bool hasLogicalPartitionKey,
             bool allowDCount,
             bool useSystemPrefix,
+            bool hybridSearchSkipOrderByRewrite,
             GeospatialType geospatialType)
         {
             if (querySpecJsonString == null || partitionKeyDefinition == null)
@@ -243,6 +246,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
                         bIsContinuationExpected = Convert.ToInt32(isContinuationExpected),
                         bRequireFormattableOrderByQuery = Convert.ToInt32(requireFormattableOrderByQuery),
                         bUseSystemPrefix = Convert.ToInt32(useSystemPrefix),
+                        bHybridSearchSkipOrderByRewrite = Convert.ToInt32(!hybridSearchSkipOrderByRewrite),
                         eGeospatialType = Convert.ToInt32(geospatialType),
                         ePartitionKind = Convert.ToInt32(partitionKind)
                     };

--- a/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryPlanHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryPlanHandler.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
             VectorEmbeddingPolicy vectorEmbeddingPolicy,
             bool hasLogicalPartitionKey,
             bool useSystemPrefix,
+            bool isHybridSearchQueryPlanOptimizationDisabled,
             GeospatialType geospatialType,
             CancellationToken cancellationToken)
         {
@@ -51,6 +52,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
                 vectorEmbeddingPolicy,
                 hasLogicalPartitionKey,
                 useSystemPrefix,
+                isHybridSearchQueryPlanOptimizationDisabled,
                 geospatialType,
                 cancellationToken);
             if (!tryGetQueryInfo.Succeeded)
@@ -68,6 +70,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
             VectorEmbeddingPolicy vectorEmbeddingPolicy,
             bool hasLogicalPartitionKey,
             bool useSystemPrefix,
+            bool isHybridSearchQueryPlanOptimizationDisabled,
             Cosmos.GeospatialType geospatialType,
             CancellationToken cancellationToken = default)
         {
@@ -84,6 +87,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
                 hasLogicalPartitionKey: hasLogicalPartitionKey,
                 allowDCount: true,
                 useSystemPrefix: useSystemPrefix,
+                isHybridSearchQueryPlanOptimizationDisabled: isHybridSearchQueryPlanOptimizationDisabled,
                 geospatialType: geospatialType,
                 cancellationToken: cancellationToken);
         }

--- a/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryPlanRetriever.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryPlanRetriever.cs
@@ -32,20 +32,21 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
             | QueryFeatures.NonStreamingOrderBy
             | QueryFeatures.CountIf
             | QueryFeatures.HybridSearch
-            | QueryFeatures.WeightedRankFusion;
+            | QueryFeatures.WeightedRankFusion
+            | QueryFeatures.HybridSearchSkipOrderByRewrite;
 
-        private static readonly QueryFeatures SupportedQueryFeaturesWithoutNonStreamingOrderBy =
-            SupportedQueryFeatures & (~QueryFeatures.NonStreamingOrderBy);
+        private static readonly QueryFeatures SupportedQueryFeaturesWithHybridSearchQueryPlanOptimizationDisabled =
+            SupportedQueryFeatures & (~QueryFeatures.HybridSearchSkipOrderByRewrite);
 
         private static readonly string SupportedQueryFeaturesString = SupportedQueryFeatures.ToString();
 
-        private static readonly string SupportedQueryFeaturesWithoutNonStreamingOrderByString =
-            SupportedQueryFeaturesWithoutNonStreamingOrderBy.ToString();
+        private static readonly string SupportedQueryFeaturesWithHybridSearchQueryPlanOptimizationDisabledString =
+            SupportedQueryFeaturesWithHybridSearchQueryPlanOptimizationDisabled.ToString();
 
-        private static string GetSupportedQueryFeaturesString(bool isNonStreamingOrderByQueryFeatureDisabled)
+        private static string GetSupportedQueryFeaturesString(bool isHybridSearchQueryPlanOptimizationDisabled)
         {
-            return isNonStreamingOrderByQueryFeatureDisabled ?
-                SupportedQueryFeaturesWithoutNonStreamingOrderByString :
+            return isHybridSearchQueryPlanOptimizationDisabled ?
+                SupportedQueryFeaturesWithHybridSearchQueryPlanOptimizationDisabledString :
                 SupportedQueryFeaturesString;
         }
 
@@ -58,6 +59,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
             bool hasLogicalPartitionKey,
             GeospatialType geospatialType,
             bool useSystemPrefix,
+            bool isHybridSearchQueryPlanOptimizationDisabled,
             ITrace trace,
             CancellationToken cancellationToken = default)
         {
@@ -89,6 +91,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
                     vectorEmbeddingPolicy,
                     hasLogicalPartitionKey,
                     useSystemPrefix,
+                    isHybridSearchQueryPlanOptimizationDisabled,
                     geospatialType,
                     cancellationToken);
 
@@ -113,7 +116,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
             SqlQuerySpec sqlQuerySpec,
             string resourceLink,
             PartitionKey? partitionKey,
-            bool isNonStreamingOrderByQueryFeatureDisabled,
+            bool isHybridSearchQueryPlanOptimizationDisabled,
             ITrace trace,
             CancellationToken cancellationToken = default)
         {
@@ -149,7 +152,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
                     OperationType.QueryPlan,
                     sqlQuerySpec,
                     partitionKey,
-                    GetSupportedQueryFeaturesString(isNonStreamingOrderByQueryFeatureDisabled),
+                    GetSupportedQueryFeaturesString(isHybridSearchQueryPlanOptimizationDisabled),
                     trace,
                     cancellationToken);
             }

--- a/Microsoft.Azure.Cosmos/src/Query/v2Query/DocumentQueryExecutionContextBase.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v2Query/DocumentQueryExecutionContextBase.cs
@@ -187,6 +187,7 @@ namespace Microsoft.Azure.Cosmos.Query
                 allowNonValueAggregateQuery: allowNonValueAggregateQuery,
                 hasLogicalPartitionKey: hasLogicalPartitionKey,
                 allowDCount: allowDCount,
+                hybridSearchSkipOrderByRewrite: false,
                 geospatialType: geospatialType,
                 useSystemPrefix: false);
             if (!tryGetPartitionedQueryExecutionInfo.Succeeded)

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/CosmosQueryClientCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/CosmosQueryClientCore.cs
@@ -290,7 +290,7 @@ namespace Microsoft.Azure.Cosmos
 
         public override bool BypassQueryParsing()
         {
-            return true; // CustomTypeExtensions.ByPassQueryParsing();
+            return CustomTypeExtensions.ByPassQueryParsing();
         }
 
         public override void ClearSessionTokenCache(string collectionFullName)

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/CosmosQueryClientCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/CosmosQueryClientCore.cs
@@ -101,6 +101,7 @@ namespace Microsoft.Azure.Cosmos
             bool hasLogicalPartitionKey,
             bool allowDCount,
             bool useSystemPrefix,
+            bool isHybridSearchQueryPlanOptimizationDisabled,
             Cosmos.GeospatialType geospatialType,
             CancellationToken cancellationToken)
         {
@@ -126,6 +127,7 @@ namespace Microsoft.Azure.Cosmos
                 hasLogicalPartitionKey: hasLogicalPartitionKey,
                 allowDCount: allowDCount,
                 useSystemPrefix: useSystemPrefix,
+                hybridSearchSkipOrderByRewrite: !isHybridSearchQueryPlanOptimizationDisabled,
                 geospatialType: geospatialType);
         }
 
@@ -288,7 +290,7 @@ namespace Microsoft.Azure.Cosmos
 
         public override bool BypassQueryParsing()
         {
-            return CustomTypeExtensions.ByPassQueryParsing();
+            return true; // CustomTypeExtensions.ByPassQueryParsing();
         }
 
         public override void ClearSessionTokenCache(string collectionFullName)

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryIterator.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryIterator.cs
@@ -149,7 +149,7 @@ namespace Microsoft.Azure.Cosmos.Query
                 partitionedQueryExecutionInfo: partitionedQueryExecutionInfo,
                 returnResultsInDeterministicOrder: queryRequestOptions.ReturnResultsInDeterministicOrder,
                 enableOptimisticDirectExecution: queryRequestOptions.EnableOptimisticDirectExecution,
-                isNonStreamingOrderByQueryFeatureDisabled: queryRequestOptions.IsNonStreamingOrderByQueryFeatureDisabled,
+                isHybridSearchQueryPlanOptimizationDisabled: queryRequestOptions.IsHybridSearchQueryPlanOptimizationDisabled,
                 enableDistributedQueryGatewayMode: queryRequestOptions.EnableDistributedQueryGatewayMode && (clientContext.ClientOptions.ConnectionMode == ConnectionMode.Gateway),
                 testInjections: queryRequestOptions.TestSettings);
 

--- a/Microsoft.Azure.Cosmos/src/RequestOptions/QueryRequestOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/RequestOptions/QueryRequestOptions.cs
@@ -208,7 +208,7 @@ namespace Microsoft.Azure.Cosmos
 
         internal FeedRange FeedRange { get; set; }
 
-        internal bool IsNonStreamingOrderByQueryFeatureDisabled { get; set; } = ConfigurationManager.IsNonStreamingOrderByQueryFeatureDisabled(defaultValue: false);
+        internal bool IsHybridSearchQueryPlanOptimizationDisabled { get; set; } = ConfigurationManager.IsHybridSearchQueryPlanOptimizationDisabled(defaultValue: false);
 
         // This is a temporary flag to enable the distributed query gateway mode.
         // This flag will be removed once we have a way for the client to determine

--- a/Microsoft.Azure.Cosmos/src/Routing/PartitionRoutingHelper.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/PartitionRoutingHelper.cs
@@ -65,6 +65,7 @@ namespace Microsoft.Azure.Cosmos.Routing
                 allowNonValueAggregateQuery: allowNonValueAggregates,
                 hasLogicalPartitionKey: hasLogicalPartitionKey,
                 allowDCount: allowDCount,
+                hybridSearchSkipOrderByRewrite: false,
                 useSystemPrefix: useSystemPrefix,
                 geospatialType: geospatialType);
             if (!tryGetPartitionQueryExecutionInfo.Succeeded)

--- a/Microsoft.Azure.Cosmos/src/Util/ConfigurationManager.cs
+++ b/Microsoft.Azure.Cosmos/src/Util/ConfigurationManager.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Environment variable name to disable sending non streaming order by query feature flag to the gateway.
         /// </summary>
-        internal static readonly string NonStreamingOrderByQueryFeatureDisabled = "AZURE_COSMOS_NON_STREAMING_ORDER_BY_FLAG_DISABLED";
+        internal static readonly string HybridSearchQueryPlanOptimizationDisabled = "AZURE_COSMOS_HYBRID_SEARCH_QUERYPLAN_OPTIMIZATION_DISABLED";
 
         /// <summary>
         /// Environment variable name to enable distributed query gateway mode.
@@ -246,15 +246,15 @@ namespace Microsoft.Azure.Cosmos
         }
 
         /// <summary>
-        /// Gets the boolean value indicating whether the non streaming order by query feature flag should be sent to the gateway
+        /// Gets the boolean value indicating whether the hybrid search query plan optimization feature flag should be sent to the gateway
         /// based on the environment variable override.
         /// </summary>
-        public static bool IsNonStreamingOrderByQueryFeatureDisabled(
+        public static bool IsHybridSearchQueryPlanOptimizationDisabled(
             bool defaultValue)
         {
             return ConfigurationManager
                     .GetEnvironmentVariable(
-                        variable: NonStreamingOrderByQueryFeatureDisabled,
+                        variable: HybridSearchQueryPlanOptimizationDisabled,
                         defaultValue: defaultValue);
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/NonStreamingOrderByQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/NonStreamingOrderByQueryTests.cs
@@ -83,8 +83,8 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
         [TestMethod]
         public async Task QueryFeatureFlagTests()
         {
-            using EnvironmentVariable nonStreamingOrderByDisabled = new EnvironmentVariable(
-                ConfigurationManager.NonStreamingOrderByQueryFeatureDisabled);
+            using EnvironmentVariable hybridSearchQueryPlanOptimizationDisabled = new EnvironmentVariable(
+                ConfigurationManager.HybridSearchQueryPlanOptimizationDisabled);
 
             static async Task ImplementationAsync(Container container, IReadOnlyList<CosmosObject> _)
             {
@@ -136,13 +136,13 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
                     if (testCase.EnvironmentVariable.HasValue)
                     {
                         Environment.SetEnvironmentVariable(
-                            ConfigurationManager.NonStreamingOrderByQueryFeatureDisabled,
+                            ConfigurationManager.HybridSearchQueryPlanOptimizationDisabled,
                             testCase.EnvironmentVariable.Value.ToString());
                     }
                     else
                     {
                         Environment.SetEnvironmentVariable(
-                            ConfigurationManager.NonStreamingOrderByQueryFeatureDisabled,
+                            ConfigurationManager.HybridSearchQueryPlanOptimizationDisabled,
                             null);
                     }
 
@@ -153,7 +153,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
 
                     if (testCase.RequestOption.HasValue)
                     {
-                        requestOptions.IsNonStreamingOrderByQueryFeatureDisabled = testCase.RequestOption.Value;
+                        requestOptions.IsHybridSearchQueryPlanOptimizationDisabled = testCase.RequestOption.Value;
                     }
 
                     validator.ExpectNonStreamingOrderBy = testCase.ExpectNonStreamingOrderBy;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/NonStreamingOrderByQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/NonStreamingOrderByQueryTests.cs
@@ -92,7 +92,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
 
                 SupportedQueryFeaturesValidator validator = new SupportedQueryFeaturesValidator
                 {
-                    ExpectNonStreamingOrderBy = true
+                    ExpectQueryPlanOptimizationDisabled = true
                 };
 
                 CosmosQueryClient cosmosQueryClient = new MockCosmosQueryClient(
@@ -111,23 +111,23 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
                     MakeQueryFeaturesTest(
                         environmentVariable: null,
                         requestOption: null,
-                        expectNonStreamingOrderBy: true),
+                        expectHybridSearchOptimizationDisabled: false),
                     MakeQueryFeaturesTest(
                         environmentVariable: true,
                         requestOption: null,
-                        expectNonStreamingOrderBy: false),
+                        expectHybridSearchOptimizationDisabled: true),
                     MakeQueryFeaturesTest(
                         environmentVariable: null,
                         requestOption: true,
-                        expectNonStreamingOrderBy: false),
+                        expectHybridSearchOptimizationDisabled: true),
                     MakeQueryFeaturesTest(
                         environmentVariable: false,
                         requestOption: null,
-                        expectNonStreamingOrderBy: true),
+                        expectHybridSearchOptimizationDisabled: false),
                     MakeQueryFeaturesTest(
                         environmentVariable: null,
                         requestOption: false,
-                        expectNonStreamingOrderBy: true),
+                        expectHybridSearchOptimizationDisabled: false),
                 };
 
                 int validationCount = validator.InvocationCount;
@@ -156,7 +156,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
                         requestOptions.IsHybridSearchQueryPlanOptimizationDisabled = testCase.RequestOption.Value;
                     }
 
-                    validator.ExpectNonStreamingOrderBy = testCase.ExpectNonStreamingOrderBy;
+                    validator.ExpectQueryPlanOptimizationDisabled = testCase.ExpectHybridSearchOptimizationDisabled;
                     ++validationCount;
 
                     DebugTraceHelpers.TraceSupportedFeaturesTestCase(testCase);
@@ -181,7 +181,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
                     if (responseMessage.StatusCode != System.Net.HttpStatusCode.OK)
                     {
                         Trace.WriteLine("Failed test case:");
-                        Trace.WriteLine($"EnvironmentVariable: {testCase.EnvironmentVariable}, RequestOption: {testCase.RequestOption}, ExpectNonStreamingOrderBy: {testCase.ExpectNonStreamingOrderBy}");
+                        Trace.WriteLine($"EnvironmentVariable: {testCase.EnvironmentVariable}, RequestOption: {testCase.RequestOption}, ExpectHybridSearchOptimizationDisabled: {testCase.ExpectHybridSearchOptimizationDisabled}");
                         Trace.WriteLine($"Unexpected response: {responseMessage.StatusCode}");
                         Trace.WriteLine(responseMessage.Content.ReadAsString());
                         Trace.Flush();
@@ -199,9 +199,9 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
                 ImplementationAsync);
         }
 
-        private static QueryFeaturesTest MakeQueryFeaturesTest(bool? environmentVariable, bool? requestOption, bool expectNonStreamingOrderBy)
+        private static QueryFeaturesTest MakeQueryFeaturesTest(bool? environmentVariable, bool? requestOption, bool expectHybridSearchOptimizationDisabled)
         {
-            return new QueryFeaturesTest(environmentVariable, requestOption, expectNonStreamingOrderBy);
+            return new QueryFeaturesTest(environmentVariable, requestOption, expectHybridSearchOptimizationDisabled);
         }
 
         private sealed class QueryFeaturesTest
@@ -210,13 +210,13 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
 
             public bool? RequestOption { get; }
 
-            public bool ExpectNonStreamingOrderBy { get; }
+            public bool ExpectHybridSearchOptimizationDisabled { get; }
 
-            public QueryFeaturesTest(bool? environmentVariable, bool? requestOption, bool expectNonStreamingOrderBy)
+            public QueryFeaturesTest(bool? environmentVariable, bool? requestOption, bool expectHybridSearchOptimizationDisabled)
             {
                 this.EnvironmentVariable = environmentVariable;
                 this.RequestOption = requestOption;
-                this.ExpectNonStreamingOrderBy = expectNonStreamingOrderBy;
+                this.ExpectHybridSearchOptimizationDisabled = expectHybridSearchOptimizationDisabled;
             }
         }
 
@@ -339,7 +339,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
             {
                 if (Enabled)
                 {
-                    Trace.WriteLine($"EnvironmentVariable: {testCase.EnvironmentVariable}, RequestOption: {testCase.RequestOption}, ExpectNonStreamingOrderBy: {testCase.ExpectNonStreamingOrderBy}");
+                    Trace.WriteLine($"EnvironmentVariable: {testCase.EnvironmentVariable}, RequestOption: {testCase.RequestOption}, ExpectNonStreamingOrderBy: {testCase.ExpectHybridSearchOptimizationDisabled}");
                 }
             }
 #pragma warning restore CS0162 // Unreachable code detected
@@ -366,14 +366,14 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
         {
             public int InvocationCount { get; private set; }
 
-            public bool ExpectNonStreamingOrderBy { get; set;}
+            public bool ExpectQueryPlanOptimizationDisabled { get; set;}
 
             public void Validate(string supportedQueryFeatures)
             {
                 DebugTraceHelpers.TraceSupportedFeaturesString(supportedQueryFeatures);
                 ++this.InvocationCount;
-                bool hasNonStreamingOrderBy = supportedQueryFeatures.Contains(QueryFeatures.NonStreamingOrderBy.ToString());
-                Assert.AreEqual(this.ExpectNonStreamingOrderBy, hasNonStreamingOrderBy);
+                bool hybridSearchOptimizationDisabled = !supportedQueryFeatures.Contains(QueryFeatures.HybridSearchSkipOrderByRewrite.ToString());
+                Assert.AreEqual(this.ExpectQueryPlanOptimizationDisabled, hybridSearchOptimizationDisabled);
             }
         }
 
@@ -426,7 +426,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
             {
                 this.validator.Validate(supportedQueryFeatures);
 
-                if (this.validator.ExpectNonStreamingOrderBy)
+                if (this.validator.ExpectQueryPlanOptimizationDisabled)
                 {
                     // older emulator in the github repo does not support non-streaming order by, and will send back 400
                     supportedQueryFeatures = SupportedQueryFeaturesString;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/NonStreamingOrderByQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/NonStreamingOrderByQueryTests.cs
@@ -339,7 +339,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
             {
                 if (Enabled)
                 {
-                    Trace.WriteLine($"EnvironmentVariable: {testCase.EnvironmentVariable}, RequestOption: {testCase.RequestOption}, ExpectNonStreamingOrderBy: {testCase.ExpectHybridSearchOptimizationDisabled}");
+                    Trace.WriteLine($"EnvironmentVariable: {testCase.EnvironmentVariable}, RequestOption: {testCase.RequestOption}, ExpectHybridSearchOptimizationDisabled: {testCase.ExpectHybridSearchOptimizationDisabled}");
                 }
             }
 #pragma warning restore CS0162 // Unreachable code detected

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Tracing/EndToEndTraceWriterBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Tracing/EndToEndTraceWriterBaselineTests.cs
@@ -500,7 +500,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Tracing
         public async Task QueryAsync()
         {
             List<Input> inputs = new List<Input>();
-            QueryRequestOptions requestOptions = new QueryRequestOptions() { IsNonStreamingOrderByQueryFeatureDisabled = true };
+            QueryRequestOptions requestOptions = new QueryRequestOptions() { IsHybridSearchQueryPlanOptimizationDisabled = true };
 
             int startLineNumber;
             int endLineNumber;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Query/ParsingBenchmark.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Query/ParsingBenchmark.cs
@@ -127,6 +127,7 @@ namespace Microsoft.Azure.Cosmos.Query
                 allowNonValueAggregateQuery: true,
                 hasLogicalPartitionKey: false,
                 allowDCount: true,
+                hybridSearchSkipOrderByRewrite: false,
                 useSystemPrefix: false,
                 geospatialType: Cosmos.GeospatialType.Geography);
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OptimisticDirectExecutionQueryBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/OptimisticDirectExecutionQueryBaselineTests.cs
@@ -827,6 +827,7 @@
                 allowNonValueAggregateQuery: true,
                 hasLogicalPartitionKey: false,
                 allowDCount: true,
+                hybridSearchSkipOrderByRewrite: false,
                 useSystemPrefix: false,
                 geospatialType: Cosmos.GeospatialType.Geography);
 
@@ -1027,7 +1028,7 @@
                 partitionedQueryExecutionInfo: null,
                 returnResultsInDeterministicOrder: null,
                 enableOptimisticDirectExecution: queryRequestOptions.EnableOptimisticDirectExecution,
-                isNonStreamingOrderByQueryFeatureDisabled: queryRequestOptions.IsNonStreamingOrderByQueryFeatureDisabled,
+                isHybridSearchQueryPlanOptimizationDisabled: queryRequestOptions.IsHybridSearchQueryPlanOptimizationDisabled,
                 enableDistributedQueryGatewayMode: queryRequestOptions.EnableDistributedQueryGatewayMode,
                 testInjections: queryRequestOptions.TestSettings);
 
@@ -1357,6 +1358,7 @@
             bool allowNonValueAggregateQuery,
             bool hasLogicalPartitionKey,
             bool allowDCount,
+            bool hybridSearchQuerySkipOrderByRewrite,
             bool useSystemPrefix,
             Cosmos.GeospatialType geospatialType,
             CancellationToken cancellationToken)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/FullPipelineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/FullPipelineTests.cs
@@ -393,6 +393,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                 bool hasLogicalPartitionKey,
                 bool allowDCount,
                 bool useSystemPrefix,
+                bool isHybridSearchQueryPlanOptimizationDisabled,
                 Cosmos.GeospatialType geospatialType,
                 CancellationToken cancellationToken) =>
                 {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/FullPipelineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/FullPipelineTests.cs
@@ -338,7 +338,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                 partitionedQueryExecutionInfo: null,
                 returnResultsInDeterministicOrder: null,
                 enableOptimisticDirectExecution: queryRequestOptions.EnableOptimisticDirectExecution,
-                isNonStreamingOrderByQueryFeatureDisabled: queryRequestOptions.IsNonStreamingOrderByQueryFeatureDisabled,
+                isHybridSearchQueryPlanOptimizationDisabled: queryRequestOptions.IsHybridSearchQueryPlanOptimizationDisabled,
                 enableDistributedQueryGatewayMode: queryRequestOptions.EnableDistributedQueryGatewayMode,
                 testInjections: queryRequestOptions.TestSettings);
 
@@ -373,6 +373,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                 It.IsAny<ResourceType>(),
                 It.IsAny<PartitionKeyDefinition>(),
                 It.IsAny<Cosmos.VectorEmbeddingPolicy>(),
+                It.IsAny<bool>(),
                 It.IsAny<bool>(),
                 It.IsAny<bool>(),
                 It.IsAny<bool>(),
@@ -635,6 +636,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
                 allowNonValueAggregateQuery: true,
                 allowDCount: true,
                 hasLogicalPartitionKey: false,
+                hybridSearchSkipOrderByRewrite: false,
                 useSystemPrefix: false,
                 geospatialType: Cosmos.GeospatialType.Geography);
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/QueryPartitionProviderTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/QueryPartitionProviderTests.cs
@@ -40,6 +40,7 @@
                     allowNonValueAggregateQuery: true,
                     hasLogicalPartitionKey: false,
                     allowDCount: true,
+                    hybridSearchSkipOrderByRewrite: false,
                     useSystemPrefix: false,
                     geospatialType: Cosmos.GeospatialType.Geography);
 
@@ -57,6 +58,7 @@
                             allowNonValueAggregateQuery: true,
                             hasLogicalPartitionKey: false,
                             allowDCount: true,
+                            hybridSearchSkipOrderByRewrite: false,
                             useSystemPrefix: false,
                             geospatialType: Cosmos.GeospatialType.Geography);
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/QueryPlanBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/QueryPlanBaselineTests.cs
@@ -1697,6 +1697,7 @@
                 allowNonValueAggregateQuery: true,
                 hasLogicalPartitionKey: false,
                 allowDCount: true,
+                hybridSearchSkipOrderByRewrite: false,
                 useSystemPrefix: false,
                 geospatialType: input.GeospatialType ?? Cosmos.GeospatialType.Geography);
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/QueryPlanRetrieverTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/QueryPlanRetrieverTests.cs
@@ -39,6 +39,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query
                 It.IsAny<bool>(),
                 It.IsAny<bool>(),
                 It.IsAny<bool>(),
+                It.IsAny<bool>(),
                 It.IsAny<Cosmos.GeospatialType>(),
                 It.IsAny<CancellationToken>())).ReturnsAsync(TryCatch<PartitionedQueryExecutionInfo>.FromException(innerException));
 
@@ -51,6 +52,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query
                 hasLogicalPartitionKey: false,
                 geospatialType: Cosmos.GeospatialType.Geography,
                 useSystemPrefix: false,
+                isHybridSearchQueryPlanOptimizationDisabled: false,
                 NoOpTrace.Singleton));
 
             Assert.AreEqual(HttpStatusCode.BadRequest, cosmosException.StatusCode);
@@ -76,6 +78,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query
                 It.IsAny<bool>(),
                 It.IsAny<bool>(),
                 It.IsAny<bool>(),
+                It.IsAny<bool>(),
                 It.IsAny<Cosmos.GeospatialType>(),
                 It.IsAny<CancellationToken>())).ReturnsAsync(TryCatch<PartitionedQueryExecutionInfo>.FromException(expectedException));
 
@@ -89,6 +92,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query
                 hasLogicalPartitionKey: false,
                 geospatialType: Cosmos.GeospatialType.Geography,
                 useSystemPrefix: false,
+                isHybridSearchQueryPlanOptimizationDisabled: false,
                 trace.Object,
                 default));
 
@@ -112,6 +116,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query
                 It.IsAny<bool>(),
                 It.IsAny<bool>(),
                 It.IsAny<bool>(),
+                It.IsAny<bool>(),
                 It.IsAny<Cosmos.GeospatialType>(),
                 It.IsAny<CancellationToken>())).ReturnsAsync(TryCatch<PartitionedQueryExecutionInfo>.FromException(innerException));
 
@@ -124,6 +129,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query
                 hasLogicalPartitionKey: false,
                 geospatialType: Cosmos.GeospatialType.Geography,
                 useSystemPrefix: false,
+                isHybridSearchQueryPlanOptimizationDisabled: false,
                 NoOpTrace.Singleton));
 
             Assert.AreEqual(HttpStatusCode.InternalServerError, cosmosException.StatusCode);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/SubpartitionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/SubpartitionTests.cs
@@ -136,7 +136,7 @@
                 partitionedQueryExecutionInfo: null,
                 returnResultsInDeterministicOrder: null,
                 enableOptimisticDirectExecution: queryRequestOptions.EnableOptimisticDirectExecution,
-                isNonStreamingOrderByQueryFeatureDisabled: queryRequestOptions.IsNonStreamingOrderByQueryFeatureDisabled,
+                isHybridSearchQueryPlanOptimizationDisabled: queryRequestOptions.IsHybridSearchQueryPlanOptimizationDisabled,
                 enableDistributedQueryGatewayMode: queryRequestOptions.EnableDistributedQueryGatewayMode,
                 testInjections: queryRequestOptions.TestSettings);
 
@@ -184,6 +184,7 @@
                 allowNonValueAggregateQuery: true,
                 hasLogicalPartitionKey: false,
                 allowDCount: true,
+                hybridSearchSkipOrderByRewrite: false,
                 useSystemPrefix: false,
                 geospatialType: Cosmos.GeospatialType.Geography);
 
@@ -368,6 +369,7 @@
                 bool hasLogicalPartitionKey,
                 bool allowDCount,
                 bool useSystemPrefix,
+                bool isHybridSearchQueryPlanOptimizationDisabled,
                 Cosmos.GeospatialType geospatialType,
                 CancellationToken cancellationToken)
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Routing/PartitionRoutingHelperTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Routing/PartitionRoutingHelperTest.cs
@@ -719,6 +719,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Routing
                         allowNonValueAggregateQuery: false,
                         hasLogicalPartitionKey: false,
                         allowDCount: true,
+                        hybridSearchSkipOrderByRewrite: false,
                         useSystemPrefix: false,
                         geospatialType: Cosmos.GeospatialType.Geography);
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Tracing/TraceWriterBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Tracing/TraceWriterBaselineTests.cs
@@ -781,6 +781,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Tracing
                 allowNonValueAggregateQuery: true,
                 hasLogicalPartitionKey: false,
                 allowDCount: true,
+                hybridSearchSkipOrderByRewrite: false,
                 useSystemPrefix: false,
                 geospatialType: Cosmos.GeospatialType.Geography);
 


### PR DESCRIPTION
## Description
This change adds a configuration whose value will be read from the environment variable `AZURE_COSMOS_HYBRID_SEARCH_QUERYPLAN_OPTIMIZATION_DISABLED`. If this evaluates to true, then the optimization for skipping the order by rewrite for hybrid search is disabled.

The environment variable is read, and the value is propagated as an internally visible query request option. This is plumbed down in the query plan APIs where it is either used to populate the supported query features header in case of a gateway or it is used as a flag passed into ServiceInterop.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

