### PR TITLE
[Internal] PPAF: Adds Code to Enable Read Hedging By Default

### DIFF
--- a/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
@@ -57,6 +57,12 @@ namespace Microsoft.Azure.Cosmos
         private const ApiType DefaultApiType = ApiType.None;
 
         /// <summary>
+        /// Default thresholds for PPAF request hedging.
+        /// </summary>
+        private const int DefaultHedgingThresholdInMilliseconds = 1000;
+        private const int DefaultHedgingThresholdStepInMilliseconds = 500;
+
+        /// <summary>
         /// Default request timeout
         /// </summary>
         private int gatewayModeMaxConnectionLimit;
@@ -1263,11 +1269,11 @@ namespace Microsoft.Azure.Cosmos
             {
                 // The default threshold is the minimum value of 1 second and a fraction (currently it's half) of
                 // the request timeout value provided by the end customer.
-                double defaultThresholdInMillis = Math.Min(1000, this.RequestTimeout.TotalMilliseconds / 2);
+                double defaultThresholdInMillis = Math.Min(CosmosClientOptions.DefaultHedgingThresholdInMilliseconds, this.RequestTimeout.TotalMilliseconds / 2);
 
                 this.AvailabilityStrategy = AvailabilityStrategy.CrossRegionHedgingStrategy(
                     threshold: TimeSpan.FromMilliseconds(defaultThresholdInMillis),
-                    thresholdStep: TimeSpan.FromMilliseconds(10));
+                    thresholdStep: TimeSpan.FromMilliseconds(CosmosClientOptions.DefaultHedgingThresholdStepInMilliseconds));
             }
         }
 

--- a/Microsoft.Azure.Cosmos/src/Routing/GlobalPartitionEndpointManagerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GlobalPartitionEndpointManagerCore.cs
@@ -608,7 +608,7 @@ namespace Microsoft.Azure.Cosmos.Routing
                 this.ConsecutiveWriteRequestFailureCount = 0;
                 this.ReadRequestFailureCounterThreshold = ConfigurationManager.GetCircuitBreakerConsecutiveFailureCountForReads(10);
                 this.WriteRequestFailureCounterThreshold = ConfigurationManager.GetCircuitBreakerConsecutiveFailureCountForWrites(5);
-                this.TimeoutCounterResetWindowInMinutes = TimeSpan.FromMinutes(2);
+                this.TimeoutCounterResetWindowInMinutes = TimeSpan.FromMinutes(1);
                 this.FirstRequestFailureTime = DateTime.UtcNow;
                 this.LastRequestFailureTime = DateTime.UtcNow;
             }

--- a/Microsoft.Azure.Cosmos/src/Routing/GlobalPartitionEndpointManagerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GlobalPartitionEndpointManagerCore.cs
@@ -44,9 +44,9 @@ namespace Microsoft.Azure.Cosmos.Routing
         private readonly int partitionUnavailabilityDurationInSeconds = ConfigurationManager.GetAllowedPartitionUnavailabilityDurationInSeconds(5);
 
         /// <summary>
-        /// A readonly integer containing the partition failback refresh interval in seconds. The default value is 60 seconds.
+        /// A readonly integer containing the partition failback refresh interval in seconds. The default value is 5 minutes.
         /// </summary>
-        private readonly int backgroundConnectionInitTimeIntervalInSeconds = ConfigurationManager.GetStalePartitionUnavailabilityRefreshIntervalInSeconds(60);
+        private readonly int backgroundConnectionInitTimeIntervalInSeconds = ConfigurationManager.GetStalePartitionUnavailabilityRefreshIntervalInSeconds(300);
 
         /// <summary>
         /// A readonly boolean flag used to determine if partition level failover is enabled.
@@ -608,7 +608,7 @@ namespace Microsoft.Azure.Cosmos.Routing
                 this.ConsecutiveWriteRequestFailureCount = 0;
                 this.ReadRequestFailureCounterThreshold = ConfigurationManager.GetCircuitBreakerConsecutiveFailureCountForReads(10);
                 this.WriteRequestFailureCounterThreshold = ConfigurationManager.GetCircuitBreakerConsecutiveFailureCountForWrites(5);
-                this.TimeoutCounterResetWindowInMinutes = TimeSpan.FromMinutes(1);
+                this.TimeoutCounterResetWindowInMinutes = TimeSpan.FromMinutes(2);
                 this.FirstRequestFailureTime = DateTime.UtcNow;
                 this.LastRequestFailureTime = DateTime.UtcNow;
             }

--- a/Microsoft.Azure.Cosmos/src/Util/ConfigurationManager.cs
+++ b/Microsoft.Azure.Cosmos/src/Util/ConfigurationManager.cs
@@ -100,12 +100,6 @@ namespace Microsoft.Azure.Cosmos
         /// </summary>
         internal static readonly string TcpChannelMultiplexingEnabled = "AZURE_COSMOS_TCP_CHANNEL_MULTIPLEX_ENABLED";
 
-        /// <summary>
-        /// A read-only string containing the environment variable name for disabling/ opting out the cross regional hedging
-        /// in conjunction with partition level failover.
-        /// </summary>
-        internal static readonly string SkipDefaultHedgingWithPartitionLevelFailover = "AZURE_COSMOS_SKIP_PPAF_DEFAULT_HEDGING";
-
         public static T GetEnvironmentVariable<T>(string variable, T defaultValue)
         {
             string value = Environment.GetEnvironmentVariable(variable);
@@ -337,22 +331,6 @@ namespace Microsoft.Azure.Cosmos
             return ConfigurationManager
                     .GetEnvironmentVariable(
                         variable: ConfigurationManager.TcpChannelMultiplexingEnabled,
-                        defaultValue: false);
-        }
-
-        /// <summary>
-        /// Determines whether the default hedging is disabled/ opted-out in conjunction with partition-level failover.
-        /// This method checks the environment configuration to retrieve the value of the 
-        /// AZURE_COSMOS_SKIP_PPAF_DEFAULT_HEDGING environment variable, defaulting to false if not explicitly set.
-        /// </summary>
-        /// <returns>
-        /// A boolean value indicating whether cross region hedging is disabled with partition-level failover.
-        /// </returns>
-        public static bool IsDefaultHedgingDisabledWithPartitionLevelFailover()
-        {
-            return ConfigurationManager
-                    .GetEnvironmentVariable(
-                        variable: ConfigurationManager.SkipDefaultHedgingWithPartitionLevelFailover,
                         defaultValue: false);
         }
     }

--- a/Microsoft.Azure.Cosmos/src/Util/ConfigurationManager.cs
+++ b/Microsoft.Azure.Cosmos/src/Util/ConfigurationManager.cs
@@ -100,6 +100,12 @@ namespace Microsoft.Azure.Cosmos
         /// </summary>
         internal static readonly string TcpChannelMultiplexingEnabled = "AZURE_COSMOS_TCP_CHANNEL_MULTIPLEX_ENABLED";
 
+        /// <summary>
+        /// A read-only string containing the environment variable name for disabling/ opting out the cross regional hedging
+        /// in conjunction with partition level failover.
+        /// </summary>
+        internal static readonly string SkipDefaultHedgingWithPartitionLevelFailover = "AZURE_COSMOS_SKIP_PPAF_DEFAULT_HEDGING";
+
         public static T GetEnvironmentVariable<T>(string variable, T defaultValue)
         {
             string value = Environment.GetEnvironmentVariable(variable);
@@ -331,6 +337,22 @@ namespace Microsoft.Azure.Cosmos
             return ConfigurationManager
                     .GetEnvironmentVariable(
                         variable: ConfigurationManager.TcpChannelMultiplexingEnabled,
+                        defaultValue: false);
+        }
+
+        /// <summary>
+        /// Determines whether the default hedging is disabled/ opted-out in conjunction with partition-level failover.
+        /// This method checks the environment configuration to retrieve the value of the 
+        /// AZURE_COSMOS_SKIP_PPAF_DEFAULT_HEDGING environment variable, defaulting to false if not explicitly set.
+        /// </summary>
+        /// <returns>
+        /// A boolean value indicating whether cross region hedging is disabled with partition-level failover.
+        /// </returns>
+        public static bool IsDefaultHedgingDisabledWithPartitionLevelFailover()
+        {
+            return ConfigurationManager
+                    .GetEnvironmentVariable(
+                        variable: ConfigurationManager.SkipDefaultHedgingWithPartitionLevelFailover,
                         defaultValue: false);
         }
     }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemIntegrationTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemIntegrationTests.cs
