### PR TITLE
[Internal] msdata/direct: Removes encryption.custom from pipeline runs

### DIFF
--- a/templates/build-preview-msdata.yml
+++ b/templates/build-preview-msdata.yml
@@ -39,38 +39,6 @@ jobs:
       projects: Microsoft.Azure.Cosmos.sln 
       arguments: -p:Optimize=true -p:IsPreview=true
       versioningScheme: OFF
-      
-- job:
-  displayName: Encryption.Custom Project Ref SDK Preview ${{ parameters.BuildConfiguration }} 
-  pool:
-    name: 'OneES'
-
-  steps:
-  - checkout: self  # self represents the repo where the initial Pipelines YAML file was found
-    clean: true  # if true, execute `execute git clean -ffdx && git reset --hard HEAD` before fetching
-
-  # Add this Command to Include the .NET 6 SDK
-  - task: UseDotNet@2
-    displayName: Use .NET 6.0
-    inputs:
-      packageType: 'runtime'
-      version: '6.x'      
-
-  - task: UseDotNet@2
-    displayName: Use .NET 8.0
-    inputs:
-      packageType: 'sdk'
-      version: '8.x'
-
-  - task: DotNetCoreCLI@2
-    displayName: Build Microsoft.Azure.Cosmos.Encryption.Custom Project Ref
-    inputs: 
-      command: build  
-      configuration: $(parameters.BuildConfiguration)
-      nugetConfigPath: NuGet.config
-      projects: Microsoft.Azure.Cosmos.sln 
-      arguments: -p:Optimize=true -p:IsPreview=true;SdkProjectRef=true
-      versioningScheme: OFF
 
 - job:
   displayName: Preview Tests ${{ parameters.BuildConfiguration }}


### PR DESCRIPTION
Removing Microsoft.Azure.Cosmos.Encryption.Custom Project Ref build pipeline from msdata-preview list

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber