### PR TITLE
VectorDataType: Fixes Enum Ordering for `Float16` Data Type

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/VectorDataType.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/VectorDataType.cs
@@ -11,12 +11,6 @@ namespace Microsoft.Azure.Cosmos
     public enum VectorDataType
     {
         /// <summary>
-        /// Represent a float16 data type.
-        /// </summary>
-        [EnumMember(Value = "float16")]
-        Float16,
-
-        /// <summary>
         /// Represent a float32 data type.
         /// </summary>
         [EnumMember(Value = "float32")]
@@ -32,6 +26,12 @@ namespace Microsoft.Azure.Cosmos
         /// Represent a int8 data type.
         /// </summary>
         [EnumMember(Value = "int8")]
-        Int8
+        Int8,
+
+        /// <summary>
+        /// Represent a float16 data type.
+        /// </summary>
+        [EnumMember(Value = "float16")]
+        Float16
     }
 }


### PR DESCRIPTION
# Pull Request Template

## Description

This PR fixes the enum ordering for `Float16` value in `VectorDataType` to avoid any unnecessary issues in the future.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #5367 