### PR TITLE
Direct Package Upgrade: Fixes `Cosmos.Direct` Package to `3.40.0`

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
 		<ClientOfficialVersion>3.52.0</ClientOfficialVersion>
 		<ClientPreviewVersion>3.53.0</ClientPreviewVersion>
 		<ClientPreviewSuffixVersion>preview.0</ClientPreviewSuffixVersion>
-		<DirectVersion>3.39.1</DirectVersion>
+		<DirectVersion>3.40.0</DirectVersion>
 		<FaultInjectionVersion>1.0.0</FaultInjectionVersion>
 		<FaultInjectionSuffixVersion>beta.0</FaultInjectionSuffixVersion>
 		<EncryptionOfficialVersion>2.0.5</EncryptionOfficialVersion>


### PR DESCRIPTION
# Pull Request Template

## Description
This PR also bumps up the Microsoft.Azure.Cosmos.Direct version from 3.39.1 to 3.40.0. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber