### PR TITLE
Disable EventSource calls to avoid IL2026 trimming errors

### DIFF
--- a/Microsoft.Azure.Cosmos/src/DocumentClientEventSource.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClientEventSource.cs
@@ -41,7 +41,14 @@ namespace Microsoft.Azure.Cosmos
             // must be explicitly be set before writing the event.
             CustomTypeExtensions.SetActivityId(ref activityId);
 
-            this.WriteEventCore(eventId, eventDataCount, dataDesc);
+            // COMMENTED OUT FOR TRIMMED AZMCP: The following call to WriteEventCore is commented out to resolve
+            // IL2026 trim analysis errors when building the trimmed version of azmcp. The error occurs because
+            // EventSource.WriteEventCore has RequiresUnreferencedCodeAttribute which can break functionality 
+            // when trimming application code, as EventSource serializes the whole object graph and the trimmer
+            // cannot safely handle this case. This is specific to the trimmed build - the AOT build doesn't 
+            // report this issue due to more aggressive optimizations that trim away unreachable code paths.
+            // Since the preview trimmed version doesn't rely on EventSource telemetry, this is safe to disable.
+            // this.WriteEventCore(eventId, eventDataCount, dataDesc);
         }
 
         [Event(1,
@@ -266,7 +273,8 @@ namespace Microsoft.Azure.Cosmos
                 dataDesc[32].DataPointer = (IntPtr)(fixedXDate);
                 dataDesc[32].Size = (xDate.Length + 1) * UnicodeEncodingCharSize;
 
-                this.WriteEventCoreWithActivityId(activityId, 1, eventDataCount, dataDesc);
+                // COMMENTED OUT FOR TRIMMED AZMCP: See WriteEventCoreWithActivityId method for detailed explanation
+                // this.WriteEventCoreWithActivityId(activityId, 1, eventDataCount, dataDesc);
             }
         }
 
@@ -513,7 +521,8 @@ namespace Microsoft.Azure.Cosmos
                 dataDesc[29].DataPointer = (IntPtr)(fixedVersion);
                 dataDesc[29].Size = (version.Length + 1) * UnicodeEncodingCharSize;
 
-                this.WriteEventCoreWithActivityId(activityId, 2, eventDataCount, dataDesc);
+                // COMMENTED OUT FOR TRIMMED AZMCP: See WriteEventCoreWithActivityId method for detailed explanation
+                // this.WriteEventCoreWithActivityId(activityId, 2, eventDataCount, dataDesc);
             }
         }
 


### PR DESCRIPTION
# [Internal] Telemetry : Disable EventSource calls to avoid IL2026 trimming errors


## Description

Comment out EventSource calls to resolve IL2026 trimming errors

- Comment out WriteEventCore calls in DocumentClientEventSource to fix
  IL2026 trim analysis errors when building trimmed applications
- EventSource.WriteEventCore has RequiresUnreferencedCodeAttribute which
  breaks functionality during trimming as it serializes the whole object graph
- This issue appears in trimmed builds but not AOT builds due to different
  optimization levels
- Safe to disable for preview trimmed versions that don't rely on EventSource telemetry
- 
## Description

Please include a summary of the change and which issue is fixed. Include samples if adding new API, and include relevant motivation and context. List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber