### PR TITLE
[Internal] PPAF: Fixes Integration Tests to Intercept Gateway Response

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemIntegrationTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemIntegrationTests.cs
@@ -5,6 +5,7 @@
     using System.IO;
     using System.Linq;
     using System.Net;
+    using System.Net.Http;
     using System.Text;
     using System.Text.Json;
     using System.Text.Json.Serialization;
@@ -13,6 +14,7 @@
     using Microsoft.Azure.Cosmos.Diagnostics;
     using Microsoft.Azure.Cosmos.FaultInjection;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Newtonsoft.Json.Linq;
     using static Microsoft.Azure.Cosmos.Routing.GlobalPartitionEndpointManagerCore;
     using static Microsoft.Azure.Cosmos.SDK.EmulatorTests.MultiRegionSetupHelpers;
 
@@ -1358,6 +1360,28 @@
             List<FaultInjectionRule> rules = new List<FaultInjectionRule> { serviceUnavailableRule };
             FaultInjector faultInjector = new FaultInjector(rules);
 
+            // Now that the ppaf enablement flag is returned from gateway, we need to intercept the response and set the flag to null, so that
+            // the environment variable set above is honored.
+            HttpClientHandlerHelper httpClientHandlerHelper = new HttpClientHandlerHelper()
+            {
+                ResponseIntercepter = async (response, request) =>
+                {
+                    string json = await response?.Content?.ReadAsStringAsync();
+                    if (json.Length > 0 && json.Contains("enablePerPartitionFailoverBehavior"))
+                    {
+                        JObject parsedDatabaseAccountResponse = JObject.Parse(json);
+                        parsedDatabaseAccountResponse.Property("enablePerPartitionFailoverBehavior").Value = null;
+
+                        HttpResponseMessage interceptedResponse = Newtonsoft.Json.JsonConvert.DeserializeObject<HttpResponseMessage>(
+                            value: parsedDatabaseAccountResponse.ToString());
+
+                        return interceptedResponse;
+                    }
+
+                    return response;
+                },
+            };
+
             List<string> preferredRegions = new List<string> { region1, region2, region3 };
             CosmosClientOptions cosmosClientOptions = new CosmosClientOptions()
             {
@@ -1365,6 +1389,7 @@
                 FaultInjector = faultInjector,
                 RequestTimeout = TimeSpan.FromSeconds(5),
                 ApplicationPreferredRegions = preferredRegions,
+                HttpClientFactory = () => new HttpClient(httpClientHandlerHelper),
             };
 
             List<CosmosIntegrationTestObject> itemsList = new()

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemIntegrationTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemIntegrationTests.cs
@@ -1360,7 +1360,7 @@
             List<FaultInjectionRule> rules = new List<FaultInjectionRule> { serviceUnavailableRule };
             FaultInjector faultInjector = new FaultInjector(rules);
 
-            // Now that the ppaf enablement flag is returned from gateway, we need to intercept the response and set the flag to null, so that
+            // Now that the ppaf enablement flag is returned from gateway, we need to intercept the response and remove the flag from the response, so that
             // the environment variable set above is honored.
             HttpClientHandlerHelper httpClientHandlerHelper = new HttpClientHandlerHelper()
             {
@@ -1370,7 +1370,7 @@
                     if (json.Length > 0 && json.Contains("enablePerPartitionFailoverBehavior"))
                     {
                         JObject parsedDatabaseAccountResponse = JObject.Parse(json);
-                        parsedDatabaseAccountResponse.Property("enablePerPartitionFailoverBehavior").Value = null;
+                        parsedDatabaseAccountResponse.Remove("enablePerPartitionFailoverBehavior");
 
                         HttpResponseMessage interceptedResponse = Newtonsoft.Json.JsonConvert.DeserializeObject<HttpResponseMessage>(
                             value: parsedDatabaseAccountResponse.ToString());

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyRangeFailoverTests/MockSetupsHelper.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyRangeFailoverTests/MockSetupsHelper.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             string endpoint,
             IList<AccountRegion> writeRegions,
             IList<AccountRegion> readRegions,
-            bool shouldEnablePPAF)
+            bool? shouldEnablePPAF)
         {
             HttpResponseMessage httpResponseMessage = MockSetupsHelper.CreateStrongAccount(
                 accountName,
@@ -109,7 +109,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             string accountName,
             IList<AccountRegion> writeRegions,
             IList<AccountRegion> readRegions,
-            bool shouldEnablePPAF = false)
+            bool? shouldEnablePPAF = null)
         {
             AccountProperties accountProperties = new AccountProperties()
             {


### PR DESCRIPTION
# Pull Request Template

## Description

Recently, we started observing in our CI pipeline gates that, the gateway started returning the ppaf enablement flag as `False` (instead of `null`) for the account used for end to end test. Below are the significance of the values returned from the gateway:

| Flag    | GW Response | Description |
| -------- | ------- | ------- |
| `enablePerPartitionFailoverBehavior`  | `True`    | PPAF was enabled for the account.
| `enablePerPartitionFailoverBehavior`  | `False`    | PPAF was manually disabled for the account.
| `enablePerPartitionFailoverBehavior`  | `null`     | PPAF was never set for the account.
| `enablePerPartitionFailoverBehavior`  | flag not present     | PPAF was never set for the account.

This PR fixes the integration test by intercepting the `enablePerPartitionFailoverBehavior` flag for the gateway response to set it as `null`, so that the PPAF enablement environment variable can be honored.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #IssueNumber