### PR TITLE
[Internal] Query : Removes Newtonsft usage from query components (Part 1)

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/CompositeIndexIndexMetrics.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/CompositeIndexIndexMetrics.cs
@@ -3,14 +3,13 @@
 //------------------------------------------------------------
 namespace Microsoft.Azure.Cosmos.Query.Core.Metrics
 {
-    using System;
     using System.Collections.Generic;
-    using Newtonsoft.Json;
+    using System.Text.Json.Serialization;
 
     /// <summary>
     /// Query index utilization data for composite indexes (sub-structure of the Index Metrics class) in the Azure Cosmos database service.
     /// </summary>
-    #if INTERNAL
+#if INTERNAL
 #pragma warning disable SA1600
 #pragma warning disable CS1591
     public
@@ -25,7 +24,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Metrics
         /// <param name="indexDocumentExpressions">The string list representation of the composite index.</param>
         /// <param name="indexImpactScore">The index impact score.</param>
         [JsonConstructor]
-        private CompositeIndexIndexMetrics(
+        public CompositeIndexIndexMetrics(
             IReadOnlyList<string> indexDocumentExpressions,
             string indexImpactScore)
         {
@@ -36,13 +35,13 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Metrics
         /// <summary>
         /// String list representation of index paths of a composite index.
         /// </summary>
-        [JsonProperty(PropertyName = "IndexSpecs")]
+        [JsonPropertyName("IndexSpecs")]
         public IReadOnlyList<string> IndexSpecs { get; }
 
         /// <summary>
         /// The index impact score of the composite index.
         /// </summary>
-        [JsonProperty(PropertyName = "IndexImpactScore")]
+        [JsonPropertyName("IndexImpactScore")]
         public string IndexImpactScore { get; }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/CompositeIndexUtilizationEntity.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/CompositeIndexUtilizationEntity.cs
@@ -5,7 +5,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Metrics
 {
     using System;
     using System.Collections.Generic;
-    using Newtonsoft.Json;
+    using System.Text.Json.Serialization;
 
     /// <summary>
     /// Query index utilization data for composite indexes (sub-structure of the Index Utilization metrics) in the Azure Cosmos database service.
@@ -36,13 +36,13 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Metrics
             this.IndexImpactScore = indexImpactScore;
         }
 
-        [JsonProperty(PropertyName = "IndexSpecs")]
+        [JsonPropertyName("IndexSpecs")]
         public IReadOnlyList<string> IndexDocumentExpressions { get; }
 
-        [JsonProperty(PropertyName = "IndexPreciseSet")]
+        [JsonPropertyName("IndexPreciseSet")]
         public bool IndexPlanFullFidelity { get; }
 
-        [JsonProperty(PropertyName = "IndexImpactScore")]
+        [JsonPropertyName("IndexImpactScore")]
         public string IndexImpactScore { get; }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/IndexMetricsInfo.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/IndexMetricsInfo.cs
@@ -3,13 +3,9 @@
 //------------------------------------------------------------
 namespace Microsoft.Azure.Cosmos.Query.Core.Metrics
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
     using System.Text;
-    using Microsoft.Azure.Cosmos.Core;
-    using Microsoft.Azure.Cosmos.Core.Utf8;
-    using Newtonsoft.Json;
+    using System.Text.Json;
+    using System.Text.Json.Serialization;
 
     /// <summary>
     /// Query index utilization data for composite indexes (sub-structure of the Index Metrics class) in the Azure Cosmos database service.
@@ -37,10 +33,10 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Metrics
             this.PotentialEntity = potentialEntity;
         }
 
-        [JsonProperty("Utilized")]
+        [JsonPropertyName("Utilized")]
         public IndexMetricsInfoEntity UtilizedEntity { get; }
 
-        [JsonProperty("Potential")]
+        [JsonPropertyName("Potential")]
         public IndexMetricsInfoEntity PotentialEntity { get; }
 
         /// <summary>
@@ -62,13 +58,10 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Metrics
                 // Decode and deserialize the response string
                 string decodedString = System.Web.HttpUtility.UrlDecode(delimitedString, Encoding.UTF8);
 
-                result = JsonConvert.DeserializeObject<IndexMetricsInfo>(decodedString, new JsonSerializerSettings()
+                result = JsonSerializer.Deserialize<IndexMetricsInfo>(decodedString, new JsonSerializerOptions()
                     {
                         // Allowing null values to be resilient to Json structure change
-                        MissingMemberHandling = MissingMemberHandling.Ignore,
-                        NullValueHandling = NullValueHandling.Ignore,
-                        // Ignore parsing error encountered in deserialization
-                        Error = (sender, parsingErrorEvent) => parsingErrorEvent.ErrorContext.Handled = true
+                        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
                     }) ?? null;
 
                 return true;

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/IndexMetricsInfoEntity.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/IndexMetricsInfoEntity.cs
@@ -3,13 +3,9 @@
 //------------------------------------------------------------
 namespace Microsoft.Azure.Cosmos.Query.Core.Metrics
 {
-    using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Text;
-    using Microsoft.Azure.Cosmos.Core;
-    using Microsoft.Azure.Cosmos.Core.Utf8;
-    using Newtonsoft.Json;
+    using System.Text.Json.Serialization;
 
     /// <summary>
     /// Query index utilization metrics in the Azure Cosmos database service.

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/IndexUtilizationInfo.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/IndexUtilizationInfo.cs
@@ -6,10 +6,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Metrics
     using System;
     using System.Collections.Generic;
     using System.Linq;
-    using System.Text;
-    using Microsoft.Azure.Cosmos.Core;
-    using Microsoft.Azure.Cosmos.Core.Utf8;
-    using Newtonsoft.Json;
+    using System.Text.Json;
+    using System.Text.Json.Serialization;
 
     /// <summary>
     /// Query index utilization metrics in the Azure Cosmos database service.
@@ -76,13 +74,9 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Metrics
             {
                 string decodedString = System.Text.Encoding.UTF8.GetString(Convert.FromBase64String(delimitedString));
 
-                result = JsonConvert.DeserializeObject<IndexUtilizationInfo>(decodedString, new JsonSerializerSettings()
+                result = JsonSerializer.Deserialize<IndexUtilizationInfo>(decodedString, new JsonSerializerOptions()
                 {
-                    // Allowing null values to be resilient to Json structure change
-                    MissingMemberHandling = MissingMemberHandling.Ignore,
-                    NullValueHandling = NullValueHandling.Ignore,
-                    // Ignore parsing error encountered in desrialization
-                    Error = (sender, parsingErrorEvent) => parsingErrorEvent.ErrorContext.Handled = true
+                    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
                 }) ?? IndexUtilizationInfo.Empty;
 
                 return true;

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/SchedulingTimeSpan.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/SchedulingTimeSpan.cs
@@ -7,8 +7,6 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Metrics
     using System.Collections.Generic;
     using System.Globalization;
     using System.Linq;
-    using System.Text;
-    using Newtonsoft.Json;
 
     /// <summary>
     /// This struct is the TimeSpan equivalent to Stopwatch for SchedulingStopwatch.cs.
@@ -130,30 +128,6 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Metrics
             return totalRunTimeTicksDouble / maxTurnaroundTime;
         }
         #endregion
-
-        /// <summary>
-        /// Appends a JSON version of this SchedulingMetricsResult
-        /// </summary>
-        public void WriteJsonObject(JsonWriter jsonWriter)
-        {
-            if (jsonWriter == null)
-            {
-                throw new ArgumentNullException(nameof(jsonWriter));
-            }
-
-            jsonWriter.WriteStartObject();
-            jsonWriter.WritePropertyName("TurnaroundTimeInMs");
-            jsonWriter.WriteValue(this.TurnaroundTime.TotalMilliseconds);
-            jsonWriter.WritePropertyName("ResponseTimeInMs");
-            jsonWriter.WriteValue(this.ResponseTime.TotalMilliseconds);
-            jsonWriter.WritePropertyName("RunTimeInMs");
-            jsonWriter.WriteValue(this.RunTime.TotalMilliseconds);
-            jsonWriter.WritePropertyName("WaitTime");
-            jsonWriter.WriteValue(this.WaitTime.TotalMilliseconds);
-            jsonWriter.WritePropertyName("NumberOfPreemptions");
-            jsonWriter.WriteValue(this.NumPreemptions);
-            jsonWriter.WriteEndObject();
-        }
 
         /// <summary>
         /// Returns a string version of this SchedulingMetricsResult

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/SingleIndexIndexMetrics.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/SingleIndexIndexMetrics.cs
@@ -3,13 +3,12 @@
 //------------------------------------------------------------
 namespace Microsoft.Azure.Cosmos.Query.Core.Metrics
 {
-    using System;
-    using Newtonsoft.Json;
+    using System.Text.Json.Serialization;
 
     /// <summary>
     /// Query index utilization data for single indexes (sub-structure of the Index Metrics class) in the Azure Cosmos database service.
     /// </summary>
-    #if INTERNAL
+#if INTERNAL
 #pragma warning disable SA1600
 #pragma warning disable CS1591
     public
@@ -35,13 +34,13 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Metrics
         /// <summary>
         /// String representation of index paths of a composite index.
         /// </summary>
-        [JsonProperty(PropertyName = "IndexSpec")]
+        [JsonPropertyName("IndexSpec")]
         public string IndexDocumentExpression { get; }
 
         /// <summary>
         /// The index impact score of the single index.
         /// </summary>
-        [JsonProperty(PropertyName = "IndexImpactScore")]
+        [JsonPropertyName("IndexImpactScore")]
         public string IndexImpactScore { get; }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/SingleIndexUtilizationEntity.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Metrics/SingleIndexUtilizationEntity.cs
@@ -3,8 +3,7 @@
 //------------------------------------------------------------
 namespace Microsoft.Azure.Cosmos.Query.Core.Metrics
 {
-    using System;
-    using Newtonsoft.Json;
+    using System.Text.Json.Serialization;
 
     /// <summary>
     /// Query index utilization data for single index (sub-structure of the Index Utilization metrics) in the Azure Cosmos database service.
@@ -41,19 +40,19 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Metrics
             this.IndexImpactScore = indexImpactScore;
         }
 
-        [JsonProperty(PropertyName = "FilterExpression")]
+        [JsonPropertyName("FilterExpression")]
         public string FilterExpression { get; }
 
-        [JsonProperty(PropertyName = "IndexSpec")]
+        [JsonPropertyName("IndexSpec")]
         public string IndexDocumentExpression { get; }
 
-        [JsonProperty(PropertyName = "FilterPreciseSet")]
+        [JsonPropertyName("FilterPreciseSet")]
         public bool FilterExpressionPrecision { get; }
 
-        [JsonProperty(PropertyName = "IndexPreciseSet")]
+        [JsonPropertyName("IndexPreciseSet")]
         public bool IndexPlanFullFidelity { get; }
 
-        [JsonProperty(PropertyName = "IndexImpactScore")]
+        [JsonPropertyName("IndexImpactScore")]
         public string IndexImpactScore { get; }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/CosmosElementToQueryLiteral.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/CosmosElementToQueryLiteral.cs
@@ -7,10 +7,10 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
     using System;
     using System.Collections.Generic;
     using System.Text;
+    using System.Text.Json;
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.CosmosElements.Numbers;
     using Microsoft.Azure.Documents.Routing;
-    using Newtonsoft.Json;
 
     internal sealed class CosmosElementToQueryLiteral : ICosmosElementVisitor
     {
@@ -93,7 +93,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
 
         public void Visit(CosmosString cosmosString)
         {
-            this.stringBuilder.Append(JsonConvert.SerializeObject(cosmosString.Value.ToString(), DefaultJsonSerializationSettings.Value));
+            this.stringBuilder.Append(JsonSerializer.Serialize(cosmosString.Value.ToString()));
         }
 
         private sealed class CosmosNumberToQueryLiteral : ICosmosNumberVisitor

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/OrderByContinuationToken.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/CrossPartition/OrderBy/OrderByContinuationToken.cs
@@ -7,13 +7,13 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Text.Json.Serialization;
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.CosmosElements.Numbers;
     using Microsoft.Azure.Cosmos.Query.Core.Exceptions;
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.Parallel;
     using Microsoft.Azure.Documents.Routing;
-    using Newtonsoft.Json;
 
     /// <summary>
     /// <para>
@@ -133,7 +133,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
         ///  {"compositeToken":{"token":"+RID:OpY0AN-mFAACAAAAAAAABA==#RT:1#TRC:1#RTD:qdTAEA==","range":{"min":"05C1D9CD673398","max":"05C1E399CD6732"}}
         /// ]]>
         /// </example>
-        [JsonProperty(PropertyNames.CompositeToken)]
+        [JsonPropertyName(PropertyNames.CompositeToken)]
         public ParallelContinuationToken ParallelContinuationToken
         {
             get;
@@ -153,7 +153,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
         /// <remarks>
         /// This is an array to support multi item orderby.
         /// </remarks>>
-        [JsonProperty(PropertyNames.OrderByItems)]
+        [JsonPropertyName(PropertyNames.OrderByItems)]
         public IReadOnlyList<OrderByItem> OrderByItems
         {
             get;
@@ -172,7 +172,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
         /// <remarks>
         /// This is an array to support multi item orderby.
         /// </remarks>>
-        [JsonProperty(PropertyNames.ResumeValues)]
+        [JsonPropertyName(PropertyNames.ResumeValues)]
         public IReadOnlyList<SqlQueryResumeValue> ResumeValues
         {
             get;
@@ -193,7 +193,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
         ///  "rid":"OpY0AN-mFAACAAAAAAAABA=="
         /// ]]>
         /// </example>
-        [JsonProperty(PropertyNames.Rid)]
+        [JsonPropertyName(PropertyNames.Rid)]
         public string Rid
         {
             get;
@@ -219,7 +219,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
         /// </para>
         /// The skip count keeps track of that information. 
         /// </summary> 
-        [JsonProperty(PropertyNames.SkipCount)]
+        [JsonPropertyName(PropertyNames.SkipCount)]
         public int SkipCount
         {
             get;
@@ -242,7 +242,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy
         /// ]]>
         /// </para>
         /// </example>
-        [JsonProperty(PropertyNames.Filter)]
+        [JsonPropertyName(PropertyNames.Filter)]
         public string Filter
         {
             get;

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Distinct/DistinctQueryPipelineStage.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Distinct/DistinctQueryPipelineStage.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Distinct
 {
     using System;
     using System.Collections.Generic;
+    using System.Text.Json;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.CosmosElements;
@@ -14,7 +15,6 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Distinct
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
     using Microsoft.Azure.Cosmos.Tracing;
-    using Newtonsoft.Json;
 
     internal class DistinctQueryPipelineStage : QueryPipelineStageBase
     {
@@ -254,7 +254,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Distinct
             /// <returns>The serialized form of DistinctContinuationToken</returns>
             public override string ToString()
             {
-                return JsonConvert.SerializeObject(this);
+                return JsonSerializer.Serialize(this);
             }
         }
     }

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Skip/SkipQueryPipelineStage.Client.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Skip/SkipQueryPipelineStage.Client.cs
@@ -8,6 +8,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Skip
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.Linq;
+    using System.Text.Json;
+    using System.Text.Json.Serialization;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.CosmosElements;
@@ -15,7 +17,6 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Skip
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
     using Microsoft.Azure.Cosmos.Tracing;
-    using Newtonsoft.Json;
 
     internal abstract partial class SkipQueryPipelineStage : QueryPipelineStageBase
     {
@@ -177,13 +178,13 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Skip
                 /// <summary>
                 /// The number of items to skip in the query.
                 /// </summary>
-                [JsonProperty("offset")]
+                [JsonPropertyName("offset")]
                 public int Offset { get; }
 
                 /// <summary>
                 /// Gets the continuation token for the source component of the query.
                 /// </summary>
-                [JsonProperty("sourceToken")]
+                [JsonPropertyName("sourceToken")]
                 public string SourceToken { get; }
 
                 /// <summary>
@@ -202,7 +203,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Skip
 
                     try
                     {
-                        offsetContinuationToken = JsonConvert.DeserializeObject<OffsetContinuationToken>(value);
+                        offsetContinuationToken = JsonSerializer.Deserialize<OffsetContinuationToken>(value);
                         return true;
                     }
                     catch (JsonException)
@@ -217,7 +218,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Skip
                 /// <returns>The string version of the continuation token that can be passed in a response header.</returns>
                 public override string ToString()
                 {
-                    return JsonConvert.SerializeObject(this);
+                    return JsonSerializer.Serialize(this);
                 }
             }
         }

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Take/TakeQueryPipelineStage.Client.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Pipeline/Take/TakeQueryPipelineStage.Client.cs
@@ -7,6 +7,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Take
     using System;
     using System.Collections.Generic;
     using System.Linq;
+    using System.Text.Json;
+    using System.Text.Json.Serialization;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.CosmosElements;
@@ -14,7 +16,6 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Take
     using Microsoft.Azure.Cosmos.Query.Core.Monads;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Pagination;
     using Microsoft.Azure.Cosmos.Tracing;
-    using Newtonsoft.Json;
 
     internal abstract partial class TakeQueryPipelineStage : QueryPipelineStageBase
     {
@@ -269,7 +270,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Take
                 /// <summary>
                 /// Gets the limit to the number of document drained for the remainder of the query.
                 /// </summary>
-                [JsonProperty("limit")]
+                [JsonPropertyName("limit")]
                 public int Limit
                 {
                     get;
@@ -278,7 +279,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Take
                 /// <summary>
                 /// Gets the continuation token for the source component of the query.
                 /// </summary>
-                [JsonProperty("sourceToken")]
+                [JsonPropertyName("sourceToken")]
                 public string SourceToken
                 {
                     get;
@@ -300,7 +301,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Take
 
                     try
                     {
-                        limitContinuationToken = JsonConvert.DeserializeObject<LimitContinuationToken>(value);
+                        limitContinuationToken = JsonSerializer.Deserialize<LimitContinuationToken>(value);
                         return true;
                     }
                     catch (JsonException)
@@ -315,7 +316,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Take
                 /// <returns>The string version of the continuation token that can be passed in a response header.</returns>
                 public override string ToString()
                 {
-                    return JsonConvert.SerializeObject(this);
+                    return JsonSerializer.Serialize(this);
                 }
             }
 
@@ -338,7 +339,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Take
                 /// <summary>
                 /// Gets the limit to the number of document drained for the remainder of the query.
                 /// </summary>
-                [JsonProperty("top")]
+                [JsonPropertyName("top")]
                 public int Top
                 {
                     get;
@@ -347,7 +348,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Take
                 /// <summary>
                 /// Gets the continuation token for the source component of the query.
                 /// </summary>
-                [JsonProperty("sourceToken")]
+                [JsonPropertyName("sourceToken")]
                 public string SourceToken
                 {
                     get;
@@ -369,7 +370,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Take
 
                     try
                     {
-                        topContinuationToken = JsonConvert.DeserializeObject<TopContinuationToken>(value);
+                        topContinuationToken = JsonSerializer.Deserialize<TopContinuationToken>(value);
                         return true;
                     }
                     catch (JsonException)
@@ -384,7 +385,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Pipeline.Take
                 /// <returns>The string version of the continuation token that can be passed in a response header.</returns>
                 public override string ToString()
                 {
-                    return JsonConvert.SerializeObject(this);
+                    return JsonSerializer.Serialize(this);
                 }
             }
         }

--- a/Microsoft.Azure.Cosmos/src/Query/Core/QueryClient/CosmosQueryExecutionInfo.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/QueryClient/CosmosQueryExecutionInfo.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.Azure.Cosmos.Query.Core.QueryClient
 {
-    using Newtonsoft.Json;
+    using System.Text.Json.Serialization;
 
     internal sealed class CosmosQueryExecutionInfo
     {
@@ -18,13 +18,13 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryClient
         /// <summary>
         /// Whether or not the backend has the reverseRid feature enabled.
         /// </summary>
-        [JsonProperty("reverseRidEnabled")]
+        [JsonPropertyName("reverseRidEnabled")]
         public bool ReverseRidEnabled { get; }
 
         /// <summary>
         /// Indicates the direction of the index scan.
         /// </summary>
-        [JsonProperty("reverseIndexScan")]
+        [JsonPropertyName("reverseIndexScan")]
         public bool ReverseIndexScan { get; }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/DCountInfo.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/DCountInfo.cs
@@ -4,12 +4,11 @@
 
 namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
 {
-    using Newtonsoft.Json;
+    using System.Text.Json.Serialization;
 
-    [JsonObject(MemberSerialization.OptIn)]
     internal sealed class DCountInfo
     {
-        [JsonProperty("dCountAlias")]
+        [JsonPropertyName("dCountAlias")]
         public string DCountAlias
         {
             get;

--- a/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/HybridSearchQueryInfo.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/HybridSearchQueryInfo.cs
@@ -5,60 +5,60 @@
 namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
 {
     using System.Collections.Generic;
-    using Newtonsoft.Json;
+    using System.Text.Json.Serialization;
 
     internal sealed class HybridSearchQueryInfo
     {
-        [JsonProperty("globalStatisticsQuery")]
+        [JsonPropertyName("globalStatisticsQuery")]
         public string GlobalStatisticsQuery
         {
             get;
             set;
         }
 
-        [JsonProperty("componentQueryInfos")]
+        [JsonPropertyName("componentQueryInfos")]
         public List<QueryInfo> ComponentQueryInfos
         {
             get;
             set;
         }
 
-        [JsonProperty("componentWithoutPayloadQueryInfos")]
+        [JsonPropertyName("componentWithoutPayloadQueryInfos")]
         public List<QueryInfo> ComponentWithoutPayloadQueryInfos
         {
             get;
             set;
         }
 
-        [JsonProperty("projectionQueryInfo")]
+        [JsonPropertyName("projectionQueryInfo")]
         public QueryInfo ProjectionQueryInfo
         {
             get;
             set;
         }
 
-        [JsonProperty("componentWeights")]
+        [JsonPropertyName("componentWeights")]
         public List<double> ComponentWeights
         {
             get;
             set;
         }
 
-        [JsonProperty("skip")]
+        [JsonPropertyName("skip")]
         public uint? Skip
         {
             get;
             set;
         }
 
-        [JsonProperty("take")]
+        [JsonPropertyName("take")]
         public uint? Take
         {
             get;
             set;
         }
 
-        [JsonProperty("requiresGlobalStatistics")]
+        [JsonPropertyName("requiresGlobalStatistics")]
         public bool RequiresGlobalStatistics
         {
             get;

--- a/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/PartitionedQueryExecutionInfo.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/PartitionedQueryExecutionInfo.cs
@@ -6,7 +6,8 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
 {
     using System;
     using System.Collections.Generic;
-    using Newtonsoft.Json;
+    using System.Text.Json;
+    using System.Text.Json.Serialization;
     using Constants = Documents.Constants;
 
     internal sealed class PartitionedQueryExecutionInfo
@@ -16,21 +17,21 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
             this.Version = Constants.PartitionedQueryExecutionInfo.CurrentVersion;
         }
 
-        [JsonProperty(Constants.Properties.PartitionedQueryExecutionInfoVersion)]
+        [JsonPropertyName(Constants.Properties.PartitionedQueryExecutionInfoVersion)]
         public int Version
         {
             get;
             private set;
         }
 
-        [JsonProperty(Constants.Properties.QueryInfo)]
+        [JsonPropertyName(Constants.Properties.QueryInfo)]
         public QueryInfo QueryInfo
         {
             get;
             set;
         }
 
-        [JsonProperty(Constants.Properties.QueryRanges)]
+        [JsonPropertyName(Constants.Properties.QueryRanges)]
         public List<Documents.Routing.Range<string>> QueryRanges
         {
             get;
@@ -39,7 +40,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
 
         // Change to the below after Direct package upgrade
         // [JsonProperty(Constants.Properties.HybridSearchQueryInfo)]
-        [JsonProperty("hybridSearchQueryInfo")]
+        [JsonPropertyName("hybridSearchQueryInfo")]
         public HybridSearchQueryInfo HybridSearchQueryInfo
         {
             get;
@@ -48,7 +49,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
 
         public override string ToString()
         {
-            return JsonConvert.SerializeObject(this);
+            return JsonSerializer.Serialize(this);
         }
 
         public static bool TryParse(string serializedQueryPlan, out PartitionedQueryExecutionInfo partitionedQueryExecutionInfo)
@@ -60,7 +61,7 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
 
             try
             {
-                partitionedQueryExecutionInfo = JsonConvert.DeserializeObject<PartitionedQueryExecutionInfo>(serializedQueryPlan);
+                partitionedQueryExecutionInfo = JsonSerializer.Deserialize<PartitionedQueryExecutionInfo>(serializedQueryPlan);
                 return true;
             }
             catch (JsonException)

--- a/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/PartitionedQueryExecutionInfoInternal.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/PartitionedQueryExecutionInfoInternal.cs
@@ -5,28 +5,28 @@
 namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
 {
     using System.Collections.Generic;
-    using Newtonsoft.Json;
+    using System.Text.Json.Serialization;
     using Constants = Documents.Constants;
     using PartitionKeyInternal = Documents.Routing.PartitionKeyInternal;
 
     // Note: We also return this to client when query execution is disallowed by Gateway
     internal sealed class PartitionedQueryExecutionInfoInternal
     {
-        [JsonProperty(Constants.Properties.QueryInfo)]
+        [JsonPropertyName(Constants.Properties.QueryInfo)]
         public QueryInfo QueryInfo
         {
             get;
             set;
         }
 
-        [JsonProperty(Constants.Properties.QueryRanges)]
+        [JsonPropertyName(Constants.Properties.QueryRanges)]
         public List<Documents.Routing.Range<PartitionKeyInternal>> QueryRanges
         {
             get;
             set;
         }
 
-        [JsonProperty(Constants.Properties.HybridSearchQueryInfo)]
+        [JsonPropertyName(Constants.Properties.HybridSearchQueryInfo)]
         public HybridSearchQueryInfo HybridSearchQueryInfo
         {
             get;

--- a/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryInfo.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/QueryPlan/QueryInfo.cs
@@ -6,108 +6,105 @@ namespace Microsoft.Azure.Cosmos.Query.Core.QueryPlan
 {
     using System.Collections.Generic;
     using System.Linq;
+    using System.Text.Json.Serialization;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Aggregate;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.OrderBy;
     using Microsoft.Azure.Cosmos.Query.Core.Pipeline.Distinct;
-    using Newtonsoft.Json;
-    using Newtonsoft.Json.Converters;
 
-    [JsonObject(MemberSerialization.OptIn)]
     internal sealed class QueryInfo
     {
-        [JsonProperty("distinctType")]
-        [JsonConverter(typeof(StringEnumConverter))]
+        [JsonPropertyName("distinctType")]
         public DistinctQueryType DistinctType
         {
             get;
             set;
         }
 
-        [JsonProperty("top")]
+        [JsonPropertyName("top")]
         public uint? Top
         {
             get;
             set;
         }
 
-        [JsonProperty("offset")]
+        [JsonPropertyName("offset")]
         public uint? Offset
         {
             get;
             set;
         }
 
-        [JsonProperty("limit")]
+        [JsonPropertyName("limit")]
         public uint? Limit
         {
             get;
             set;
         }
 
-        [JsonProperty("orderBy", ItemConverterType = typeof(StringEnumConverter))]
+        [JsonPropertyName("orderBy")]
         public IReadOnlyList<SortOrder> OrderBy
         {
             get;
             set;
         }
 
-        [JsonProperty("orderByExpressions")]
+        [JsonPropertyName("orderByExpressions")]
         public IReadOnlyList<string> OrderByExpressions
         {
             get;
             set;
         }
 
-        [JsonProperty("groupByExpressions")]
+        [JsonPropertyName("groupByExpressions")]
         public IReadOnlyList<string> GroupByExpressions
         {
             get;
             set;
         }
 
-        [JsonProperty("groupByAliases")]
+        [JsonPropertyName("groupByAliases")]
         public IReadOnlyList<string> GroupByAliases
         {
             get;
             set;
         }
 
-        [JsonProperty("aggregates", ItemConverterType = typeof(StringEnumConverter))]
+        [JsonPropertyName("aggregates")]
         public IReadOnlyList<AggregateOperator> Aggregates
         {
             get;
             set;
         }
 
-        [JsonProperty("groupByAliasToAggregateType", ItemConverterType = typeof(StringEnumConverter))]
+        [JsonPropertyName("groupByAliasToAggregateType")]
         public IReadOnlyDictionary<string, AggregateOperator?> GroupByAliasToAggregateType
         {
             get;
             set;
         }
 
-        [JsonProperty("rewrittenQuery")]
+        [JsonPropertyName("rewrittenQuery")]
         public string RewrittenQuery
         {
             get;
             set;
         }
 
-        [JsonProperty("hasSelectValue")]
+        [JsonPropertyName("hasSelectValue")]
         public bool HasSelectValue
         {
             get;
             set;
         }
 
-        [JsonProperty("dCountInfo")]
+        [JsonPropertyName("dCountInfo")]
         public DCountInfo DCountInfo
         {
             get;
             set;
         }
 
-        [JsonProperty("hasNonStreamingOrderBy")]
+        [JsonPropertyName("hasNonStreamingOrderBy")]
         public bool HasNonStreamingOrderBy
         {
             get;

--- a/Microsoft.Azure.Cosmos/src/Query/v2Query/DefaultDocumentQueryExecutionContext.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v2Query/DefaultDocumentQueryExecutionContext.cs
@@ -12,7 +12,6 @@ namespace Microsoft.Azure.Cosmos.Query
     using Microsoft.Azure.Cosmos.Common;
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Query.Core.Metrics;
-    using Microsoft.Azure.Cosmos.Query.Core.Pipeline.CrossPartition.Parallel;
     using Microsoft.Azure.Cosmos.Query.Core.QueryPlan;
     using Microsoft.Azure.Cosmos.Routing;
     using Microsoft.Azure.Cosmos.Tracing;


### PR DESCRIPTION
# [Internal] Query : Removes Newtonsft usage from query components (Part 1)

## Description

This change removes the usage of newtonsoft library from query owned components.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber