### PR TITLE
Query: Fixes function signature for RRF, OrderByRank and FullTextScore LINQ extension methods

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Linq/BuiltinFunctions/OtherBuiltinSystemFunctions.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/BuiltinFunctions/OtherBuiltinSystemFunctions.cs
@@ -38,7 +38,12 @@ namespace Microsoft.Azure.Cosmos.Linq
                     {
                         if (!(argument is MethodCallExpression functionCallExpression))
                         {
-                            throw new DocumentQueryException(string.Format(CultureInfo.CurrentCulture, ClientResources.ExpressionTypeIsNotSupported, argument.Type));
+                            throw new ArgumentException(
+                                string.Format(
+                                    CultureInfo.CurrentCulture,
+                                    "Expressions of type {0} is not supported as an argument to CosmosLinqExtensions.RRF. Supported expressions are method calls to {1}.",
+                                    argument.Type,
+                                    nameof(CosmosLinqExtensions.FullTextScore)));
                         }
                         
                         if (functionCallExpression.Method.Name != nameof(CosmosLinqExtensions.FullTextScore))
@@ -46,7 +51,7 @@ namespace Microsoft.Azure.Cosmos.Linq
                             throw new ArgumentException(
                                 string.Format(
                                     CultureInfo.CurrentCulture,
-                                    ClientResources.BadQuery_InvalidMethodCall,
+                                    "Method {0} is not supported as an argument to CosmosLinqExtensions.RRF. Supported methods are {1}.",
                                     functionCallExpression.Method.Name,
                                     nameof(CosmosLinqExtensions.FullTextScore)));
                         }

--- a/Microsoft.Azure.Cosmos/src/Linq/CosmosLinqExtensions.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/CosmosLinqExtensions.cs
@@ -318,7 +318,7 @@ namespace Microsoft.Azure.Cosmos.Linq
         /// ]]>
         /// </code>
         /// </example>
-        public static Func<TSource, object> FullTextScore<TSource>(this TSource obj, params string[] terms)
+        public static double FullTextScore<TSource>(this TSource obj, params string[] terms)
         {
             throw new NotImplementedException(ClientResources.ExtensionMethodNotImplemented); 
         }
@@ -339,7 +339,7 @@ namespace Microsoft.Azure.Cosmos.Linq
         /// ]]>
         /// </code>
         /// </example>
-        public static IOrderedQueryable<TSource> OrderByRank<TSource>(this IQueryable<TSource> source, Expression<Func<TSource, object>> scoreFunction)
+        public static IOrderedQueryable<TSource> OrderByRank<TSource, TKey>(this IQueryable<TSource> source, Expression<Func<TSource, TKey>> scoreFunction)
         {
             if (!(source is CosmosLinqQuery<TSource>))
             {
@@ -349,7 +349,7 @@ namespace Microsoft.Azure.Cosmos.Linq
             return (IOrderedQueryable<TSource>)source.Provider.CreateQuery<TSource>(
                Expression.Call(
                 null,
-                typeof(CosmosLinqExtensions).GetMethod("OrderByRank").MakeGenericMethod(typeof(TSource)),
+                typeof(CosmosLinqExtensions).GetMethod("OrderByRank").MakeGenericMethod(typeof(TSource), typeof(TKey)),
                 source.Expression,
                 Expression.Quote(scoreFunction)));
         }
@@ -360,7 +360,7 @@ namespace Microsoft.Azure.Cosmos.Linq
         /// This method is to be used in LINQ expressions only and will be evaluated on server.
         /// There's no implementation provided in the client library.
         /// </summary>
-        /// <param name="scoringFunctions">the scoring functions to combine.</param>
+        /// <param name="scoringFunctions">the scoring functions to combine. Valid functions are FullTextScore and VectorDistance</param>
         /// <returns>Returns the the combined scores of the scoring functions.</returns>
         /// <example>
         /// <code>
@@ -369,7 +369,7 @@ namespace Microsoft.Azure.Cosmos.Linq
         /// ]]>
         /// </code>
         /// </example>
-        public static Func<TSource, object> RRF<TSource>(params Func<TSource, object>[] scoringFunctions)
+        public static double RRF(params double[] scoringFunctions)
         {
             // The reason for not defining "this" keyword is because this causes undesirable serialization when call Expression.ToString() on this method
             throw new NotImplementedException(ClientResources.ExtensionMethodNotImplemented); 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqTranslationBaselineTests.TestFullTextScoreOrderByRankFunction.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqTranslationBaselineTests.TestFullTextScoreOrderByRankFunction.xml
@@ -66,52 +66,52 @@ ORDER BY RANK FullTextScore(root["StringField"], "test1", "test2", "test3")]]></
   <Result>
     <Input>
       <Description><![CDATA[FullTextScore in WHERE clause]]></Description>
