### PR TITLE
Hedging: Fixes Concurrency Issue

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosAvailabilityStrategyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosAvailabilityStrategyTests.cs
@@ -264,26 +264,18 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 CosmosTraceDiagnostics traceDiagnostic = ir.Diagnostics as CosmosTraceDiagnostics;
                 Assert.IsNotNull(traceDiagnostic);
 
-                //Should send out hedge request but original should be returned
-                traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out object hedgeContext);
-                Assert.IsNotNull(hedgeContext);
-                IReadOnlyCollection<string> hedgeContextList;
-                hedgeContextList = hedgeContext as IReadOnlyCollection<string>;
-
                 if (isPreferredLocationsEmpty)
                 {
-                    Assert.AreEqual(3, hedgeContextList.Count);
-                    Assert.IsTrue(hedgeContextList.Contains(region1));
-                    Assert.IsTrue(hedgeContextList.Contains(region2));
-                    Assert.IsTrue(hedgeContextList.Contains(region3));
+                    Assert.IsTrue(traceDiagnostic.ToString()
+                        .Contains($"\"Hedge Context\":[\"{region1}\",\"{region2}\",\"{region3}\"]"));
                 }
                 else
                 {
-                    Assert.AreEqual(2, hedgeContextList.Count);
-                    Assert.IsTrue(hedgeContextList.Contains(region1));
-                    Assert.IsTrue(hedgeContextList.Contains(region2));
+                    Assert.IsTrue(traceDiagnostic.ToString()
+                        .Contains($"\"Hedge Context\":[\"{region1}\",\"{region2}\"]"));
                 }
-            };
+            }
+            ;
         }
 
         [TestMethod]
@@ -343,9 +335,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                 CosmosTraceDiagnostics traceDiagnostic = ir.Diagnostics as CosmosTraceDiagnostics;
                 Assert.IsNotNull(traceDiagnostic);
-                traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out object hedgeContext);
-                Assert.IsNotNull(hedgeContext);
-                Assert.IsTrue(((IReadOnlyCollection<string>)hedgeContext).Contains(region2));
+                Assert.IsTrue(traceDiagnostic.ToString()
+                        .Contains($"\"Hedge Context\":[\"{region1}\",\"{region2}\"]"));
             }
         }
 
@@ -565,9 +556,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                         Assert.IsTrue(rule.GetHitCount() > 0);
                         traceDiagnostic = ir.Diagnostics as CosmosTraceDiagnostics;
                         Assert.IsNotNull(traceDiagnostic);
-                        traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out hedgeContext);
-                        Assert.IsNotNull(hedgeContext);
-                        Assert.IsTrue(((IReadOnlyCollection<string>)hedgeContext).Contains(region2));
+                        Assert.IsTrue(traceDiagnostic.ToString()
+                            .Contains($"\"Hedge Context\":[\"{region1}\",\"{region2}\"]"));
 
 
                         break;
@@ -598,9 +588,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                             Assert.IsTrue(rule.GetHitCount() > 0);
                             traceDiagnostic = feedResponse.Diagnostics as CosmosTraceDiagnostics;
                             Assert.IsNotNull(traceDiagnostic);
-                            traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out hedgeContext);
-                            Assert.IsNotNull(hedgeContext);
-                            Assert.IsTrue(((IReadOnlyCollection<string>)hedgeContext).Contains(region2));
+                            Assert.IsTrue(traceDiagnostic.ToString()
+                                .Contains($"\"Hedge Context\":[\"{region1}\",\"{region2}\"]"));
                         }
 
                         break;
@@ -629,9 +618,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                             Assert.IsTrue(rule.GetHitCount() > 0);
                             traceDiagnostic = feedResponse.Diagnostics as CosmosTraceDiagnostics;
                             Assert.IsNotNull(traceDiagnostic);
-                            traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out hedgeContext);
-                            Assert.IsNotNull(hedgeContext);
-                            Assert.IsTrue(((IReadOnlyCollection<string>)hedgeContext).Contains(region2));
+                            Assert.IsTrue(traceDiagnostic.ToString()
+                                .Contains($"\"Hedge Context\":[\"{region1}\",\"{region2}\"]"));
                         }
 
                         break;
@@ -659,9 +647,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                         Assert.IsTrue(rule.GetHitCount() > 0);
                         traceDiagnostic = readManyResponse.Diagnostics as CosmosTraceDiagnostics;
                         Assert.IsNotNull(traceDiagnostic);
-                        traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out hedgeContext);
-                        Assert.IsNotNull(hedgeContext);
-                        Assert.IsTrue(((IReadOnlyCollection<string>)hedgeContext).Contains(region2));
+                        Assert.IsTrue(traceDiagnostic.ToString()
+                                .Contains($"\"Hedge Context\":[\"{region1}\",\"{region2}\"]"));
 
                         break;
 
@@ -778,9 +765,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                         traceDiagnostic = ir.Diagnostics as CosmosTraceDiagnostics;
                         Assert.IsNotNull(traceDiagnostic);
-                        traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out hedgeContext);
-                        Assert.IsNotNull(hedgeContext);
-                        Assert.IsTrue(((IReadOnlyCollection<string>)hedgeContext).Contains(region3));
+                        Assert.IsTrue(traceDiagnostic.ToString()
+                            .Contains($"\"Hedge Context\":[\"{region1}\",\"{region2}\",\"{region3}\"]"));
 
                         break;
 
@@ -805,9 +791,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                             traceDiagnostic = feedResponse.Diagnostics as CosmosTraceDiagnostics;
                             Assert.IsNotNull(traceDiagnostic);
