### PR TITLE
[Internal] Thin Client Integration: Adds Diagnostics User Agent info for Thin Client Feature

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Diagnostics/UserAgentFeatureFlags.cs
+++ b/Microsoft.Azure.Cosmos/src/Diagnostics/UserAgentFeatureFlags.cs
@@ -18,5 +18,11 @@ namespace Microsoft.Azure.Cosmos
         PerPartitionAutomaticFailover = 1,
 
         PerPartitionCircuitBreaker = 2,
+
+        ThinClient = 4,
+
+        BinaryEncoding = 8,
+
+        Http2 = 16,
     }
 }

--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -6858,6 +6858,16 @@ namespace Microsoft.Azure.Cosmos
                 featureFlag += (int)UserAgentFeatureFlags.PerPartitionCircuitBreaker;
             }
 
+            if (this.isThinClientEnabled)
+            {
+                featureFlag += (int)UserAgentFeatureFlags.ThinClient;
+            }
+
+            if (ConfigurationManager.IsBinaryEncodingEnabled())
+            {
+                featureFlag += (int)UserAgentFeatureFlags.BinaryEncoding;
+            }
+
             return featureFlag == 0 ? string.Empty : $"F{featureFlag:X}";
         }
 


### PR DESCRIPTION
# Pull Request Template

## Description

This PR adds the following new features in the [UserAgentFeatureFlags](https://github.com/Azure/azure-cosmos-dotnet-v3/blob/master/Microsoft.Azure.Cosmos/src/Diagnostics/UserAgentFeatureFlags.cs), so that the diagnostics user agent can contain the thin client enablement flag:

- A new Feature Flag for Thin Client.
- A new Feature Flag for Binary Encoding.
- A new Feature Flag for Http 2.0.

```csharp
internal enum UserAgentFeatureFlags
{
 	PerPartitionAutomaticFailover = 1,
         PerPartitionCircuitBreaker = 2,
         ThinClient = 4,
         BinaryEncoding = 8,
         Http2 = 16
}
```
An updated user agent will look like the following: 

`"User Agent": "cosmos-netstandard-sdk/3.51.0|1|X64|Microsoft Windows 10.0.26100|.NET 6.0.36|L|F4|"` if only thin-client is enabled.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Closing issues

To automatically close an issue: closes #4615 