### PR TITLE
QuorumReader code not yielding on 429

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ClientRetryPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/ClientRetryPolicy.cs
@@ -152,7 +152,11 @@ namespace Microsoft.Azure.Cosmos
             ResponseMessage cosmosResponseMessage,
             CancellationToken cancellationToken)
         {
-            this.retryContext = null;
+            // Only set retryContext to null if it's not the first retry to a new region
+            if (this.failoverRetryCount == 0)
+            {
+                this.retryContext = null;
+            }
 
             ShouldRetryResult shouldRetryResult = await this.ShouldRetryInternalAsync(
                     cosmosResponseMessage?.StatusCode,
@@ -180,6 +184,7 @@ namespace Microsoft.Azure.Cosmos
             }
 
             return await this.throttlingRetry.ShouldRetryAsync(cosmosResponseMessage, cancellationToken);
+            
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/ClientRetryPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/ClientRetryPolicy.cs
@@ -152,12 +152,7 @@ namespace Microsoft.Azure.Cosmos
             ResponseMessage cosmosResponseMessage,
             CancellationToken cancellationToken)
         {
-            // Only set retryContext to null if it's not the first retry to a new region
-            if (this.failoverRetryCount == 0)
-            {
-                this.retryContext = null;
-            }
-
+            this.retryContext = null;
             ShouldRetryResult shouldRetryResult = await this.ShouldRetryInternalAsync(
                     cosmosResponseMessage?.StatusCode,
                     cosmosResponseMessage?.Headers.SubStatusCode);

--- a/Microsoft.Azure.Cosmos/src/ResourceThrottleRetryPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/ResourceThrottleRetryPolicy.cs
@@ -110,6 +110,7 @@ namespace Microsoft.Azure.Cosmos
                 DefaultTrace.TraceError(
                     "Operation will NOT be retried. Current attempt {0} maxAttempts {1} Cumulative delay {2} requested retryAfter {3} maxWaitTime {4}",
                     this.currentAttemptCount, this.maxAttemptCount, this.cumulativeRetryDelay, retryAfter, this.maxWaitTimeInMilliseconds);
+
                 return Task.FromResult(ShouldRetryResult.NoRetry());
             }
         }

--- a/Microsoft.Azure.Cosmos/src/ResourceThrottleRetryPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/ResourceThrottleRetryPolicy.cs
@@ -110,7 +110,6 @@ namespace Microsoft.Azure.Cosmos
                 DefaultTrace.TraceError(
                     "Operation will NOT be retried. Current attempt {0} maxAttempts {1} Cumulative delay {2} requested retryAfter {3} maxWaitTime {4}",
                     this.currentAttemptCount, this.maxAttemptCount, this.cumulativeRetryDelay, retryAfter, this.maxWaitTimeInMilliseconds);
-
                 return Task.FromResult(ShouldRetryResult.NoRetry());
             }
         }

--- a/Microsoft.Azure.Cosmos/src/direct/QuorumReader.cs
+++ b/Microsoft.Azure.Cosmos/src/direct/QuorumReader.cs
@@ -552,7 +552,6 @@ namespace Microsoft.Azure.Documents
                 IList<ReferenceCountedDisposable<StoreResult>> responses = disposableResponses.Value;
 
                 // Check if all replicas returned 429
-                // TO DO: check with Kiran/Fabian if 429 from one replica is going to be enough to yield but that may be turn out to be flase alarm considering calls are async so the 429 state could be transient
                 if (responses.All(response => response.Target.StatusCode == StatusCodes.TooManyRequests))
                 {
                     DefaultTrace.TraceWarning("WaitForReadBarrierOldAsync: All replicas returned 429 Too Many Requests. Yielding early to ResourceThrottleRetryPolicy.");

--- a/Microsoft.Azure.Cosmos/src/direct/QuorumReader.cs
+++ b/Microsoft.Azure.Cosmos/src/direct/QuorumReader.cs
@@ -550,6 +550,9 @@ namespace Microsoft.Azure.Documents
                     checkMinLSN: false,
                     forceReadAll: true));
                 IList<ReferenceCountedDisposable<StoreResult>> responses = disposableResponses.Value;
+
+                // Check if all replicas returned 429
+                // TO DO: check with Kiran/Fabian if 429 from one replica is going to be enough to yield but that may be turn out to be flase alarm considering calls are async so the 429 state could be transient
                 if (responses.All(response => response.Target.StatusCode == StatusCodes.TooManyRequests))
                 {
                     DefaultTrace.TraceWarning("WaitForReadBarrierOldAsync: All replicas returned 429 Too Many Requests. Yielding early to ResourceThrottleRetryPolicy.");

--- a/Microsoft.Azure.Cosmos/src/direct/QuorumReader.cs
+++ b/Microsoft.Azure.Cosmos/src/direct/QuorumReader.cs
@@ -256,7 +256,6 @@ namespace Microsoft.Azure.Documents
                     useSessionToken: false, 
                     readMode: readMode));
                 IList<ReferenceCountedDisposable<StoreResult>> responseResult = disposableResponseResult.Value;
-                
                 responsesForLogging = new StoreResult[responseResult.Count];
                 for (int i = 0; i < responseResult.Count; i++)
                 {
@@ -860,7 +859,6 @@ namespace Microsoft.Azure.Documents
             }
 
             public ReadQuorumResultKind QuorumResult { get; private set; }
-            public StoreResult[] StoreResponses => this.storeResponses;
 
             public long SelectedLsn { get; private set; }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTests.cs
@@ -929,7 +929,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.AreEqual(socketHandlerType, clientMessageHandlerType);
         }
 
-
+        // This Test is not part of this PR. It was written solely to verify the existing behaviour of 429 requests
+        // when exceptionLess is turned off for 429 errors.It still make multiple calls instead of just making call to one replica and yield.
         [TestMethod]
         public async Task AssertExisting429BehaviourByTurningOffExceptionLess()
         {
@@ -1056,6 +1057,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     testObject.id,
                     new Cosmos.PartitionKey(testObject.id));
 
+                // Print diagnostics
+                Console.WriteLine("Diagnostics:");
+                Console.WriteLine(itemResponse.Diagnostics.ToString());
             }
             
             catch (CosmosException ex)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTests.cs
@@ -1000,6 +1000,89 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.IsTrue(failureRequestRetryCount > 0, "No retries were made for 429 error code.");
         }
 