-                            traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out hedgeContext);
-                            Assert.IsNotNull(hedgeContext);
-                            Assert.IsTrue(((IReadOnlyCollection<string>)hedgeContext).Contains(region3));
+                            Assert.IsTrue(traceDiagnostic.ToString()
+                                .Contains($"\"Hedge Context\":[\"{region1}\",\"{region2}\",\"{region3}\"]"));
                         }
 
                         break;
@@ -826,9 +811,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                             traceDiagnostic = feedResponse.Diagnostics as CosmosTraceDiagnostics;
                             Assert.IsNotNull(traceDiagnostic);
-                            traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out hedgeContext);
-                            Assert.IsNotNull(hedgeContext);
-                            Assert.IsTrue(((IReadOnlyCollection<string>)hedgeContext).Contains(region3));
+                            Assert.IsTrue(traceDiagnostic.ToString()
+                                .Contains($"\"Hedge Context\":[\"{region1}\",\"{region2}\",\"{region3}\"]"));
                         }
 
                         break;
@@ -848,9 +832,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                         traceDiagnostic = readManyResponse.Diagnostics as CosmosTraceDiagnostics;
                         Assert.IsNotNull(traceDiagnostic);
-                        traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out hedgeContext);
-                        Assert.IsNotNull(hedgeContext);
-                        Assert.IsTrue(((IReadOnlyCollection<string>)hedgeContext).Contains(region3));
+                        Assert.IsTrue(traceDiagnostic.ToString()
+                            .Contains($"\"Hedge Context\":[\"{region1}\",\"{region2}\",\"{region3}\"]"));
 
                         break;
 
@@ -960,9 +943,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                 CosmosTraceDiagnostics traceDiagnostic = ir.Diagnostics as CosmosTraceDiagnostics;
                 Assert.IsNotNull(traceDiagnostic);
-                traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out object hedgeContext);
-                Assert.IsNotNull(hedgeContext);
-                Assert.IsTrue(((IReadOnlyCollection<string>)hedgeContext).Contains(region2));
+                Assert.IsTrue(traceDiagnostic.ToString()
+                    .Contains($"\"Hedge Context\":[\"{region1}\",\"{region2}\"]"));
             }
         }
 
@@ -1035,9 +1017,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                     CosmosTraceDiagnostics traceDiagnostic = ex.Diagnostics as CosmosTraceDiagnostics;
                     Assert.IsNotNull(traceDiagnostic);
-                    traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out object hedgeContext);
-                    Assert.IsNotNull(hedgeContext);
-                    Assert.IsTrue(((IReadOnlyCollection<string>)hedgeContext).Contains(region2));
+                    Assert.IsTrue(traceDiagnostic.ToString()
+                        .Contains($"\"Hedge Context\":[\"{region1}\",\"{region2}\"]"));
                 }
                 finally
                 {
@@ -1139,9 +1120,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                 CosmosTraceDiagnostics traceDiagnostic = ir.Diagnostics as CosmosTraceDiagnostics;
                 Assert.IsNotNull(traceDiagnostic);
-                traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out object hedgeContext);
-                Assert.IsNotNull(hedgeContext);
-                Assert.IsTrue(((IReadOnlyCollection<string>)hedgeContext).Contains(region3));
+                Assert.IsTrue(traceDiagnostic.ToString()
+                    .Contains($"\"Hedge Context\":[\"{region1}\",\"{region2}\",\"{region3}\"]"));
             }
         }
 
@@ -1241,9 +1221,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                     CosmosTraceDiagnostics traceDiagnostic = ex.Diagnostics as CosmosTraceDiagnostics;
                     Assert.IsNotNull(traceDiagnostic);
-                    traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out object hedgeContext);
-                    Assert.IsNotNull(hedgeContext);
-                    Assert.IsTrue(((IReadOnlyCollection<string>)hedgeContext).Contains(region3));
+                    Assert.IsTrue(traceDiagnostic.ToString()
+                        .Contains($"\"Hedge Context\":[\"{region1}\",\"{region2}\",\"{region3}\"]"));
                 }
                 finally
                 {
@@ -1393,9 +1372,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                     CosmosTraceDiagnostics traceDiagnostic = ir.Diagnostics as CosmosTraceDiagnostics;
                     Assert.IsNotNull(traceDiagnostic);
-                    traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out object hedgeContext);
-                    Assert.IsNotNull(hedgeContext);
-                    Assert.IsTrue(((IReadOnlyCollection<string>)hedgeContext).Contains(region2));
+                    Assert.IsTrue(traceDiagnostic.ToString()
+                        .Contains($"\"Hedge Context\":[\"{region1}\",\"{region2}\"]"));
                 }
                 catch (CosmosException ex)
                 {
@@ -1419,9 +1397,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             CosmosTraceDiagnostics traceDiagnostic = context.Diagnostics as CosmosTraceDiagnostics;
             Assert.IsNotNull(traceDiagnostic);
-            traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out object hedgeContext);
-            Assert.IsNotNull(hedgeContext);
-            Assert.IsTrue(((IReadOnlyCollection<string>)hedgeContext).Contains(region2));
+            Assert.IsTrue(traceDiagnostic.ToString()
+                .Contains($"\"Hedge Context\":[\"{region1}\",\"{region2}\"]"));
             await Task.Delay(1);
         }
 
@@ -1437,9 +1414,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             
             CosmosTraceDiagnostics traceDiagnostic = context.Diagnostics as CosmosTraceDiagnostics;
             Assert.IsNotNull(traceDiagnostic);
-            traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out object hedgeContext);
-            Assert.IsNotNull(hedgeContext);
-            Assert.IsTrue(((IReadOnlyCollection<string>)hedgeContext).Contains(region3));
+            Assert.IsTrue(traceDiagnostic.ToString()
+                .Contains($"\"Hedge Context\":[\"{region1}\",\"{region2}\",\"{region3}\"]"));
             await Task.Delay(1);
         }
     }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosAvailabilityStrategyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosAvailabilityStrategyTests.cs
@@ -534,7 +534,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 ItemResponse<CosmosIntegrationTestObject> _ = await container.ReadItemAsync<CosmosIntegrationTestObject>("testId", new PartitionKey("pk"));
 
                 CosmosTraceDiagnostics traceDiagnostic;
-                object hedgeContext;
 
                 switch (operation)
                 {
@@ -751,7 +750,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 ItemResponse<CosmosIntegrationTestObject> _ = await container.ReadItemAsync<CosmosIntegrationTestObject>("testId", new PartitionKey("pk"));
 
                 CosmosTraceDiagnostics traceDiagnostic;
-                object hedgeContext;
 
                 switch (operation)
                 {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosAvailabilityStrategyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosAvailabilityStrategyTests.cs
@@ -345,9 +345,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Assert.IsNotNull(traceDiagnostic);
                 traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out object hedgeContext);
                 Assert.IsNotNull(hedgeContext);
-                IReadOnlyCollection<string> hedgeContextList;
-                hedgeContextList = hedgeContext as IReadOnlyCollection<string>;
-                Assert.IsTrue(hedgeContextList.Contains(region2));
+                Assert.IsTrue(((IReadOnlyCollection<string>)hedgeContext).Contains(region2));
             }
         }
 
@@ -546,7 +544,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                 CosmosTraceDiagnostics traceDiagnostic;
                 object hedgeContext;
-                IReadOnlyCollection<string> hedgeContextList;
 
                 switch (operation)
                 {
@@ -568,11 +565,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                         Assert.IsTrue(rule.GetHitCount() > 0);
                         traceDiagnostic = ir.Diagnostics as CosmosTraceDiagnostics;
                         Assert.IsNotNull(traceDiagnostic);
-                        Console.WriteLine(traceDiagnostic);
                         traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out hedgeContext);
                         Assert.IsNotNull(hedgeContext);
-                        hedgeContextList = hedgeContext as IReadOnlyCollection<string>;
-                        Assert.IsTrue(hedgeContextList.Contains(region2));
+                        Assert.IsTrue(((IReadOnlyCollection<string>)hedgeContext).Contains(region2));
 
 
                         break;
@@ -603,11 +598,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                             Assert.IsTrue(rule.GetHitCount() > 0);
                             traceDiagnostic = feedResponse.Diagnostics as CosmosTraceDiagnostics;
                             Assert.IsNotNull(traceDiagnostic);
-                            Console.WriteLine(traceDiagnostic);
                             traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out hedgeContext);
                             Assert.IsNotNull(hedgeContext);
-                            hedgeContextList = hedgeContext as IReadOnlyCollection<string>;
-                            Assert.IsTrue(hedgeContextList.Contains(region2));
+                            Assert.IsTrue(((IReadOnlyCollection<string>)hedgeContext).Contains(region2));
                         }
 
                         break;
@@ -636,11 +629,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                             Assert.IsTrue(rule.GetHitCount() > 0);
                             traceDiagnostic = feedResponse.Diagnostics as CosmosTraceDiagnostics;
                             Assert.IsNotNull(traceDiagnostic);
-                            Console.WriteLine(traceDiagnostic);
                             traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out hedgeContext);
                             Assert.IsNotNull(hedgeContext);
-                            hedgeContextList = hedgeContext as IReadOnlyCollection<string>;
-                            Assert.IsTrue(hedgeContextList.Contains(region2));
+                            Assert.IsTrue(((IReadOnlyCollection<string>)hedgeContext).Contains(region2));
                         }
 
                         break;
@@ -668,11 +659,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                         Assert.IsTrue(rule.GetHitCount() > 0);
                         traceDiagnostic = readManyResponse.Diagnostics as CosmosTraceDiagnostics;
                         Assert.IsNotNull(traceDiagnostic);
-                        Console.WriteLine(traceDiagnostic);
                         traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out hedgeContext);
                         Assert.IsNotNull(hedgeContext);
-                        hedgeContextList = hedgeContext as IReadOnlyCollection<string>;
-                        Assert.IsTrue(hedgeContextList.Contains(region2));
+                        Assert.IsTrue(((IReadOnlyCollection<string>)hedgeContext).Contains(region2));
 
                         break;
 
@@ -792,8 +781,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                         Assert.IsNotNull(traceDiagnostic);
                         traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out hedgeContext);
                         Assert.IsNotNull(hedgeContext);
-                        hedgeContextList = hedgeContext as IReadOnlyCollection<string>;
-                        Assert.IsTrue(hedgeContextList.Contains(region3));
+                        Assert.IsTrue(((IReadOnlyCollection<string>)hedgeContext).Contains(region3));
 
                         break;
 
@@ -820,8 +808,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                             Assert.IsNotNull(traceDiagnostic);
                             traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out hedgeContext);
                             Assert.IsNotNull(hedgeContext);
-                            hedgeContextList = hedgeContext as IReadOnlyCollection<string>;
-                            Assert.IsTrue(hedgeContextList.Contains(region3));
+                            Assert.IsTrue(((IReadOnlyCollection<string>)hedgeContext).Contains(region3));
                         }
 
                         break;
@@ -842,8 +829,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                             Assert.IsNotNull(traceDiagnostic);
                             traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out hedgeContext);
                             Assert.IsNotNull(hedgeContext);
-                            hedgeContextList = hedgeContext as IReadOnlyCollection<string>;
-                            Assert.IsTrue(hedgeContextList.Contains(region3));
+                            Assert.IsTrue(((IReadOnlyCollection<string>)hedgeContext).Contains(region3));
                         }
 
                         break;
