### PR TITLE
[Internal] Query : Adds new test project for AOT

### DIFF
--- a/Microsoft.Azure.Cosmos.sln
+++ b/Microsoft.Azure.Cosmos.sln
@@ -40,6 +40,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Azure.Cosmos.Encr
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AOT-Sample", "AOT-Sample\AOT-Sample.csproj", "{41813CD4-EBAB-418D-8F27-57CAB655A94B}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Azure.Cosmos.Tests.Aot", "Microsoft.Azure.Cosmos\tests\Microsoft.Azure.Cosmos.Tests.Aot\Microsoft.Azure.Cosmos.Tests.Aot.csproj", "{DE09354D-4B04-471A-BF67-8FB1B03EFCF7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Cover|Any CPU = Cover|Any CPU
@@ -305,6 +307,24 @@ Global
 		{41813CD4-EBAB-418D-8F27-57CAB655A94B}.Release|x64.Build.0 = Release|Any CPU
 		{41813CD4-EBAB-418D-8F27-57CAB655A94B}.Release|x86.ActiveCfg = Release|Any CPU
 		{41813CD4-EBAB-418D-8F27-57CAB655A94B}.Release|x86.Build.0 = Release|Any CPU
+		{DE09354D-4B04-471A-BF67-8FB1B03EFCF7}.Cover|Any CPU.ActiveCfg = Debug|Any CPU
+		{DE09354D-4B04-471A-BF67-8FB1B03EFCF7}.Cover|Any CPU.Build.0 = Debug|Any CPU
+		{DE09354D-4B04-471A-BF67-8FB1B03EFCF7}.Cover|x64.ActiveCfg = Debug|Any CPU
+		{DE09354D-4B04-471A-BF67-8FB1B03EFCF7}.Cover|x64.Build.0 = Debug|Any CPU
+		{DE09354D-4B04-471A-BF67-8FB1B03EFCF7}.Cover|x86.ActiveCfg = Debug|Any CPU
+		{DE09354D-4B04-471A-BF67-8FB1B03EFCF7}.Cover|x86.Build.0 = Debug|Any CPU
+		{DE09354D-4B04-471A-BF67-8FB1B03EFCF7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DE09354D-4B04-471A-BF67-8FB1B03EFCF7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DE09354D-4B04-471A-BF67-8FB1B03EFCF7}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{DE09354D-4B04-471A-BF67-8FB1B03EFCF7}.Debug|x64.Build.0 = Debug|Any CPU
+		{DE09354D-4B04-471A-BF67-8FB1B03EFCF7}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{DE09354D-4B04-471A-BF67-8FB1B03EFCF7}.Debug|x86.Build.0 = Debug|Any CPU
+		{DE09354D-4B04-471A-BF67-8FB1B03EFCF7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DE09354D-4B04-471A-BF67-8FB1B03EFCF7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DE09354D-4B04-471A-BF67-8FB1B03EFCF7}.Release|x64.ActiveCfg = Release|Any CPU
+		{DE09354D-4B04-471A-BF67-8FB1B03EFCF7}.Release|x64.Build.0 = Release|Any CPU
+		{DE09354D-4B04-471A-BF67-8FB1B03EFCF7}.Release|x86.ActiveCfg = Release|Any CPU
+		{DE09354D-4B04-471A-BF67-8FB1B03EFCF7}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Microsoft.Azure.Cosmos/src/AssemblyInfo.cs
+++ b/Microsoft.Azure.Cosmos/src/AssemblyInfo.cs
@@ -27,6 +27,8 @@ using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("Microsoft.Azure.Cosmos.Portal.Services.Backend" + AssemblyKeys.TestPublicKey)]
 [assembly: InternalsVisibleTo("Microsoft.Azure.Cosmos.Tests" + AssemblyKeys.ProductPublicKey)]
 [assembly: InternalsVisibleTo("Microsoft.Azure.Cosmos.Tests" + AssemblyKeys.TestPublicKey)]
+[assembly: InternalsVisibleTo("Microsoft.Azure.Cosmos.Tests.Aot" + AssemblyKeys.ProductPublicKey)]
+[assembly: InternalsVisibleTo("Microsoft.Azure.Cosmos.Tests.Aot" + AssemblyKeys.TestPublicKey)]
 [assembly: InternalsVisibleTo("Microsoft.Azure.Cosmos.EmulatorTests" + AssemblyKeys.ProductPublicKey)]
 [assembly: InternalsVisibleTo("Microsoft.Azure.Cosmos.EmulatorTests" + AssemblyKeys.TestPublicKey)]
 [assembly: InternalsVisibleTo("Microsoft.Azure.Cosmos.NetFramework.Tests" + AssemblyKeys.ProductPublicKey)]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests.Aot/Common/ConfigurationManager.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests.Aot/Common/ConfigurationManager.cs
@@ -2,14 +2,8 @@
 {
     using System.Text.Json;
 
-    /// <summary>
-    /// ConfigurationManager shim for netstandard
-    /// </summary>
     internal static class ConfigurationManager
     {
-        private const string GatewayEndpointSettingName = "GatewayEndpoint";
-        private const string GatewayEndpointEnvironmentName = "COSMOSDBEMULATOR_ENDPOINT";
-
         static ConfigurationManager()
         {
             AppSettings = new Dictionary<string, string>();

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests.Aot/Common/ConfigurationManager.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests.Aot/Common/ConfigurationManager.cs
@@ -1,0 +1,29 @@
+﻿namespace Microsoft.Azure.Cosmos.Tests.Aot.Common
+{
+    using System.Text.Json;
+
+    /// <summary>
+    /// ConfigurationManager shim for netstandard
+    /// </summary>
+    internal static class ConfigurationManager
+    {
+        private const string GatewayEndpointSettingName = "GatewayEndpoint";
+        private const string GatewayEndpointEnvironmentName = "COSMOSDBEMULATOR_ENDPOINT";
+
+        static ConfigurationManager()
+        {
+            AppSettings = new Dictionary<string, string>();
+
+            dynamic config = JsonSerializer.Deserialize<dynamic>(File.ReadAllText("settings.json"));
+            dynamic appSettings = config.GetProperty("AppSettings");
+
+            AppSettings = new Dictionary<string, string>();
+            foreach(var propertyName in appSettings.EnumerateObject())
+            {
+                AppSettings[propertyName.Name] = propertyName.Value.ToString();
+            }
+        }
+
+        public static Dictionary<string, string> AppSettings { get; private set; }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests.Aot/Common/RestHelper.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests.Aot/Common/RestHelper.cs
@@ -8,20 +8,21 @@
 
     internal class RestHelper
     {
-        private readonly string accountEndpoint;
-        private readonly string cosmosKey;
         private readonly string baseUrl;
+        private readonly string cosmosKey;
         private readonly HttpClient httpClient;
         private readonly bool outputToConsole;
 
         public RestHelper(string accountEndpoint, string cosmosKey, bool outputToConsole = false)
         {
-            this.accountEndpoint = accountEndpoint;
-            this.cosmosKey = cosmosKey;
             this.baseUrl = $"{accountEndpoint}/";
+            this.cosmosKey = cosmosKey;
             this.httpClient = new HttpClient();
             this.outputToConsole = outputToConsole;
         }
+
+        // Rest helper implementation is based on the sample found here:
+        // https://github.com/Azure-Samples/cosmos-db-rest-samples/blob/main/Program.cs
 
         #region Database Operations
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests.Aot/Common/RestHelper.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests.Aot/Common/RestHelper.cs
@@ -1,0 +1,595 @@
+﻿namespace Microsoft.Azure.Cosmos.Tests.Aot.Common
+{
+    using System;
+    using System.Net;
+    using System.Security.Cryptography;
+    using System.Text.Json;
+    using System.Threading.Tasks;
+
+    internal class RestHelper
+    {
+        private readonly string accountEndpoint;
+        private readonly string cosmosKey;
+        private readonly string baseUrl;
+        private readonly HttpClient httpClient;
+        private readonly bool outputToConsole;
+
+        public RestHelper(string accountEndpoint, string cosmosKey, bool outputToConsole = false)
+        {
+            this.accountEndpoint = accountEndpoint;
+            this.cosmosKey = cosmosKey;
+            this.baseUrl = $"{accountEndpoint}/";
+            this.httpClient = new HttpClient();
+            this.outputToConsole = outputToConsole;
+        }
+
+        #region Database Operations
+
+        public async Task CreateDatabase(string databaseId, DatabaseThoughputMode mode)
+        {
+            HttpMethod method = HttpMethod.Post;
+
+            ResourceType resourceType = ResourceType.dbs;
+            string resourceLink = $"";
+            string requestDateString = DateTime.UtcNow.ToString("r");
+            string auth = this.GenerateMasterKeyAuthorizationSignature(method, resourceType, resourceLink, requestDateString, this.cosmosKey);
+
+            this.httpClient.DefaultRequestHeaders.Clear();
+            this.httpClient.DefaultRequestHeaders.Add("Accept", "application/json");
+            this.httpClient.DefaultRequestHeaders.Add("authorization", auth);
+            this.httpClient.DefaultRequestHeaders.Add("x-ms-date", requestDateString);
+            this.httpClient.DefaultRequestHeaders.Add("x-ms-version", "2018-12-31");
+
+            if (mode == DatabaseThoughputMode.@fixed)
+                this.httpClient.DefaultRequestHeaders.Add("x-ms-offer-throughput", "400");
+            if (mode == DatabaseThoughputMode.autopilot)
+                this.httpClient.DefaultRequestHeaders.Add("x-ms-cosmos-offer-autopilot-settings", "{\"maxThroughput\": 4000}");
+
+            Uri requestUri = new Uri($"{this.baseUrl}/dbs");
+            string requestBody = $"{{\"id\":\"{databaseId}\"}}";
+            StringContent requestContent = new StringContent(requestBody, System.Text.Encoding.UTF8, "application/json");
+
+            HttpRequestMessage httpRequest = new HttpRequestMessage { Method = method, Content = requestContent, RequestUri = requestUri };
+
+            HttpResponseMessage httpResponse = await this.httpClient.SendAsync(httpRequest);
+            await this.ReportOutput($"Create Database with thoughput mode {mode}:", httpResponse);
+        }
+
+        public async Task ListDatabases()
+        {
+            HttpMethod method = HttpMethod.Get;
+
+            ResourceType resourceType = ResourceType.dbs;
+            string resourceLink = string.Empty;
+            string requestDateString = DateTime.UtcNow.ToString("r");
+            string auth = this.GenerateMasterKeyAuthorizationSignature(method, resourceType, resourceLink, requestDateString, this.cosmosKey);
+
+            this.httpClient.DefaultRequestHeaders.Clear();
+            this.httpClient.DefaultRequestHeaders.Add("Accept", "application/json");
+            this.httpClient.DefaultRequestHeaders.Add("authorization", auth);
+            this.httpClient.DefaultRequestHeaders.Add("x-ms-date", requestDateString);
+            this.httpClient.DefaultRequestHeaders.Add("x-ms-version", "2018-12-31");
+
+            Uri requestUri = new Uri($"{this.baseUrl}/dbs");
+            HttpRequestMessage httpRequest = new HttpRequestMessage { Method = method, RequestUri = requestUri };
+
+            HttpResponseMessage httpResponse = await this.httpClient.SendAsync(httpRequest);
+            await this.ReportOutput($"List Databases:", httpResponse);
+        }
+
+        public async Task GetDatabase(string databaseId)
+        {
+            HttpMethod method = HttpMethod.Get;
+
+            ResourceType resourceType = ResourceType.dbs;
+            string resourceLink = $"dbs/{databaseId}";
+            string requestDateString = DateTime.UtcNow.ToString("r");
+            string auth = this.GenerateMasterKeyAuthorizationSignature(method, resourceType, resourceLink, requestDateString, this.cosmosKey);
+
+            this.httpClient.DefaultRequestHeaders.Clear();
+            this.httpClient.DefaultRequestHeaders.Add("Accept", "application/json");
+            this.httpClient.DefaultRequestHeaders.Add("authorization", auth);
+            this.httpClient.DefaultRequestHeaders.Add("x-ms-date", requestDateString);
+            this.httpClient.DefaultRequestHeaders.Add("x-ms-version", "2018-12-31");
+
+            Uri requestUri = new Uri($"{this.baseUrl}/{resourceLink}");
+            HttpRequestMessage httpRequest = new HttpRequestMessage { Method = method, RequestUri = requestUri };
+
+            HttpResponseMessage httpResponse = await this.httpClient.SendAsync(httpRequest);
+            await this.ReportOutput($"Get Database with id: '{databaseId}' :", httpResponse);
+        }
+
+        public async Task DeleteDatabase(string databaseId)
+        {
+            HttpMethod method = HttpMethod.Delete;
+
+            ResourceType resourceType = ResourceType.dbs;
+            string resourceLink = $"dbs/{databaseId}";
+            string requestDateString = DateTime.UtcNow.ToString("r");
+            string auth = this.GenerateMasterKeyAuthorizationSignature(method, resourceType, resourceLink, requestDateString, this.cosmosKey);
+
+            this.httpClient.DefaultRequestHeaders.Clear();
+            this.httpClient.DefaultRequestHeaders.Add("Accept", "application/json");
+            this.httpClient.DefaultRequestHeaders.Add("authorization", auth);
+            this.httpClient.DefaultRequestHeaders.Add("x-ms-date", requestDateString);
+            this.httpClient.DefaultRequestHeaders.Add("x-ms-version", "2018-12-31");
+
+            Uri requestUri = new Uri($"{this.baseUrl}/{resourceLink}");
+            HttpRequestMessage httpRequest = new HttpRequestMessage { Method = method, RequestUri = requestUri };
+
+            HttpResponseMessage httpResponse = await this.httpClient.SendAsync(httpRequest);
+            await this.ReportOutput("Delete Database", httpResponse);
+        }
+
+        #endregion
+
+
+        #region Container Operations
+
+        public async Task CreateContainer(string databaseId, string containerId, DatabaseThoughputMode mode)
+        {
+            HttpMethod method = HttpMethod.Post;
+
+            ResourceType resourceType = ResourceType.colls;
+            string resourceLink = $"dbs/{databaseId}";
+            string requestDateString = DateTime.UtcNow.ToString("r");
+            string auth = this.GenerateMasterKeyAuthorizationSignature(method, resourceType, resourceLink, requestDateString, this.cosmosKey);
+
+            this.httpClient.DefaultRequestHeaders.Clear();
+            this.httpClient.DefaultRequestHeaders.Add("Accept", "application/json");
+            this.httpClient.DefaultRequestHeaders.Add("authorization", auth);
+            this.httpClient.DefaultRequestHeaders.Add("x-ms-date", requestDateString);
+            this.httpClient.DefaultRequestHeaders.Add("x-ms-version", "2018-12-31");
+
+            if (mode == DatabaseThoughputMode.@fixed)
+                this.httpClient.DefaultRequestHeaders.Add("x-ms-offer-throughput", "400");
+            if (mode == DatabaseThoughputMode.autopilot)
+                this.httpClient.DefaultRequestHeaders.Add("x-ms-cosmos-offer-autopilot-settings", "{\"maxThroughput\": 4000}");
+
+            Uri requestUri = new Uri($"{this.baseUrl}/{resourceLink}/colls");
+            string requestBody = $@"{{
+        ""id"":""{containerId}"",
+         ""partitionKey"": {{  
+            ""paths"": [
+              ""/pk""  
+            ],  
+            ""kind"": ""Hash"",
+             ""Version"": 2
+          }}  
+        }}";
+            StringContent requestContent = new StringContent(requestBody, System.Text.Encoding.UTF8, "application/json");
+
+            HttpRequestMessage httpRequest = new HttpRequestMessage { Method = method, Content = requestContent, RequestUri = requestUri };
+
+            HttpResponseMessage httpResponse = await this.httpClient.SendAsync(httpRequest);
+            await this.ReportOutput($"Create Container with thoughput mode {mode}:", httpResponse);
+        }
+
+        public async Task GetContainer(string databaseId, string containerId)
+        {
+            HttpMethod method = HttpMethod.Get;
+
+            ResourceType resourceType = ResourceType.colls;
+            string resourceLink = $"dbs/{databaseId}/colls/{containerId}";
+            string requestDateString = DateTime.UtcNow.ToString("r");
+            string auth = this.GenerateMasterKeyAuthorizationSignature(method, resourceType, resourceLink, requestDateString, this.cosmosKey);
+
+            this.httpClient.DefaultRequestHeaders.Clear();
+            this.httpClient.DefaultRequestHeaders.Add("Accept", "application/json");
+            this.httpClient.DefaultRequestHeaders.Add("authorization", auth);
+            this.httpClient.DefaultRequestHeaders.Add("x-ms-date", requestDateString);
+            this.httpClient.DefaultRequestHeaders.Add("x-ms-version", "2018-12-31");
+
+            Uri requestUri = new Uri($"{this.baseUrl}/{resourceLink}");
+            HttpRequestMessage httpRequest = new HttpRequestMessage { Method = method, RequestUri = requestUri };
+
+            HttpResponseMessage httpResponse = await this.httpClient.SendAsync(httpRequest);
+            await this.ReportOutput($"Get Container with id: '{databaseId}' :", httpResponse);
+        }
+
+
+        public async Task DeleteContainer(string databaseId, string containerId)
+        {
+            HttpMethod method = HttpMethod.Delete;
+
+            ResourceType resourceType = ResourceType.colls;
+            string resourceLink = $"dbs/{databaseId}/colls/{containerId}";
+            string requestDateString = DateTime.UtcNow.ToString("r");
+            string auth = this.GenerateMasterKeyAuthorizationSignature(method, resourceType, resourceLink, requestDateString, this.cosmosKey);
+
+            this.httpClient.DefaultRequestHeaders.Clear();
+            this.httpClient.DefaultRequestHeaders.Add("Accept", "application/json");
+            this.httpClient.DefaultRequestHeaders.Add("authorization", auth);
+            this.httpClient.DefaultRequestHeaders.Add("x-ms-date", requestDateString);
+            this.httpClient.DefaultRequestHeaders.Add("x-ms-version", "2018-12-31");
+
+            Uri requestUri = new Uri($"{this.baseUrl}/{resourceLink}");
+            HttpRequestMessage httpRequest = new HttpRequestMessage { Method = method, RequestUri = requestUri };
+
+            HttpResponseMessage httpResponse = await this.httpClient.SendAsync(httpRequest);
+            await this.ReportOutput("Delete Container", httpResponse);
+        }
+
+        public async Task GetContainerPartitionKeys(string databaseId, string containerId)
+        {
+            HttpMethod method = HttpMethod.Get;
+
+            ResourceType resourceType = ResourceType.pkranges;
+            string resourceLink = $"dbs/{databaseId}/colls/{containerId}";
+            string requestDateString = DateTime.UtcNow.ToString("r");
+            string auth = this.GenerateMasterKeyAuthorizationSignature(method, resourceType, resourceLink, requestDateString, this.cosmosKey);
+
+            this.httpClient.DefaultRequestHeaders.Clear();
+            this.httpClient.DefaultRequestHeaders.Add("Accept", "application/json");
+            this.httpClient.DefaultRequestHeaders.Add("authorization", auth);
+            this.httpClient.DefaultRequestHeaders.Add("x-ms-date", requestDateString);
+            this.httpClient.DefaultRequestHeaders.Add("x-ms-version", "2018-12-31");
+            Uri requestUri = new Uri($"{this.baseUrl}/{resourceLink}/pkranges");
+
+            HttpRequestMessage httpRequest = new HttpRequestMessage { Method = method, RequestUri = requestUri };
+
+            HttpResponseMessage httpResponse = await this.httpClient.SendAsync(httpRequest);
+            await this.ReportOutput($"Get Partition Key Ranges for collection '{containerId}':", httpResponse);
+        }
+
+        #endregion
+
+        #region Stored Procedures
+
+        public async Task CreateStoredProcedure(string databaseId, string containerId, string storedProcedureName)
+        {
+            HttpMethod method = HttpMethod.Post;
+
+            ResourceType resourceType = ResourceType.sprocs;
+            string resourceLink = $"dbs/{databaseId}/colls/{containerId}";
+            string requestDateString = DateTime.UtcNow.ToString("r");
+            string auth = this.GenerateMasterKeyAuthorizationSignature(method, resourceType, resourceLink, requestDateString, this.cosmosKey);
+
+            this.httpClient.DefaultRequestHeaders.Clear();
+            this.httpClient.DefaultRequestHeaders.Add("Accept", "application/json");
+            this.httpClient.DefaultRequestHeaders.Add("authorization", auth);
+            this.httpClient.DefaultRequestHeaders.Add("x-ms-date", requestDateString);
+            this.httpClient.DefaultRequestHeaders.Add("x-ms-version", "2018-12-31");
+
+            Uri requestUri = new Uri($"{this.baseUrl}/{resourceLink}/sprocs");
+            string requestBody = $@"{{
+            ""body"": ""function (testParam) {{ var context = getContext(); var response = context.getResponse(); response.setBody(\""Hello, \""+testParam);}}"",
+            ""id"":""{storedProcedureName}""
+        }}";
+
+            StringContent requestContent = new StringContent(requestBody, System.Text.Encoding.UTF8, "application/json");
+            HttpRequestMessage httpRequest = new HttpRequestMessage { Method = method, Content = requestContent, RequestUri = requestUri };
+
+            HttpResponseMessage httpResponse = await this.httpClient.SendAsync(httpRequest);
+            await this.ReportOutput($"Create Stored procedure '{storedProcedureName}' on container '{containerId}' :", httpResponse);
+        }
+
+        public async Task DeleteStoredProcedure(string databaseId, string containerId, string storedProcedureName)
+        {
+            HttpMethod method = HttpMethod.Delete;
+
+            ResourceType resourceType = ResourceType.sprocs;
+            string resourceLink = $"dbs/{databaseId}/colls/{containerId}/sprocs/{storedProcedureName}";
+            string requestDateString = DateTime.UtcNow.ToString("r");
+            string auth = this.GenerateMasterKeyAuthorizationSignature(method, resourceType, resourceLink, requestDateString, this.cosmosKey);
+
+            this.httpClient.DefaultRequestHeaders.Clear();
+            this.httpClient.DefaultRequestHeaders.Add("Accept", "application/json");
+            this.httpClient.DefaultRequestHeaders.Add("authorization", auth);
+            this.httpClient.DefaultRequestHeaders.Add("x-ms-date", requestDateString);
+            this.httpClient.DefaultRequestHeaders.Add("x-ms-version", "2018-12-31");
+
+            Uri requestUri = new Uri($"{this.baseUrl}/{resourceLink}");
+            HttpRequestMessage httpRequest = new HttpRequestMessage { Method = method, RequestUri = requestUri };
+
+            HttpResponseMessage httpResponse = await this.httpClient.SendAsync(httpRequest);
+            await this.ReportOutput($"Delete Stored Procedure '{storedProcedureName}", httpResponse);
+        }
+
+        public async Task ExecuteStoredProcedure(string databaseId, string containerId, string storedProcedureName)
+        {
+            HttpMethod method = HttpMethod.Post;
+
+            ResourceType resourceType = ResourceType.sprocs;
+            string resourceLink = $"dbs/{databaseId}/colls/{containerId}/sprocs/{storedProcedureName}";
+            string requestDateString = DateTime.UtcNow.ToString("r");
+            string auth = this.GenerateMasterKeyAuthorizationSignature(method, resourceType, resourceLink, requestDateString, this.cosmosKey);
+
+            this.httpClient.DefaultRequestHeaders.Clear();
+            this.httpClient.DefaultRequestHeaders.Add("Accept", "application/json");
+            this.httpClient.DefaultRequestHeaders.Add("authorization", auth);
+            this.httpClient.DefaultRequestHeaders.Add("x-ms-date", requestDateString);
+            this.httpClient.DefaultRequestHeaders.Add("x-ms-version", "2018-12-31");
+
+            Uri requestUri = new Uri($"{this.baseUrl}/{resourceLink}");
+            string requestBody = $@"[""test param""]";
+
+            StringContent requestContent = new StringContent(requestBody, System.Text.Encoding.UTF8, "application/json");
+            HttpRequestMessage httpRequest = new HttpRequestMessage { Method = method, Content = requestContent, RequestUri = requestUri };
+
+            HttpResponseMessage httpResponse = await this.httpClient.SendAsync(httpRequest);
+            await this.ReportOutput($"Executed Stored Procedure '{storedProcedureName}", httpResponse);
+        }
+
+        #endregion
+
+        public async Task CreateDocument(string databaseId, string containerId, Item item)
+        {
+            HttpMethod method = HttpMethod.Post;
+
+            ResourceType resourceType = ResourceType.docs;
+            string resourceLink = $"dbs/{databaseId}/colls/{containerId}";
+            string requestDateString = DateTime.UtcNow.ToString("r");
+            string auth = this.GenerateMasterKeyAuthorizationSignature(method, resourceType, resourceLink, requestDateString, this.cosmosKey);
+
+            this.httpClient.DefaultRequestHeaders.Clear();
+            this.httpClient.DefaultRequestHeaders.Add("Accept", "application/json");
+            this.httpClient.DefaultRequestHeaders.Add("authorization", auth);
+            this.httpClient.DefaultRequestHeaders.Add("x-ms-version", "2018-12-31");
+            this.httpClient.DefaultRequestHeaders.Add("x-ms-date", requestDateString);
+            this.httpClient.DefaultRequestHeaders.Add("x-ms-documentdb-is-upsert", "True");
+            this.httpClient.DefaultRequestHeaders.Add("x-ms-documentdb-partitionkey", $"[\"{item.pk}\"]");
+
+            Uri requestUri = new Uri($"{this.baseUrl}/{resourceLink}/docs");
+            StringContent requestContent = new StringContent(JsonSerializer.Serialize(item), System.Text.Encoding.UTF8, "application/json");
+
+            HttpRequestMessage httpRequest = new HttpRequestMessage { Method = method, Content = requestContent, RequestUri = requestUri };
+
+            HttpResponseMessage httpResponse = await this.httpClient.SendAsync(httpRequest);
+            await this.ReportOutput("Create Document", httpResponse);
+        }
+
+        public async Task ListDocuments(string databaseId, string containerId, string partitionKey)
+        {
+            HttpMethod method = HttpMethod.Get;
+            ResourceType resourceType = ResourceType.docs;
+            string resourceLink = $"dbs/{databaseId}/colls/{containerId}";
+            string requestDateString = DateTime.UtcNow.ToString("r");
+            string auth = this.GenerateMasterKeyAuthorizationSignature(method, resourceType, resourceLink, requestDateString, this.cosmosKey);
+
+            this.httpClient.DefaultRequestHeaders.Clear();
+            this.httpClient.DefaultRequestHeaders.Add("Accept", "application/json");
+            this.httpClient.DefaultRequestHeaders.Add("authorization", auth);
+            this.httpClient.DefaultRequestHeaders.Add("x-ms-date", requestDateString);
+            this.httpClient.DefaultRequestHeaders.Add("x-ms-version", "2018-12-31");
+            this.httpClient.DefaultRequestHeaders.Add("x-ms-documentdb-partitionkey", $"[\"{partitionKey}\"]");
+
+            Uri requestUri = new Uri($"{this.baseUrl}/{resourceLink}/docs");
+            HttpRequestMessage httpRequest = new HttpRequestMessage { Method = method, RequestUri = requestUri };
+
+            HttpResponseMessage httpResponse = await this.httpClient.SendAsync(httpRequest);
+            await this.ReportOutput($"List Documents for partitionKey {partitionKey}", httpResponse);
+        }
+
+        public async Task GetDocument(string databaseId, string containerId, string id, string partitionKey)
+        {
+            HttpMethod method = HttpMethod.Get;
+            ResourceType resourceType = ResourceType.docs;
+            string resourceLink = $"dbs/{databaseId}/colls/{containerId}/docs/{id}";
+            string requestDateString = DateTime.UtcNow.ToString("r");
+            string auth = this.GenerateMasterKeyAuthorizationSignature(method, resourceType, resourceLink, requestDateString, this.cosmosKey);
+
+            this.httpClient.DefaultRequestHeaders.Clear();
+            this.httpClient.DefaultRequestHeaders.Add("Accept", "application/json");
+            this.httpClient.DefaultRequestHeaders.Add("authorization", auth);
+            this.httpClient.DefaultRequestHeaders.Add("x-ms-date", requestDateString);
+            this.httpClient.DefaultRequestHeaders.Add("x-ms-version", "2018-12-31");
+            this.httpClient.DefaultRequestHeaders.Add("x-ms-documentdb-partitionkey", $"[\"{partitionKey}\"]");
+
+            Uri requestUri = new Uri($"{this.baseUrl}/{resourceLink}");
+            HttpRequestMessage httpRequest = new HttpRequestMessage { Method = method, RequestUri = requestUri };
+
+            HttpResponseMessage httpResponse = await this.httpClient.SendAsync(httpRequest);
+            await this.ReportOutput($"Get Document by id: '{id}'", httpResponse);
+        }
+
+        public async Task ReplaceDocument(string databaseId, string containerId, string id, Item newItem)
+        {
+            HttpMethod method = HttpMethod.Put;
+
+            ResourceType resourceType = ResourceType.docs;
+            string resourceLink = $"dbs/{databaseId}/colls/{containerId}/docs/{id}";
+            string requestDateString = DateTime.UtcNow.ToString("r");
+            string auth = this.GenerateMasterKeyAuthorizationSignature(method, resourceType, resourceLink, requestDateString, this.cosmosKey);
+
+            this.httpClient.DefaultRequestHeaders.Clear();
+            this.httpClient.DefaultRequestHeaders.Add("Accept", "application/json");
+            this.httpClient.DefaultRequestHeaders.Add("authorization", auth);
+            this.httpClient.DefaultRequestHeaders.Add("x-ms-date", requestDateString);
+            this.httpClient.DefaultRequestHeaders.Add("x-ms-version", "2018-12-31");
+            this.httpClient.DefaultRequestHeaders.Add("x-ms-documentdb-partitionkey", $"[\"{newItem.pk}\"]");
+
+            Uri requestUri = new Uri($"{this.baseUrl}/{resourceLink}");
+            StringContent requestContent = new StringContent(JsonSerializer.Serialize(newItem), System.Text.Encoding.UTF8, "application/json");
+
+            HttpRequestMessage httpRequest = new HttpRequestMessage { Method = method, Content = requestContent, RequestUri = requestUri };
+
+            HttpResponseMessage httpResponse = await this.httpClient.SendAsync(httpRequest);
+            await this.ReportOutput($"Replace Document with id '{id}'", httpResponse);
+
+        }
+
+        public async Task PatchDocument(string databaseId, string containerId, string id, string partitionKey)
+        {
+            HttpMethod method = HttpMethod.Patch;
+
+            ResourceType resourceType = ResourceType.docs;
+            string resourceLink = $"dbs/{databaseId}/colls/{containerId}/docs/{id}";
+            string requestDateString = DateTime.UtcNow.ToString("r");
+            string auth = this.GenerateMasterKeyAuthorizationSignature(method, resourceType, resourceLink, requestDateString, this.cosmosKey);
+
+            this.httpClient.DefaultRequestHeaders.Clear();
+            this.httpClient.DefaultRequestHeaders.Add("Accept", "application/json");
+            this.httpClient.DefaultRequestHeaders.Add("authorization", auth);
+            this.httpClient.DefaultRequestHeaders.Add("x-ms-date", requestDateString);
+            this.httpClient.DefaultRequestHeaders.Add("x-ms-version", "2018-12-31");
+            this.httpClient.DefaultRequestHeaders.Add("x-ms-documentdb-partitionkey", $"[\"{partitionKey}\"]");
+
+            Uri requestUri = new Uri($"{this.baseUrl}/{resourceLink}");
+            string requestBody = @"
+        {
+          ""operations"": [
+            {
+              ""op"": ""set"",
+              ""path"": ""/someProperty"",
+              ""value"": ""value-patched""
+            }
+          ]
+        }  ";
+
+            StringContent requestContent = new StringContent(requestBody, System.Text.Encoding.UTF8, "application/json");
+
+            HttpRequestMessage httpRequest = new HttpRequestMessage { Method = method, Content = requestContent, RequestUri = requestUri };
+
+            HttpResponseMessage httpResponse = await this.httpClient.SendAsync(httpRequest);
+            await this.ReportOutput($"Patch Document with id '{id}'", httpResponse);
+        }
+
+
+        public async Task DeleteDocument(string databaseId, string containerId, string id, string partitionKey)
+        {
+            HttpMethod method = HttpMethod.Delete;
+            ResourceType resourceType = ResourceType.docs;
+            string resourceLink = $"dbs/{databaseId}/colls/{containerId}/docs/{id}";
+            string requestDateString = DateTime.UtcNow.ToString("r");
+            string auth = this.GenerateMasterKeyAuthorizationSignature(method, resourceType, resourceLink, requestDateString, this.cosmosKey);
+
+            this.httpClient.DefaultRequestHeaders.Clear();
+            this.httpClient.DefaultRequestHeaders.Add("Accept", "application/json");
+            this.httpClient.DefaultRequestHeaders.Add("authorization", auth);
+            this.httpClient.DefaultRequestHeaders.Add("x-ms-date", requestDateString);
+            this.httpClient.DefaultRequestHeaders.Add("x-ms-version", "2018-12-31");
+            this.httpClient.DefaultRequestHeaders.Add("x-ms-documentdb-partitionkey", $"[\"{partitionKey}\"]");
+
+            Uri requestUri = new Uri($"{this.baseUrl}/{resourceLink}");
+            HttpRequestMessage httpRequest = new HttpRequestMessage { Method = method, RequestUri = requestUri };
+
+            HttpResponseMessage httpResponse = await this.httpClient.SendAsync(httpRequest);
+
+            await this.ReportOutput($"Deleted item with id '{id}':", httpResponse);
+        }
+
+
+        // Change var by explicit types in the entire file
+        public async Task QueryDocuments(string databaseId, string containerId, string partitionKey)
+        {
+            HttpMethod method = HttpMethod.Post;
+            ResourceType resourceType = ResourceType.docs;
+            string resourceLink = $"dbs/{databaseId}/colls/{containerId}";
+            string requestDateString = DateTime.UtcNow.ToString("r");
+            string auth = this.GenerateMasterKeyAuthorizationSignature(method, resourceType, resourceLink, requestDateString, this.cosmosKey);
+
+            this.httpClient.DefaultRequestHeaders.Clear();
+            this.httpClient.DefaultRequestHeaders.Add("Accept", "application/json");
+            this.httpClient.DefaultRequestHeaders.Add("authorization", auth);
+            this.httpClient.DefaultRequestHeaders.Add("x-ms-date", requestDateString);
+            this.httpClient.DefaultRequestHeaders.Add("x-ms-version", "2018-12-31");
+            this.httpClient.DefaultRequestHeaders.Add("x-ms-documentdb-isquery", "True");
+
+            Uri requestUri = new Uri($"{this.baseUrl}/{resourceLink}/docs");
+            string requestBody = @$"
+        {{  
+          ""query"": ""SELECT * FROM c WHERE c.pk = @pk"",  
+          ""parameters"": [
+            {{  
+              ""name"": ""@pk"",
+              ""value"": ""{partitionKey}""  
+            }}
+          ]  
+        }}";
+            StringContent requestContent = new StringContent(requestBody, System.Text.Encoding.UTF8, "application/query+json");
+            //NOTE -> this is important. CosmosDB expects a specific Content-Type with no CharSet on a query request.
+            requestContent.Headers.ContentType.CharSet = "";
+            HttpRequestMessage httpRequest = new HttpRequestMessage { Method = method, Content = requestContent, RequestUri = requestUri };
+
+            HttpResponseMessage httpResponse = await this.httpClient.SendAsync(httpRequest);
+
+            await this.ReportOutput("Query: ", httpResponse);
+        }
+
+        public async Task QueryDocumentsCrossPartition(string databaseId, string containerId)
+        {
+            HttpMethod method = HttpMethod.Post;
+            ResourceType resourceType = ResourceType.docs;
+            string resourceLink = $"dbs/{databaseId}/colls/{containerId}";
+            string requestDateString = DateTime.UtcNow.ToString("r");
+            string auth = this.GenerateMasterKeyAuthorizationSignature(method, resourceType, resourceLink, requestDateString, this.cosmosKey);
+
+            this.httpClient.DefaultRequestHeaders.Clear();
+            this.httpClient.DefaultRequestHeaders.Add("Accept", "application/json");
+            this.httpClient.DefaultRequestHeaders.Add("authorization", auth);
+            this.httpClient.DefaultRequestHeaders.Add("x-ms-date", requestDateString);
+            this.httpClient.DefaultRequestHeaders.Add("x-ms-version", "2018-12-31");
+            this.httpClient.DefaultRequestHeaders.Add("x-ms-max-item-count", "2");
+            this.httpClient.DefaultRequestHeaders.Add("x-ms-documentdb-query-enablecrosspartition", "True");
+            this.httpClient.DefaultRequestHeaders.Add("x-ms-documentdb-isquery", "True");
+
+            Uri requestUri = new Uri($"{this.baseUrl}/{resourceLink}/docs");
+            string requestBody = @$"
+        {{  
+          ""query"": ""SELECT * FROM c"",  
+          ""parameters"": []  
+        }}";
+
+            StringContent requestContent = new StringContent(requestBody, System.Text.Encoding.UTF8, "application/query+json");
+            //NOTE -> this is important. CosmosDB expects a specific Content-Type with no CharSet on a query request.
+            requestContent.Headers.ContentType.CharSet = "";
+            HttpRequestMessage httpRequest = new HttpRequestMessage { Method = method, Content = requestContent, RequestUri = requestUri };
+
+            HttpResponseMessage httpResponse = await this.httpClient.SendAsync(httpRequest);
+            //var continuation = httpResponse.Headers.GetValues("x-ms-continuation");
+
+            await this.ReportOutput("Query: ", httpResponse);
+        }
+
+        private string GenerateMasterKeyAuthorizationSignature(HttpMethod verb, ResourceType resourceType, string resourceLink, string date, string key)
+        {
+            string keyType = "master";
+            string tokenVersion = "1.0";
+            string payload = $"{verb.ToString().ToLowerInvariant()}\n{resourceType.ToString().ToLowerInvariant()}\n{resourceLink}\n{date.ToLowerInvariant()}\n\n";
+
+            HMACSHA256 hmacSha256 = new HMACSHA256 { Key = Convert.FromBase64String(key) };
+            byte[] hashPayload = hmacSha256.ComputeHash(System.Text.Encoding.UTF8.GetBytes(payload));
+            string signature = Convert.ToBase64String(hashPayload);
+            string authSet = WebUtility.UrlEncode($"type={keyType}&ver={tokenVersion}&sig={signature}");
+
+            return authSet;
+        }
+
+        private async Task ReportOutput(string methodName, HttpResponseMessage httpResponse)
+        {
+            string responseContent = await httpResponse.Content.ReadAsStringAsync();
+            if (this.outputToConsole)
+            {
+                if (httpResponse.IsSuccessStatusCode)
+                {
+                    Console.WriteLine($"{methodName}: SUCCESS\n    {responseContent}\n\n");
+                }
+                else
+                {
+                    Console.ForegroundColor = ConsoleColor.DarkRed;
+                    Console.WriteLine($"{methodName}: FAILED -> {(int)httpResponse.StatusCode}: {httpResponse.ReasonPhrase}.\n    {responseContent}\n\n");
+                    Console.ForegroundColor = ConsoleColor.White;
+                }
+            }
+        }
+
+        public record Item(string id, string pk, string value);
+
+        public enum ResourceType
+        {
+            dbs,
+            colls,
+            docs,
+            sprocs,
+            pkranges,
+        }
+
+        public enum DatabaseThoughputMode
+        {
+            none,
+            @fixed,
+            autopilot,
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests.Aot/Common/TestUtil.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests.Aot/Common/TestUtil.cs
@@ -1,0 +1,60 @@
+﻿namespace Microsoft.Azure.Cosmos.Tests.Aot.Common
+{
+    using Microsoft.Azure.Documents;
+    using System.Net;
+    using System.Security.Cryptography;
+
+    internal class TestUtil
+    {
+        public static FeedIterator<T> GetQueryIterator<T>(string database, string collection, string query = null)
+        {
+            CosmosClient client = CreateCosmosClient();
+            Container container = client.GetContainer(database, collection);
+            return container.GetItemQueryIterator<T>(query);
+        }
+
+        public static async Task SetupTestDataAsync(string databaseId, string containerId, int documentCount = 100)
+        {
+            (string accountEndpoint, string cosmosKey) = TestUtil.GetAccountDetails();
+
+            RestHelper restHelper = new RestHelper(accountEndpoint, cosmosKey);
+
+            await restHelper.CreateDatabase(databaseId, RestHelper.DatabaseThoughputMode.@fixed);
+            await restHelper.CreateContainer(databaseId, containerId, RestHelper.DatabaseThoughputMode.none);
+
+            for (int i = 0; i < documentCount; i++)
+            {
+                RestHelper.Item item = new RestHelper.Item($"id{i}", $"pk{i % 10}", $"value{i}");
+                await restHelper.CreateDocument(databaseId, containerId, item);
+            }
+        }
+
+        public string GenerateMasterKeyAuthorizationSignature(HttpMethod verb, ResourceType resourceType, string resourceLink, string date, string key)
+        {
+            string keyType = "master";
+            string tokenVersion = "1.0";
+            string payload = $"{verb.ToString().ToLowerInvariant()}\n{resourceType.ToString().ToLowerInvariant()}\n{resourceLink}\n{date.ToLowerInvariant()}\n\n";
+
+            HMACSHA256 hmacSha256 = new HMACSHA256 { Key = Convert.FromBase64String(key) };
+            byte[] hashPayload = hmacSha256.ComputeHash(System.Text.Encoding.UTF8.GetBytes(payload));
+            string signature = Convert.ToBase64String(hashPayload);
+            string authSet = WebUtility.UrlEncode($"type={keyType}&ver={tokenVersion}&sig={signature}");
+
+            return authSet;
+        }
+
+        public static CosmosClient CreateCosmosClient()
+        {
+            (string endpoint, string accountKey) = GetAccountDetails();
+            return new CosmosClient(endpoint, accountKey);
+        }
+
+        public static (string endpoint, string accountKey) GetAccountDetails()
+        {
+            return (
+                ConfigurationManager.AppSettings["GatewayEndpoint"],
+                ConfigurationManager.AppSettings["MasterKey"]
+                );
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests.Aot/MSTestSettings.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests.Aot/MSTestSettings.cs
@@ -1,0 +1,1 @@
+﻿[assembly: Parallelize(Scope = ExecutionScope.MethodLevel)]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests.Aot/Microsoft.Azure.Cosmos.Tests.Aot.csproj
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests.Aot/Microsoft.Azure.Cosmos.Tests.Aot.csproj
@@ -1,0 +1,46 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <EnableMSTestRunner>true</EnableMSTestRunner>
+    <OutputType>Exe</OutputType>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+    <!--
+      Displays error on console in addition to the log file. Note that this feature comes with a performance impact.
+      For more information, visit https://learn.microsoft.com/dotnet/core/testing/unit-testing-platform-integration-dotnet-test#show-failure-per-test
+      -->
+    <TestingPlatformShowTestsFailure>true</TestingPlatformShowTestsFailure>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.HybridRow" Version="1.1.0-preview4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.12.6" />
+    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="1.4.3" />
+    <PackageReference Include="MSTest" Version="3.6.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.Azure.Cosmos.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <None Include="..\Microsoft.Azure.Cosmos.EmulatorTests\settings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  
+  <PropertyGroup>
+    <SignAssembly>true</SignAssembly>
+    <DelaySign>true</DelaySign>
+    <AssemblyOriginatorKeyFile>..\..\..\testkey.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+
+</Project>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests.Aot/Query/QueryTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests.Aot/Query/QueryTest.cs
@@ -1,0 +1,38 @@
+﻿namespace Microsoft.Azure.Cosmos.Tests.Aot.Query
+{
+    using Microsoft.Azure.Cosmos.Tests.Aot.Common;
+
+    [TestClass]
+    public class QueryTest
+    {
+        private const string DatabaseName = "QueryTest";
+        private const string CollectionName = "c1";
+
+        [TestInitialize]
+        public async Task TestInitialize()
+        {
+            await TestUtil.SetupTestDataAsync(DatabaseName, CollectionName);
+        }
+
+        [TestMethod]
+        public async Task SampleTest()
+        {
+            string query = "SELECT * FROM c";
+            
+            FeedIterator<object> iterator = TestUtil.GetQueryIterator<object>(DatabaseName, CollectionName, query);
+            List<object> results = new List<object>();
+
+            while (iterator.HasMoreResults)
+            {
+                FeedResponse<object> response = await iterator.ReadNextAsync();
+                results.AddRange(response);
+            }
+
+            Assert.IsTrue(results.Count > 0);
+            foreach (object item in results)
+            {
+                Console.WriteLine(item);
+            }
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests.Aot/Query/QueryTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests.Aot/Query/QueryTest.cs
@@ -15,7 +15,7 @@
         }
 
         [TestMethod]
-        public async Task SampleTest()
+        public async Task SelectAll()
         {
             string query = "SELECT * FROM c";
             
@@ -28,7 +28,7 @@
                 results.AddRange(response);
             }
 
-            Assert.IsTrue(results.Count > 0);
+            Assert.AreEqual(100, results.Count);
             foreach (object item in results)
             {
                 Console.WriteLine(item);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests.Aot/RestHelperTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests.Aot/RestHelperTest.cs
@@ -1,0 +1,66 @@
+﻿namespace Microsoft.Azure.Cosmos.Tests.Aot
+{
+    using System;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Tests.Aot.Common;
+
+    [TestClass]
+    public class RestHelperTest
+    {
+        [TestMethod]
+        public async Task TestRestHelperMethods()
+        {
+            (string accountEndpoint, string cosmosKey) = TestUtil.GetAccountDetails();
+
+            if (string.IsNullOrEmpty(cosmosKey) || string.IsNullOrEmpty(accountEndpoint))
+            {
+                Console.WriteLine("Missing one or more configuration values. Please make sure to set them in the `environmenVariables` section");
+                return;
+            }
+            
+            string databaseId = "testdb";
+            string containerId = "c1";
+            RestHelper.Item item1 = new RestHelper.Item("id1", "pk1", "value1");
+            RestHelper.Item item11 = new RestHelper.Item("id11", "pk1", "value-11");
+            RestHelper.Item item2 = new RestHelper.Item("id2", "pk1", "value2");
+            RestHelper.Item item3 = new RestHelper.Item("id3", "pk2", "value3");
+
+            RestHelper restHelper = new RestHelper(accountEndpoint, cosmosKey, outputToConsole: true);
+
+            await restHelper.CreateDatabase(databaseId, RestHelper.DatabaseThoughputMode.@fixed);
+
+            await restHelper.ListDatabases();
+            await restHelper.GetDatabase(databaseId);
+
+            await restHelper.CreateContainer(databaseId, containerId, RestHelper.DatabaseThoughputMode.none);
+
+            await restHelper.GetContainer(databaseId, containerId);
+            await restHelper.GetContainerPartitionKeys(databaseId, containerId);
+
+            await restHelper.CreateStoredProcedure(databaseId, containerId, "sproc1");
+            await restHelper.ExecuteStoredProcedure(databaseId, containerId, "sproc1");
+            await restHelper.DeleteStoredProcedure(databaseId, containerId, "sproc1");
+
+            await restHelper.CreateDocument(databaseId, containerId, item1);
+            await restHelper.CreateDocument(databaseId, containerId, item2);
+            await restHelper.CreateDocument(databaseId, containerId, item3);
+
+            await restHelper.PatchDocument(databaseId, containerId, id: item1.id, partitionKey: item1.pk);
+            await restHelper.ReplaceDocument(databaseId, containerId, id: item1.id, newItem: item11);
+
+            await restHelper.ListDocuments(databaseId, containerId, partitionKey: item1.pk);
+            await restHelper.GetDocument(databaseId, containerId, id: item2.id, partitionKey: item2.pk);
+
+            await restHelper.QueryDocuments(databaseId, containerId, partitionKey: item1.pk);
+            await restHelper.QueryDocumentsCrossPartition(databaseId, containerId);
+
+            await restHelper.DeleteDocument(databaseId, containerId, id: item11.id, partitionKey: item11.pk);
+            await restHelper.DeleteDocument(databaseId, containerId, id: item2.id, partitionKey: item2.pk);
+            await restHelper.DeleteDocument(databaseId, containerId, id: item3.id, partitionKey: item3.pk);
+
+            await restHelper.DeleteContainer(databaseId, containerId);
+
+            await restHelper.DeleteDatabase(databaseId);
+        }
+    }
+}


### PR DESCRIPTION
# [Internal] Query : Adds new test project for AOT

## Description

This change adds a new test project for AOT purposes. Existing test projects are not AOT compliant. They are also unable to reference the AOT product dll, since much of the functionality has been removed (for e.g. database and collection CRUD API, LINQ, ChangeFeed to name a few). This generates over 1000 errors on the emulator test project alone and it's not tenable at the moment to address those all in time.
The purpose of this new dll is to serve as a smoke test/validation. Over time, it is expected to contain a subset of tests that are required to have sufficient confidence in quality of AOT flavor of product code.

Since database/collection CRUD functionality is not available in the AOT SDK, the test dll contains a ```RestHelper``` to facilitate common management operations at database/collection level that can be utilized for test setup/cleanup purposes.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber