### PR TITLE
Remove references to System.Net.Http and System.Text.RegularExpressions

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
+++ b/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
@@ -130,8 +130,6 @@
 		<PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
 		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
 		<PackageReference Include="Newtonsoft.Json" Version="10.0.2" NoWarn="NU1903" PrivateAssets="All" />
-		<PackageReference Include="System.Net.Http" Version="4.3.4" />
-		<PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
 
 		<!--Direct Dependencies-->
 		<PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />


### PR DESCRIPTION
# Pull Request Template

## Description

Remove references to System.Net.Http and System.Text.RegularExpressions

This PR removes direct references to System.Net.Http and System.Text.RegularExpressions packages. These packages originated from .NET Core 1.x and have been included in the shared framework since .NET Core 2.0.

As all supported .NET platforms are compatible with .NET Standard 2.0 or higher, these packages are no longer necessary. Their functionality is already available via the target framework’s built-in reference assemblies.

This cleanup helps simplify the project dependencies and avoids unnecessary package resolution during builds.

[Read More](https://devblogs.microsoft.com/dotnet/nugetaudit-2-0-elevating-security-and-trust-in-package-management/#notes-on-specific-packages)

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #5216