### PR TITLE
[Internal] Pipeline Improvement: Adds "Flaky" Tag to Test

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Tracing/EndToEndTraceWriterBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Tracing/EndToEndTraceWriterBaselineTests.cs
@@ -820,6 +820,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Tracing
         }
 
         [TestMethod]
+        [TestCategory("Flaky")]
         public async Task TypedPointOperationsAsync()
         {
             List<Input> inputs = new List<Input>();


### PR DESCRIPTION
# Pull Request Template

## Description

This PR adds the Flaky tag to the TypedPointOperationsAsync test in the EndToEndTraceWriterBaselineTests.cs file. This test has a failure rate of 70% in our nightly rolling pipeline runs. Until the cause of this is found then we will mark this as flaky to ensure the pipeline pass. 

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber