### PR TITLE
[Internal] Thin Client Integration: Fixes 400/1041 Error for Query Operations in Thin Client Mode.

### DIFF
--- a/Microsoft.Azure.Cosmos/src/GatewayStoreModel.cs
+++ b/Microsoft.Azure.Cosmos/src/GatewayStoreModel.cs
@@ -101,8 +101,9 @@ namespace Microsoft.Azure.Cosmos
                     request.RequestContext.RegionName = regionName;
                 }
 
+                bool isPPAFEnabled = this.IsPartitionLevelFailoverEnabled();
                 // This is applicable for both per partition automatic failover and per partition circuit breaker.
-                if ((this.IsPartitionLevelFailoverEnabled() || this.isThinClientEnabled)
+                if ((isPPAFEnabled || this.isThinClientEnabled)
                     && !ReplicatedResourceClient.IsMasterResource(request.ResourceType)
                     && request.ResourceType.IsPartitioned())
                 {
@@ -115,7 +116,7 @@ namespace Microsoft.Azure.Cosmos
 
                     request.RequestContext.ResolvedPartitionKeyRange = partitionKeyRange;
 
-                    if (this.IsPartitionLevelFailoverEnabled())
+                    if (isPPAFEnabled)
                     {
                         this.globalPartitionEndpointManager.TryAddPartitionLevelLocationOverride(request);
                     }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemThinClientTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemThinClientTests.cs
@@ -517,10 +517,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         [TestCategory("ThinClient")]
         public async Task QueryItemsTestWithStrongConsistency()
         {
-            string connectionString = ConfigurationManager.GetEnvironmentVariable<string>("COSMOSDB_TC_STRONG", string.Empty);
+            string connectionString = ConfigurationManager.GetEnvironmentVariable<string>("COSMOSDB_THINCLIENTSTRONG", string.Empty);
             if (string.IsNullOrEmpty(connectionString))
             {
-                Assert.Fail("Set environment variable COSMOSDB_TC_STRONG to run the tests");
+                Assert.Fail("Set environment variable COSMOSDB_THINCLIENTSTRONG to run the tests");
             }
             this.client = new CosmosClient(
                  connectionString,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyRangeFailoverTests/RegionFailoverTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyRangeFailoverTests/RegionFailoverTests.cs
@@ -302,13 +302,14 @@ namespace Microsoft.Azure.Cosmos.Tests
                     containerName: containerName,
                     containerRid: containerRid);
 
-                if (enablePartitionLevelFailover)
+                bool isThinClientEnabled = ConfigurationManager.IsThinClientEnabled(defaultValue: false);
+                if (enablePartitionLevelFailover || isThinClientEnabled)
                 {
                     MockSetupsHelper.SetupPartitionKeyRanges(
-                        mockHttpHandler: mockHttpHandler,
-                        regionEndpoint: primaryRegionEndpoint,
-                        containerResourceId: containerResourceId,
-                        partitionKeyRangeIds: out IReadOnlyList<string> secondaryRegionPartitionKeyRangeIds);
+                         mockHttpHandler: mockHttpHandler,
+                         regionEndpoint: primaryRegionEndpoint,
+                         containerResourceId: containerResourceId,
+                         partitionKeyRangeIds: out IReadOnlyList<string> secondaryRegionPartitionKeyRangeIds);
                 }
 
                 CosmosClientOptions cosmosClientOptions = new CosmosClientOptions()
@@ -456,6 +457,12 @@ namespace Microsoft.Azure.Cosmos.Tests
                     databaseName: databaseName,
                     containerName: containerName,
                     containerRid: containerRid);
+
+                MockSetupsHelper.SetupPartitionKeyRanges(
+                    mockHttpHandler: mockHttpHandler,
+                    regionEndpoint: primaryRegionEndpoint,
+                    containerResourceId: containerResourceId,
+                    partitionKeyRangeIds: out IReadOnlyList<string> partitionKeyRangeIds);
 
                 CosmosClientOptions cosmosClientOptions = new CosmosClientOptions()
                 {
@@ -606,6 +613,12 @@ namespace Microsoft.Azure.Cosmos.Tests
                     databaseName: databaseName,
                     containerName: containerName,
                     containerRid: containerRid);
+
+                MockSetupsHelper.SetupPartitionKeyRanges(
+                    mockHttpHandler: mockHttpHandler,
+                    regionEndpoint: primaryRegionEndpoint,
+                    containerResourceId: containerResourceId,
+                    partitionKeyRangeIds: out IReadOnlyList<string> partitionKeyRangeIds);
 
                 CosmosClientOptions cosmosClientOptions = new CosmosClientOptions()
                 {

--- a/azure-pipelines-msdata-direct.yml
+++ b/azure-pipelines-msdata-direct.yml
@@ -65,5 +65,6 @@ jobs:
     Arguments: $(ReleaseArguments)
     VmImage: $(VmImage)
     ThinClientConnectionString: $(COSMOSDB_THINCLIENT)
+    ThinClientStrongConsistencyString: $(COSMOSDB_THINCLIENTSTRONG)
     IncludePerformance: true
     IncludeCoverage: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -79,6 +79,7 @@ jobs:
     Arguments: $(ReleaseArguments)
     VmImage: $(VmImage)
     ThinClientConnectionString: $(COSMOSDB_THINCLIENT)
+    ThinClientStrongConsistencyString: $(COSMOSDB_THINCLIENTSTRONG)
     MultiRegionConnectionString: $(COSMOSDB_MULTI_REGION)
     IncludePerformance: true
     IncludeCoverage: true

--- a/templates/build-thinclient.yml
+++ b/templates/build-thinclient.yml
@@ -7,6 +7,7 @@ parameters:
   OS: 'Windows'
   EmulatorPipeline5Arguments: ' --filter "TestCategory=ThinClient" --verbosity normal '
   EmulatorPipeline5CategoryListName: ' ThinClient '
+  ThinClientStrongConsistencyString: ''
   ThinClientConnectionString: ''
   MultiRegionConnectionString : ''
   IncludeEncryption: true
@@ -50,6 +51,7 @@ jobs:
       testRunTitle: Microsoft.Azure.Cosmos.EmulatorTests - ${{ parameters.EmulatorPipeline5CategoryListName }}
     env:
       COSMOSDB_THINCLIENT: ${{ parameters.ThinClientConnectionString }}
+      COSMOSDB_THINCLIENTSTRONG: ${{ parameters.ThinClientStrongConsistencyString }}
       COSMOSDB_MULTI_REGION: ${{ parameters.MultiRegionConnectionString }}
       AZURE_COSMOS_THIN_CLIENT_ENABLED: 'True'
       AZURE_COSMOS_NON_STREAMING_ORDER_BY_FLAG_DISABLED: 'true'


### PR DESCRIPTION
# Pull Request Template

## Description
With the existing code, query requests are getting 400/1041 error response which indicates that proxy is returning an error due to missing headers. This is happening because it appears that the .NET SDK is not sending the startepk and endEpk headers, as the resolved partition key range is appearing to be null. So, these required headers are appearing missing at the proxy layer and hence the operation fails.

Updated the check in GatewayStoreModel to ensure that it resolves partitionKeyRange and added more tests to cover different consistencies for query operations.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #5343