@@ -865,8 +851,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                         Assert.IsNotNull(traceDiagnostic);
                         traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out hedgeContext);
                         Assert.IsNotNull(hedgeContext);
-                        hedgeContextList = hedgeContext as IReadOnlyCollection<string>;
-                        Assert.IsTrue(hedgeContextList.Contains(region3));
+                        Assert.IsTrue(((IReadOnlyCollection<string>)hedgeContext).Contains(region3));
 
                         break;
 
@@ -978,8 +963,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Assert.IsNotNull(traceDiagnostic);
                 traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out object hedgeContext);
                 Assert.IsNotNull(hedgeContext);
-                IReadOnlyCollection<string> hedgeContextList = hedgeContext as IReadOnlyCollection<string>;
-                Assert.IsTrue(hedgeContextList.Contains(region2));
+                Assert.IsTrue(((IReadOnlyCollection<string>)hedgeContext).Contains(region2));
             }
         }
 
@@ -1054,8 +1038,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     Assert.IsNotNull(traceDiagnostic);
                     traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out object hedgeContext);
                     Assert.IsNotNull(hedgeContext);
-                    IReadOnlyCollection<string> hedgeContextList = hedgeContext as IReadOnlyCollection<string>;
-                    Assert.IsTrue(hedgeContextList.Contains(region2));
+                    Assert.IsTrue(((IReadOnlyCollection<string>)hedgeContext).Contains(region2));
                 }
                 finally
                 {
@@ -1159,8 +1142,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Assert.IsNotNull(traceDiagnostic);
                 traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out object hedgeContext);
                 Assert.IsNotNull(hedgeContext);
-                IReadOnlyCollection<string> hedgeContextList = hedgeContext as IReadOnlyCollection<string>;
-                Assert.IsTrue(hedgeContextList.Contains(region3));
+                IAssert.IsTrue(((IReadOnlyCollection<string>)hedgeContext).Contains(region3));
             }
         }
 
@@ -1262,8 +1244,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     Assert.IsNotNull(traceDiagnostic);
                     traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out object hedgeContext);
                     Assert.IsNotNull(hedgeContext);
-                    IReadOnlyCollection<string> hedgeContextList = hedgeContext as IReadOnlyCollection<string>;
-                    Assert.IsTrue(hedgeContextList.Contains(region3));
+                    Assert.IsTrue(((IReadOnlyCollection<string>)hedgeContext).Contains(region3));
                 }
                 finally
                 {
@@ -1441,8 +1422,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.IsNotNull(traceDiagnostic);
             traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out object hedgeContext);
             Assert.IsNotNull(hedgeContext);
-            IReadOnlyCollection<string> hedgeContextList = hedgeContext as IReadOnlyCollection<string>;
-            Assert.IsTrue(hedgeContextList.Contains(region2));
+            Assert.IsTrue(((IReadOnlyCollection<string>)hedgeContext).Contains(region2));
             await Task.Delay(1);
         }
 
@@ -1460,8 +1440,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.IsNotNull(traceDiagnostic);
             traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out object hedgeContext);
             Assert.IsNotNull(hedgeContext);
-            IReadOnlyCollection<string> hedgeContextList = hedgeContext as IReadOnlyCollection<string>;
-            Assert.IsTrue(hedgeContextList.Contains(region3));
+            Assert.IsTrue(((IReadOnlyCollection<string>)hedgeContext).Contains(region3));
             await Task.Delay(1);
         }
     }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosAvailabilityStrategyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosAvailabilityStrategyTests.cs
@@ -568,6 +568,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                         Assert.IsTrue(rule.GetHitCount() > 0);
                         traceDiagnostic = ir.Diagnostics as CosmosTraceDiagnostics;
                         Assert.IsNotNull(traceDiagnostic);
+                        Console.WriteLine(traceDiagnostic);
                         traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out hedgeContext);
                         Assert.IsNotNull(hedgeContext);
                         hedgeContextList = hedgeContext as IReadOnlyCollection<string>;
@@ -602,6 +603,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                             Assert.IsTrue(rule.GetHitCount() > 0);
                             traceDiagnostic = feedResponse.Diagnostics as CosmosTraceDiagnostics;
                             Assert.IsNotNull(traceDiagnostic);
+                            Console.WriteLine(traceDiagnostic);
                             traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out hedgeContext);
                             Assert.IsNotNull(hedgeContext);
                             hedgeContextList = hedgeContext as IReadOnlyCollection<string>;
@@ -634,6 +636,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                             Assert.IsTrue(rule.GetHitCount() > 0);
                             traceDiagnostic = feedResponse.Diagnostics as CosmosTraceDiagnostics;
                             Assert.IsNotNull(traceDiagnostic);
+                            Console.WriteLine(traceDiagnostic);
                             traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out hedgeContext);
                             Assert.IsNotNull(hedgeContext);
                             hedgeContextList = hedgeContext as IReadOnlyCollection<string>;
@@ -665,6 +668,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                         Assert.IsTrue(rule.GetHitCount() > 0);
                         traceDiagnostic = readManyResponse.Diagnostics as CosmosTraceDiagnostics;
                         Assert.IsNotNull(traceDiagnostic);
+                        Console.WriteLine(traceDiagnostic);
                         traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out hedgeContext);
                         Assert.IsNotNull(hedgeContext);
                         hedgeContextList = hedgeContext as IReadOnlyCollection<string>;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosAvailabilityStrategyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosAvailabilityStrategyTests.cs
@@ -255,14 +255,14 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Database database = faultInjectionClient.GetDatabase(MultiRegionSetupHelpers.dbName);
                 Container container = database.GetContainer(MultiRegionSetupHelpers.containerName);
 
+                //warm up connections read
+                ItemResponse<CosmosIntegrationTestObject> _ = await container.ReadItemAsync<CosmosIntegrationTestObject>("testId", new PartitionKey("pk"));
+
                 responseDelay.Enable();
                 ItemResponse<CosmosIntegrationTestObject> ir = await container.ReadItemAsync<CosmosIntegrationTestObject>("testId", new PartitionKey("pk"));
 
                 CosmosTraceDiagnostics traceDiagnostic = ir.Diagnostics as CosmosTraceDiagnostics;
                 Assert.IsNotNull(traceDiagnostic);
-                traceDiagnostic.Value.Data.TryGetValue("Response Region", out object responseRegion);
-                Assert.IsNotNull(responseRegion);
-                Assert.AreEqual(region1, (string)responseRegion);
 
                 //Should send out hedge request but original should be returned
                 traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out object hedgeContext);
@@ -325,6 +325,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Database database = faultInjectionClient.GetDatabase(MultiRegionSetupHelpers.dbName);
                 Container container = database.GetContainer(MultiRegionSetupHelpers.containerName);
 
+                //warm up connections read
+                ItemResponse<CosmosIntegrationTestObject> _ = await container.ReadItemAsync<CosmosIntegrationTestObject>("testId", new PartitionKey("pk"));
+
                 responseDelay.Enable();
 
                 ItemRequestOptions requestOptions = new ItemRequestOptions
@@ -340,9 +343,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                 CosmosTraceDiagnostics traceDiagnostic = ir.Diagnostics as CosmosTraceDiagnostics;
                 Assert.IsNotNull(traceDiagnostic);
-                traceDiagnostic.Value.Data.TryGetValue("Response Region", out object hedgeContext);
+                traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out object hedgeContext);
                 Assert.IsNotNull(hedgeContext);
-                Assert.AreEqual(region2, (string)hedgeContext);
+                IReadOnlyCollection<string> hedgeContextList;
+                hedgeContextList = hedgeContext as IReadOnlyCollection<string>;
+                Assert.IsTrue(hedgeContextList.Contains(region2));
             }
         }
 
@@ -389,6 +394,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Database database = faultInjectionClient.GetDatabase(MultiRegionSetupHelpers.dbName);
                 Container container = database.GetContainer(MultiRegionSetupHelpers.containerName);
 
+                //warm up connections read
+                ItemResponse<CosmosIntegrationTestObject> _ = await container.ReadItemAsync<CosmosIntegrationTestObject>("testId", new PartitionKey("pk"));
+
                 responseDelay.Enable();
                 ItemRequestOptions requestOptions = new ItemRequestOptions
                 {
@@ -403,7 +411,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 CosmosTraceDiagnostics traceDiagnostic = ir.Diagnostics as CosmosTraceDiagnostics;
                 Assert.IsNotNull(traceDiagnostic);
 
-                Assert.IsFalse(traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out _));
+                Assert.IsFalse(traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out object _));
             }
         }
 
@@ -533,8 +541,12 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Database database = faultInjectionClient.GetDatabase(MultiRegionSetupHelpers.dbName);
                 Container container = database.GetContainer(MultiRegionSetupHelpers.containerName);
 
+                //warm up connections read
+                ItemResponse<CosmosIntegrationTestObject> _ = await container.ReadItemAsync<CosmosIntegrationTestObject>("testId", new PartitionKey("pk"));
+
                 CosmosTraceDiagnostics traceDiagnostic;
                 object hedgeContext;
+                IReadOnlyCollection<string> hedgeContextList;
 
                 switch (operation)
                 {
@@ -556,9 +568,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                         Assert.IsTrue(rule.GetHitCount() > 0);
                         traceDiagnostic = ir.Diagnostics as CosmosTraceDiagnostics;
                         Assert.IsNotNull(traceDiagnostic);
-                        traceDiagnostic.Value.Data.TryGetValue("Response Region", out hedgeContext);
+                        traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out hedgeContext);
                         Assert.IsNotNull(hedgeContext);
-                        Assert.AreEqual(region2, (string)hedgeContext);
+                        hedgeContextList = hedgeContext as IReadOnlyCollection<string>;
+                        Assert.IsTrue(hedgeContextList.Contains(region2));
+
 
                         break;
 
@@ -588,9 +602,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                             Assert.IsTrue(rule.GetHitCount() > 0);
                             traceDiagnostic = feedResponse.Diagnostics as CosmosTraceDiagnostics;
                             Assert.IsNotNull(traceDiagnostic);
-                            traceDiagnostic.Value.Data.TryGetValue("Response Region", out hedgeContext);
+                            traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out hedgeContext);
                             Assert.IsNotNull(hedgeContext);
-                            Assert.AreEqual(region2, (string)hedgeContext);
+                            hedgeContextList = hedgeContext as IReadOnlyCollection<string>;
+                            Assert.IsTrue(hedgeContextList.Contains(region2));
                         }
 
                         break;
@@ -619,9 +634,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                             Assert.IsTrue(rule.GetHitCount() > 0);
                             traceDiagnostic = feedResponse.Diagnostics as CosmosTraceDiagnostics;
                             Assert.IsNotNull(traceDiagnostic);
-                            traceDiagnostic.Value.Data.TryGetValue("Response Region", out hedgeContext);
+                            traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out hedgeContext);
                             Assert.IsNotNull(hedgeContext);
-                            Assert.AreEqual(region2, (string)hedgeContext);
+                            hedgeContextList = hedgeContext as IReadOnlyCollection<string>;
+                            Assert.IsTrue(hedgeContextList.Contains(region2));
                         }
 
                         break;
@@ -649,9 +665,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                         Assert.IsTrue(rule.GetHitCount() > 0);
                         traceDiagnostic = readManyResponse.Diagnostics as CosmosTraceDiagnostics;
                         Assert.IsNotNull(traceDiagnostic);
-                        traceDiagnostic.Value.Data.TryGetValue("Response Region", out hedgeContext);
+                        traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out hedgeContext);
                         Assert.IsNotNull(hedgeContext);
-                        Assert.AreEqual(region2, (string)hedgeContext);
+                        hedgeContextList = hedgeContext as IReadOnlyCollection<string>;
+                        Assert.IsTrue(hedgeContextList.Contains(region2));
 
                         break;
 
@@ -750,8 +767,12 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Database database = faultInjectionClient.GetDatabase(MultiRegionSetupHelpers.dbName);
                 Container container = database.GetContainer(MultiRegionSetupHelpers.containerName);
 
+                //warm up connections read
+                ItemResponse<CosmosIntegrationTestObject> _ = await container.ReadItemAsync<CosmosIntegrationTestObject>("testId", new PartitionKey("pk"));
+
                 CosmosTraceDiagnostics traceDiagnostic;
                 object hedgeContext;
+                IReadOnlyCollection<string> hedgeContextList;
 
                 switch (operation)
                 {
@@ -765,9 +786,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                         traceDiagnostic = ir.Diagnostics as CosmosTraceDiagnostics;
                         Assert.IsNotNull(traceDiagnostic);
-                        traceDiagnostic.Value.Data.TryGetValue("Response Region", out hedgeContext);
+                        traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out hedgeContext);
                         Assert.IsNotNull(hedgeContext);
-                        Assert.AreEqual(region3, (string)hedgeContext);
+                        hedgeContextList = hedgeContext as IReadOnlyCollection<string>;
+                        Assert.IsTrue(hedgeContextList.Contains(region3));
 
                         break;
 
@@ -792,9 +814,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                             traceDiagnostic = feedResponse.Diagnostics as CosmosTraceDiagnostics;
                             Assert.IsNotNull(traceDiagnostic);
-                            traceDiagnostic.Value.Data.TryGetValue("Response Region", out hedgeContext);
+                            traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out hedgeContext);
                             Assert.IsNotNull(hedgeContext);
-                            Assert.AreEqual(region3, (string)hedgeContext);
+                            hedgeContextList = hedgeContext as IReadOnlyCollection<string>;
+                            Assert.IsTrue(hedgeContextList.Contains(region3));
                         }
 
                         break;
@@ -813,9 +836,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                             traceDiagnostic = feedResponse.Diagnostics as CosmosTraceDiagnostics;
                             Assert.IsNotNull(traceDiagnostic);
-                            traceDiagnostic.Value.Data.TryGetValue("Response Region", out hedgeContext);
+                            traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out hedgeContext);
                             Assert.IsNotNull(hedgeContext);
-                            Assert.AreEqual(region3, (string)hedgeContext);
+                            hedgeContextList = hedgeContext as IReadOnlyCollection<string>;
+                            Assert.IsTrue(hedgeContextList.Contains(region3));
                         }
 
                         break;
@@ -835,9 +859,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                         traceDiagnostic = readManyResponse.Diagnostics as CosmosTraceDiagnostics;
                         Assert.IsNotNull(traceDiagnostic);
-                        traceDiagnostic.Value.Data.TryGetValue("Response Region", out hedgeContext);
+                        traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out hedgeContext);
                         Assert.IsNotNull(hedgeContext);
-                        Assert.AreEqual(region3, (string)hedgeContext);
+                        hedgeContextList = hedgeContext as IReadOnlyCollection<string>;
+                        Assert.IsTrue(hedgeContextList.Contains(region3));
 
                         break;
 
@@ -919,6 +944,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Database database = faultInjectionClient.GetDatabase(MultiRegionSetupHelpers.dbName);
                 Container container = database.GetContainer(MultiRegionSetupHelpers.containerName);
 
+                //warm up connections read
+                ItemResponse<CosmosIntegrationTestObject> _ = await container.ReadItemAsync<CosmosIntegrationTestObject>("testId", new PartitionKey("pk"));
+
                 sendDelay.Enable();
 
                 ItemRequestOptions requestOptions = new ItemRequestOptions
@@ -944,9 +972,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                 CosmosTraceDiagnostics traceDiagnostic = ir.Diagnostics as CosmosTraceDiagnostics;
                 Assert.IsNotNull(traceDiagnostic);
-                traceDiagnostic.Value.Data.TryGetValue("Response Region", out object hedgeContext);
+                traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out object hedgeContext);
                 Assert.IsNotNull(hedgeContext);
-                Assert.AreEqual(region2, (string)hedgeContext);
+                IReadOnlyCollection<string> hedgeContextList = hedgeContext as IReadOnlyCollection<string>;
+                Assert.IsTrue(hedgeContextList.Contains(region2));
             }
         }
 
@@ -987,6 +1016,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Database database = faultInjectionClient.GetDatabase(MultiRegionSetupHelpers.dbName);
                 Container container = database.GetContainer(MultiRegionSetupHelpers.containerName);
 
+                //warm up connections read
+                ItemResponse<CosmosIntegrationTestObject> _ = await container.ReadItemAsync<CosmosIntegrationTestObject>("testId", new PartitionKey("pk"));
+
                 responseDelay.Enable();
 
                 ItemRequestOptions requestOptions = new ItemRequestOptions
@@ -1016,9 +1048,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                     CosmosTraceDiagnostics traceDiagnostic = ex.Diagnostics as CosmosTraceDiagnostics;
                     Assert.IsNotNull(traceDiagnostic);
-                    traceDiagnostic.Value.Data.TryGetValue("Response Region", out object hedgeContext);
+                    traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out object hedgeContext);
                     Assert.IsNotNull(hedgeContext);
-                    Assert.AreEqual(region2, (string)hedgeContext);
+                    IReadOnlyCollection<string> hedgeContextList = hedgeContext as IReadOnlyCollection<string>;
+                    Assert.IsTrue(hedgeContextList.Contains(region2));
                 }
                 finally
                 {
@@ -1079,7 +1112,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Database database = faultInjectionClient.GetDatabase(MultiRegionSetupHelpers.dbName);
                 Container container = database.GetContainer(MultiRegionSetupHelpers.containerName);
 
-                
+                //warm up connections read
+                ItemResponse<CosmosIntegrationTestObject> _ = await container.ReadItemAsync<CosmosIntegrationTestObject>("testId", new PartitionKey("pk"));
 
                 ItemRequestOptions requestOptions = new ItemRequestOptions
                 {
@@ -1119,9 +1153,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                 CosmosTraceDiagnostics traceDiagnostic = ir.Diagnostics as CosmosTraceDiagnostics;
                 Assert.IsNotNull(traceDiagnostic);
-                traceDiagnostic.Value.Data.TryGetValue("Response Region", out object hedgeContext);
+                traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out object hedgeContext);
                 Assert.IsNotNull(hedgeContext);
-                Assert.AreEqual(region3, (string)hedgeContext);
+                IReadOnlyCollection<string> hedgeContextList = hedgeContext as IReadOnlyCollection<string>;
+                Assert.IsTrue(hedgeContextList.Contains(region3));
             }
         }
 
@@ -1177,6 +1212,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Database database = faultInjectionClient.GetDatabase(MultiRegionSetupHelpers.dbName);
                 Container container = database.GetContainer(MultiRegionSetupHelpers.containerName);
 
+                //warm up connections read
+                ItemResponse<CosmosIntegrationTestObject> _ = await container.ReadItemAsync<CosmosIntegrationTestObject>("testId", new PartitionKey("pk"));
+
                 ItemRequestOptions requestOptions = new ItemRequestOptions
                 {
                     AvailabilityStrategy = new CrossRegionHedgingAvailabilityStrategy(
@@ -1218,9 +1256,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                     CosmosTraceDiagnostics traceDiagnostic = ex.Diagnostics as CosmosTraceDiagnostics;
                     Assert.IsNotNull(traceDiagnostic);
-                    traceDiagnostic.Value.Data.TryGetValue("Response Region", out object hedgeContext);
+                    traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out object hedgeContext);
                     Assert.IsNotNull(hedgeContext);
-                    Assert.AreEqual(region3, (string)hedgeContext);
+                    IReadOnlyCollection<string> hedgeContextList = hedgeContext as IReadOnlyCollection<string>;
+                    Assert.IsTrue(hedgeContextList.Contains(region3));
                 }
                 finally
                 {
@@ -1274,14 +1313,114 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Database database = faultInjectionClient.GetDatabase(MultiRegionSetupHelpers.dbName);
                 Container container = database.GetContainer(MultiRegionSetupHelpers.containerName);
 
+                //warm up connections read
+                ItemResponse<CosmosIntegrationTestObject> _ = await container.ReadItemAsync<CosmosIntegrationTestObject>("testId", new PartitionKey("pk"));
+
                 CosmosOperationCanceledException cancelledException = await Assert.ThrowsExceptionAsync<CosmosOperationCanceledException>(() =>
                         container.ReadItemAsync<CosmosIntegrationTestObject>(
                             "testId",
                             new PartitionKey("pk"), cancellationToken: cts.Token
                     ));
-
             }
+        }
 
+        [TestMethod]
+        [TestCategory("MultiMaster")]
+        public async Task HedgingCancellationTokenHandling()
+        {
+            List<FeedRange> feedRanges = (List<FeedRange>)await this.container.GetFeedRangesAsync();
+            Assert.IsTrue(feedRanges.Any());
+
+            try
+            {
+                await this.container.DeleteItemAsync<CosmosIntegrationTestObject>("deleteMe", new PartitionKey("MMWrite"));
+            }
+            catch (Exception) { }
+
+
+            FaultInjectionRule sendDelay = new FaultInjectionRuleBuilder(
+                             id: "sendDelay",
+                             condition:
+                                 new FaultInjectionConditionBuilder()
+                                     .WithRegion(region1)
+                                     .WithConnectionType(FaultInjectionConnectionType.Gateway)
+                                     .WithEndpoint(
+                                        new FaultInjectionEndpointBuilder(
+                                            MultiRegionSetupHelpers.dbName,
+                                            MultiRegionSetupHelpers.containerName,
+                                            feedRanges[0])
+                                        .WithIncludePrimary(true)
+                                        .WithReplicaCount(4)
+                                        .Build())
+                                    .Build(),
+                            result:
+                                FaultInjectionResultBuilder.GetResultBuilder(FaultInjectionServerErrorType.SendDelay)
+                                    .WithDelay(TimeSpan.FromMilliseconds(8000))
+                                    .Build())
+                            .WithDuration(TimeSpan.FromMinutes(90))
+                            .Build();
+
+            List<FaultInjectionRule> rules = new List<FaultInjectionRule>() { sendDelay };
+            FaultInjector faultInjector = new FaultInjector(rules);
+
+            sendDelay.Disable();
+
+            CosmosClientOptions clientOptions = new CosmosClientOptions()
+            {
+                ConnectionMode = ConnectionMode.Direct,
+                ApplicationPreferredRegions = new List<string>() { region1, region2 },
+                Serializer = this.cosmosSystemTextJsonSerializer,
+                RequestTimeout = TimeSpan.FromMilliseconds(5000)
+            };
+
+            using (CosmosClient faultInjectionClient = new CosmosClient(
+                connectionString: this.connectionString,
+                clientOptions: faultInjector.GetFaultInjectionClientOptions(clientOptions)))
+            {
+                Database database = faultInjectionClient.GetDatabase(MultiRegionSetupHelpers.dbName);
+                Container container = database.GetContainer(MultiRegionSetupHelpers.containerName);
+
+                sendDelay.Enable();
+
+                CancellationTokenSource cts = new CancellationTokenSource();
+                cts.CancelAfter(TimeSpan.FromSeconds(5)); // Cancellation token expiry time is 5 seconds.
+
+                ItemRequestOptions requestOptions = new ItemRequestOptions
+                {
+                    AvailabilityStrategy = new CrossRegionHedgingAvailabilityStrategy(
+                        threshold: TimeSpan.FromMilliseconds(100),
+                        thresholdStep: TimeSpan.FromMilliseconds(50),
+                        enableMultiWriteRegionHedge: true)
+                };
+
+                CosmosIntegrationTestObject CosmosIntegrationTestObject = new CosmosIntegrationTestObject
+                {
+                    Id = "deleteMe",
+                    Pk = "MMWrite",
+                    Other = "test"
+                };
+
+                try
+                {
+                    ItemResponse<CosmosIntegrationTestObject> ir = await container.CreateItemAsync<CosmosIntegrationTestObject>(
+                    CosmosIntegrationTestObject,
+                    requestOptions: requestOptions,
+                    cancellationToken: cts.Token);
+
+                    CosmosTraceDiagnostics traceDiagnostic = ir.Diagnostics as CosmosTraceDiagnostics;
+                    Assert.IsNotNull(traceDiagnostic);
+                    traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out object hedgeContext);
+                    Assert.IsNotNull(hedgeContext);
+                    Assert.IsTrue(((IReadOnlyCollection<string>)hedgeContext).Contains(region2));
+                }
+                catch (CosmosException ex)
+                {
+                    Assert.Fail(ex.Message);
+                }
+
+
+                sendDelay.Disable();
+            }
         }
 
         private static async Task HandleChangesAsync(
@@ -1296,9 +1435,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             CosmosTraceDiagnostics traceDiagnostic = context.Diagnostics as CosmosTraceDiagnostics;
             Assert.IsNotNull(traceDiagnostic);
-            traceDiagnostic.Value.Data.TryGetValue("Response Region", out object hedgeContext);
+            traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out object hedgeContext);
             Assert.IsNotNull(hedgeContext);
-            Assert.AreNotEqual(region1, (string)hedgeContext);
+            IReadOnlyCollection<string> hedgeContextList = hedgeContext as IReadOnlyCollection<string>;
+            Assert.IsTrue(hedgeContextList.Contains(region2));
             await Task.Delay(1);
         }
 
@@ -1314,10 +1454,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             
             CosmosTraceDiagnostics traceDiagnostic = context.Diagnostics as CosmosTraceDiagnostics;
             Assert.IsNotNull(traceDiagnostic);
-            traceDiagnostic.Value.Data.TryGetValue("Response Region", out object hedgeContext);
+            traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out object hedgeContext);
             Assert.IsNotNull(hedgeContext);
-            Assert.AreNotEqual(region1, (string)hedgeContext);
-            Assert.AreNotEqual(region2, (string)hedgeContext);
+            IReadOnlyCollection<string> hedgeContextList = hedgeContext as IReadOnlyCollection<string>;
+            Assert.IsTrue(hedgeContextList.Contains(region3));
             await Task.Delay(1);
         }
     }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosAvailabilityStrategyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosAvailabilityStrategyTests.cs
@@ -336,7 +336,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 CosmosTraceDiagnostics traceDiagnostic = ir.Diagnostics as CosmosTraceDiagnostics;
                 Assert.IsNotNull(traceDiagnostic);
                 Assert.IsTrue(traceDiagnostic.ToString()
-                        .Contains($"\"Hedge Context\":[\"{region1}\",\"{region2}\"]"));
+                        .Contains($"\"Hedge Context\":[\"{region1}\",\"{region2}\""));
             }
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosAvailabilityStrategyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosAvailabilityStrategyTests.cs
@@ -765,7 +765,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                 CosmosTraceDiagnostics traceDiagnostic;
                 object hedgeContext;
-                IReadOnlyCollection<string> hedgeContextList;
 
                 switch (operation)
                 {
@@ -1142,7 +1141,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Assert.IsNotNull(traceDiagnostic);
                 traceDiagnostic.Value.Data.TryGetValue("Hedge Context", out object hedgeContext);
                 Assert.IsNotNull(hedgeContext);
-                IAssert.IsTrue(((IReadOnlyCollection<string>)hedgeContext).Contains(region3));
+                Assert.IsTrue(((IReadOnlyCollection<string>)hedgeContext).Contains(region3));
             }
         }
 


### PR DESCRIPTION
# Pull Request Template

## Description


This pull request refactors the `CrossRegionHedgingAvailabilityStrategy` class in the Azure Cosmos SDK to fix a rare concurrency issue regarding session tokens and improve diagnostics for improved debugging.. It also updates related tests to align with the changes. The most important changes include replacing the `Response Region` diagnostic with a new `Hedge Config` diagnostic, modifying the `HedgingResponse` class, and updating test cases to validate the new behavior. the `Response Region` field can sometimes be inaccurate with internal cross regional retries so it has been removed. To find the response region, you can look at the existing store response to see where the response came from. 


## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)

## Closing issues

To automatically close an issue: closes #IssueNumber