### PR TITLE
Query: Adds support for the optimized query plan that skips the order by rewrite

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/HybridSearch/HybridSearchQueryResult.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/HybridSearch/HybridSearchQueryResult.cs
@@ -54,17 +54,26 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.HybridSearch
                 throw new ArgumentException($"{FieldNames.Payload} must exist.");
             }
 
-            if (!outerPayload.TryGetValue(FieldNames.Payload, out CosmosElement innerPayload))
+            if (outerPayload.TryGetValue(FieldNames.ComponentScores, out CosmosArray componentScores))
             {
-                innerPayload = CosmosUndefined.Create();
+                // Using the older format where the payload is nested.
+                if (!outerPayload.TryGetValue(FieldNames.Payload, out CosmosObject innerPayload))
+                {
+                    innerPayload = CosmosUndefined.Create();
+                }
+
+                return new HybridSearchQueryResult(rid, componentScores, innerPayload);
             }
 
-            if (!outerPayload.TryGetValue(FieldNames.ComponentScores, out CosmosArray componentScores))
             {
-                throw new ArgumentException($"{FieldNames.ComponentScores} must exist.");
-            }
+                // Using the newer format where the payload is not nested.
+                if (!cosmosObject.TryGetValue(FieldNames.ComponentScores, out CosmosArray componentScores))
+                {
+                    throw new ArgumentException($"{FieldNames.ComponentScores} must exist.");
+                }
 
-            return new HybridSearchQueryResult(rid, componentScores, innerPayload);
+                return new HybridSearchQueryResult(rid, componentScores, outerPayload);
+            }
         }
 
         private static class FieldNames

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/NonStreamingOrderByQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/NonStreamingOrderByQueryTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
     [TestClass]
     public class NonStreamingOrderByQueryTests
     {
-        private const int MaxConcurrency = 0;
+        private const int MaxConcurrency = 10;
 
         private const int DocumentCount = 420;
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/NonStreamingOrderByQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/Pipeline/NonStreamingOrderByQueryTests.cs
@@ -1256,7 +1256,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Query.Pipeline
         private static class DebugTraceHelpers
         {
 #pragma warning disable CS0162, CS0649 // Unreachable code detected
-            private static readonly bool Enabled = true;
+            private static readonly bool Enabled;
 
             [Conditional("DEBUG")]
             public static void TraceSplit(FeedRangeInternal feedRange)


### PR DESCRIPTION
## Description

Adds support for the optimized query plan that skips the order by rewrite. The new hybrid search component query plan "lies" to the SDK about there being no ORDER BY on the component queries. However, the hybrid search query pipeline stage knows that the component scores need to be sorted. Since there is no information about this sorting on the query plan anymore, the hybrid search query pipeline stage will always sort descending in this scenario. The component score projections are rewritten to safeguard this assumption.

This change is backward compatible so that the SDK can accept both the old style query plan with rewritten ORDER BY as well as the new one that skips the order by rewrite.

The end user can disable the optimized query plan by setting the environment variable `AZURE_COSMOS_HYBRID_SEARCH_QUERYPLAN_OPTIMIZATION_DISABLED` flag to `true`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