+        [TestMethod]
+        public async Task AssertBarrierCallsWhenQuorumStateIsQuorumSelected()
+        {
+            int barrier429Count = 0;
+            string databaseName = "newdatabase";
+            bool isReadOperation = false;
+
+            CosmosClientOptions clientOptions = new CosmosClientOptions()
+            {
+                ConnectionMode = ConnectionMode.Direct,
+                ConnectionProtocol = Protocol.Tcp,
+                TransportClientHandlerFactory = (transport) => new TransportClientWrapper(transport,
+                    interceptorAfterResult: (request, storeResponse) =>
+                    {
+                        // Force a barrier request on read item in strong consistency.
+                        // There needs to be 2 regions and the GlobalCommittedLSN must be behind the LSN.
+                        long lsn = storeResponse.LSN - 2;
+                        if (request.OperationType == Documents.OperationType.Read)
+                        {
+                            // Simulate a barrier request by setting GLSN < LSN
+                            storeResponse.Headers.Set(Documents.WFConstants.BackendHeaders.GlobalCommittedLSN, lsn.ToString());
+                        }
+                        // only simulate 429 errors for read operations not write
+                        if (request.OperationType == Documents.OperationType.Head && isReadOperation)
+                        {
+                            
+                            request.UseStatusCodeFor429 = false;
+                            // Simulate a 429 for barrier requests
+                            storeResponse.Status = (int)HttpStatusCode.TooManyRequests; // Simulate 429 error
+                            storeResponse.Headers.Set(Documents.WFConstants.BackendHeaders.GlobalCommittedLSN, lsn.ToString());
+                            barrier429Count++;
+                        }
+
+                        return storeResponse;
+                    })
+            };
+
+            CosmosClient cosmosClient = new CosmosClientBuilder(
+                 connectionString: "points to test environment with one read and one write region")
+                .WithTransportClientHandlerFactory(clientOptions.TransportClientHandlerFactory)
+                .WithThrottlingRetryOptions(
+                                    maxRetryWaitTimeOnThrottledRequests: TimeSpan.FromSeconds(5), // Maximum wait time for retries
+                                    maxRetryAttemptsOnThrottledRequests: 2) // Maximum retry attempts
+                .WithConnectionModeDirect()
+                .WithConsistencyLevel(Cosmos.ConsistencyLevel.Strong)
+                .Build();
+
+            Container container = cosmosClient.GetDatabase(databaseName).GetContainer("test");
+
+            dynamic testObject = new
+            {
+                id = Guid.NewGuid().ToString(),
+                Company = "Microsoft",
+                State = "WA"
+            };
+            await container.CreateItemAsync<dynamic>(testObject);
+
+            try
+            {
+                isReadOperation = true;
+                // Perform a read operation to trigger barrier calls
+                ItemResponse<dynamic> response = await container.ReadItemAsync<dynamic>(
+                    testObject.id,
+                    new Cosmos.PartitionKey(testObject.id));
+
+                
+                Console.WriteLine("Diagnostics:");
+                Console.WriteLine(response.Diagnostics.ToString());
+            }
+            catch (CosmosException ex)
+            {
+                // Handle other Cosmos exceptions
+                Console.WriteLine($"CosmosException: {ex.StatusCode} - {ex.Message}");
+                Console.WriteLine("Diagnostics:");
+                Console.WriteLine(ex.Diagnostics.ToString());
+            }
+            
+            Console.WriteLine($"Total 429 responses on barrier calls: {barrier429Count}");
+            // Assert that retries occurred
+            Assert.IsTrue(barrier429Count > 0, "No retries were made for 429 error code.");
+
+        }
+
 
         [TestMethod]
         [DataRow(5 , 2, DisplayName = "Validate Read Item operation with simulated error count < 4 * (maxRetryAttempts + 1) means we will get eventually 200 status Code")]


### PR DESCRIPTION


When receiving 429s on a single region account with strong consistency, quorum reader code does not yield on QuorumRead and Barrier. 


[Single429Failure-BarrierCalls.json](https://github.com/user-attachments/files/20106664/Single429Failure-BarrierCalls.json)

[429WriteBarrierCallsWithoutFix.json](https://github.com/user-attachments/files/20093289/429WriteBarrierCallsWithoutFix.json)

[429WriteBarrierCallsWithFix.json](https://github.com/user-attachments/files/20093288/429WriteBarrierCallsWithFix.json)

// original issue diagnostics - QuorumRead
[429-OriginalIssueWithOutFix.json](https://github.com/user-attachments/files/19980803/429-OriginalIssueWithOutFix.json)

// verifying existing behavior by turning off exceptionless for 429
[429-OriginalIssueWithExceptionLessTurnedoOfFor429.json](https://github.com/user-attachments/files/19980788/429-OriginalIssueWithExceptionLessTurnedoOfFor429.json)

//fix Diagnostics with a large number of 429 failures- - QuorumRead
[429-WithFixAll429s.json](https://github.com/user-attachments/files/19980805/429-WithFixAll429s.json)

//fix Diagnostics with fewer 429 failures resulting in eventual success- - QuorumRead 
[429-Withfewer429sResultsInEventualSuccess.json](https://github.com/user-attachments/files/19980804/429-Withfewer429sResultsInEventualSuccess.json)

// original issue diagnostics - Barrier calls
[429 BarrierCallsOriginalIssueWithDiagnostics.json](https://github.com/user-attachments/files/20005545/429.BarrierCallsOriginalIssueWithDiagnostics.json)

//  Barrier calls fix with Diagnostics
[429-BarrierCallsFixWithDianogstics.json](https://github.com/user-attachments/files/20005546/429-BarrierCallsFixWithDianogstics.json)


Unit tests for QuorumReader is pending which I will submit along with the Direct code changes.
- [] Bug fix (non-breaking change which fixes an issue)


To automatically close an issue: closes #5035