### PR TITLE
Query: Fixes default for the query plan optimization for Hybrid Search to be disabled

### DIFF
--- a/Microsoft.Azure.Cosmos/src/RequestOptions/QueryRequestOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/RequestOptions/QueryRequestOptions.cs
@@ -208,7 +208,7 @@ namespace Microsoft.Azure.Cosmos
 
         internal FeedRange FeedRange { get; set; }
 
-        internal bool IsHybridSearchQueryPlanOptimizationDisabled { get; set; } = ConfigurationManager.IsHybridSearchQueryPlanOptimizationDisabled(defaultValue: false);
+        internal bool IsHybridSearchQueryPlanOptimizationDisabled { get; set; } = ConfigurationManager.IsHybridSearchQueryPlanOptimizationDisabled(defaultValue: true);
 
         // This is a temporary flag to enable the distributed query gateway mode.
         // This flag will be removed once we have a way for the client to determine

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/NonStreamingOrderByQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/NonStreamingOrderByQueryTests.cs
@@ -111,7 +111,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
                     MakeQueryFeaturesTest(
                         environmentVariable: null,
                         requestOption: null,
-                        expectHybridSearchOptimizationDisabled: false),
+                        expectHybridSearchOptimizationDisabled: true),
                     MakeQueryFeaturesTest(
                         environmentVariable: true,
                         requestOption: null,


### PR DESCRIPTION
This is a cherry-pick of #5171 

## Description
#5120 enabled the switch to ask for the optimized query plan by default. However, the pipeline support for the optimized query plan is in #5121. This will lead to exceptions in the hybrid search query pipeline in version 3.49.0 if the SDK talks to a newer gateway that can return the optimized query plan. To prevent this, we change this optimization to be disabled by default.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