-      <Expression><![CDATA[query.Where(doc => (doc.StringField.FullTextScore(new [] {"test1"}) != null))]]></Expression>
+      <Expression><![CDATA[query.Where(doc => (doc.StringField.FullTextScore(new [] {"test1"}) != 123))]]></Expression>
     </Input>
     <Output>
       <SqlQuery><![CDATA[
 SELECT VALUE root 
 FROM root 
-WHERE (FullTextScore(root["StringField"], "test1") != null)]]></SqlQuery>
+WHERE (FullTextScore(root["StringField"], "test1") != 123)]]></SqlQuery>
       <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":35,"end":78},"code":"SC2240","message":"The FullTextScore function is only allowed in the ORDER BY RANK clause."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
     <Input>
       <Description><![CDATA[FullTextScore in WHERE clause 2]]></Description>
-      <Expression><![CDATA[query.Where(doc => (doc.StringField.FullTextScore(new [] {"test1", "test2", "test3"}) != null))]]></Expression>
+      <Expression><![CDATA[query.Where(doc => (doc.StringField.FullTextScore(new [] {"test1", "test2", "test3"}) != 123))]]></Expression>
     </Input>
     <Output>
       <SqlQuery><![CDATA[
 SELECT VALUE root 
 FROM root 
-WHERE (FullTextScore(root["StringField"], "test1", "test2", "test3") != null)]]></SqlQuery>
+WHERE (FullTextScore(root["StringField"], "test1", "test2", "test3") != 123)]]></SqlQuery>
       <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":35,"end":96},"code":"SC2240","message":"The FullTextScore function is only allowed in the ORDER BY RANK clause."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
     <Input>
       <Description><![CDATA[FullTextScore in WHERE clause]]></Description>
-      <Expression><![CDATA[query.Where(doc => (doc.StringField.FullTextScore(new [] {"test1"}) != null))]]></Expression>
+      <Expression><![CDATA[query.Where(doc => (doc.StringField.FullTextScore(new [] {"test1"}) != 123))]]></Expression>
     </Input>
     <Output>
       <SqlQuery><![CDATA[
 SELECT VALUE root 
 FROM root 
-WHERE (FullTextScore(root["StringField"], "test1") != null)]]></SqlQuery>
+WHERE (FullTextScore(root["StringField"], "test1") != 123)]]></SqlQuery>
       <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":35,"end":78},"code":"SC2240","message":"The FullTextScore function is only allowed in the ORDER BY RANK clause."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
     <Input>
       <Description><![CDATA[FullTextScore in WHERE clause 2]]></Description>
-      <Expression><![CDATA[query.Where(doc => (doc.StringField.FullTextScore(new [] {"test1", "test2", "test3"}) != null))]]></Expression>
+      <Expression><![CDATA[query.Where(doc => (doc.StringField.FullTextScore(new [] {"test1", "test2", "test3"}) != 123))]]></Expression>
     </Input>
     <Output>
       <SqlQuery><![CDATA[
 SELECT VALUE root 
 FROM root 
-WHERE (FullTextScore(root["StringField"], "test1", "test2", "test3") != null)]]></SqlQuery>
+WHERE (FullTextScore(root["StringField"], "test1", "test2", "test3") != 123)]]></SqlQuery>
       <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":35,"end":96},"code":"SC2240","message":"The FullTextScore function is only allowed in the ORDER BY RANK clause."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqTranslationBaselineTests.TestRRFOrderByRankFunction.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqTranslationBaselineTests.TestRRFOrderByRankFunction.xml
