### PR TITLE
Added check for connection policy

### DIFF
--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -6822,6 +6822,13 @@ namespace Microsoft.Azure.Cosmos
 
             await this.accountServiceConfiguration.InitializeAsync();
             AccountProperties accountProperties = this.accountServiceConfiguration.AccountProperties;
+            this.ConnectionPolicy.EnablePartitionLevelFailover = accountProperties.EnablePartitionLevelFailover;
+            this.PartitionKeyRangeLocation = this.ConnectionPolicy.EnablePartitionLevelFailover || this.ConnectionPolicy.EnablePartitionLevelCircuitBreaker
+                ? new GlobalPartitionEndpointManagerCore(
+                    this.GlobalEndpointManager,
+                    this.ConnectionPolicy.EnablePartitionLevelFailover,
+                    this.ConnectionPolicy.EnablePartitionLevelCircuitBreaker)
+                : GlobalPartitionEndpointManagerNoOp.Instance;
             this.UseMultipleWriteLocations = this.ConnectionPolicy.UseMultipleWriteLocations && accountProperties.EnableMultipleWriteLocations;
 
             this.GlobalEndpointManager.InitializeAccountPropertiesAndStartBackgroundRefresh(accountProperties);

--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/AccountProperties.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/AccountProperties.cs
@@ -244,6 +244,9 @@ namespace Microsoft.Azure.Cosmos
         [JsonProperty(PropertyName = Constants.Properties.EnableMultipleWriteLocations)]
         internal bool EnableMultipleWriteLocations { get; set; }
 
+        [JsonProperty(PropertyName = Constants.Properties.EnablePartitionLevelFailover)]
+        internal bool EnablePartitionLevelFailover { get; set; }
+
         private IDictionary<string, object> QueryStringToDictConverter()
         {
             if (!string.IsNullOrEmpty(this.QueryEngineConfigurationString))

--- a/Microsoft.Azure.Cosmos/src/Routing/GlobalEndpointManager.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GlobalEndpointManager.cs
@@ -554,6 +554,7 @@ namespace Microsoft.Azure.Cosmos.Routing
             {
                 return;
             }
+            this.connectionPolicy.EnablePartitionLevelFailover = databaseAccount.EnablePartitionLevelFailover;
             GlobalEndpointManager.ParseThinClientLocationsFromAdditionalProperties(databaseAccount);
 
             this.locationCache.OnDatabaseAccountRead(databaseAccount);


### PR DESCRIPTION
# Pull Request Template

## Description

This pull request introduces support for partition-level failover in the Cosmos DB SDK. Key changes include updating the connection policy, adding a new property to account settings, and modifying the global endpoint manager to handle the new feature.

### Feature: Partition-Level Failover Support

* [`Microsoft.Azure.Cosmos/src/DocumentClient.cs`](diffhunk://#diff-9c2d1053a5a751b63e86de0b895ff4db38276df25eead51fddec3664ccf88a32R6825-R6831): Updated the `InitializeGatewayConfigurationReaderAsync` method to configure `EnablePartitionLevelFailover` and set up a new `PartitionKeyRangeLocation` manager based on the failover and circuit breaker settings.

* [`Microsoft.Azure.Cosmos/src/Resource/Settings/AccountProperties.cs`](diffhunk://#diff-540cbf7eac51202ec82f12c9be23c2c3c61e367a0180e405eb794a6159730e22R247-R249): Added a new property, `EnablePartitionLevelFailover`, to store the configuration for partition-level failover in account properties.

* [`Microsoft.Azure.Cosmos/src/Routing/GlobalEndpointManager.cs`](diffhunk://#diff-f63d79326ed627000f22586f341f5d5d2bedfa149f33a1b5c88296b5ba2984e3R557): Modified `InitializeAccountPropertiesAndStartBackgroundRefresh` to initialize the `EnablePartitionLevelFailover` setting in the connection policy from the database account.

## Type of change

Please delete options that are not relevant.

- [] New feature (non-breaking change which adds functionality)

## Closing issues

To automatically close an issue: closes #IssueNumber