### PR TITLE
Query: Fixes handling of undefined projections in hybrid search

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/HybridSearch/HybridSearchQueryResult.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/HybridSearch/HybridSearchQueryResult.cs
@@ -54,9 +54,9 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.HybridSearch
                 throw new ArgumentException($"{FieldNames.Payload} must exist.");
             }
 
-            if (!outerPayload.TryGetValue(FieldNames.Payload, out CosmosObject innerPayload))
+            if (!outerPayload.TryGetValue(FieldNames.Payload, out CosmosElement innerPayload))
             {
-                throw new ArgumentException($"{FieldNames.Payload} must exist nested within the outer payload field.");
+                innerPayload = CosmosUndefined.Create();
             }
 
             if (!outerPayload.TryGetValue(FieldNames.ComponentScores, out CosmosArray componentScores))


### PR DESCRIPTION
## Description
This changes allows the projections in a hybrid search query to be undefined, bringing the behavior of hybrid search in line with other base pipelines such as the order by pipeline stage and parallel cross partition pipeline stage.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