@@ -77,7 +77,7 @@ WHERE (RRF(FullTextScore(root["StringField"], "test1"), FullTextScore(root["Stri
     </Input>
     <Output>
       <SqlQuery><![CDATA[]]></SqlQuery>
-      <ErrorMessage><![CDATA[Expression with NodeType 'System.Double' is not supported.]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Expressions of type System.Double is not supported as an argument to CosmosLinqExtensions.RRF. Supported expressions are method calls to FullTextScore.]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -87,7 +87,7 @@ WHERE (RRF(FullTextScore(root["StringField"], "test1"), FullTextScore(root["Stri
     </Input>
     <Output>
       <SqlQuery><![CDATA[]]></SqlQuery>
-      <ErrorMessage><![CDATA[Expression with NodeType 'System.Double' is not supported.]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Expressions of type System.Double is not supported as an argument to CosmosLinqExtensions.RRF. Supported expressions are method calls to FullTextScore.]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -97,7 +97,7 @@ WHERE (RRF(FullTextScore(root["StringField"], "test1"), FullTextScore(root["Stri
     </Input>
     <Output>
       <SqlQuery><![CDATA[]]></SqlQuery>
-      <ErrorMessage><![CDATA[Expression with NodeType 'System.Double' is not supported.]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Expressions of type System.Double is not supported as an argument to CosmosLinqExtensions.RRF. Supported expressions are method calls to FullTextScore.]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -107,7 +107,7 @@ WHERE (RRF(FullTextScore(root["StringField"], "test1"), FullTextScore(root["Stri
     </Input>
     <Output>
       <SqlQuery><![CDATA[]]></SqlQuery>
-      <ErrorMessage><![CDATA[Expression with NodeType 'System.Double' is not supported.]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Expressions of type System.Double is not supported as an argument to CosmosLinqExtensions.RRF. Supported expressions are method calls to FullTextScore.]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
@@ -117,7 +117,7 @@ WHERE (RRF(FullTextScore(root["StringField"], "test1"), FullTextScore(root["Stri
     </Input>
     <Output>
       <SqlQuery><![CDATA[]]></SqlQuery>
-      <ErrorMessage><![CDATA[Query expression is invalid, method call RRF is not allowed at this context. Allowed methods are FullTextScore.]]></ErrorMessage>
+      <ErrorMessage><![CDATA[Method RRF is not supported as an argument to CosmosLinqExtensions.RRF. Supported methods are FullTextScore.]]></ErrorMessage>
     </Output>
   </Result>
 </Results>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqTranslationBaselineTests.TestRRFOrderByRankFunction.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqTranslationBaselineTests.TestRRFOrderByRankFunction.xml
@@ -47,27 +47,77 @@ ORDER BY RANK RRF(FullTextScore(root["StringField"], "test1"))]]></SqlQuery>
   <Result>
     <Input>
       <Description><![CDATA[RRF in WHERE clause]]></Description>
-      <Expression><![CDATA[query.Where(doc => (RRF(new [] {doc.StringField.FullTextScore(new [] {"test1"})}) != null))]]></Expression>
+      <Expression><![CDATA[query.Where(doc => (RRF(new [] {doc.StringField.FullTextScore(new [] {"test1"})}) != 123))]]></Expression>
     </Input>
     <Output>
       <SqlQuery><![CDATA[
 SELECT VALUE root 
 FROM root 
-WHERE (RRF(FullTextScore(root["StringField"], "test1")) != null)]]></SqlQuery>
+WHERE (RRF(FullTextScore(root["StringField"], "test1")) != 123)]]></SqlQuery>
       <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":39,"end":82},"code":"SC2240","message":"The FullTextScore function is only allowed in the ORDER BY RANK clause."},{"severity":"Error","location":{"start":35,"end":38},"code":"SC2005","message":"'RRF' is not a recognized built-in function name."}]},0x800A0B00]]></ErrorMessage>
     </Output>
   </Result>
   <Result>
     <Input>
       <Description><![CDATA[RRF in WHERE clause 2]]></Description>
-      <Expression><![CDATA[query.Where(doc => (RRF(new [] {doc.StringField.FullTextScore(new [] {"test1"}), doc.StringField2.FullTextScore(new [] {"test1", "test2", "test3"})}) != null))]]></Expression>
+      <Expression><![CDATA[query.Where(doc => (RRF(new [] {doc.StringField.FullTextScore(new [] {"test1"}), doc.StringField2.FullTextScore(new [] {"test1", "test2", "test3"})}) != 123))]]></Expression>
     </Input>
     <Output>
       <SqlQuery><![CDATA[
 SELECT VALUE root 
 FROM root 
-WHERE (RRF(FullTextScore(root["StringField"], "test1"), FullTextScore(root["StringField2"], "test1", "test2", "test3")) != null)]]></SqlQuery>
+WHERE (RRF(FullTextScore(root["StringField"], "test1"), FullTextScore(root["StringField2"], "test1", "test2", "test3")) != 123)]]></SqlQuery>
       <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":39,"end":82},"code":"SC2240","message":"The FullTextScore function is only allowed in the ORDER BY RANK clause."},{"severity":"Error","location":{"start":84,"end":146},"code":"SC2240","message":"The FullTextScore function is only allowed in the ORDER BY RANK clause."},{"severity":"Error","location":{"start":35,"end":38},"code":"SC2005","message":"'RRF' is not a recognized built-in function name."}]},0x800A0B00]]></ErrorMessage>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[RRF with non scoring function]]></Description>
+      <Expression><![CDATA[query.OrderByRank(doc => RRF(new [] {doc.StringField.FullTextScore(new [] {"test1"}), 123}))]]></Expression>
+    </Input>
+    <Output>
+      <SqlQuery><![CDATA[]]></SqlQuery>
+      <ErrorMessage><![CDATA[Expression with NodeType 'System.Double' is not supported.]]></ErrorMessage>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[RRF with non scoring function 2]]></Description>
+      <Expression><![CDATA[query.OrderByRank(doc => RRF(new [] {doc.StringField.FullTextScore(new [] {"test1"}), (doc.IntField * 1)}))]]></Expression>
+    </Input>
+    <Output>
+      <SqlQuery><![CDATA[]]></SqlQuery>
+      <ErrorMessage><![CDATA[Expression with NodeType 'System.Double' is not supported.]]></ErrorMessage>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[RRF with non scoring function 3]]></Description>
+      <Expression><![CDATA[query.OrderByRank(doc => RRF(new [] {doc.StringField.FullTextScore(new [] {"test1"}), Convert(doc.StringField2.Length, Double)}))]]></Expression>
+    </Input>
+    <Output>
+      <SqlQuery><![CDATA[]]></SqlQuery>
+      <ErrorMessage><![CDATA[Expression with NodeType 'System.Double' is not supported.]]></ErrorMessage>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[RRF with non scoring function 4]]></Description>
+      <Expression><![CDATA[query.OrderByRank(doc => RRF(new [] {doc.StringField.FullTextScore(new [] {"test1"}), Convert(doc.ArrayField.Count(), Double)}))]]></Expression>
+    </Input>
+    <Output>
+      <SqlQuery><![CDATA[]]></SqlQuery>
+      <ErrorMessage><![CDATA[Expression with NodeType 'System.Double' is not supported.]]></ErrorMessage>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[RRF with RRF]]></Description>
+      <Expression><![CDATA[query.OrderByRank(doc => RRF(new [] {doc.StringField.FullTextScore(new [] {"test1"}), RRF(new [] {doc.StringField2.FullTextScore(new [] {"test1", "test2", "test3"}), doc.StringField.FullTextScore(new [] {"test1", "test2"})})}))]]></Expression>
+    </Input>
+    <Output>
+      <SqlQuery><![CDATA[]]></SqlQuery>
+      <ErrorMessage><![CDATA[Query expression is invalid, method call RRF is not allowed at this context. Allowed methods are FullTextScore.]]></ErrorMessage>
     </Output>
   </Result>
 </Results>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Linq/LinqTranslationBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Linq/LinqTranslationBaselineTests.cs
@@ -425,14 +425,14 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests.LinqProviderTests
 
                 // Negative case: FullTextScore in non order by clause
                 new LinqTestInput("FullTextScore in WHERE clause", b => getQuery(b)
-                    .Where(doc => doc.StringField.FullTextScore(new string[] { "test1" }) != null)),
+                    .Where(doc => doc.StringField.FullTextScore(new string[] { "test1" }) != 123)),
                 new LinqTestInput("FullTextScore in WHERE clause 2", b => getQuery(b)
-                    .Where(doc => doc.StringField.FullTextScore(new string[] { "test1", "test2", "test3" }) != null)),
+                    .Where(doc => doc.StringField.FullTextScore(new string[] { "test1", "test2", "test3" }) != 123)),
 
                 new LinqTestInput("FullTextScore in WHERE clause", b => getQuery(b)
-                    .Where(doc => doc.StringField.FullTextScore("test1") != null)),
+                    .Where(doc => doc.StringField.FullTextScore("test1") != 123)),
                 new LinqTestInput("FullTextScore in WHERE clause 2", b => getQuery(b)
-                    .Where(doc => doc.StringField.FullTextScore("test1", "test2", "test3") != null)),
+                    .Where(doc => doc.StringField.FullTextScore("test1", "test2", "test3") != 123)),
             };
 
             foreach (LinqTestInput input in inputs)
@@ -456,6 +456,7 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests.LinqProviderTests
                 DataObject obj = new DataObject
                 {
                     StringField = LinqTestsCommon.RandomString(random, random.Next(MaxStringLength)),
+                    IntField = 1,
                     Id = Guid.NewGuid().ToString(),
                     Pk = "Test"
                 };
@@ -466,25 +467,39 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests.LinqProviderTests
             List<LinqTestInput> inputs = new List<LinqTestInput>
             {
                 new LinqTestInput("RRF with 2 functions", b => getQuery(b)
-                    .OrderByRank(doc => RRF(doc.StringField.FullTextScore(new string[] { "test1" }), doc.StringField2.FullTextScore(new string[] { "test1", "test2", "test3" })))
+                    .OrderByRank(doc => RRF(doc.StringField.FullTextScore(new string[] { "test1" }), 
+                                                doc.StringField2.FullTextScore(new string[] { "test1", "test2", "test3" })))
                     .Select(doc => doc.Pk)),
 
                 new LinqTestInput("RRF with 3 functions", b => getQuery(b)
                     .OrderByRank(doc => RRF(doc.StringField.FullTextScore(new string[] { "test1" }),
-                                            doc.StringField.FullTextScore(new string[] { "test1", "text2" }), 
+                                            doc.StringField.FullTextScore(new string[] { "test1", "text2" }),
                                             doc.StringField2.FullTextScore(new string[] { "test1", "test2", "test3" })))
                     .Select(doc => doc.Pk)),
 
                 // Negative case: FullTextScore in non order by clause
                 new LinqTestInput("RRF with 1 function", b => getQuery(b)
-                    .OrderByRank(doc => CosmosLinqExtensions.RRF(doc.StringField.FullTextScore(new string[] { "test1" })))
+                    .OrderByRank(doc => RRF(doc.StringField.FullTextScore(new string[] { "test1" })))
                     .Select(doc => doc.Pk)),
 
                 new LinqTestInput("RRF in WHERE clause", b => getQuery(b)
-                    .Where(doc => RRF(doc.StringField.FullTextScore(new string[] { "test1" })) != null)),
+                    .Where(doc => RRF(doc.StringField.FullTextScore(new string[] { "test1" })) != 123)),
                 new LinqTestInput("RRF in WHERE clause 2", b => getQuery(b)
                     .Where(doc => RRF(doc.StringField.FullTextScore(new string[] { "test1" }),
-                                  doc.StringField2.FullTextScore(new string[] { "test1", "test2", "test3" })) != null)),
+                                  doc.StringField2.FullTextScore(new string[] { "test1", "test2", "test3" })) != 123)),
+
+                new LinqTestInput("RRF with non scoring function", b => getQuery(b)
+                    .OrderByRank(doc => RRF(doc.StringField.FullTextScore(new string[] { "test1" }), 123))),
+                new LinqTestInput("RRF with non scoring function 2", b => getQuery(b)
+                    .OrderByRank(doc => RRF(doc.StringField.FullTextScore(new string[] { "test1" }), doc.IntField * 1.0))),
+                new LinqTestInput("RRF with non scoring function 3", b => getQuery(b)
+                    .OrderByRank(doc => RRF(doc.StringField.FullTextScore(new string[] { "test1" }), doc.StringField2.Length))),
+                new LinqTestInput("RRF with non scoring function 4", b => getQuery(b)
+                    .OrderByRank(doc => RRF(doc.StringField.FullTextScore(new string[] { "test1" }), doc.ArrayField.Count()))),
+                new LinqTestInput("RRF with RRF", b => getQuery(b)
+                    .OrderByRank(doc => RRF(doc.StringField.FullTextScore(new string[] { "test1" }),
+                                            RRF(doc.StringField2.FullTextScore(new string[] { "test1", "test2", "test3" }),
+                                                doc.StringField.FullTextScore(new string[] { "test1", "test2"})))))
             };
 
             foreach (LinqTestInput input in inputs)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetSDKAPI.json
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetSDKAPI.json
@@ -6344,6 +6344,18 @@
           ],
           "MethodInfo": "Boolean RegexMatch(System.Object, System.String);IsAbstract:False;IsStatic:True;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
         },