@@ -1315,7 +1315,7 @@
                 if (cosmosClientOptions.EnablePartitionLevelFailover)
                 {
                     Assert.IsNotNull(hedgeContext);
-                    IReadOnlyList<string> hedgedRegions = (IReadOnlyList<string>)hedgeContext;
+                    ICollection<string> hedgedRegions = (ICollection<string>)hedgeContext;
 
                     Assert.AreEqual(3, hedgedRegions.Count);
                     Assert.IsTrue(hedgedRegions.Contains(region1) && hedgedRegions.Contains(region2) && hedgedRegions.Contains(region3));

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemIntegrationTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemIntegrationTests.cs
@@ -675,6 +675,123 @@
         }
 
         [TestMethod]
+        [TestCategory("MultiRegion")]
+        [Owner("dkunda")]
+        [Timeout(70000)]
+        public async Task ReadItemAsync_WithNoPreferredRegionsAndCircuitBreakerEnabledAndSingleMasterAccountAndServiceUnavailableReceived_ShouldApplyPartitionLevelOverride()
+        {
+            // Arrange.
+            Environment.SetEnvironmentVariable(ConfigurationManager.PartitionLevelCircuitBreakerEnabled, "True");
+            Environment.SetEnvironmentVariable(ConfigurationManager.CircuitBreakerConsecutiveFailureCountForReads, "10");
+
+            // Enabling fault injection rule to simulate a 503 service unavailable scenario.
+            string serviceUnavailableRuleId = "503-rule-" + Guid.NewGuid().ToString();
+            FaultInjectionRule serviceUnavailableRule = new FaultInjectionRuleBuilder(
+                id: serviceUnavailableRuleId,
+                condition:
+                    new FaultInjectionConditionBuilder()
+                        .WithOperationType(FaultInjectionOperationType.ReadItem)
+                        .WithRegion(region1)
+                        .Build(),
+                result:
+                    FaultInjectionResultBuilder.GetResultBuilder(FaultInjectionServerErrorType.ServiceUnavailable)
+                        .WithDelay(TimeSpan.FromMilliseconds(10))
+                        .Build())
+                .Build();
+
+            List<FaultInjectionRule> rules = new List<FaultInjectionRule> { serviceUnavailableRule };
+            FaultInjector faultInjector = new FaultInjector(rules);
+
+            CosmosClientOptions cosmosClientOptions = new CosmosClientOptions()
+            {
+                ConnectionMode = ConnectionMode.Direct,
+                ConsistencyLevel = ConsistencyLevel.Session,
+                FaultInjector = faultInjector,
+                RequestTimeout = TimeSpan.FromSeconds(5),
+            };
+
+            List<CosmosIntegrationTestObject> itemsList = new()
+            {
+                new() { Id = "smTestId1", Pk = "smpk1" },
+            };
+
+            try
+            {
+                using CosmosClient cosmosClient = new(connectionString: this.connectionString, clientOptions: cosmosClientOptions);
+                Database database = cosmosClient.GetDatabase(MultiRegionSetupHelpers.dbName);
+                Container container = database.GetContainer(MultiRegionSetupHelpers.containerName);
+
+                // Act and Assert.
+                await this.TryCreateItems(itemsList);
+
+                //Must Ensure the data is replicated to all regions
+                await Task.Delay(3000);
+
+                int consecutiveFailureCount = 10;
+                int totalIterations = 15;
+
+                for (int attemptCount = 1; attemptCount <= totalIterations; attemptCount++)
+                {
+                    try
+                    {
+                        ItemResponse<CosmosIntegrationTestObject> readResponse = await container.ReadItemAsync<CosmosIntegrationTestObject>(
+                            id: itemsList[0].Id,
+                            partitionKey: new PartitionKey(itemsList[0].Pk));
+
+                        IReadOnlyList<(string regionName, Uri uri)> contactedRegionMapping = readResponse.Diagnostics.GetContactedRegions();
+                        HashSet<string> contactedRegions = new(contactedRegionMapping.Select(r => r.regionName));
+
+                        Assert.AreEqual(
+                            expected: HttpStatusCode.OK,
+                            actual: readResponse.StatusCode);
+
+                        Assert.IsNotNull(contactedRegions);
+
+                        PartitionKeyRangeFailoverInfo failoverInfo = TestCommon.GetFailoverInfoForFirstPartitionUsingReflection(
+                            globalPartitionEndpointManager: cosmosClient.ClientContext.DocumentClient.PartitionKeyRangeLocation,
+                            isReadOnlyOrMultiMaster: true);
+
+                        if (attemptCount > consecutiveFailureCount + 1)
+                        {
+                            Assert.IsTrue(contactedRegions.Count == 1, "Asserting that when the consecutive failure count reaches the threshold, the partition was failed over to the next region, and the subsequent read request/s were successful on the next region.");
+                            Assert.IsTrue(contactedRegions.Contains(region2));
+                            Assert.AreEqual(this.readRegionsMapping[region2], failoverInfo.Current);
+                        }
+                        else
+                        {
+                            Assert.IsTrue(contactedRegions.Count == 2, "Asserting that when the read request succeeds before the consecutive failure count reaches the threshold, the partition didn't over to the next region, and the request was retried on the next region.");
+                            Assert.IsTrue(contactedRegions.Contains(region1) && contactedRegions.Contains(region2));
+
+                            if (attemptCount > consecutiveFailureCount)
+                            {
+                                Assert.AreEqual(this.readRegionsMapping[region2], failoverInfo.Current);
+                            }
+                            else
+                            {
+                                Assert.AreEqual(this.readRegionsMapping[region1], failoverInfo.Current);
+                            }
+                        }
+                    }
+                    catch (CosmosException)
+                    {
+                        Assert.Fail("Read Item operation should succeed.");
+                    }
+                    catch (Exception ex)
+                    {
+                        Assert.Fail($"Unhandled Exception was thrown during ReadItemAsync call. Message: {ex.Message}");
+                    }
+                }
+            }
+            finally
+            {
+                Environment.SetEnvironmentVariable(ConfigurationManager.PartitionLevelCircuitBreakerEnabled, null);
+                Environment.SetEnvironmentVariable(ConfigurationManager.CircuitBreakerConsecutiveFailureCountForReads, null);
+
+                await this.TryDeleteItems(itemsList);
+            }
+        }
+
+        [TestMethod]
         [Owner("dkunda")]
         [TestCategory("MultiRegion")]
         [Timeout(70000)]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemIntegrationTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemIntegrationTests.cs
