### PR TITLE
[Internal]Nregion: Adds support for including nregioncommit synchronous for less than Strong Consistency

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
 		<ClientOfficialVersion>3.53.1</ClientOfficialVersion>
 		<ClientPreviewVersion>3.54.0</ClientPreviewVersion>
 		<ClientPreviewSuffixVersion>preview.1</ClientPreviewSuffixVersion>
-		<DirectVersion>3.40.3</DirectVersion>
+		<DirectVersion>3.41.0</DirectVersion>
 		<FaultInjectionVersion>1.0.0</FaultInjectionVersion>
 		<FaultInjectionSuffixVersion>beta.0</FaultInjectionSuffixVersion>
 		<EncryptionOfficialVersion>2.0.5</EncryptionOfficialVersion>

--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -6778,10 +6778,7 @@ namespace Microsoft.Azure.Cosmos
 
         private void CreateStoreModel(bool subscribeRntbdStatus)
         {
-            AccountProperties accountProperties = this.accountServiceConfiguration.AccountProperties;
-
-            bool enableNRegionSynchronousCommit = accountProperties.EnableNRegionSynchronousCommit;
-            AccountConfigurationProperties accountConfigurationProperties = new (EnableNRegionSynchronousCommit: enableNRegionSynchronousCommit);
+            AccountConfigurationProperties accountConfigurationProperties = new (EnableNRegionSynchronousCommit: this.accountServiceConfiguration.AccountProperties.EnableNRegionSynchronousCommit);
 
             //EnableReadRequestsFallback, if not explicity set on the connection policy,
             //is false if the account's consistency is bounded staleness,

--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -6778,6 +6778,11 @@ namespace Microsoft.Azure.Cosmos
 
         private void CreateStoreModel(bool subscribeRntbdStatus)
         {
+            AccountProperties accountProperties = this.accountServiceConfiguration.AccountProperties;
+
+            bool enableNRegionSynchronousCommit = accountProperties.EnableNRegionSynchronousCommit;
+            AccountConfigurationProperties accountConfigurationProperties = new (EnableNRegionSynchronousCommit: enableNRegionSynchronousCommit);
+
             //EnableReadRequestsFallback, if not explicity set on the connection policy,
             //is false if the account's consistency is bounded staleness,
             //and true otherwise.
@@ -6792,7 +6797,8 @@ namespace Microsoft.Azure.Cosmos
                 this.UseMultipleWriteLocations && (this.accountServiceConfiguration.DefaultConsistencyLevel != Documents.ConsistencyLevel.Strong),
                 true,
                 enableReplicaValidation: this.isReplicaAddressValidationEnabled,
-                sessionRetryOptions: this.ConnectionPolicy.SessionRetryOptions);
+                sessionRetryOptions: this.ConnectionPolicy.SessionRetryOptions,
+                accountConfigurationProperties: accountConfigurationProperties);
 
             if (subscribeRntbdStatus)
             {

--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/AccountProperties.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/AccountProperties.cs
@@ -269,5 +269,7 @@ namespace Microsoft.Azure.Cosmos
         [JsonExtensionData]
         internal IDictionary<string, JToken> AdditionalProperties { get; set; }
 
+        [JsonProperty(PropertyName = Constants.Properties.EnableNRegionSynchronousCommit, NullValueHandling = NullValueHandling.Ignore)]
+        internal bool EnableNRegionSynchronousCommit { get; set; }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/ThinClientTransportSerializer.cs
+++ b/Microsoft.Azure.Cosmos/src/ThinClientTransportSerializer.cs
@@ -113,6 +113,7 @@ namespace Microsoft.Azure.Cosmos
                     activityId,
                     bufferProvider.Provider,
                     accountName,
+                    accountName,
                     out _,
                     out _);
 

--- a/Microsoft.Azure.Cosmos/src/Tracing/TraceWriter.TraceJsonWriter.cs
+++ b/Microsoft.Azure.Cosmos/src/Tracing/TraceWriter.TraceJsonWriter.cs
@@ -406,6 +406,9 @@ namespace Microsoft.Azure.Cosmos.Tracing
                 this.jsonWriter.WriteFieldName(nameof(storeResult.GlobalCommittedLSN));
                 this.jsonWriter.WriteNumberValue(storeResult.GlobalCommittedLSN);
 