+        "Double FullTextScore[TSource](TSource, System.String[])[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "ExtensionAttribute"
+          ],
+          "MethodInfo": "Double FullTextScore[TSource](TSource, System.String[]);IsAbstract:False;IsStatic:True;IsVirtual:False;IsGenericMethod:True;IsConstructor:False;IsFinal:False;"
+        },
+        "Double RRF(Double[])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Double RRF(Double[]);IsAbstract:False;IsStatic:True;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
         "Int32 DocumentId(System.Object)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
           "Type": "Method",
           "Attributes": [
@@ -6372,24 +6384,12 @@
           ],
           "MethodInfo": "Microsoft.Azure.Cosmos.QueryDefinition ToQueryDefinition[T](System.Linq.IQueryable`1[T]);IsAbstract:False;IsStatic:True;IsVirtual:False;IsGenericMethod:True;IsConstructor:False;IsFinal:False;"
         },
-        "System.Func`2[TSource,System.Object] FullTextScore[TSource](TSource, System.String[])[System.Runtime.CompilerServices.ExtensionAttribute()]": {
+        "System.Linq.IOrderedQueryable`1[TSource] OrderByRank[TSource,TKey](System.Linq.IQueryable`1[TSource], System.Linq.Expressions.Expression`1[System.Func`2[TSource,TKey]])[System.Runtime.CompilerServices.ExtensionAttribute()]": {
           "Type": "Method",
           "Attributes": [
             "ExtensionAttribute"
           ],
-          "MethodInfo": "System.Func`2[TSource,System.Object] FullTextScore[TSource](TSource, System.String[]);IsAbstract:False;IsStatic:True;IsVirtual:False;IsGenericMethod:True;IsConstructor:False;IsFinal:False;"
-        },
-        "System.Func`2[TSource,System.Object] RRF[TSource](System.Func`2[TSource,System.Object][])": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "System.Func`2[TSource,System.Object] RRF[TSource](System.Func`2[TSource,System.Object][]);IsAbstract:False;IsStatic:True;IsVirtual:False;IsGenericMethod:True;IsConstructor:False;IsFinal:False;"
-        },
-        "System.Linq.IOrderedQueryable`1[TSource] OrderByRank[TSource](System.Linq.IQueryable`1[TSource], System.Linq.Expressions.Expression`1[System.Func`2[TSource,System.Object]])[System.Runtime.CompilerServices.ExtensionAttribute()]": {
-          "Type": "Method",
-          "Attributes": [
-            "ExtensionAttribute"
-          ],
-          "MethodInfo": "System.Linq.IOrderedQueryable`1[TSource] OrderByRank[TSource](System.Linq.IQueryable`1[TSource], System.Linq.Expressions.Expression`1[System.Func`2[TSource,System.Object]]);IsAbstract:False;IsStatic:True;IsVirtual:False;IsGenericMethod:True;IsConstructor:False;IsFinal:False;"
+          "MethodInfo": "System.Linq.IOrderedQueryable`1[TSource] OrderByRank[TSource,TKey](System.Linq.IQueryable`1[TSource], System.Linq.Expressions.Expression`1[System.Func`2[TSource,TKey]]);IsAbstract:False;IsStatic:True;IsVirtual:False;IsGenericMethod:True;IsConstructor:False;IsFinal:False;"
         },
         "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.Response`1[System.Decimal]] AverageAsync(System.Linq.IQueryable`1[System.Decimal], System.Threading.CancellationToken)[System.Runtime.CompilerServices.ExtensionAttribute()]": {
           "Type": "Method",


### PR DESCRIPTION
# Pull Request Template

## Description

This PR changes the function signature for RRF, OrderByRank and FullTextScore for LINQ extension methods to more closely align with vector distance

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber