### PR TITLE
[Client encryption]: Fixes Encryption.Custom contract tests

### DIFF
--- a/Microsoft.Azure.Cosmos.Encryption.Custom/tests/Microsoft.Azure.Cosmos.Encryption.Custom.Tests/Contracts/DotNetSDKEncryptionCustomAPI.net8.json
+++ b/Microsoft.Azure.Cosmos.Encryption.Custom/tests/Microsoft.Azure.Cosmos.Encryption.Custom.Tests/Contracts/DotNetSDKEncryptionCustomAPI.net8.json
@@ -1306,6 +1306,11 @@
           "Type": "Field",
           "Attributes": [],
           "MethodInfo": "Microsoft.Azure.Cosmos.Encryption.Custom.JsonProcessor Newtonsoft;IsInitOnly:False;IsStatic:True;"
+        },
+        "Microsoft.Azure.Cosmos.Encryption.Custom.JsonProcessor Stream": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Encryption.Custom.JsonProcessor Stream;IsInitOnly:False;IsStatic:True;"
         }
       },
       "NestedTypes": {}


### PR DESCRIPTION
# Pull Request Template

## Description

Adds missing `JsonProcessor.Stream` enum value to ContractEnforcementTests.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
