### PR TITLE
Query: Adds Weighted RRF capability to LINQ

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Linq/BuiltinFunctions/OtherBuiltinSystemFunctions.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/BuiltinFunctions/OtherBuiltinSystemFunctions.cs
@@ -24,17 +24,21 @@ namespace Microsoft.Azure.Cosmos.Linq
                     true,
                     new List<Type[]>()
                     {
-                        new Type[]{typeof(double[])}
+                        new Type[]{typeof(double[])},
+                        new Type[]{typeof(double[]), typeof(double[])}
                     })
             {
             }
 
             protected override SqlScalarExpression VisitImplicit(MethodCallExpression methodCallExpression, TranslationContext context)
             {
-                if (methodCallExpression.Arguments.Count == 1
-                    && methodCallExpression.Arguments[0] is NewArrayExpression argumentsExpressions)
+                if (methodCallExpression.Arguments.Count != 1 && methodCallExpression.Arguments.Count != 2)
                 {
-                    // For RRF, We don't need to care about the first argument, it is the object itself and have no relevance to the computation
+                    throw new DocumentQueryException("Invalid Argument Count.");
+                }
+
+                if (methodCallExpression.Arguments[0] is NewArrayExpression argumentsExpressions)
+                {
                     ReadOnlyCollection<Expression> functionListExpression = argumentsExpressions.Expressions;
                     List<SqlScalarExpression> arguments = new List<SqlScalarExpression>();
                     foreach (Expression argument in functionListExpression)
@@ -63,12 +67,18 @@ namespace Microsoft.Azure.Cosmos.Linq
                         }
 
                         arguments.Add(ExpressionToSql.VisitNonSubqueryScalarExpression(argument, context));
+
+                        // Append the weight if exists
+                        if (methodCallExpression.Arguments.Count == 2)
+                        {
+                            arguments.Add(ExpressionToSql.VisitNonSubqueryScalarExpression(methodCallExpression.Arguments[1], context));
+                        }
                     }
 
                     return SqlFunctionCallScalarExpression.CreateBuiltin(SqlFunctionCallScalarExpression.Names.RRF, arguments.ToImmutableArray());
                 }
 
-                return null;
+                throw new DocumentQueryException(string.Format(CultureInfo.CurrentCulture, "Method {0} is not supported with the given argument list.", methodCallExpression.Method.Name));
             }
 
             protected override SqlScalarExpression VisitExplicit(MethodCallExpression methodCallExpression, TranslationContext context)

--- a/Microsoft.Azure.Cosmos/src/Linq/CosmosLinqExtensions.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/CosmosLinqExtensions.cs
@@ -471,6 +471,73 @@ namespace Microsoft.Azure.Cosmos.Linq
         }
 
         /// <summary>
+        /// This system function is used to combine two or more scores provided by other scoring functions.
+        /// For more information, see https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/query/rrf.
+        /// This method is to be used in LINQ expressions only and will be evaluated on server.
+        /// There's no implementation provided in the client library.
+        /// </summary>
+        /// <param name="weights">the weights to use for scoring functions</param>
+        /// <param name="scoringFunctions">the scoring functions to combine. Valid functions are FullTextScore and VectorDistance</param>
+        /// <returns>Returns the the combined scores of the scoring functions.</returns>
+        /// <example>
+        /// <code>
+        /// <![CDATA[
+        /// var matched = documents.OrderByRank(document => document.RRF(document.Name.FullTextScore(<keyword1>), document.Address.FullTextScore(<keyword2>)));
+        /// ]]>
+        /// </code>
+        /// </example>
+        public static double RRF(double[] weights, params double[] scoringFunctions)
+        {
+            // The reason for not defining "this" keyword is because this causes undesirable serialization when call Expression.ToString() on this method
+            throw new NotImplementedException(ClientResources.ExtensionMethodNotImplemented);
+        }
+
+        /// <summary>
+        /// This system function is used to combine two or more scores provided by other scoring functions.
+        /// For more information, see https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/query/rrf.
+        /// This method is to be used in LINQ expressions only and will be evaluated on server.
+        /// There's no implementation provided in the client library.
+        /// </summary>
+        /// <param name="isWeighted">boolean to indicate whether the RRF is weighted. If set to true, The last array will be considered the weights </param>
+        /// <param name="weightLength">length of the weights</param>
+        /// <param name="scoringFunctionsAndWeights">the scoring functions to combine. Valid functions are FullTextScore and VectorDistance. </param>
+        /// <returns>Returns the the combined scores of the scoring functions.</returns>
+        /// <example>
+        /// <code>
+        /// <![CDATA[
+        /// var matched = documents.OrderByRank(document => document.RRF(document.Name.FullTextScore(<keyword1>), document.Address.FullTextScore(<keyword2>)));
+        /// ]]>
+        /// </code>
+        /// </example>
+        public static double RRF(bool isWeighted, int weightLength, params double[] scoringFunctionsAndWeights)
+        {
+            // The reason for not defining "this" keyword is because this causes undesirable serialization when call Expression.ToString() on this method
+            throw new NotImplementedException(ClientResources.ExtensionMethodNotImplemented);
+        }
+
+        /// <summary>
+        /// This system function is used to combine two or more scores provided by other scoring functions.
+        /// For more information, see https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/query/rrf.
+        /// This method is to be used in LINQ expressions only and will be evaluated on server.
+        /// There's no implementation provided in the client library.
+        /// </summary>
+        /// <param name="scoringFunctions">the scoring functions to combine. Valid functions are FullTextScore and VectorDistance. </param>
+        /// <param name="weights">the weights to use for scoring functions</param>
+        /// <returns>Returns the the combined scores of the scoring functions.</returns>
+        /// <example>
+        /// <code>
+        /// <![CDATA[
+        /// var matched = documents.OrderByRank(document => document.RRF(document.Name.FullTextScore(<keyword1>), document.Address.FullTextScore(<keyword2>)));
+        /// ]]>
+        /// </code>
+        /// </example>
+        public static double RRF(double[][] scoringFunctions, double[] weights)
+        {
+            // The reason for not defining "this" keyword is because this causes undesirable serialization when call Expression.ToString() on this method
+            throw new NotImplementedException(ClientResources.ExtensionMethodNotImplemented);
+        }
+
+        /// <summary>
         /// This method generate query definition from LINQ query.
         /// </summary>
         /// <typeparam name="T">the type of object to query.</typeparam>

--- a/Microsoft.Azure.Cosmos/src/Linq/CosmosLinqExtensions.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/CosmosLinqExtensions.cs
@@ -476,28 +476,6 @@ namespace Microsoft.Azure.Cosmos.Linq
         /// This method is to be used in LINQ expressions only and will be evaluated on server.
         /// There's no implementation provided in the client library.
         /// </summary>
-        /// <param name="weights">the weights to use for scoring functions</param>
-        /// <param name="scoringFunctions">the scoring functions to combine. Valid functions are FullTextScore and VectorDistance</param>
-        /// <returns>Returns the the combined scores of the scoring functions.</returns>
-        /// <example>
-        /// <code>
-        /// <![CDATA[
-        /// var matched = documents.OrderByRank(document => document.RRF(document.Name.FullTextScore(<keyword1>), document.Address.FullTextScore(<keyword2>)));
-        /// ]]>
-        /// </code>
-        /// </example>
-        public static double RRF(double[] weights, params double[] scoringFunctions)
-        {
-            // The reason for not defining "this" keyword is because this causes undesirable serialization when call Expression.ToString() on this method
-            throw new NotImplementedException(ClientResources.ExtensionMethodNotImplemented);
-        }
-
-        /// <summary>
-        /// This system function is used to combine two or more scores provided by other scoring functions.
-        /// For more information, see https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/query/rrf.
-        /// This method is to be used in LINQ expressions only and will be evaluated on server.
-        /// There's no implementation provided in the client library.
-        /// </summary>
         /// <param name="scoringFunctions">the scoring functions to combine. Valid functions are FullTextScore and VectorDistance. </param>
         /// <param name="weights">the weights to use for scoring functions</param>
         /// <returns>Returns the the combined scores of the scoring functions.</returns>
@@ -508,7 +486,7 @@ namespace Microsoft.Azure.Cosmos.Linq
         /// ]]>
         /// </code>
         /// </example>