@@ -1315,7 +1315,7 @@
                 if (cosmosClientOptions.EnablePartitionLevelFailover)
                 {
                     Assert.IsNotNull(hedgeContext);
-                    ICollection<string> hedgedRegions = (ICollection<string>)hedgeContext;
+                    List<string> hedgedRegions = ((IEnumerable<string>)hedgeContext).ToList();
 
                     Assert.AreEqual(3, hedgedRegions.Count);
                     Assert.IsTrue(hedgedRegions.Contains(region1) && hedgedRegions.Contains(region2) && hedgedRegions.Contains(region3));

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemIntegrationTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemIntegrationTests.cs
@@ -1317,8 +1317,8 @@
                     Assert.IsNotNull(hedgeContext);
                     List<string> hedgedRegions = ((IEnumerable<string>)hedgeContext).ToList();
 
-                    Assert.AreEqual(3, hedgedRegions.Count);
-                    Assert.IsTrue(hedgedRegions.Contains(region1) && hedgedRegions.Contains(region2) && hedgedRegions.Contains(region3));
+                    Assert.IsTrue(hedgedRegions.Count > 1, "Since the first region is not available, the request should atleast hedge to the next region.");
+                    Assert.IsTrue(hedgedRegions.Contains(region1) && (hedgedRegions.Contains(region2) || hedgedRegions.Contains(region3)));
                 }
                 else
                 {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
@@ -282,11 +282,10 @@ namespace Microsoft.Azure.Cosmos.Tests
                         .WithPartitionLevelFailoverEnabled();
                 }
 
-                ArgumentException exception = Assert.ThrowsException<ArgumentException>(() => cosmosClientBuilder.Build());
+                CosmosClient cosmosClient = cosmosClientBuilder.Build();
 
-                Assert.AreEqual(
-                    expected: "ApplicationPreferredRegions or ApplicationRegion is required when EnablePartitionLevelFailover is enabled.",
-                    actual: exception.Message);
+                Assert.IsNotNull(cosmosClient,
+                    message: "ApplicationPreferredRegions or ApplicationRegion is no longer mandatory fields, hence the client initialization should succeed.");
             }
             finally
             {
@@ -1246,7 +1245,6 @@ namespace Microsoft.Azure.Cosmos.Tests
         }
 
         [TestMethod]
-        [ExpectedException(typeof(ArgumentException))]
         public void PPAFClientNoRegionsTest()
         {
             CosmosClientOptions cosmosClientOptions = new CosmosClientOptions
@@ -1254,7 +1252,9 @@ namespace Microsoft.Azure.Cosmos.Tests
                 EnablePartitionLevelFailover = true
             };
 
-            _ = new CosmosClient(ConnectionString, cosmosClientOptions);
+            CosmosClient cosmosClient = new(ConnectionString, cosmosClientOptions);
+
+            Assert.IsNotNull(cosmosClient);
         }
 
         private class TestWebProxy : IWebProxy

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
@@ -227,13 +227,14 @@ namespace Microsoft.Azure.Cosmos.Tests
 
         /// <summary>
         /// Test to validate that when the partition level failover is enabled with the preferred regions list is missing, then the client
-        /// initialization should throw an argument exception and fail. This should hold true for both environment variable and CosmosClientOptions.
+        /// initialization should succeed. This should hold true for both environment variable and CosmosClientOptions.
         /// </summary>
         [TestMethod]
         [Owner("dkunda")]
         [DataRow(true, DisplayName = "Validate that when environment variable is used to enable PPAF, the outcome of the test should be same.")]
         [DataRow(false, DisplayName = "Validate that when CosmosClientOptions is used to enable PPAF, the outcome of the test should be same.")]
-        public void CosmosClientOptions_WhenPartitionLevelFailoverEnabledAndPreferredRegionsNotSet_ShouldThrowArgumentException(bool useEnvironmentVariable)
+        public void CosmosClientOptions_WhenPartitionLevelFailoverEnabledAndPreferredRegionsNotSet_ShouldInitializeCosmosClientSuccessfully(
+            bool useEnvironmentVariable)
         {
             try
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyRangeFailoverTests/GlobalPartitionEndpointManagerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyRangeFailoverTests/GlobalPartitionEndpointManagerTests.cs
@@ -284,7 +284,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             {
                 // Default availability strategy values.
                 Assert.AreEqual(TimeSpan.FromMilliseconds(1000), crossRegionHedgingStrategy.Threshold);
-                Assert.AreEqual(TimeSpan.FromMilliseconds(10), crossRegionHedgingStrategy.ThresholdStep);
+                Assert.AreEqual(TimeSpan.FromMilliseconds(500), crossRegionHedgingStrategy.ThresholdStep);
             }
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyRangeFailoverTests/GlobalPartitionEndpointManagerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyRangeFailoverTests/GlobalPartitionEndpointManagerTests.cs
@@ -247,14 +247,13 @@ namespace Microsoft.Azure.Cosmos.Tests
                 TransportClientHandlerFactory = (original) => mockTransport.Object,
             };
 
-            ArgumentException exception = Assert.ThrowsException<ArgumentException>(() => new CosmosClient(
-                 globalEndpoint,
-                 Convert.ToBase64String(Encoding.UTF8.GetBytes(Guid.NewGuid().ToString())),
-                 cosmosClientOptions));
+            CosmosClient cosmosClient = new CosmosClient(
+                globalEndpoint,
+                Convert.ToBase64String(Encoding.UTF8.GetBytes(Guid.NewGuid().ToString())),
+                cosmosClientOptions);
 
-            Assert.AreEqual(
-                expected: "ApplicationPreferredRegions or ApplicationRegion is required when EnablePartitionLevelFailover is enabled.",
-                actual: exception.Message);
+            Assert.IsNotNull(cosmosClient,
+                message: "ApplicationPreferredRegions or ApplicationRegion is no longer mandatory fields, hence the client initialization should succeed.");
         }
 
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyRangeFailoverTests/GlobalPartitionEndpointManagerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyRangeFailoverTests/GlobalPartitionEndpointManagerTests.cs
@@ -200,11 +200,17 @@ namespace Microsoft.Azure.Cosmos.Tests
 
         /// <summary>
         /// Test to validate that when the partition level failover is enabled with the preferred regions list is missing, then the client
-        /// initialization should throw an argument exception and fail.
+        /// initialization should succeed without throwing any argument exception.
         /// </summary>
         [TestMethod]
-        public void CreateItemAsync_WithNoPreferredRegionsAndServiceUnavailable_ShouldThrowArgumentException()
+        [DataRow(true, DisplayName = "Validate that when an explict availability strategy is provided, the same will be honored by bypassing the default one, when PPAF is enabled.")]
+        [DataRow(false, DisplayName = "Validate that when no explict availability strategy is provided, a default availability strategy will be applied, when PPAF is enabled.")]
+        public void CreateItemAsync_WithNoPreferredRegionsAndServiceUnavailable_ShouldNotThrowArgumentException(
+            bool isExplictAvailabilityStrategyProvided)
         {
+            TimeSpan explictAvailabilityStrategyThreshold = TimeSpan.FromMilliseconds(2000);
+            TimeSpan explictAvailabilityStrategyThresholdStep = TimeSpan.FromMilliseconds(500);
+
             GlobalPartitionEndpointManagerTests.SetupAccountAndCacheOperations(
                 out string secondaryRegionNameForUri,
                 out string globalEndpoint,
@@ -247,6 +253,13 @@ namespace Microsoft.Azure.Cosmos.Tests
                 TransportClientHandlerFactory = (original) => mockTransport.Object,
             };
 
+            if (isExplictAvailabilityStrategyProvided)
+            {
+                cosmosClientOptions.AvailabilityStrategy = AvailabilityStrategy.CrossRegionHedgingStrategy(
+                    threshold: explictAvailabilityStrategyThreshold,
+                    thresholdStep: explictAvailabilityStrategyThresholdStep);
+            }
+
             CosmosClient cosmosClient = new CosmosClient(
                 globalEndpoint,
                 Convert.ToBase64String(Encoding.UTF8.GetBytes(Guid.NewGuid().ToString())),
@@ -254,6 +267,25 @@ namespace Microsoft.Azure.Cosmos.Tests
 
             Assert.IsNotNull(cosmosClient,
                 message: "ApplicationPreferredRegions or ApplicationRegion is no longer mandatory fields, hence the client initialization should succeed.");
+
+            Assert.IsNotNull(cosmosClient.ClientOptions.AvailabilityStrategy);
+
+            CrossRegionHedgingAvailabilityStrategy crossRegionHedgingStrategy = (CrossRegionHedgingAvailabilityStrategy)cosmosClient.ClientOptions.AvailabilityStrategy;
+            
+            Assert.IsNotNull(crossRegionHedgingStrategy);
+
+            if (isExplictAvailabilityStrategyProvided)
+            {
+                // Explict availability strategy values.
+                Assert.AreEqual(explictAvailabilityStrategyThreshold, crossRegionHedgingStrategy.Threshold);
+                Assert.AreEqual(explictAvailabilityStrategyThresholdStep, crossRegionHedgingStrategy.ThresholdStep);
+            }
+            else
+            {
+                // Default availability strategy values.
+                Assert.AreEqual(TimeSpan.FromMilliseconds(1000), crossRegionHedgingStrategy.Threshold);
+                Assert.AreEqual(TimeSpan.FromMilliseconds(10), crossRegionHedgingStrategy.ThresholdStep);
+            }
         }
 
         [TestMethod]


### PR DESCRIPTION
# Pull Request Template

## Description

This PR does the following two things:

- Enables Cross Regional Hedging by default with a threshold of either `1` second or half of the request timeout value provided, whichever is minimum, when PPAF is enabled. Note that the default availability strategy can be opted out by setting the `AvailabilityStrategy` to `DisabledAvailabilityStrategy` in the `CosmosClientOptions`. To understand this better, please take a look at the example below:

            CosmosClientOptions cosmosClientOptions = new CosmosClientOptions()
            {
                EnablePartitionLevelFailover = true,
                ConsistencyLevel = Cosmos.ConsistencyLevel.Strong,
                AvailabilityStrategy = new DisabledAvailabilityStrategy(),
            };

- As of today, during the cosmos client initialization, with PPAF enabled we ensure that either the `ApplicationRegion` or `ApplicationPreferredRegions` is present through a validation. Since we now have established the concept of Effective Preferred Region, this PR removes the above mandatory validation on `ApplicationRegion` or `ApplicationPreferredRegions`, as in the if there are no preferred regions passed explicitly, the .NET SDK can populate the effective preferred regions.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Closing issues

To automatically close an issue: closes #5047, #5164 