### PR TITLE
[Internal] Pipeline: Fixes pipelines by fixing the StoredProc and UserDefined Script Blacklisting emulator tests

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/GatewayTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/GatewayTests.cs
@@ -2275,7 +2275,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             {
                 PartitionKey = new Documents.PartitionKey("test")
             };
-            for (int numExec = 0; numExec < 3; numExec++)
+            for (int numExec = 0; numExec < 6; numExec++)
             {
                 client.ExecuteStoredProcedureAsync<string>(retrievedStoredProcedure, requestOptions).Wait();
             }
@@ -2472,7 +2472,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             // create one doc and try again
             await client.CreateDocumentAsync(collection, new Document() { Id = "newdoc1" });
-            for (int i = 0; i < 3; i++)
+            for (int i = 0; i < 6; i++)
             {
                 IDocumentQuery<dynamic> docQuery2 = secondaryClient.CreateDocumentQuery(collection.DocumentsLink,
                     "select udf.badUdf(r.id) from root r", new FeedOptions { EnableCrossPartitionQuery = true }).AsDocumentQuery();


### PR DESCRIPTION
## Description

Our emulator tests

ValidateUserDefinedFunctionsBlacklisting

 https://github.com/Azure/azure-cosmos-dotnet-v3/blob/master/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/GatewayTests.cs#L2422

ValidateUserDefinedFunctionsBlacklistingInternal

https://github.com/Azure/azure-cosmos-dotnet-v3/blob/master/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/GatewayTests.cs#L2251

These tests rely on the config `StoredProcedureMaximumChargeInSeconds`  and as a threshold value for the number of times an overcharged script will be run before its Blacklisted by Foreboding it. This config max default value has been changed from 2 to 5 and the emulator uses the default value in the pipeline.


https://msdata.visualstudio.com/_git/CosmosDB/commit/549cf989d273604e42023dcf3c1210f6f6eb5faf?_a=compare&path=%2FProduct%2FServices%2FDocuments%2FImageStore%2FStorage%2FSingleServiceMasterServerApplication%2FServerServicePackage%2FSettings.xml

Fixing the value to 5.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber