### PR TITLE
Hedging: Fixes behavior of hedging for metadata requests

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Routing/AvailabilityStrategy/AvailabilityStrategyInternal.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/AvailabilityStrategy/AvailabilityStrategyInternal.cs
@@ -5,8 +5,11 @@
 namespace Microsoft.Azure.Cosmos
 {
     using System;
+    using System.IO;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Tracing;
+    using Microsoft.Azure.Documents;
 
     internal abstract class AvailabilityStrategyInternal : AvailabilityStrategy
     {
@@ -16,12 +19,43 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="sender"></param>
         /// <param name="client"></param>
         /// <param name="requestMessage"></param>
+        /// <param name="childTrace"></param>
+        /// <param name="resourceUriString"></param>
+        /// <param name="resourceType"></param>
+        /// <param name="operationType"></param>
+        /// <param name="requestOptions"></param>
+        /// <param name="cosmosContainerCore"></param>
+        /// <param name="feedRange"></param>
+        /// <param name="streamPayload"></param>
+        /// <param name="requestEnricher"></param>
+        /// <param name="trace"></param>
         /// <param name="cancellationToken"></param>
         /// <returns>The response from the service after the availability strategy is executed</returns>
         internal abstract Task<ResponseMessage> ExecuteAvailabilityStrategyAsync(
-            Func<RequestMessage, CancellationToken, Task<ResponseMessage>> sender,
+            Func<RequestMessage,
+                ITrace,
+                string,
+                ResourceType,
+                OperationType,
+                RequestOptions,
+                ContainerInternal,
+                FeedRange,
+                Stream,
+                Action<RequestMessage>,
+                ITrace, CancellationToken,
+                Task<ResponseMessage>> sender,
             CosmosClient client,
             RequestMessage requestMessage,
+            ITrace childTrace,
+            string resourceUriString,
+            ResourceType resourceType,
+            OperationType operationType,
+            RequestOptions requestOptions,
+            ContainerInternal cosmosContainerCore,
+            FeedRange feedRange,
+            Stream streamPayload,
+            Action<RequestMessage> requestEnricher,
+            ITrace trace,
             CancellationToken cancellationToken);
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Routing/AvailabilityStrategy/DisabledAvailabilityStrategy.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/AvailabilityStrategy/DisabledAvailabilityStrategy.cs
@@ -4,8 +4,11 @@
 namespace Microsoft.Azure.Cosmos
 {
     using System;
+    using System.IO;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Tracing;
+    using Microsoft.Azure.Documents;
 
     /// <summary>
     /// A Disabled availability strategy that does not do anything. Used for overriding the default global availability strategy.
@@ -24,14 +27,43 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="sender"></param>
         /// <param name="client"></param>
         /// <param name="requestMessage"></param>
+        /// <param name="childTrace"></param>
+        /// <param name="resourceUriString"></param>
+        /// <param name="resourceType"></param>
+        /// <param name="operationType"></param>
+        /// <param name="requestOptions"></param>
+        /// <param name="cosmosContainerCore"></param>
+        /// <param name="feedRange"></param>
+        /// <param name="streamPayload"></param>
+        /// <param name="requestEnricher"></param>
+        /// <param name="trace"></param>
         /// <param name="cancellationToken"></param>
         /// <returns>nothing, this will throw.</returns>
         internal override Task<ResponseMessage> ExecuteAvailabilityStrategyAsync(
             Func<RequestMessage,
-            CancellationToken,
-            Task<ResponseMessage>> sender,
+                ITrace,
+                string,
+                ResourceType,
+                OperationType,
+                RequestOptions,
+                ContainerInternal,
+                FeedRange,
+                Stream,
+                Action<RequestMessage>,
+                ITrace, CancellationToken,
+                Task<ResponseMessage>> sender,
             CosmosClient client,
             RequestMessage requestMessage,
+            ITrace childTrace,
+            string resourceUriString,
+            ResourceType resourceType,
+            OperationType operationType,
+            RequestOptions requestOptions,
+            ContainerInternal cosmosContainerCore,
+            FeedRange feedRange,
+            Stream streamPayload,
+            Action<RequestMessage> requestEnricher,
+            ITrace trace,
             CancellationToken cancellationToken)
         {
             throw new NotImplementedException();


### PR DESCRIPTION
# Pull Request Template

## Description

This pull request refactors the request handling and availability strategy implementation. The changes streamline method signatures, improve traceability, and enhance the extensibility of the availability strategy logic. Key updates include the introduction of a new `SendInternalAsync` method, modifications to the `ExecuteAvailabilityStrategyAsync` method, and updates to cross-region hedging logic.

### Background

There is currently a bug in the SDK where hedging will not kick in if there is a delay for the metadata calls to the gateway that are made with every request. This is because hedging occurs after these requests are made. This PR refactors the behavior of hedging, so the metadata calls are included as part of the hedging flow. This PR also fixes a bug where cancellation tokens would not properly work for hedged write requests.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #5061