### PR TITLE
[Internal] Query: Adds override for bypassing query parsing using environment variable

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryPlanRetriever.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryPlanRetriever.cs
@@ -50,6 +50,11 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
                 SupportedQueryFeaturesString;
         }
 
+        public static bool BypassQueryParsing()
+        {
+            return Documents.CustomTypeExtensions.ByPassQueryParsing() || ConfigurationManager.ForceBypassQueryParsing();
+        }
+
         public static async Task<PartitionedQueryExecutionInfo> GetQueryPlanWithServiceInteropAsync(
             CosmosQueryClient queryClient,
             SqlQuerySpec sqlQuerySpec,

--- a/Microsoft.Azure.Cosmos/src/Query/v2Query/DefaultDocumentQueryExecutionContext.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v2Query/DefaultDocumentQueryExecutionContext.cs
@@ -156,7 +156,7 @@ namespace Microsoft.Azure.Cosmos.Query
                 else
                 {
                     // The query is going to become a full fan out, but we go one partition at a time.
-                    if (ServiceInteropAvailable())
+                    if (!QueryPlanRetriever.BypassQueryParsing())
                     {
                         // Get the routing map provider
                         CollectionCache collectionCache = await this.Client.GetCollectionCacheAsync();
@@ -246,11 +246,6 @@ namespace Microsoft.Azure.Cosmos.Query
         private static bool PhysicalPartitionKeyRangeIdProvided(DefaultDocumentQueryExecutionContext context)
         {
             return !string.IsNullOrEmpty(context.PartitionKeyRangeId);
-        }
-
-        private static bool ServiceInteropAvailable()
-        {
-            return !CustomTypeExtensions.ByPassQueryParsing();
         }
 
         private async Task<Tuple<PartitionRoutingHelper.ResolvedRangeInfo, IReadOnlyList<Range<string>>>> TryGetTargetPartitionKeyRangeAsync(

--- a/Microsoft.Azure.Cosmos/src/Query/v2Query/DocumentQueryExecutionContextFactory.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v2Query/DocumentQueryExecutionContextFactory.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Azure.Cosmos.Query
 
             // For non-Windows platforms(like Linux and OSX) in .NET Core SDK, we cannot use ServiceInterop, so need to bypass in that case.
             // We are also now bypassing this for 32 bit host process running even on Windows as there are many 32 bit apps that will not work without this
-            if (CustomTypeExtensions.ByPassQueryParsing())
+            if (QueryPlanRetriever.BypassQueryParsing())
             {
                 // We create a ProxyDocumentQueryExecutionContext that will be initialized with DefaultDocumentQueryExecutionContext
                 // which will be used to send the query to Gateway and on getting 400(bad request) with 1004(cross partition query not servable), we initialize it with

--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/CosmosQueryClientCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/CosmosQueryClientCore.cs
@@ -288,7 +288,7 @@ namespace Microsoft.Azure.Cosmos
 
         public override bool BypassQueryParsing()
         {
-            return CustomTypeExtensions.ByPassQueryParsing();
+            return QueryPlanRetriever.BypassQueryParsing();
         }
 
         public override void ClearSessionTokenCache(string collectionFullName)

--- a/Microsoft.Azure.Cosmos/src/Util/ConfigurationManager.cs
+++ b/Microsoft.Azure.Cosmos/src/Util/ConfigurationManager.cs
@@ -105,6 +105,12 @@ namespace Microsoft.Azure.Cosmos
         /// </summary>
         internal static readonly string TcpChannelMultiplexingEnabled = "AZURE_COSMOS_TCP_CHANNEL_MULTIPLEX_ENABLED";
 
+        /// <summary>
+        /// A read-only string containing the environment variable name for bypassing query parsing.
+        /// and GA.
+        /// </summary>
+        internal static readonly string BypassQueryParsing = "AZURE_COSMOS_BYPASS_QUERY_PARSING";
+
         public static T GetEnvironmentVariable<T>(string variable, T defaultValue)
         {
             string value = Environment.GetEnvironmentVariable(variable);
@@ -350,6 +356,19 @@ namespace Microsoft.Azure.Cosmos
             return ConfigurationManager
                     .GetEnvironmentVariable(
                         variable: ConfigurationManager.TcpChannelMultiplexingEnabled,
+                        defaultValue: false);
+        }
+
+        /// <summary>
+        /// Gets the boolean value indicating if channel multiplexing enabled on TCP channel.
+        /// Default: false
+        /// </summary>
+        /// <returns>A boolean flag indicating if channel multiplexing is enabled.</returns>
+        public static bool ForceBypassQueryParsing()
+        {
+            return ConfigurationManager
+                    .GetEnvironmentVariable(
+                        variable: ConfigurationManager.BypassQueryParsing,
                         defaultValue: false);
         }
     }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/SanityQueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/SanityQueryTests.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.CosmosElements.Numbers;
     using Microsoft.Azure.Cosmos.Query.Core;
+    using Microsoft.Azure.Cosmos.Query.Core.QueryPlan;
     using Microsoft.Azure.Cosmos.SDK.EmulatorTests.QueryOracle;
     using Microsoft.Azure.Cosmos.Tracing;
     using Microsoft.Azure.Documents;
@@ -645,7 +646,7 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
         public void ServiceInteropUsedByDefault()
         {
             // Test initialie does load CosmosClient
-            Assert.IsFalse(CustomTypeExtensions.ByPassQueryParsing());
+            Assert.IsFalse(QueryPlanRetriever.BypassQueryParsing());
         }
 
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/SmokeTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/SmokeTests.cs
@@ -59,11 +59,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         {
             if (IntPtr.Size == 8)
             {
-                Assert.IsFalse(Documents.CustomTypeExtensions.ByPassQueryParsing());
+                Assert.IsFalse(Query.Core.QueryPlan.QueryPlanRetriever.BypassQueryParsing());
             }
             else
             {
-                Assert.IsTrue(Documents.CustomTypeExtensions.ByPassQueryParsing());
+                Assert.IsTrue(Query.Core.QueryPlan.QueryPlanRetriever.BypassQueryParsing());
             }
         }
 


### PR DESCRIPTION
# [Internal] Query: Adds override for bypassing query parsing using environment variable
## Description

This change adds an override for bypassing query parsing using environment variable.
To leverage this switch, one can set AZURE_COSMOS_BYPASS_QUERY_PARSING set to true in process' environment variables.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

