### PR TITLE
[Internal] Thin Client Integration: Adds runner tests for thinclient test scenarios.

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemThinClientTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemThinClientTests.cs
@@ -1,0 +1,359 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Net;
+    using System.Text.Json;
+    using System.Text.Json.Serialization;
+    using System.Threading.Tasks;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using static Microsoft.Azure.Cosmos.SDK.EmulatorTests.MultiRegionSetupHelpers;
+    using TestObject = MultiRegionSetupHelpers.CosmosIntegrationTestObject;
+
+    [TestClass]
+    public class CosmosItemThinClientTests
+    {
+        private string connectionString;
+        private CosmosClient client;
+        private Database database;
+        private Container container;
+        private CosmosSystemTextJsonSerializer cosmosSystemTextJsonSerializer;
+
+        private const int ItemCount = 1000;
+
+        [TestInitialize]
+        public async Task TestInitAsync()
+        {
+            this.connectionString = Environment.GetEnvironmentVariable("COSMOSDB_THINCLIENT");
+            Environment.SetEnvironmentVariable(ConfigurationManager.ThinClientModeEnabled, "True");
+
+            if (string.IsNullOrEmpty(this.connectionString))
+            {
+                Assert.Fail("Set environment variable COSMOSDB_THINCLIENT to run the tests");
+            }
+
+            JsonSerializerOptions jsonSerializerOptions = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = null,
+                PropertyNameCaseInsensitive = true,
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+            };
+            this.cosmosSystemTextJsonSerializer = new MultiRegionSetupHelpers.CosmosSystemTextJsonSerializer(jsonSerializerOptions);
+
+            this.client = new CosmosClient(
+                  this.connectionString,
+                  new CosmosClientOptions()
+                  {
+                      ConnectionMode = ConnectionMode.Gateway,
+                      Serializer = this.cosmosSystemTextJsonSerializer,
+                  });
+
+            string uniqueDbName = "TestDb_" + Guid.NewGuid().ToString();
+            this.database = await this.client.CreateDatabaseIfNotExistsAsync(uniqueDbName);
+            string uniqueContainerName = "TestContainer_" + Guid.NewGuid().ToString();
+            this.container = await this.database.CreateContainerIfNotExistsAsync(uniqueContainerName, "/pk");
+        }
+
+
+        [TestCleanup]
+        public async Task TestCleanupAsync()
+        {
+            Environment.SetEnvironmentVariable(ConfigurationManager.ThinClientModeEnabled, "False");
+
+            if (this.database != null)
+            {
+                await this.database.DeleteAsync();
+            }
+
+            this.client?.Dispose();
+        }
+
+        private IEnumerable<TestObject> GenerateItems(string partitionKey)
+        {
+            List<TestObject> items = new List<TestObject>();
+            for (int i = 0; i < ItemCount; i++)
+            {
+                items.Add(new TestObject
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    Pk = partitionKey,
+                    Other = "Test Item " + i
+                });
+            }
+
+            return items;
+        }
+
+        [TestMethod]
+        [TestCategory("ThinClient")]
+        public async Task CreateItemsTest()
+        {
+            string pk = "pk_create";
+            IEnumerable<TestObject> items = this.GenerateItems(pk);
+
+            foreach (TestObject item in items)
+            {
+                ItemResponse<TestObject> response = await this.container.CreateItemAsync(item, new PartitionKey(item.Pk));
+                Assert.AreEqual(HttpStatusCode.Created, response.StatusCode);
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("ThinClient")]
+        public async Task ReadItemsTest()
+        {
+            string pk = "pk_read";
+            List<TestObject> items = this.GenerateItems(pk).ToList();
+
+            foreach (TestObject item in items)
+            {
+                await this.container.CreateItemAsync(item, new PartitionKey(item.Pk));
+            }
+
+            foreach (TestObject item in items)
+            {
+                ItemResponse<TestObject> response = await this.container.ReadItemAsync<TestObject>(item.Id, new PartitionKey(item.Pk));
+                Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+                Assert.AreEqual(item.Id, response.Resource.Id);
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("ThinClient")]
+        public async Task ReplaceItemsTest()
+        {
+            string pk = "pk_replace";
+            List<TestObject> items = this.GenerateItems(pk).ToList();
+
+            foreach (TestObject item in items)
+            {
+                await this.container.CreateItemAsync(item, new PartitionKey(item.Pk));
+            }
+
+            foreach (TestObject item in items)
+            {
+                TestObject updatedItem = new TestObject
+                {
+                    Id = item.Id,
+                    Pk = item.Pk,
+                    Other = "Updated " + item.Other
+                };
+
+                ItemResponse<TestObject> response = await this.container.ReplaceItemAsync(updatedItem, updatedItem.Id, new PartitionKey(updatedItem.Pk));
+                Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+                Assert.AreEqual("Updated " + item.Other, response.Resource.Other);
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("ThinClient")]
+        public async Task UpsertItemsTest()
+        {
+            string pk = "pk_upsert";
+            IEnumerable<TestObject> items = this.GenerateItems(pk);
+
+            foreach (TestObject item in items)
+            {
+                ItemResponse<TestObject> response = await this.container.UpsertItemAsync(item, new PartitionKey(item.Pk));
+                Assert.IsTrue(response.StatusCode == HttpStatusCode.Created || response.StatusCode == HttpStatusCode.OK);
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("ThinClient")]
+        public async Task DeleteItemsTest()
+        {
+            string pk = "pk_delete";
+            List<TestObject> items = this.GenerateItems(pk).ToList();
+
+            foreach (TestObject item in items)
+            {
+                await this.container.CreateItemAsync(item, new PartitionKey(item.Pk));
+            }
+
+            foreach (TestObject item in items)
+            {
+                ItemResponse<TestObject> response = await this.container.DeleteItemAsync<TestObject>(item.Id, new PartitionKey(item.Pk));
+                Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("ThinClient")]
+        public async Task CreateItemStreamTest()
+        {
+            string pk = "pk_create_stream";
+            IEnumerable<TestObject> items = this.GenerateItems(pk);
+
+            foreach (TestObject item in items)
+            {
+                using (Stream stream = this.cosmosSystemTextJsonSerializer.ToStream(item))
+                {
+                    using (ResponseMessage response = await this.container.CreateItemStreamAsync(stream, new PartitionKey(item.Pk)))
+                    {
+                        Assert.AreEqual(HttpStatusCode.Created, response.StatusCode);
+                    }
+                }
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("ThinClient")]
+        public async Task ReadItemStreamTest()
+        {
+            string pk = "pk_read_stream";
+            List<TestObject> items = this.GenerateItems(pk).ToList();
+
+            foreach (TestObject item in items)
+            {
+                await this.container.CreateItemAsync(item, new PartitionKey(item.Pk));
+            }
+
+            foreach (TestObject item in items)
+            {
+                using (ResponseMessage response = await this.container.ReadItemStreamAsync(item.Id, new PartitionKey(item.Pk)))
+                {
+                    Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+                }
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("ThinClient")]
+        public async Task ReplaceItemStreamTest()
+        {
+            string pk = "pk_replace_stream";
+            List<TestObject> items = this.GenerateItems(pk).ToList();
+
+            foreach (TestObject item in items)
+            {
+                await this.container.CreateItemAsync(item, new PartitionKey(item.Pk));
+            }
+
+            foreach (TestObject item in items)
+            {
+                TestObject updatedItem = new TestObject
+                {
+                    Id = item.Id,
+                    Pk = item.Pk,
+                    Other = "Updated " + item.Other
+                };
+
+                using (Stream stream = this.cosmosSystemTextJsonSerializer.ToStream(updatedItem))
+                {
+                    using (ResponseMessage response = await this.container.ReplaceItemStreamAsync(stream, updatedItem.Id, new PartitionKey(updatedItem.Pk)))
+                    {
+                        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+                    }
+                }
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("ThinClient")]
+        public async Task UpsertItemStreamTest()
+        {
+            string pk = "pk_upsert_stream";
+            IEnumerable<TestObject> items = this.GenerateItems(pk);
+
+            foreach (TestObject item in items)
+            {
+                using (Stream stream = this.cosmosSystemTextJsonSerializer.ToStream(item))
+                {
+                    using (ResponseMessage response = await this.container.UpsertItemStreamAsync(stream, new PartitionKey(item.Pk)))
+                    {
+                        Assert.IsTrue(response.StatusCode == HttpStatusCode.Created || response.StatusCode == HttpStatusCode.OK);
+                    }
+                }
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("ThinClient")]
+        public async Task DeleteItemStreamTest()
+        {
+            string pk = "pk_delete_stream";
+            List<TestObject> items = this.GenerateItems(pk).ToList();
+
+            foreach (TestObject item in items)
+            {
+                await this.container.CreateItemAsync(item, new PartitionKey(item.Pk));
+            }
+
+            foreach (TestObject item in items)
+            {
+                using (ResponseMessage response = await this.container.DeleteItemStreamAsync(item.Id, new PartitionKey(item.Pk)))
+                {
+                    Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
+                }
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("ThinClient")]
+        public async Task QueryItemsTest()
+        {
+            string pk = "pk_query";
+            List<TestObject> items = this.GenerateItems(pk).ToList();
+
+            foreach (TestObject item in items)
+            {
+                await this.container.CreateItemAsync(item, new PartitionKey(item.Pk));
+            }
+
+            string query = $"SELECT * FROM c WHERE c.partitionKey = '{pk}'";
+            FeedIterator<TestObject> iterator = this.container.GetItemQueryIterator<TestObject>(query);
+
+            int count = 0;
+            while (iterator.HasMoreResults)
+            {
+                FeedResponse<TestObject> response = await iterator.ReadNextAsync();
+                count += response.Count;
+            }
+
+            Assert.AreEqual(ItemCount, count);
+        }
+
+        [TestMethod]
+        [TestCategory("ThinClient")]
+        public async Task QueryItemsStreamTest()
+        {
+            string pk = "pk_query_stream";
+            List<TestObject> items = this.GenerateItems(pk).ToList();
+
+            foreach (dynamic item in items)
+            {
+                await this.container.CreateItemAsync(item, new PartitionKey(item.partitionKey));
+            }
+
+            QueryDefinition query = new QueryDefinition("SELECT * FROM c WHERE c.partitionKey = @pk").WithParameter("@pk", pk);
+            FeedIterator iterator = this.container.GetItemQueryStreamIterator(query);
+
+            int count = 0;
+            while (iterator.HasMoreResults)
+            {
+                using (ResponseMessage response = await iterator.ReadNextAsync())
+                {
+                    Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+
+                    using (StreamReader reader = new StreamReader(response.Content))
+                    {
+                        string json = await reader.ReadToEndAsync();
+                        using (JsonDocument doc = JsonDocument.Parse(json))
+                        {
+                            count += doc.RootElement.GetProperty("Documents").GetArrayLength();
+                        }
+                    }
+                }
+            }
+
+            Assert.AreEqual(ItemCount, count);
+        }
+    }
+}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -73,7 +73,7 @@ jobs:
     Arguments: $(ReleaseArguments)
     VmImage:  $(VmImage)
     
- - template:  templates/build-thinclient.yml
+- template:  templates/build-thinclient.yml
   parameters:
     BuildConfiguration: Release
     Arguments: $(ReleaseArguments)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,3 +72,12 @@ jobs:
     BuildConfiguration: Release
     Arguments: $(ReleaseArguments)
     VmImage:  $(VmImage)
+    
+ - template:  templates/build-thinclient.yml
+  parameters:
+    BuildConfiguration: Release
+    Arguments: $(ReleaseArguments)
+    VmImage: $(VmImage)
+    ThinClientConnectionString: $(COSMOSDB_THINCLIENT)
+    IncludePerformance: true
+    IncludeCoverage: true

--- a/templates/build-test.yml
+++ b/templates/build-test.yml
@@ -5,8 +5,8 @@ parameters:
   Arguments: ''
   VmImage: '' # https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops
   OS: 'Windows'
-  EmulatorPipeline1Arguments: ' --filter "TestCategory!=Flaky & TestCategory!=Quarantine & TestCategory!=Functional & TestCategory!=ClientTelemetryRelease & TestCategory!=LongRunning & TestCategory!=MultiRegion & TestCategory!=MultiMaster & (TestCategory=ClientTelemetryEmulator|TestCategory=Query|TestCategory=ReadFeed|TestCategory=Batch|TestCategory=ChangeFeed)" --verbosity normal '
-  EmulatorPipeline2Arguments: ' --filter "TestCategory!=Flaky & TestCategory!=Quarantine & TestCategory!=Functional & TestCategory!=ClientTelemetryRelease & TestCategory!=ClientTelemetryEmulator & TestCategory!=Query & TestCategory!=ReadFeed & TestCategory!=Batch & TestCategory!=ChangeFeed & TestCategory!=LongRunning & TestCategory!=MultiRegion & TestCategory!=MultiMaster" --verbosity normal '
+  EmulatorPipeline1Arguments: ' --filter "TestCategory!=Flaky & TestCategory!=Quarantine & TestCategory!=Functional & TestCategory!=ClientTelemetryRelease & TestCategory !=ThinClient & TestCategory!=LongRunning & TestCategory!=MultiRegion & TestCategory!=MultiMaster & (TestCategory=ClientTelemetryEmulator|TestCategory=Query|TestCategory=ReadFeed|TestCategory=Batch|TestCategory=ChangeFeed)" --verbosity normal '
+  EmulatorPipeline2Arguments: ' --filter "TestCategory!=Flaky & TestCategory!=Quarantine & TestCategory!=Functional & TestCategory!=ClientTelemetryRelease & TestCategory !=ThinClient & TestCategory!=ClientTelemetryEmulator & TestCategory!=Query & TestCategory!=ReadFeed & TestCategory!=Batch & TestCategory!=ChangeFeed & TestCategory!=LongRunning & TestCategory!=MultiRegion & TestCategory!=MultiMaster" --verbosity normal '
   EmulatorPipeline3Arguments: ' --filter "TestCategory=MultiRegion" --verbosity normal '
   EmulatorPipeline4Arguments: ' --filter "TestCategory=MultiMaster" --verbosity normal '
   EmulatorPipeline1CategoryListName: ' Client Telemetry, Query, ChangeFeed, ReadFeed, Batch ' # Divided in 2 categories to run them in parallel and reduce the PR feedback time

--- a/templates/build-thinclient.yml
+++ b/templates/build-thinclient.yml
@@ -1,0 +1,53 @@
+# File: templates/build-thinclient.yml
+
+parameters:
+  BuildConfiguration: ''
+  Arguments: ''
+  VmImage: '' # https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops
+  OS: 'Windows'
+  EmulatorPipeline5Arguments: ' --filter "TestCategory=ThinClient" --verbosity normal '
+  EmulatorPipeline5CategoryListName: ' ThinClient '
+  ThinClientConnectionString: ''
+  IncludeEncryption: true
+  IncludePerformance: true
+  IncludeCoverage: true
+
+jobs:
+- job:
+  displayName: EmulatorTests ${{ parameters.BuildConfiguration }} - ${{ parameters.EmulatorPipeline5CategoryListName }}
+  timeoutInMinutes: 120
+  condition: always()
+  continueOnError: true
+  pool:
+    name: 'OneES'
+
+  steps:
+  - checkout: self
+    clean: true
+
+  - task: UseDotNet@2
+    displayName: Use .NET 6.0
+    inputs:
+      packageType: 'runtime'
+      version: '6.x'
+
+  - task: UseDotNet@2
+    displayName: Use .NET 8.0
+    inputs:
+      packageType: 'sdk'
+      version: '8.x'
+
+  - task: DotNetCoreCLI@2
+    displayName: Microsoft.Azure.Cosmos.EmulatorTests - ${{ parameters.EmulatorPipeline5CategoryListName }}
+    continueOnError: true
+    inputs:
+      command: test
+      projects: 'Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/*.csproj'
+      arguments: ${{ parameters.EmulatorPipeline5Arguments }} --configuration ${{ parameters.BuildConfiguration }} /p:OS=${{ parameters.OS }}
+      nugetConfigPath: NuGet.config
+      publishTestResults: true
+      testRunTitle: Microsoft.Azure.Cosmos.EmulatorTests - ${{ parameters.EmulatorPipeline5CategoryListName }}
+    env:
+      COSMOSDB_THINCLIENT: ${{ parameters.ThinClientConnectionString }}
+      AZURE_COSMOS_THIN_CLIENT_ENABLED: 'True'
+      AZURE_COSMOS_NON_STREAMING_ORDER_BY_FLAG_DISABLED: 'true'


### PR DESCRIPTION
# Pull Request Template

## Description

Adds pipeline to allow integration tests to run for thinclient test scenarios. Creating a separate pipeline which does not impact the main PR pipeline as the thinclient tests are still unstable. Adding new endpoint variable dotnet-v3-CI pipeline $(COSMOSDB_THINCLIENT).

Test Results:
- When Thinclient category tests are failing, it does not impact the entire pipeline(optional) and allows PR merge.
https://cosmos-db-sdk-public.visualstudio.com/cosmos-db-sdk-public/_build/results?buildId=55136&view=results
<img width="578" alt="image" src="https://github.com/user-attachments/assets/1545978c-f666-4dee-b198-cff8d55c1d4e" />

- Pipeline failing when tests other than thinclient tests fail.
<img width="598" alt="image" src="https://github.com/user-attachments/assets/2049bc2e-c2ef-4fb8-be0f-303ac45b7ec5" />


## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)


## Closing issues

To automatically close an issue: closes #5144