+                this.jsonWriter.WriteFieldName(nameof(storeResult.GlobalNRegionCommittedGLSN));
+                this.jsonWriter.WriteNumberValue(storeResult.GlobalNRegionCommittedGLSN);
+
                 this.jsonWriter.WriteFieldName(nameof(storeResult.ItemLSN));
                 this.jsonWriter.WriteNumberValue(storeResult.ItemLSN);
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/DocumentClientUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/DocumentClientUnitTests.cs
@@ -277,8 +277,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        [DataRow(false)]
-        [DataRow(true)]
+        [DataRow(false, DisplayName = "NRegion Synchronous commit is disabled for the account")]
+        [DataRow(true, DisplayName = "NRegion Synchronous commit is enabled for the account")]
         public void EnableNRegionSynchronousCommit_PassedToStoreClient(bool nRegionCommitEnabled)
         {
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/DocumentClientUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/DocumentClientUnitTests.cs
@@ -8,14 +8,18 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
     using System.Globalization;
     using System.Net;
     using System.Net.Http;
+    using System.Net.Security;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Common;
     using Microsoft.Azure.Cosmos.Internal;
     using Microsoft.Azure.Cosmos.Linq;
     using Microsoft.Azure.Cosmos.Query.Core.QueryPlan;
+    using Microsoft.Azure.Cosmos.Tests;
     using Microsoft.Azure.Cosmos.Tracing;
     using Microsoft.Azure.Cosmos.Utils;
     using Microsoft.Azure.Documents;
+    using Microsoft.Azure.Documents.Client;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Moq;
 
@@ -272,6 +276,112 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.IsTrue(throttled);
         }
 
