### PR TITLE
[Internal] Thin Client Integration: Adds diagnostic log info for thinclient mode.

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Diagnostics/UserAgentFeatureFlags.cs
+++ b/Microsoft.Azure.Cosmos/src/Diagnostics/UserAgentFeatureFlags.cs
@@ -18,5 +18,9 @@ namespace Microsoft.Azure.Cosmos
         PerPartitionAutomaticFailover = 1,
 
         PerPartitionCircuitBreaker = 2,
+
+        ThinClientEnabled = 3,
+
+        BinaryEncodingEnabled = 4,
     }
 }

--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -6858,6 +6858,16 @@ namespace Microsoft.Azure.Cosmos
                 featureFlag += (int)UserAgentFeatureFlags.PerPartitionCircuitBreaker;
             }
 
+            if (this.isThinClientEnabled)
+            {
+                featureFlag += (int)UserAgentFeatureFlags.ThinClientEnabled;
+            }
+
+            if (ConfigurationManager.IsBinaryEncodingEnabled())
+            {
+                featureFlag += (int)UserAgentFeatureFlags.BinaryEncodingEnabled;
+            }
+
             return featureFlag == 0 ? string.Empty : $"F{featureFlag:X}";
         }
 


### PR DESCRIPTION
# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Include samples if adding new API, and include relevant motivation and context. List any dependencies that are required for this change.

## Type of change
- Update the Diagnostics Summary to contain the proxy interactions:

	```
	"Summary": {
        "GatewayCalls": {
            "(200, 0)": 1,
            "(304, 0)": 1
        },
        "ThinclientCalls": {
            "(200, 0)": 1
        }
	```

- Add a new feature in the [UserAgentFeatureFlags](https://github.com/Azure/azure-cosmos-dotnet-v3/blob/master/Microsoft.Azure.Cosmos/src/Diagnostics/UserAgentFeatureFlags.cs) the following, so that the diagnostics user agent can contain the
  thin client enablement flag:

	- A new Feature Flag for Thin Client.
	- A new Feature Flag for Binary Encoding.

	```
		internal enum UserAgentFeatureFlags
		{
			 PerPartitionAutomaticFailover = 1,

                        PerPartitionCircuitBreaker = 2,

                        ThinClientEnabled = 3,

                        BinaryEncodingEnabled = 4,
		}	
	```

   An updated user agent can look like the following: `"User Agent": "cosmos-netstandard-sdk/3.51.0|1|X64|Microsoft Windows 10.0.26100|.NET 6.0.36|L|F3|"`		if only thinclient is enabled.

<img width="735" alt="image" src="https://github.com/user-attachments/assets/0e368aa2-7c2c-4d76-82b2-5f27fd9017e4" />


- [X] New feature (non-breaking change which adds functionality)

## Closing issues

To automatically close an issue: closes #4615