-        public static double RRF(double[][] scoringFunctions, double[] weights)
+        public static double RRF(double[] scoringFunctions, double[] weights)
         {
             // The reason for not defining "this" keyword is because this causes undesirable serialization when call Expression.ToString() on this method
             throw new NotImplementedException(ClientResources.ExtensionMethodNotImplemented);

--- a/Microsoft.Azure.Cosmos/src/Linq/CosmosLinqExtensions.cs
+++ b/Microsoft.Azure.Cosmos/src/Linq/CosmosLinqExtensions.cs
@@ -498,29 +498,6 @@ namespace Microsoft.Azure.Cosmos.Linq
         /// This method is to be used in LINQ expressions only and will be evaluated on server.
         /// There's no implementation provided in the client library.
         /// </summary>
-        /// <param name="isWeighted">boolean to indicate whether the RRF is weighted. If set to true, The last array will be considered the weights </param>
-        /// <param name="weightLength">length of the weights</param>
-        /// <param name="scoringFunctionsAndWeights">the scoring functions to combine. Valid functions are FullTextScore and VectorDistance. </param>
-        /// <returns>Returns the the combined scores of the scoring functions.</returns>
-        /// <example>
-        /// <code>
-        /// <![CDATA[
-        /// var matched = documents.OrderByRank(document => document.RRF(document.Name.FullTextScore(<keyword1>), document.Address.FullTextScore(<keyword2>)));
-        /// ]]>
-        /// </code>
-        /// </example>
-        public static double RRF(bool isWeighted, int weightLength, params double[] scoringFunctionsAndWeights)
-        {
-            // The reason for not defining "this" keyword is because this causes undesirable serialization when call Expression.ToString() on this method
-            throw new NotImplementedException(ClientResources.ExtensionMethodNotImplemented);
-        }
-
-        /// <summary>
-        /// This system function is used to combine two or more scores provided by other scoring functions.
-        /// For more information, see https://learn.microsoft.com/en-us/azure/cosmos-db/nosql/query/rrf.
-        /// This method is to be used in LINQ expressions only and will be evaluated on server.
-        /// There's no implementation provided in the client library.
-        /// </summary>
         /// <param name="scoringFunctions">the scoring functions to combine. Valid functions are FullTextScore and VectorDistance. </param>
         /// <param name="weights">the weights to use for scoring functions</param>
         /// <returns>Returns the the combined scores of the scoring functions.</returns>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqTranslationBaselineTests.TestWeightedRRF.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/BaselineTest/TestBaseline/LinqTranslationBaselineTests.TestWeightedRRF.xml
@@ -1,0 +1,35 @@
+﻿<Results>
+  <Result>
+    <Input>
+      <Description><![CDATA[Standard weighted RRF calls]]></Description>
+      <Expression><![CDATA[query.OrderByRank(doc => RRF(new [] {doc.StringField.FullTextScore(new [] {"test1"}), doc.StringField.FullTextScore(new [] {"test1", "text2"})}, new [] {1, 2})).Select(doc => doc.Pk)]]></Expression>
+    </Input>
+    <Output>
+      <SqlQuery><![CDATA[
+SELECT VALUE root["Pk"] 
+FROM root 
+ORDER BY RANK RRF(FullTextScore(root["StringField"], "test1"), [1, 2], FullTextScore(root["StringField"], "test1", "text2"), [1, 2])]]></SqlQuery>
+      <ErrorMessage><![CDATA[Status Code: BadRequest,{"errors":[{"severity":"Error","location":{"start":34,"end":166},"code":"SC2229","message":"The last parameter of the RRF function is an optional array of weights. When present, it must be a literal array of numbers, one for each of the component scores used for the RRF function. The length of this array must be the same as the number of the component scores."},{"severity":"Error","location":{"start":34,"end":166},"code":"SC2221","message":"The ORDER BY RANK clause must be followed by a VectorDistance and/or a FullTextScore function call."}]},0x800A0B00]]></ErrorMessage>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[Weighted RRF with weights and functions not in a list]]></Description>
+      <Expression><![CDATA[query.OrderByRank(doc => RRF(new [] {doc.StringField.FullTextScore(new [] {"test1"}), doc.StringField2.FullTextScore(new [] {"test1", "test2", "test3"}), 1, 2})).Select(doc => doc.Pk)]]></Expression>
+    </Input>
+    <Output>
+      <SqlQuery><![CDATA[]]></SqlQuery>
+      <ErrorMessage><![CDATA[Expressions of type System.Double is not supported as an argument to CosmosLinqExtensions.RRF. Supported expressions are method calls to FullTextScore, VectorDistance.]]></ErrorMessage>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description><![CDATA[Weighted RRF with weights array first]]></Description>
+      <Expression><![CDATA[query.OrderByRank(doc => RRF(new [] {1, 2}, new [] {doc.StringField.FullTextScore(new [] {"test1"}), doc.StringField.FullTextScore(new [] {"test1", "text2"})})).Select(doc => doc.Pk)]]></Expression>
+    </Input>
+    <Output>
+      <SqlQuery><![CDATA[]]></SqlQuery>
+      <ErrorMessage><![CDATA[Method RRF is not supported with the given argument list.]]></ErrorMessage>
+    </Output>
+  </Result>
+</Results>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Linq/LinqTranslationBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Linq/LinqTranslationBaselineTests.cs
@@ -687,30 +687,32 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests.LinqProviderTests
 
             List<LinqTestInput> inputs = new List<LinqTestInput>
             {
-                // public static double RRF(double[] weights, params double[] scoringFunctions)
-                new LinqTestInput("RRF with weight in fronts", b => getQuery(b)
-                    .OrderByRank(doc => RRF(new double[] { 1.0, 2.0 },
-                                            doc.StringField.FullTextScore(new string[] { "test1" }),
-                                            doc.StringField2.FullTextScore(new string[] { "test1", "test2", "test3" })))
+                // public static double RRF(double[][] scoringFunctions, double[] weights)
+                new LinqTestInput("Standard weighted RRF calls", b => getQuery(b)
+                    .OrderByRank(doc => RRF(new double[]
+                                            {
+                                                doc.StringField.FullTextScore(new string[] { "test1" }),
+                                                doc.StringField.FullTextScore(new string[] { "test1", "text2" })
+                                            },
+                                            new double[] { 1.0, 2.0 } ))
                     .Select(doc => doc.Pk)),
 
-                // public static double RRF(params double[] scoringFunctionsAndWeights)
-                new LinqTestInput("weighted RRF with variably length weights", b => getQuery(b)
+                // Negative case: weights are not in an array
+                new LinqTestInput("Weighted RRF with weights and functions not in a list", b => getQuery(b)
                     .OrderByRank(doc => RRF(doc.StringField.FullTextScore(new string[] { "test1" }),
                                             doc.StringField2.FullTextScore(new string[] { "test1", "test2", "test3" }),
                                             1.0,
                                             2.0))
                     .Select(doc => doc.Pk)),
-
-                // public static double RRF(double[][] scoringFunctions, double[] weights)
-                new LinqTestInput("RRF with non-param scoring funcs", b => getQuery(b)
-                    .OrderByRank(doc => RRF(new double[] 
-                                            { 
+                new LinqTestInput("Weighted RRF with weights array first", b => getQuery(b)
+                    .OrderByRank(doc => RRF(new double[] { 1.0, 2.0 },
+                                            new double[]
+                                            {
                                                 doc.StringField.FullTextScore(new string[] { "test1" }),
-                                                doc.StringField.FullTextScore(new string[] { "test1", "text2" }) 
-                                            },
-                                            new double[] { 1.0, 2.0 } ))
+                                                doc.StringField.FullTextScore(new string[] { "test1", "text2" })
+                                            }))
                     .Select(doc => doc.Pk)),
+
             };
 
             foreach (LinqTestInput input in inputs)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Linq/LinqTranslationBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Linq/LinqTranslationBaselineTests.cs
@@ -668,6 +668,69 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests.LinqProviderTests
         }
 
         [TestMethod]
+        public void TestWeightedRRF()
+        {
+            const int Records = 2;
+            const int MaxStringLength = 100;
+            static DataObject createDataObj(Random random)
+            {
+                DataObject obj = new DataObject
+                {
+                    StringField = LinqTestsCommon.RandomString(random, random.Next(MaxStringLength)),
+                    IntField = 1,
+                    Id = Guid.NewGuid().ToString(),
+                    Pk = "Test"
+                };
+                return obj;
+            }
+            Func<bool, IQueryable<DataObject>> getQuery = LinqTestsCommon.GenerateTestCosmosData(createDataObj, Records, testContainer);
+
+            List<LinqTestInput> inputs = new List<LinqTestInput>
+            {
+                new LinqTestInput("RRF with weight in fronts", b => getQuery(b)
+                    .OrderByRank(doc => RRF(new double[] { 1.0, 2.0 },
+                                            doc.StringField.FullTextScore(new string[] { "test1" }),
+                                            doc.StringField2.FullTextScore(new string[] { "test1", "test2", "test3" })))
+                    .Select(doc => doc.Pk)),
+
+                new LinqTestInput("RRF with boolean weight", b => getQuery(b)
+                    .OrderByRank(doc => RRF(true, 
+                                            2,
+                                            doc.StringField.FullTextScore(new string[] { "test1" }),
+                                            doc.StringField2.FullTextScore(new string[] { "test1", "test2", "test3" }),
+                                            1.0, 
+                                            2.0))
+                    .Select(doc => doc.Pk)),
+
+                new LinqTestInput("RRF without boolean - need additional checks while parsing - curently a valid query with the current RRF signature", b => getQuery(b)
+                    .OrderByRank(doc => RRF(doc.StringField.FullTextScore(new string[] { "test1" }),
+                                            doc.StringField2.FullTextScore(new string[] { "test1", "test2", "test3" }),
+                                            1.0,
+                                            2.0))
+                    .Select(doc => doc.Pk)),
+
+                new LinqTestInput("RRF with non-param scoring funcs", b => getQuery(b)
+                    .OrderByRank(doc => RRF(new double[] 
+                                            { 
+                                                doc.StringField.FullTextScore(new string[] { "test1" }),
+                                                doc.StringField.FullTextScore(new string[] { "test1", "text2" }) 
+                                            },
+                                            new double[] { 1.0, 2.0 } ))
+                    .Select(doc => doc.Pk)),
+            };
+
+            foreach (LinqTestInput input in inputs)
+            {
+                // OrderBy are not supported client side.
+                // Therefore this method is verified with baseline only.
+                input.skipVerification = true;
+                input.serializeOutput = true;
+            }
+
+            this.ExecuteTestSuite(inputs);
+        }
+
+        [TestMethod]
         public void TestOrderByRankFunctionComposeWithOtherFunctions()
         {
             const int Records = 2;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Linq/LinqTranslationBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Linq/LinqTranslationBaselineTests.cs
@@ -687,28 +687,22 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests.LinqProviderTests
 
             List<LinqTestInput> inputs = new List<LinqTestInput>
             {
+                // public static double RRF(double[] weights, params double[] scoringFunctions)
                 new LinqTestInput("RRF with weight in fronts", b => getQuery(b)
                     .OrderByRank(doc => RRF(new double[] { 1.0, 2.0 },
                                             doc.StringField.FullTextScore(new string[] { "test1" }),
                                             doc.StringField2.FullTextScore(new string[] { "test1", "test2", "test3" })))
                     .Select(doc => doc.Pk)),
 
-                new LinqTestInput("RRF with boolean weight", b => getQuery(b)
-                    .OrderByRank(doc => RRF(true, 
-                                            2,
-                                            doc.StringField.FullTextScore(new string[] { "test1" }),
-                                            doc.StringField2.FullTextScore(new string[] { "test1", "test2", "test3" }),
-                                            1.0, 
-                                            2.0))
-                    .Select(doc => doc.Pk)),
-
-                new LinqTestInput("RRF without boolean - need additional checks while parsing - curently a valid query with the current RRF signature", b => getQuery(b)
+                // public static double RRF(params double[] scoringFunctionsAndWeights)
+                new LinqTestInput("weighted RRF with variably length weights", b => getQuery(b)
                     .OrderByRank(doc => RRF(doc.StringField.FullTextScore(new string[] { "test1" }),
                                             doc.StringField2.FullTextScore(new string[] { "test1", "test2", "test3" }),
                                             1.0,
                                             2.0))
                     .Select(doc => doc.Pk)),
 
+                // public static double RRF(double[][] scoringFunctions, double[] weights)
                 new LinqTestInput("RRF with non-param scoring funcs", b => getQuery(b)
                     .OrderByRank(doc => RRF(new double[] 
                                             { 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetSDKAPI.json
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetSDKAPI.json
@@ -6366,6 +6366,11 @@
           ],
           "MethodInfo": "Double FullTextScore[TSource](TSource, System.String[]);IsAbstract:False;IsStatic:True;IsVirtual:False;IsGenericMethod:True;IsConstructor:False;IsFinal:False;"
         },
+        "Double RRF(Double[], Double[])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Double RRF(Double[], Double[]);IsAbstract:False;IsStatic:True;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
         "Double RRF(Double[])": {
           "Type": "Method",
           "Attributes": [],


### PR DESCRIPTION
# Pull Request Template

## Description
This PR adds support for weights in the CosmosLINQExtension method. RRF now features two different signatures to allow users to specify weights in their queries

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber