### PR TITLE
[msdata/direct] Add feature switch to disable ConfigurationManager

### DIFF
--- a/Microsoft.Azure.Cosmos/src/AppConfig.cs
+++ b/Microsoft.Azure.Cosmos/src/AppConfig.cs
@@ -1,0 +1,24 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Microsoft.Azure.Cosmos
+{
+    internal sealed class AppConfig
+    {
+        [FeatureSwitchDefinition("Microsoft.Azure.Cosmos.AppConfig.IsEnabled")]
+        internal static bool IsEnabled { get; } = GetIsEnabled();
+
+        private static bool GetIsEnabled()
+        {
+#if NETSTANDARD20
+            // GetEntryAssembly returns null when loaded from native netstandard2.0
+            return System.Reflection.Assembly.GetEntryAssembly() != null;
+#else
+            return true;
+#endif
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Authorization/AuthorizationTokenProviderMasterKey.cs
+++ b/Microsoft.Azure.Cosmos/src/Authorization/AuthorizationTokenProviderMasterKey.cs
@@ -29,13 +29,11 @@ namespace Microsoft.Azure.Cosmos
             this.authKeyHashFunction = computeHash ?? throw new ArgumentNullException(nameof(computeHash));
             this.enableAuthFailureTraces = new Lazy<bool>(() =>
             {
-#if NETSTANDARD20
-                // GetEntryAssembly returns null when loaded from native netstandard2.0
-                if (System.Reflection.Assembly.GetEntryAssembly() == null)
+                if (!AppConfig.IsEnabled)
                 {
-                        return false;
+                    return false;
                 }
-#endif
+
                 string enableAuthFailureTracesString = System.Configuration.ConfigurationManager.AppSettings[EnableAuthFailureTracesConfig];
                 if (string.IsNullOrEmpty(enableAuthFailureTracesString) || 
                     !bool.TryParse(enableAuthFailureTracesString, out bool enableAuthFailureTracesFlag))

--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -710,11 +710,8 @@ namespace Microsoft.Azure.Cosmos
             }, CancellationToken.None);
 
 #if !(NETSTANDARD15 || NETSTANDARD16)
-#if NETSTANDARD20
-            // GetEntryAssembly returns null when loaded from native netstandard2.0
-            if (System.Reflection.Assembly.GetEntryAssembly() != null)
+            if (AppConfig.IsEnabled)
             {
-#endif
                 // For tests we want to allow stronger consistency during construction or per call
                 string allowOverrideStrongerConsistencyConfig = System.Configuration.ConfigurationManager.AppSettings[DocumentClient.AllowOverrideStrongerConsistency];
                 if (!string.IsNullOrEmpty(allowOverrideStrongerConsistencyConfig))
@@ -876,9 +873,7 @@ namespace Microsoft.Azure.Cosmos
                         }
                     }
                 }
-#if NETSTANDARD20
             }
-#endif
 #endif
 
             string rntbdMaxConcurrentOpeningConnectionCountOverrideString = Environment.GetEnvironmentVariable(RntbdMaxConcurrentOpeningConnectionCountConfig);

--- a/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GatewayAddressCache.cs
@@ -136,18 +136,13 @@ namespace Microsoft.Azure.Cosmos.Routing
             }
 
 #if !(NETSTANDARD15 || NETSTANDARD16)
-#if NETSTANDARD20
-            // GetEntryAssembly returns null when loaded from native netstandard2.0
-            if (System.Reflection.Assembly.GetEntryAssembly() != null)
+            if (AppConfig.IsEnabled)
             {
-#endif
                 if (int.TryParse(System.Configuration.ConfigurationManager.AppSettings[GatewayAddressCache.AddressResolutionBatchSize], out int userSpecifiedBatchSize))
                 {
                     batchSize = userSpecifiedBatchSize;
                 }
-#if NETSTANDARD20
             }
-#endif  
 #endif
 
             string collectionAltLink = string.Format(

--- a/Microsoft.Azure.Cosmos/src/Routing/GlobalEndpointManager.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GlobalEndpointManager.cs
@@ -58,11 +58,8 @@ namespace Microsoft.Azure.Cosmos.Routing
             this.connectionPolicy.PreferenceChanged += this.OnPreferenceChanged;
 
 #if !(NETSTANDARD15 || NETSTANDARD16)
-#if NETSTANDARD20
-            // GetEntryAssembly returns null when loaded from native netstandard2.0
-            if (System.Reflection.Assembly.GetEntryAssembly() != null)
+            if (AppConfig.IsEnabled)
             {
-#endif
                 string backgroundRefreshLocationTimeIntervalInMSConfig = System.Configuration.ConfigurationManager.AppSettings[GlobalEndpointManager.BackgroundRefreshLocationTimeIntervalInMS];
                 if (!string.IsNullOrEmpty(backgroundRefreshLocationTimeIntervalInMSConfig))
                 {
@@ -71,9 +68,7 @@ namespace Microsoft.Azure.Cosmos.Routing
                         this.backgroundRefreshLocationTimeIntervalInMS = GlobalEndpointManager.DefaultBackgroundRefreshLocationTimeIntervalInMS;
                     }
                 }
-#if NETSTANDARD20
             }
-#endif  
 #endif
             string minimumIntervalForNonForceRefreshLocationInMSConfig = Environment.GetEnvironmentVariable(GlobalEndpointManager.MinimumIntervalForNonForceRefreshLocationInMS);
             if (!string.IsNullOrEmpty(minimumIntervalForNonForceRefreshLocationInMSConfig))

--- a/Microsoft.Azure.Cosmos/src/Routing/LocationCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/LocationCache.cs
@@ -55,11 +55,8 @@ namespace Microsoft.Azure.Cosmos.Routing
             this.regionNameMapper = new RegionNameMapper();
 
 #if !(NETSTANDARD15 || NETSTANDARD16)
-#if NETSTANDARD20
-            // GetEntryAssembly returns null when loaded from native netstandard2.0
-            if (System.Reflection.Assembly.GetEntryAssembly() != null)
+            if (AppConfig.IsEnabled)
             {
-#endif
                 string unavailableLocationsExpirationTimeInSecondsConfig = System.Configuration.ConfigurationManager.AppSettings[LocationCache.UnavailableLocationsExpirationTimeInSeconds];
                 if (!string.IsNullOrEmpty(unavailableLocationsExpirationTimeInSecondsConfig))
                 {
@@ -74,9 +71,7 @@ namespace Microsoft.Azure.Cosmos.Routing
                         this.unavailableLocationsExpirationTime = TimeSpan.FromSeconds(unavailableLocationsExpirationTimeinSecondsConfigValue);
                     }
                 }
-#if NETSTANDARD20
             }
-#endif  
 #endif
         }
 

--- a/Microsoft.Azure.Cosmos/src/TrimmingAttributes/FeatureSwitchDefinitionAttribute.cs
+++ b/Microsoft.Azure.Cosmos/src/TrimmingAttributes/FeatureSwitchDefinitionAttribute.cs
@@ -1,0 +1,37 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace System.Diagnostics.CodeAnalysis
+{
+#if !NET9_0_OR_GREATER
+    /// <summary>
+    /// Indicates that the specified public static boolean get-only property
+    /// corresponds to the feature switch specified by name.
+    /// </summary>
+    /// <remarks>
+    /// IL rewriters and compilers can use this to substitute the return value
+    /// of the specified property with the value of the feature switch.
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Property, Inherited = false)]
+    internal sealed class FeatureSwitchDefinitionAttribute : Attribute
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FeatureSwitchDefinitionAttribute"/> class
+        /// with the specified feature switch name.
+        /// </summary>
+        /// <param name="switchName">
+        /// The name of the feature switch that provides the value for the specified property.
+        /// </param>
+        public FeatureSwitchDefinitionAttribute(string switchName)
+        {
+            SwitchName = switchName;
+        }
+
+        /// <summary>
+        /// The name of the feature switch that provides the value for the specified property.
+        /// </summary>
+        public string SwitchName { get; }
+    }
+#endif
+}

--- a/Microsoft.Azure.Cosmos/src/direct/ReplicatedResourceClient.cs
+++ b/Microsoft.Azure.Cosmos/src/direct/ReplicatedResourceClient.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Azure.Documents
     using System.Globalization;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos;
     using Microsoft.Azure.Cosmos.Core.Trace;
     using Microsoft.Azure.Documents.Client;
 
@@ -38,11 +39,8 @@ namespace Microsoft.Azure.Documents
         private static readonly Lazy<bool> enableGlobalStrong = new Lazy<bool>(() => {
             bool isGlobalStrongEnabled = true;
 #if !(NETSTANDARD15 || NETSTANDARD16)
-#if NETSTANDARD20
-        // GetEntryAssembly returns null when loaded from native netstandard2.0
-        if (System.Reflection.Assembly.GetEntryAssembly() != null)
+        if (AppConfig.IsEnabled)
         {
-#endif
             string isGlobalStrongEnabledConfig = System.Configuration.ConfigurationManager.AppSettings[ReplicatedResourceClient.EnableGlobalStrongConfigurationName];
             if (!string.IsNullOrEmpty(isGlobalStrongEnabledConfig))
             {
@@ -51,9 +49,7 @@ namespace Microsoft.Azure.Documents
                     return false;
                 }
             }
-#if NETSTANDARD20
         }
-#endif
 #endif
             return isGlobalStrongEnabled;
         });


### PR DESCRIPTION
Certain code paths check settings using ConfigurationManager APIs that are not trim-compatible.
This adds a feature switch that can be used to disable this behavior in trimmed apps.
There's precedent for ignoring these config options as indicated by the existing checks for `GetEntryAssembly()`.

Fixes this warning from Azure MCP, which was coming a transitive reference to ConfigurationManager through CosmosDB.

```
ILC : Trim analysis warning IL2067: System.Configuration.TypeUtil.CreateInstance(Type): 'type' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicParameterlessConstructor', 'DynamicallyAccessedMemberTypes.NonPublicConstructors' in call to 'System.Activator.CreateInstance(Type,Boolean)'. The parameter 'type' of method 'System.Configuration.TypeUtil.CreateInstance(Type)' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
```

This is also one of the first code paths that fails at runtime when using Azure MCP to get Cosmos DB database info. Setting the new feature switch to disabled gets past this failure:

```json
{
    "status": 500,
    "message": "Configuration system failed to initialize. To mitigate this issue, please refer to the troubleshooting guidelines here at https://aka.ms/azmcp/troubleshooting.",
    "results": {
        "message": "Configuration system failed to initialize",
        "stackTrace": "   at System.Configuration.ConfigurationManager.EnsureConfigurationSystem() \u002B 0xdb\n   at System.Configuration.ConfigurationManager.PrepareConfigSystem() \u002B 0x12\n   at System.Configuration.ConfigurationManager.GetSection(String) \u002B 0x1b\n   at System.Configuration.ConfigurationManager.get_AppSettings() \u002B 0x14\n   at Microsoft.Azure.Cosmos.DocumentClient.Initialize(Uri, ConnectionPolicy, Nullable\u00601, HttpMessageHandler, ISessionContainer, Nullable\u00601, IStoreClientFactory, TokenCredential, String, RemoteCertificateValidationCallback, CosmosClientTelemetryOptions) \u002B 0x1c5\n   at Microsoft.Azure.Cosmos.ClientContextCore.Create(CosmosClient, CosmosClientOptions) \u002B 0x1a1\n   at Microsoft.Azure.Cosmos.CosmosClient..ctor(String, AuthorizationTokenProvider, CosmosClientOptions) \u002B 0x110\n   at AzureMcp.Services.Azure.Cosmos.CosmosService.\u003CCreateCosmosClientWithAuth\u003Ed__6.MoveNext() \u002B 0xb4\n--- End of stack trace from previous location ---\n   at AzureMcp.Services.Azure.Cosmos.CosmosService.\u003CGetCosmosClientAsync\u003Ed__7.MoveNext() \u002B 0x115\n--- End of stack trace from previous location ---\n   at AzureMcp.Services.Azure.Cosmos.CosmosService.\u003CListDatabases\u003Ed__9.MoveNext() \u002B 0x6a\n--- End of stack trace from previous location ---\n   at AzureMcp.Commands.Cosmos.DatabaseListCommand.\u003CExecuteAsync\u003Ed__9.MoveNext() \u002B 0xde",
        "type": "ConfigurationErrorsException"
    },
    "duration": 0
}
```

@kirankumarkolli PTAL