+        [TestMethod]
+        [DataRow(false)]
+        [DataRow(true)]
+        public void EnableNRegionSynchronousCommit_PassedToStoreClient(bool nRegionCommitEnabled)
+        {
+
+            StoreClient storeClient = new StoreClient(
+                        new Mock<IAddressResolver>().Object,
+                        new SessionContainer(string.Empty),
+                        new Mock<IServiceConfigurationReader>().Object,
+                        new Mock<IAuthorizationTokenProvider>().Object,
+                        Protocol.Tcp,
+                        new Mock<TransportClient>().Object);
+            // Arrange
+            Mock<IStoreClientFactory> mockStoreClientFactory = new Mock<IStoreClientFactory>();
+            mockStoreClientFactory.Setup(f => f.CreateStoreClient(
+                It.IsAny<IAddressResolver>(),
+                It.IsAny<ISessionContainer>(),
+                It.IsAny<IServiceConfigurationReader>(),
+                It.IsAny<IAuthorizationTokenProvider>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>(),
+                It.IsAny<bool>(),
+                It.IsAny<AccountConfigurationProperties>(),
+                It.IsAny<ISessionRetryOptions>()
+            )).Returns(storeClient);
+
+            DocumentClient documentClient = new DocumentClient(
+                new Uri("https://localhost:8081"),
+                new Mock<AuthorizationTokenProvider>().Object,
+                new EventHandler<SendingRequestEventArgs>((s, e) => { }),
+                new ConnectionPolicy(),
+                null, // desiredConsistencyLevel
+                null, // serializerSettings
+                ApiType.None,
+                new EventHandler<ReceivedResponseEventArgs>((s, e) => { }),
+                null, // handler
+                new Mock<ISessionContainer>().Object,
+                null, // enableCpuMonitor
+                new Func<TransportClient, TransportClient>(tc => tc),
+                mockStoreClientFactory.Object,
+                false, // isLocalQuorumConsistency
+                "testClientId",
+                new RemoteCertificateValidationCallback((sender, certificate, chain, sslPolicyErrors) => true),
+                new Mock<CosmosClientTelemetryOptions>().Object,
+                new Mock<IChaosInterceptorFactory>().Object,
+                true // enableAsyncCacheExceptionNoSharing
+            );
+
+            AccountProperties accountProperties = new AccountProperties
+            {
+                // Set the property to true for test
+                EnableNRegionSynchronousCommit = nRegionCommitEnabled,
+            };
+
+            AccountConsistency ac = new AccountConsistency();
+            ac.DefaultConsistencyLevel = (Cosmos.ConsistencyLevel) ConsistencyLevel.Session;
+            accountProperties.Consistency = ac;
+
+            Func<Task<AccountProperties>> getDatabaseAccountFn = () =>
+                // When called with any Uri, return the expected AccountProperties
+                Task.FromResult(accountProperties);
+
+            CosmosAccountServiceConfiguration accountServiceConfiguration = new CosmosAccountServiceConfiguration(
+                getDatabaseAccountFn);
+
+            typeof(CosmosAccountServiceConfiguration)
+                .GetProperty("AccountProperties", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
+                .SetValue(accountServiceConfiguration, accountProperties);
+
+            //Inject the accountServiceConfiguration into the DocumentClient via reflection.
+            typeof(DocumentClient)
+                .GetProperty("accountServiceConfiguration", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
+                .SetValue(documentClient, accountServiceConfiguration);
+
+
+            typeof(DocumentClient)
+                .GetField("storeClientFactory", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
+                .SetValue(documentClient, mockStoreClientFactory.Object);
+
+            // Act: Call the private method via reflection
+            typeof(DocumentClient)
+                .GetMethod("CreateStoreModel", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)
+                .Invoke(documentClient, new object[] { true });
+
+            // Assert: Verify the correct value was passed
+            mockStoreClientFactory.Verify(f =>
+                f.CreateStoreClient(
+                    It.IsAny<IAddressResolver>(),
+                    It.IsAny<ISessionContainer>(),
+                    It.IsAny<IServiceConfigurationReader>(),
+                    It.IsAny<IAuthorizationTokenProvider>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<bool>(),
+                    It.IsAny<bool>(),
+                    It.Is<AccountConfigurationProperties>(config => config.EnableNRegionSynchronousCommit == accountProperties.EnableNRegionSynchronousCommit),
+                    It.IsAny<ISessionRetryOptions>()),
+                Times.Once,
+                "EnableNRegionSynchronousCommit was not passed correctly to AccountConfigurationProperties and StoreClient.");
+        }
 
         private DocumentClientException CreateTooManyRequestException(int retryAfterInMilliseconds)
         {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BaselineTest/TestBaseline/TraceWriterBaselineTests.TraceData.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BaselineTest/TestBaseline/TraceWriterBaselineTests.TraceData.xml
@@ -272,7 +272,8 @@
                 Exception
         )
 ]]></Text>
-      <Json><![CDATA[{
+      <Json>
+				<![CDATA[{
   "Summary": {
     "DirectCalls": {
       "(0, 0)": 1
@@ -330,6 +331,7 @@
             "LSN": 1337,
             "PartitionKeyRangeId": "42",
             "GlobalCommittedLSN": 1234,
+            "GlobalNRegionCommittedGLSN": -1,
             "ItemLSN": 15,
             "UsingLocalLSN": true,
             "QuorumAckedLSN": 23,
@@ -527,6 +529,7 @@
             "LSN": 0,
             "PartitionKeyRangeId": null,
             "GlobalCommittedLSN": 0,
+            "GlobalNRegionCommittedGLSN": 0,
             "ItemLSN": 0,
             "UsingLocalLSN": false,
             "QuorumAckedLSN": 0,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosJsonSerializerUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosJsonSerializerUnitTests.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Azure.Cosmos.Core.Tests
             string id = "testId";
             this.TestProperty<AccountProperties>(
                 id,
-                $@"{{""id"":""{id}"",""writableLocations"":[],""readableLocations"":[],""userConsistencyPolicy"":null,""addresses"":null,""userReplicationPolicy"":null,""systemReplicationPolicy"":null,""readPolicy"":null,""queryEngineConfiguration"":null,""enableMultipleWriteLocations"":false,""enablePerPartitionFailoverBehavior"":null}}");
+                $@"{{""id"":""{id}"",""writableLocations"":[],""readableLocations"":[],""userConsistencyPolicy"":null,""addresses"":null,""userReplicationPolicy"":null,""systemReplicationPolicy"":null,""readPolicy"":null,""queryEngineConfiguration"":null,""enableMultipleWriteLocations"":false,""enablePerPartitionFailoverBehavior"":null,""enableNRegionSynchronousCommit"":false}}");
 
             this.TestProperty<DatabaseProperties>(
                 id,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosSerializerCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosSerializerCoreTests.cs
@@ -143,7 +143,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             this.TestProperty<AccountProperties>(
                 serializerCore,
                 id,
-                $@"{{""id"":""{id}"",""writableLocations"":[],""readableLocations"":[],""userConsistencyPolicy"":null,""addresses"":null,""userReplicationPolicy"":null,""systemReplicationPolicy"":null,""readPolicy"":null,""queryEngineConfiguration"":null,""enableMultipleWriteLocations"":false,""enablePerPartitionFailoverBehavior"":null}}");
+                $@"{{""id"":""{id}"",""writableLocations"":[],""readableLocations"":[],""userConsistencyPolicy"":null,""addresses"":null,""userReplicationPolicy"":null,""systemReplicationPolicy"":null,""readPolicy"":null,""queryEngineConfiguration"":null,""enableMultipleWriteLocations"":false,""enablePerPartitionFailoverBehavior"":null,""enableNRegionSynchronousCommit"":false}}");
 
             this.TestProperty<DatabaseProperties>(
                 serializerCore,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/StoreReaderTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/StoreReaderTest.cs
@@ -911,7 +911,7 @@ namespace Microsoft.Azure.Cosmos
         Sequence of steps:
         1. After receiving response from primary of write region, look at GlobalNRegionCommittedGLSN and LSN headers.
         2. If GlobalNRegionCommittedGLSN == LSN, return response to caller
-        3. If GlobalNRegionCommittedGLSN < LSN && storeResponse.NumberOFReadRegions > 0 , cache LSN in request as SelectedGlobalNRegionCommittedGLSN, and issue barrier requests against any/all replicas.
+        3. If GlobalNRegionCommittedGLSN < LSN && storeResponse.NumberOfReadRegions > 0 , cache LSN in request as SelectedGlobalNRegionCommittedGLSN, and issue barrier requests against any/all replicas.
         4. Each barrier response will contain its own LSN and GlobalNRegionCommittedGLSN, check for any response that satisfies GlobalNRegionCommittedGLSN >= SelectedGlobalNRegionCommittedGLSN
         5. Return to caller on success.
         </summary>
@@ -992,7 +992,7 @@ namespace Microsoft.Azure.Cosmos
                 if (ex.InnerException is DocumentClientException goneEx)
                 {
                     DefaultTrace.TraceInformation("Gone exception expected!");
-                    //Assert.AreEqual(SubStatusCodes.Server_NRegionCommitWriteBarrierNotMet, goneEx.GetSubStatusCode());
+                    Assert.AreEqual(SubStatusCodes.Server_NRegionCommitWriteBarrierNotMet, goneEx.GetSubStatusCode());
                 }
             }
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/StoreReaderTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/StoreReaderTest.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Azure.Cosmos
     using System.Globalization;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.ChangeFeed.DocDBErrors;
     using Microsoft.Azure.Cosmos.Common;
     using Microsoft.Azure.Cosmos.Core.Trace;
     using Microsoft.Azure.Documents;
@@ -817,6 +818,182 @@ namespace Microsoft.Azure.Cosmos
 
                 long nGlobalCommitedLSN = long.Parse(globalCommitedLSN, CultureInfo.InvariantCulture);
                 Assert.IsTrue(nGlobalCommitedLSN == 90);
+            }
+        }
+
+        private TransportClient GetMockTransportClientForNRegionSynchronousWrites(
+            AddressInformation[] addressInformation, bool globalNLsnNeverCatchesUp)
+        {
+            Mock<TransportClient> mockTransportClient = new Mock<TransportClient>();
+
+            // create mock store response object
+            StoreResponse mockStoreResponse1 = new StoreResponse();
+            StoreResponse mockStoreResponse2 = new StoreResponse();
+            StoreResponse mockStoreResponse3 = new StoreResponse();
+            StoreResponse mockStoreResponse4 = new StoreResponse();
+            StoreResponse mockStoreResponse5 = new StoreResponse();
+
+
+            // set lsn and activityid on the store response.
+            mockStoreResponse1.Headers = new StoreResponseNameValueCollection()
+                {
+                    { WFConstants.BackendHeaders.LSN, "100"},
+                    { WFConstants.BackendHeaders.ActivityId, "ACTIVITYID1_1" },
+                    { WFConstants.BackendHeaders.GlobalNRegionCommittedGLSN, "90" },
+                    { WFConstants.BackendHeaders.NumberOfReadRegions, "1" },
+                };
+
+            mockStoreResponse2.Headers = new StoreResponseNameValueCollection()
+                {
+                    { WFConstants.BackendHeaders.LSN, "100"},
+                    { WFConstants.BackendHeaders.ActivityId, "ACTIVITYID1_2" },
+                    { WFConstants.BackendHeaders.GlobalNRegionCommittedGLSN, "95" },
+                    { WFConstants.BackendHeaders.NumberOfReadRegions, "1" },
+                };
+
+            mockStoreResponse3.Headers = new StoreResponseNameValueCollection()
+                {
+                    { WFConstants.BackendHeaders.LSN, "103"},
+                    { WFConstants.BackendHeaders.ActivityId, "ACTIVITYID1_3" },
+                    { WFConstants.BackendHeaders.GlobalNRegionCommittedGLSN, "98" },
+                    { WFConstants.BackendHeaders.NumberOfReadRegions, "1" },
+                };
+
+            mockStoreResponse4.Headers = new StoreResponseNameValueCollection()
+                {
+                    { WFConstants.BackendHeaders.LSN, "103"},
+                    { WFConstants.BackendHeaders.ActivityId, "ACTIVITYID1_3" },
+                    { WFConstants.BackendHeaders.GlobalNRegionCommittedGLSN, "99" },
+                    { WFConstants.BackendHeaders.NumberOfReadRegions, "1" },
+                };
+
+            mockStoreResponse5.Headers = new StoreResponseNameValueCollection()
+                {
+                    { WFConstants.BackendHeaders.LSN, "106"},
+                    { WFConstants.BackendHeaders.ActivityId, "ACTIVITYID1_3" },
+                    { WFConstants.BackendHeaders.GlobalNRegionCommittedGLSN, "100" },
+                    { WFConstants.BackendHeaders.NumberOfReadRegions, "1" },
+                };
+
+            for (int i = 0; i < addressInformation.Length; i++)
+            {
+
+                if (globalNLsnNeverCatchesUp)
+                {
+                    mockTransportClient.Setup(client => client.InvokeResourceOperationAsync(
+                       new TransportAddressUri(new Uri(addressInformation[i].PhysicalUri)), It.IsAny<DocumentServiceRequest>()))
+                        .Returns(Task.FromResult<StoreResponse>(mockStoreResponse1));
+
+                }
+                else
+                {
+                    mockTransportClient.SetupSequence(client => client.InvokeResourceOperationAsync(
+                       new TransportAddressUri(new Uri(addressInformation[i].PhysicalUri)), It.IsAny<DocumentServiceRequest>()))
+                        .Returns(Task.FromResult<StoreResponse>(mockStoreResponse1))   // initial write response
+                        .Returns(Task.FromResult<StoreResponse>(mockStoreResponse2))   // barrier retry, count 1
+                        .Returns(Task.FromResult<StoreResponse>(mockStoreResponse3))   // barrier retry, count 2
+                        .Returns(Task.FromResult<StoreResponse>(mockStoreResponse4))   // barrier retry, count 3
+                        .Returns(Task.FromResult<StoreResponse>(mockStoreResponse5));  // barrier retry, count 4 GlobalNRegionCommittedGLSN catches up.
+                }
+
+            }
+
+            return mockTransportClient.Object;
+        }
+
+        /**
+        <summary>
+        Tests the feature called nregion synchronous commit. This is an account level feature enabled via the accountConfigProperties with property name "EnableNRegionSynchronousCommit"
+
+        Business logic: We send single request to primary of the Write region,which will take care of replicating to its secondaries, one of which is XPPrimary. XPPrimary in this case will replicate this request to n read regions, which will ack from within their region.
+            In the write region where the original request was sent to , the request returns from the backend once write quorum number of replicas commits the write - but at this time, the response cannot be returned to caller, since linearizability guarantees will be violated.
+            ConsistencyWriter will continuously issue barrier head requests against the partition in question, until GlobalNRegionCommittedGLSN is at least as big as the lsn of the original response.
+        Sequence of steps:
+        1. After receiving response from primary of write region, look at GlobalNRegionCommittedGLSN and LSN headers.
+        2. If GlobalNRegionCommittedGLSN == LSN, return response to caller
+        3. If GlobalNRegionCommittedGLSN < LSN && storeResponse.NumberOFReadRegions > 0 , cache LSN in request as SelectedGlobalNRegionCommittedGLSN, and issue barrier requests against any/all replicas.
+        4. Each barrier response will contain its own LSN and GlobalNRegionCommittedGLSN, check for any response that satisfies GlobalNRegionCommittedGLSN >= SelectedGlobalNRegionCommittedGLSN
+        5. Return to caller on success.
+        </summary>
+        **/
+        [TestMethod]
+        public void TestWhenNRegionSynchronousCommitEnabledThenDoBarrierHead()
+        {
+            // create a real document service request (with auth token level = god)
+            DocumentServiceRequest entity = DocumentServiceRequest.Create(OperationType.Create, ResourceType.Document, AuthorizationTokenType.SystemAll);
+
+            // set request charge tracker -  this is referenced in store reader (ReadMultipleReplicaAsync)
+            DocumentServiceRequestContext requestContext = new DocumentServiceRequestContext
+            {
+                RequestChargeTracker = new RequestChargeTracker()
+            };
+            entity.RequestContext = requestContext;
+
+            // set a dummy resource id on the request.
+            entity.ResourceId = "1-MxAPlgMgA=";
+
+            // set consistency level on the request to Bounded Staleness
+            entity.Headers[HttpConstants.HttpHeaders.ConsistencyLevel] = ConsistencyLevel.Session.ToString();
+
+            // also setup timeout helper, used in store reader
+            entity.RequestContext.TimeoutHelper = new TimeoutHelper(new TimeSpan(2, 2, 2));
+
+            // when the store reader throws Invalid Partition exception, the higher layer should
+            // clear this target identity.
+            entity.RequestContext.TargetIdentity = new ServiceIdentity("dummyTargetIdentity1", new Uri("http://dummyTargetIdentity1"), false);
+            entity.RequestContext.ResolvedPartitionKeyRange = new PartitionKeyRange();
+
+            AddressInformation[] addressInformation = this.GetMockAddressInformationDuringUpgrade();
+            Mock<IAddressResolver> mockAddressCache = this.GetMockAddressCache(addressInformation);
+
+            // validate that the mock works
+            PartitionAddressInformation partitionAddressInformation = mockAddressCache.Object.ResolveAsync(entity, false, new CancellationToken()).Result;
+            IReadOnlyList<AddressInformation> addressInfo = partitionAddressInformation.AllAddresses;
+
+            Assert.IsTrue(addressInfo[0] == addressInformation[0]);
+
+            AddressSelector addressSelector = new AddressSelector(mockAddressCache.Object, Protocol.Tcp);
+            Uri primaryAddress = addressSelector.ResolvePrimaryTransportAddressUriAsync(entity, false /*forceAddressRefresh*/).Result.Uri;
+
+            // check if the address return from Address Selector matches the original address info
+            Assert.IsTrue(primaryAddress.Equals(addressInformation[0].PhysicalUri));
+
+            ISessionContainer sessionContainer = new SessionContainer(string.Empty);
+
+            Mock<IServiceConfigurationReader> mockServiceConfigReader = new Mock<IServiceConfigurationReader>();
+            mockServiceConfigReader.Setup(reader => reader.DefaultConsistencyLevel).Returns(Documents.ConsistencyLevel.Session);
+
+            Mock<IAuthorizationTokenProvider> mockAuthorizationTokenProvider = new Mock<IAuthorizationTokenProvider>();
+            mockAuthorizationTokenProvider.Setup(provider => provider.AddSystemAuthorizationHeaderAsync(
+                It.IsAny<DocumentServiceRequest>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+                .Returns(Task.FromResult(0));
+
+            TransportClient mockTransportClient = this.GetMockTransportClientForNRegionSynchronousWrites(addressInformation, false);
+            StoreReader storeReader = new StoreReader(mockTransportClient, addressSelector, new AddressEnumerator(), sessionContainer, false);
+
+            AccountConfigurationProperties accountConfigurationProperties = new AccountConfigurationProperties(true);
+
+            ConsistencyWriter consistencyWriter = new ConsistencyWriter(addressSelector, sessionContainer, mockTransportClient, mockServiceConfigReader.Object, mockAuthorizationTokenProvider.Object, false, false, accountConfigurationProperties: accountConfigurationProperties);
+            StoreResponse response = consistencyWriter.WriteAsync(entity, new TimeoutHelper(TimeSpan.FromSeconds(3000)), false).Result;
+            Assert.AreEqual(100, response.LSN);
+
+
+            try
+            {
+                mockTransportClient = this.GetMockTransportClientForNRegionSynchronousWrites(addressInformation, true);
+                storeReader = new StoreReader(mockTransportClient, addressSelector, new AddressEnumerator(), sessionContainer, false);
+
+                consistencyWriter = new ConsistencyWriter(addressSelector, sessionContainer, mockTransportClient, mockServiceConfigReader.Object, mockAuthorizationTokenProvider.Object, false, false, accountConfigurationProperties: accountConfigurationProperties);
+                response = consistencyWriter.WriteAsync(entity, new TimeoutHelper(TimeSpan.FromSeconds(3000)), false).Result;
+                Assert.Fail();
+            }
+            catch (AggregateException ex)
+            {
+                if (ex.InnerException is DocumentClientException goneEx)
+                {
+                    DefaultTrace.TraceInformation("Gone exception expected!");
+                    //Assert.AreEqual(SubStatusCodes.Server_NRegionCommitWriteBarrierNotMet, goneEx.GetSubStatusCode());
+                }
             }
         }
     }


### PR DESCRIPTION
## Description

Feature: N-region synchronous commit support for < Strong consistency in SDK)

This PR brings in N region syncrhonous commit for accounts that have this feature enabled. The feature primarly brings in Barrier requests for Writes for less than Strong consistencies

The change contains two parts (one part is in this PR and other is done in Msdata/released as Direct package version 3.41.0 which is consumed in this PR)


Part 2 **THIS PR** : V3 Repo changes which include changes in AccountProperties to read the support for Nregion Commit .

-Adds support for including nregioncommit account feature while creating StoreClient within DocumentClient


Part 1 CHanges to ConsistencyWriter for adding Barrier requests and StoreResult to support the new NRegionCommittedGLSN which is critical to performing the barriers. 

This is done in the Msdata ShareFiles and a new Direct package version 3.41.0 is released with this change

- Refactors ConsistencyWriter to support synchronous barrier commits in NRegion accounts (< Strong) when EnableNRegionSynchronousCommit is enabled.

- Ensures response is only returned once GlobalNRegionCommittedGLSN has caught up with the write LSN, preserving linearizability

Change PR in msdata: https://msdata.visualstudio.com/CosmosDB/_git/CosmosDB/pullrequest/1800184


## Direct package changes

Direct version upgrade to 3.41.0 brings in the following changes

- Part 1 from above: Adds write barrier logic to ConsistencyWriter using StoreResult's N-region committed LSN to enforce N region synchronous commit semantics for less-than-strong consistency writes.
-  Introduced SDK support for new regions of SingaporeCentral and SingaporeNorth
- Resolves failover handling in strong consistency writes by ensuring stale barrier context is cleared when retrying across regions.
- Introduced new Length Aware Range Comparators in EPK Range class.

## Testing

Emulator test for NregionCommit Write Barrier

Used Http interceptor to "mock" nregioncommit feature enabled in AccountProperties.
Used Transport interceptor to mock GLobalNRegionCommitLSN for testing scenario.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber