### PR TITLE
[Internal]AOT: Fixes Newtonsoft package latest version to avoid CVE Vulnerability

### DIFF
--- a/AOT-Sample/AOT-Sample.csproj
+++ b/AOT-Sample/AOT-Sample.csproj
@@ -47,6 +47,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.HybridRow" Version="1.1.0-preview3" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosElementJsonConverter.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosElements/CosmosElementJsonConverter.cs
@@ -84,7 +84,7 @@ namespace Microsoft.Azure.Cosmos.CosmosElements
 #endif
         }
 
-        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        public override object ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
         {
             JToken token = JToken.Load(reader);
             string json = JsonConvert.SerializeObject(token);
@@ -92,7 +92,7 @@ namespace Microsoft.Azure.Cosmos.CosmosElements
             return CosmosElement.CreateFromBuffer(buffer);
         }
 
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
         {
             NewtonsoftToCosmosDBWriter writerInterop = NewtonsoftToCosmosDBWriter.CreateFromWriter(writer);
 

--- a/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
+++ b/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
@@ -159,6 +159,7 @@
 
 	<ItemGroup Condition=" '$(ProjectRef)' != 'True' ">
 		<PackageReference Include="Microsoft.HybridRow" Version="[$(HybridRowVersion)]" PrivateAssets="All" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
 	</ItemGroup>
 

--- a/Microsoft.Azure.Cosmos/src/Resource/FullFidelity/ChangeFeedMetadata.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/FullFidelity/ChangeFeedMetadata.cs
@@ -27,7 +27,7 @@ namespace Microsoft.Azure.Cosmos
         /// The change's conflict resolution timestamp.
         /// </summary>
         [JsonProperty(PropertyName = ChangeFeedMetadataFields.ConflictResolutionTimestamp, NullValueHandling = NullValueHandling.Ignore)]
-        [JsonConverter(typeof(UnixDateTimeConverter))]
+        [JsonConverter(typeof(Documents.UnixDateTimeConverter))]
         public DateTime ConflictResolutionTimestamp { get; internal set; }
 
         /// <summary>


### PR DESCRIPTION
Upgraded NewtonSoft library to the latest version 13.0.3 to avoid CVE vulnerabilities that come from the Newtonsoft transitive dependency coming from Microsoft.HybridRow package dependency



## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber