### PR TITLE
[INTERNAL] Draft: DTC API modeling

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Batch/TransactionalBatch.cs
+++ b/Microsoft.Azure.Cosmos/src/Batch/TransactionalBatch.cs
@@ -4,6 +4,7 @@
 
 namespace Microsoft.Azure.Cosmos
 {
+    using System;
     using System.IO;
     using System.Net;
     using System.Threading;
@@ -283,5 +284,7 @@ namespace Microsoft.Azure.Cosmos
         public abstract Task<TransactionalBatchResponse> ExecuteAsync(
            TransactionalBatchRequestOptions requestOptions,
            CancellationToken cancellationToken = default);
+
+        public abstract TransactionalBatch ConditionalCheck<T>(string v, Func<object, bool> value, ItemRequestOptions itemRequestOptions);
     }
 }

--- a/Microsoft.Azure.Cosmos/src/CosmosClient.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClient.cs
@@ -1216,60 +1216,6 @@ namespace Microsoft.Azure.Cosmos
 #pragma warning disable SA1602 // ElementsMustBeDocumented
 #pragma warning disable CS1591 // ElementsMustBeDocumented
 #pragma warning disable IDE0090 // Use 'new(...)'
-        public virtual DistributeTransaction CreateDistributedTransaction()
-        {
-            throw new NotImplementedException();
-        }
-
-        public enum OperationType
-        {
-            Check,
-            Read, 
-            Create,
-            Replace,
-            Upsert, 
-            Delete
-        }
-
-        public class Operation
-        {
-            public Operation(OperationType, string, string, PartitionKey, string, ItemRequestOptions = null)
-            {
-
-            }
-
-            public Operation(OperationType, string, string, PartitionKey, string, Stream payload, ItemRequestOptions = null)
-            {
-
-            }
-
-            public OperationType OperationType { get; set; }
-            public string Database { get; set; }
-            public string Container { get; set; }
-            public PartitionKey PartitionKey { get; set; }
-            public string Id { get; set; }
-            public Stream Payload { get; set; }
-            public ItemRequestOptions RequestOptions { get; set; }
-
-            public static Operation With<T>(OperationType, string, string, PartitionKey, string, T payload, ItemRequestOptions = null)
-            {
-                throw new NotImplementedException();
-            }
-        }
-
-        public class DistributedTransactionResponse : ResponseMessage
-        {
-            public IEnumerable<ResponseMessage> OperationResults()
-            {
-                throw new NotImplementedException();
-            }
-        }
-
-        public virtual Task<DistributedTransactionResponse> ExecuteDistributedAsync(IEnumerable<Operation> operations)
-        {
-            throw new NotImplementedException();
-        }
-
         public async Task Usage1Async()
         {
             CosmosClient testClient = null;
@@ -1328,6 +1274,60 @@ namespace Microsoft.Azure.Cosmos
             {
                 System.Diagnostics.Trace.TraceInformation($"DTC ops status codes {operationResponse.StatusCode}");
             }
+        }
+
+        public virtual DistributeTransaction CreateDistributedTransaction()
+        {
+            throw new NotImplementedException();
+        }
+
+        public enum OperationType
+        {
+            Check,
+            Read, 
+            Create,
+            Replace,
+            Upsert, 
+            Delete
+        }
+
+        public class Operation
+        {
+            public Operation(OperationType, string, string, PartitionKey, string, ItemRequestOptions = null)
+            {
+
+            }
+
+            public Operation(OperationType, string, string, PartitionKey, string, Stream payload, ItemRequestOptions = null)
+            {
+
+            }
+
+            public OperationType OperationType { get; set; }
+            public string Database { get; set; }
+            public string Container { get; set; }
+            public PartitionKey PartitionKey { get; set; }
+            public string Id { get; set; }
+            public Stream Payload { get; set; }
+            public ItemRequestOptions RequestOptions { get; set; }
+
+            public static Operation With<T>(OperationType, string, string, PartitionKey, string, T payload, ItemRequestOptions = null)
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public class DistributedTransactionResponse : ResponseMessage
+        {
+            public IEnumerable<ResponseMessage> OperationResults()
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public virtual Task<DistributedTransactionResponse> ExecuteDistributedAsync(IEnumerable<Operation> operations)
+        {
+            throw new NotImplementedException();
         }
 
         public abstract class DistributeTransaction


### PR DESCRIPTION
Notes: 

- Transaction at the scope of account -> API at CosmosClient level
- TransactionId: CX needs to define (control back to application for control on retries)

> - No guarantee of TransactionId -> payload/contents
> - ** Service side transaction retention period: how long for clients to retry for idempotency?
             - ETag is ideal to avoid overstepping BUT there are non-Etag possiblilities as well?
                 - Blind replace
- ActivityId: So-far the model is on uniqueue activityid per NW call 
> - single activityId for all the composed operations
             -> Part of the transaction NOT per operation?
> - Possible conditon modeling
    - Item/Document existnece: Read operation (implicit)
    - Item/Document content: (including system properties)
             - Currently assumed to be some form of query-where clause
                 - Non-intutive for CX to grasp the standing variable? (From c)
                 - To be hand crafted (C# expression is a bonus not available in other languages and limited to user-types not system properties)
             - Is an option needed to return on condition failure? (ex: withReturnValuesOnConditionCheckFailure)
                 - ** Might help avoid read again?
> - RUs: Will they be hierarchical and cumulative? (Operation level and transaction level)
 
- Partition and Id: mandatory arguments
> - partial HPK: Not supported
