### PR TITLE
[Internal] AOT: Adds version bump up to 0.1.4-preview.2 release

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
-		<ClientOfficialVersion>0.1.3</ClientOfficialVersion>
-		<ClientPreviewVersion>0.1.3</ClientPreviewVersion>
+		<ClientOfficialVersion>0.1.4</ClientOfficialVersion>
+		<ClientPreviewVersion>0.1.4</ClientPreviewVersion>
 		<ClientPreviewSuffixVersion>preview.2</ClientPreviewSuffixVersion>
 		<DirectVersion>3.37.10</DirectVersion>
 		<FaultInjectionVersion>1.0.0</FaultInjectionVersion>

--- a/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
+++ b/Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj
@@ -159,7 +159,7 @@
 
 	<ItemGroup Condition=" '$(ProjectRef)' != 'True' ">
 		<PackageReference Include="Microsoft.HybridRow" Version="[$(HybridRowVersion)]" PrivateAssets="All" />
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+		<PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
 	</ItemGroup>
 


### PR DESCRIPTION
## Description

- Upgraded Newtonsoft to latest version 13.0.4 that support Trim Annotations
- Directory.build.props changes



## Closing issues

To automatically close an issue: closes #IssueNumber