### PR TITLE
Fixes race condition that can cause InvalidOperationException in CosmosOperationCancelledException.ToString()

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Tracing/TraceWriter.TraceJsonWriter.cs
+++ b/Microsoft.Azure.Cosmos/src/Tracing/TraceWriter.TraceJsonWriter.cs
@@ -130,6 +130,10 @@ namespace Microsoft.Azure.Cosmos.Tracing
             {
                 writer.WriteStringValue(stringValue);
             }
+            else if (value is CosmosOperationCanceledException cosmosTimeoutException)
+            {
+                writer.WriteStringValue(cosmosTimeoutException.EnsureToStringMessage(true));
+            }
             else
             {
                 writer.WriteStringValue(value.ToString());


### PR DESCRIPTION
# Pull Request Template

## Description

Fixes race condition that can cause InvalidOperationException in CosmosOperationCancelledException.ToString() - especially when cross-regional hedging is enabled and E2E timeouts happen (CancellationToken being cancelled).

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues
ICM#66334029
