### PR TITLE
Per Partition Automatic Failover: Adds Hub Region Processing Only While Routing Requests Failed with 404/1002 for single master accounts.

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ClientRetryPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/ClientRetryPolicy.cs
@@ -329,19 +329,19 @@ namespace Microsoft.Azure.Cosmos
                     retryOnPreferredLocations: true);
             }
 
-            if (statusCode == HttpStatusCode.NotFound
-                && subStatusCode == SubStatusCodes.ReadSessionNotAvailable)
+            if (statusCode == HttpStatusCode.NotFound && subStatusCode == SubStatusCodes.ReadSessionNotAvailable)
             {
 #if !INTERNAL
                 // Only set the hub region processing header for single master accounts
-                if (!this.canUseMultipleWriteLocations)
+                // Set header only after the first retry attempt fails with 404/1002
+                if (!this.canUseMultipleWriteLocations && this.sessionTokenRetryCount >= 1)
                 {
                     this.addHubRegionProcessingOnlyHeader = true;
                 }
 #endif
                 return this.ShouldRetryOnSessionNotAvailable(this.documentServiceRequest);
             }
-            
+
             // Received 503 due to client connect timeout or Gateway
             if (statusCode == HttpStatusCode.ServiceUnavailable)
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ClientRetryPolicyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ClientRetryPolicyTests.cs
@@ -404,13 +404,14 @@
 
         /// <summary>
         /// Test to validate that hub region header is added on 404/1002 for single master accounts only,
-        /// and persists across retries. For multi-master accounts, the header should NOT be added.
+        /// starting from the second retry (after first retry also fails). For multi-master accounts, 
+        /// the header should NOT be added.
         /// </summary>
         [TestMethod]
-        [DataRow(true, true, DisplayName = "Read request on single master - Hub region header added on 404/1002")]
-        [DataRow(false, true, DisplayName = "Write request on single master - Hub region header added on 404/1002")]
-        [DataRow(true, false, DisplayName = "Read request on multi-master - Hub region header NOT added on 404/1002")]
-        [DataRow(false, false, DisplayName = "Write request on multi-master - Hub region header NOT added on 404/1002")]
+        [DataRow(true, true, DisplayName = "Read request on single master - Hub region header added after first retry fails")]
+        [DataRow(false, true, DisplayName = "Write request on single master - Hub region header added after first retry fails")]
+        [DataRow(true, false, DisplayName = "Read request on multi-master - Hub region header NOT added")]
+        [DataRow(false, false, DisplayName = "Write request on multi-master - Hub region header NOT added")]
         public async Task ClientRetryPolicy_HubRegionHeader_AddedOn404_1002_BasedOnAccountType(bool isReadRequest, bool isSingleMaster)
         {
             // Arrange
@@ -435,7 +436,7 @@
             retryPolicy.OnBeforeSendRequest(request);
             Assert.IsNull(request.Headers.GetValues(HubRegionHeader), "Header should not exist on initial request before any 404/1002 error.");
 
-            // Simulate 404/1002 error
+            // Simulate first 404/1002 error
             DocumentClientException sessionNotAvailableException = new DocumentClientException(
                 message: "Simulated 404/1002 ReadSessionNotAvailable",
                 innerException: null,
@@ -447,37 +448,84 @@
             ShouldRetryResult shouldRetry = await retryPolicy.ShouldRetryAsync(sessionNotAvailableException, CancellationToken.None);
             Assert.IsTrue(shouldRetry.ShouldRetry, "Should retry on 404/1002.");
 
-            // Verify header behavior based on account type and that it persists across multiple retry attempts
-            for (int retryAttempt = 1; retryAttempt <= 3; retryAttempt++)
+            // First retry attempt - header should NOT be present yet
+            retryPolicy.OnBeforeSendRequest(request);
+            string[] headerValues = request.Headers.GetValues(HubRegionHeader);
+            Assert.IsNull(headerValues, "Header should NOT be present on first retry attempt (before it fails).");
+
+            // Simulate first retry also failing with 404/1002
+            DocumentClientException sessionNotAvailableException2 = new DocumentClientException(
+                message: "Simulated 404/1002 ReadSessionNotAvailable on first retry",
+                innerException: null,
+                statusCode: HttpStatusCode.NotFound,
+                substatusCode: SubStatusCodes.ReadSessionNotAvailable,
+                requestUri: request.RequestContext.LocationEndpointToRoute,
+                responseHeaders: new DictionaryNameValueCollection());
+
+            shouldRetry = await retryPolicy.ShouldRetryAsync(sessionNotAvailableException2, CancellationToken.None);
+
+            if (isSingleMaster)
             {
-                retryPolicy.OnBeforeSendRequest(request);
-                string[] headerValues = request.Headers.GetValues(HubRegionHeader);
+                // For single master, after one retry fails with 404/1002, it won't retry further
+                // But the header flag should be set for any potential future retries due to other errors
+                Assert.IsFalse(shouldRetry.ShouldRetry, "Single master should not retry again after first 404/1002 retry fails.");
 
-                if (isSingleMaster)
+                // The header flag should be set even though no more 404/1002 retries will happen
+                // This ensures if the request is retried for a different reason (e.g., 503), it will have the header
+            }
+            else
+            {
+                // Multi-master can retry across multiple regions
+                Assert.IsTrue(shouldRetry.ShouldRetry, "Multi-master should continue retrying on 404/1002.");
+            }
+
+            // For single master: Verify header would be added if request is retried for other reasons (e.g., 503)
+            // For multi-master: Verify header is NOT added even on subsequent retries
+            if (isSingleMaster)
+            {
+                // Simulate a 503 error to trigger another retry
+                DocumentClientException serviceUnavailableException = new DocumentClientException(
+                    message: "Simulated 503 ServiceUnavailable",
+                    innerException: null,
+                    statusCode: HttpStatusCode.ServiceUnavailable,
+                    substatusCode: SubStatusCodes.Unknown,
+                    requestUri: request.RequestContext.LocationEndpointToRoute,
+                    responseHeaders: new DictionaryNameValueCollection());
+
+                shouldRetry = await retryPolicy.ShouldRetryAsync(serviceUnavailableException, CancellationToken.None);
+
+                if (shouldRetry.ShouldRetry)
                 {
-                    // For single master accounts, header should be present and persist across retries
-                    Assert.IsNotNull(headerValues, $"Header should be present on retry attempt {retryAttempt} for single master account.");
-                    Assert.AreEqual(1, headerValues.Length, $"Header should have exactly one value on retry attempt {retryAttempt}.");
-                    Assert.AreEqual(bool.TrueString, headerValues[0], $"Header value should be 'True' on retry attempt {retryAttempt}.");
+                    // Now verify the header is present on this retry triggered by 503
+                    retryPolicy.OnBeforeSendRequest(request);
+                    headerValues = request.Headers.GetValues(HubRegionHeader);
+                    Assert.IsNotNull(headerValues, "Header should be present on retry after 404/1002 flag was set.");
+                    Assert.AreEqual(1, headerValues.Length, "Header should have exactly one value.");
+                    Assert.AreEqual(bool.TrueString, headerValues[0], "Header value should be 'True'.");
                 }
-                else
+            }
+            else
+            {
+                // For multi-master: Verify header is NOT added even on subsequent retries
+                for (int retryAttempt = 2; retryAttempt <= 3; retryAttempt++)
                 {
-                    // For multi-master accounts, header should NOT be present
-                    Assert.IsNull(headerValues, $"Header should NOT be present on retry attempt {retryAttempt} for multi-master account.");
-                }
+                    if (shouldRetry.ShouldRetry)
+                    {
+                        retryPolicy.OnBeforeSendRequest(request);
+                        headerValues = request.Headers.GetValues(HubRegionHeader);
+                        Assert.IsNull(headerValues, $"Header should NOT be present on retry attempt {retryAttempt} for multi-master account.");
 
-                if (retryAttempt < 3)
-                {
-                    // Simulate another error to trigger next retry
-                    DocumentClientException serviceUnavailableException = new DocumentClientException(
-                        message: "Simulated 503 ServiceUnavailable",
-                        innerException: null,
-                        statusCode: HttpStatusCode.ServiceUnavailable,
-                        substatusCode: SubStatusCodes.Unknown,
-                        requestUri: request.RequestContext.LocationEndpointToRoute,
-                        responseHeaders: new DictionaryNameValueCollection());
+                        // Simulate another 404/1002 or 503 to continue retry loop
+                        DocumentClientException nextException = new DocumentClientException(
+                            message: $"Simulated error on retry {retryAttempt}",
+                            innerException: null,
+                            statusCode: retryAttempt % 2 == 0 ? HttpStatusCode.ServiceUnavailable : HttpStatusCode.NotFound,
+                            substatusCode: retryAttempt % 2 == 0 ? SubStatusCodes.Unknown : SubStatusCodes.ReadSessionNotAvailable,
+                            requestUri: request.RequestContext.LocationEndpointToRoute,
+                            responseHeaders: new DictionaryNameValueCollection());
 
-                    await retryPolicy.ShouldRetryAsync(serviceUnavailableException, CancellationToken.None);
+                        shouldRetry = await retryPolicy.ShouldRetryAsync(nextException, CancellationToken.None);
+                    }
                 }
             }
         }


### PR DESCRIPTION
# Pull Request Template

## Description

**This change is limited to single master accounts.** During partition-level failover and failback under session consistency, a timing gap can cause read requests to fail with 404/1002 errors. When a partition temporarily fails over to a secondary region and later begins failing back to the primary region, the SDK’s read circuit breaker (PPCB) may start routing reads back to the primary region before it has fully caught up with the writes from the failover region. As a result, reads using session tokens from the previous write region may fail because the primary region does not yet have the corresponding session state. Since the SDK currently does not perform cross-regional retries for 404/1002 responses, these reads continue to fail until the primary region is fully synchronized. The goal is to leverage the new backend header **x-ms-cosmos-hub-region-processing-only** to detect such conditions and route retry requests to the correct write (hub) region, ensuring successful session-consistent reads during the failback window.

As part of this change, the hub region header is added to the second retry request that failed with 404/1002 Read Session Not Available. In order to avoid running into a loop of retries to find the hub region, the first retry request for 404/1002 does not container header and retries on the available write region from location cache. If that request also fails with 404/1002 then subsequent retry requests all contain the header. If the request has the header and it does not hit the primary hub region then backend return 403/3. SDK will retry the subsequent 403/3 retry requests with the hub region header added.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #5440