### PR TITLE
[Internal] Pipelines: Adds flaky tag to EndToEndTraceWriterBaselineTests

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Tracing/EndToEndTraceWriterBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Tracing/EndToEndTraceWriterBaselineTests.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Tracing
     using static Microsoft.Azure.Cosmos.SDK.EmulatorTests.TransportClientHelper;
 
     [VisualStudio.TestTools.UnitTesting.TestClass]
-    [TestCategory("UpdateContract")]
+    [TestCategory("Flaky")]
     public sealed class EndToEndTraceWriterBaselineTests : BaselineTests<EndToEndTraceWriterBaselineTests.Input, EndToEndTraceWriterBaselineTests.Output>
     {
         public static CosmosClient client;


### PR DESCRIPTION
# Pull Request Template

## Description

These tests are currently flaky on our pipeline runs. This test will add the flaky tag until further notice as not to block the runs. 

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber