### PR TITLE
Fix: Update session retry optimization public docs

### DIFF
--- a/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
@@ -748,7 +748,8 @@ namespace Microsoft.Azure.Cosmos
         public AvailabilityStrategy AvailabilityStrategy { get; set; }
 
         /// <summary>
-        /// provides SessionTokenMismatchRetryPolicy optimization through customer supplied region switch hints
+        /// Provides SessionTokenMismatchRetryPolicy optimization through customer supplied region switch hints which guide SDK-internal retry policies on how early to switch retries to a different region. 
+        /// If true, will retry all replicas once and add a minimum delay before switching to the next region.If false, it will retry in the local region up to 5s
         /// </summary>
 #if PREVIEW
         public

--- a/Microsoft.Azure.Cosmos/src/Fluent/CosmosClientBuilder.cs
+++ b/Microsoft.Azure.Cosmos/src/Fluent/CosmosClientBuilder.cs
@@ -584,7 +584,8 @@ namespace Microsoft.Azure.Cosmos.Fluent
         }
 
         /// <summary>
-        /// provides SessionTokenMismatchRetryPolicy optimization through customer supplied region switch hints
+        /// Provides SessionTokenMismatchRetryPolicy optimization through customer supplied region switch hints which guide SDK-internal retry policies on how early to switch retries to a different region. 
+        /// If true, will retry all replicas once and add a minimum delay before switching to the next region.If false, it will retry in the local region up to 5s
         /// </summary>
         /// <param name="enableRemoteRegionPreferredForSessionRetry"></param>
         /// <returns>The <see cref="CosmosClientBuilder"/> object</returns>


### PR DESCRIPTION
This is a public documentation update for the Session Consistency Retries policy in the CosmosClientOption and CosmosClientBuilder to provide clarity on what the EnableRemoteRegion bool does for the client in terms of retries.
