### PR TITLE
[Client encryption] Rename EncryptableItemStream to StreamEncryptableItem

### DIFF
--- a/Microsoft.Azure.Cosmos.Encryption.Custom/tests/EmulatorTests/LegacyEncryptionTests.cs
+++ b/Microsoft.Azure.Cosmos.Encryption.Custom/tests/EmulatorTests/LegacyEncryptionTests.cs
@@ -383,8 +383,8 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom.EmulatorTests
 
             // stream
             TestDoc testDoc1 = TestDoc.Create();
-            ItemResponse<EncryptableItemStream> createResponseStream = await encryptionContainer.CreateItemAsync(
-                new EncryptableItemStream(TestCommon.ToStream(testDoc1)),
+            ItemResponse<StreamEncryptableItem> createResponseStream = await encryptionContainer.CreateItemAsync(
+                new StreamEncryptableItem(TestCommon.ToStream(testDoc1)),
                 new PartitionKey(testDoc1.PK),
                 GetRequestOptions(dekId, TestDoc.PathsToEncrypt));
 
@@ -609,8 +609,8 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom.EmulatorTests
             testDoc.NonSensitive = Guid.NewGuid().ToString();
             testDoc.Sensitive = Guid.NewGuid().ToString();
 
-            ItemResponse<EncryptableItemStream> upsertResponseStream = await encryptionContainer.UpsertItemAsync(
-                new EncryptableItemStream(TestCommon.ToStream(testDoc)),
+            ItemResponse<StreamEncryptableItem> upsertResponseStream = await encryptionContainer.UpsertItemAsync(
+                new StreamEncryptableItem(TestCommon.ToStream(testDoc)),
                 new PartitionKey(testDoc.PK),
                 GetRequestOptions(dekId, TestDoc.PathsToEncrypt));
 
@@ -624,8 +624,8 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom.EmulatorTests
             testDoc.NonSensitive = Guid.NewGuid().ToString();
             testDoc.Sensitive = Guid.NewGuid().ToString();
 
-            ItemResponse<EncryptableItemStream> replaceResponseStream = await encryptionContainer.ReplaceItemAsync(
-                new EncryptableItemStream(TestCommon.ToStream(testDoc)),
+            ItemResponse<StreamEncryptableItem> replaceResponseStream = await encryptionContainer.ReplaceItemAsync(
+                new StreamEncryptableItem(TestCommon.ToStream(testDoc)),
                 testDoc.Id,
                 new PartitionKey(testDoc.PK),
                 GetRequestOptions(dekId, TestDoc.PathsToEncrypt, upsertResponseStream.ETag));

--- a/Microsoft.Azure.Cosmos.Encryption.Custom/tests/EmulatorTests/MdeCustomEncryptionTests.cs
+++ b/Microsoft.Azure.Cosmos.Encryption.Custom/tests/EmulatorTests/MdeCustomEncryptionTests.cs
@@ -937,8 +937,8 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom.EmulatorTests
 
             // stream
             TestDoc testDoc1 = TestDoc.Create();
-            ItemResponse<EncryptableItemStream> createResponseStream = await encryptionContainer.CreateItemAsync(
-                new EncryptableItemStream(TestCommon.ToStream(testDoc1)),
+            ItemResponse<StreamEncryptableItem> createResponseStream = await encryptionContainer.CreateItemAsync(
+                new StreamEncryptableItem(TestCommon.ToStream(testDoc1)),
                 new PartitionKey(testDoc1.PK),
                 GetRequestOptions(dekId, TestDoc.PathsToEncrypt));
 
@@ -1173,8 +1173,8 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom.EmulatorTests
             testDoc.NonSensitive = Guid.NewGuid().ToString();
             testDoc.Sensitive_StringFormat = Guid.NewGuid().ToString();
 
-            ItemResponse<EncryptableItemStream> upsertResponseStream = await encryptionContainer.UpsertItemAsync(
-                new EncryptableItemStream(TestCommon.ToStream(testDoc)),
+            ItemResponse<StreamEncryptableItem> upsertResponseStream = await encryptionContainer.UpsertItemAsync(
+                new StreamEncryptableItem(TestCommon.ToStream(testDoc)),
                 new PartitionKey(testDoc.PK),
                 GetRequestOptions(dekId, TestDoc.PathsToEncrypt));
 
@@ -1188,8 +1188,8 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom.EmulatorTests
             testDoc.NonSensitive = Guid.NewGuid().ToString();
             testDoc.Sensitive_StringFormat = Guid.NewGuid().ToString();
 
-            ItemResponse<EncryptableItemStream> replaceResponseStream = await encryptionContainer.ReplaceItemAsync(
-                new EncryptableItemStream(TestCommon.ToStream(testDoc)),
+            ItemResponse<StreamEncryptableItem> replaceResponseStream = await encryptionContainer.ReplaceItemAsync(
+                new StreamEncryptableItem(TestCommon.ToStream(testDoc)),
                 testDoc.Id,
                 new PartitionKey(testDoc.PK),
                 GetRequestOptions(dekId, TestDoc.PathsToEncrypt, upsertResponseStream.ETag));

--- a/Microsoft.Azure.Cosmos.Encryption.Custom/tests/Microsoft.Azure.Cosmos.Encryption.Custom.Tests/Contracts/DotNetSDKEncryptionCustomAPI.net6.json
+++ b/Microsoft.Azure.Cosmos.Encryption.Custom/tests/Microsoft.Azure.Cosmos.Encryption.Custom.Tests/Contracts/DotNetSDKEncryptionCustomAPI.net6.json
@@ -610,7 +610,7 @@
           },
           "NestedTypes": {}
         },
-        "Microsoft.Azure.Cosmos.Encryption.Custom.EncryptableItemStream;Microsoft.Azure.Cosmos.Encryption.Custom.EncryptableItem;IsAbstract:False;IsSealed:True;IsInterface:False;IsEnum:False;IsClass:True;IsValueType:False;IsNested:False;IsGenericType:False;IsSerializable:False": {
+        "Microsoft.Azure.Cosmos.Encryption.Custom.StreamEncryptableItem;Microsoft.Azure.Cosmos.Encryption.Custom.EncryptableItem;IsAbstract:False;IsSealed:True;IsInterface:False;IsEnum:False;IsClass:True;IsValueType:False;IsNested:False;IsGenericType:False;IsSerializable:False": {
           "Subclasses": {},
           "Members": {
             "Microsoft.Azure.Cosmos.Encryption.Custom.DecryptableItem DecryptableItem": {
@@ -692,44 +692,6 @@
           "Type": "Constructor",
           "Attributes": [],
           "MethodInfo": "Void .ctor(T)"
-        }
-      },
-      "NestedTypes": {}
-    },
-    "Microsoft.Azure.Cosmos.Encryption.Custom.EncryptableItemStream;Microsoft.Azure.Cosmos.Encryption.Custom.EncryptableItem;IsAbstract:False;IsSealed:True;IsInterface:False;IsEnum:False;IsClass:True;IsValueType:False;IsNested:False;IsGenericType:False;IsSerializable:False": {
-      "Subclasses": {},
-      "Members": {
-        "Microsoft.Azure.Cosmos.Encryption.Custom.DecryptableItem DecryptableItem": {
-          "Type": "Property",
-          "Attributes": [],
-          "MethodInfo": "Microsoft.Azure.Cosmos.Encryption.Custom.DecryptableItem DecryptableItem;CanRead:True;CanWrite:False;Microsoft.Azure.Cosmos.Encryption.Custom.DecryptableItem get_DecryptableItem();IsAbstract:False;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
-        },
-        "Microsoft.Azure.Cosmos.Encryption.Custom.DecryptableItem get_DecryptableItem()": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Microsoft.Azure.Cosmos.Encryption.Custom.DecryptableItem get_DecryptableItem();IsAbstract:False;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
-        },
-        "System.IO.Stream get_StreamPayload()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
-          "Type": "Method",
-          "Attributes": [
-            "CompilerGeneratedAttribute"
-          ],
-          "MethodInfo": "System.IO.Stream get_StreamPayload();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
-        },
-        "System.IO.Stream StreamPayload": {
-          "Type": "Property",
-          "Attributes": [],
-          "MethodInfo": "System.IO.Stream StreamPayload;CanRead:True;CanWrite:False;System.IO.Stream get_StreamPayload();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
-        },
-        "Void .ctor(System.IO.Stream)": {
-          "Type": "Constructor",
-          "Attributes": [],
-          "MethodInfo": "Void .ctor(System.IO.Stream)"
-        },
-        "Void Dispose()": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Void Dispose();IsAbstract:False;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:True;"
         }
       },
       "NestedTypes": {}
@@ -1136,6 +1098,44 @@
           "Type": "Method",
           "Attributes": [],
           "MethodInfo": "System.Threading.Tasks.Task`1[System.Byte[]] EncryptAsync(Byte[], System.String, System.String, System.Threading.CancellationToken);IsAbstract:True;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "Microsoft.Azure.Cosmos.Encryption.Custom.StreamEncryptableItem;Microsoft.Azure.Cosmos.Encryption.Custom.EncryptableItem;IsAbstract:False;IsSealed:True;IsInterface:False;IsEnum:False;IsClass:True;IsValueType:False;IsNested:False;IsGenericType:False;IsSerializable:False": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.Encryption.Custom.DecryptableItem DecryptableItem": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Encryption.Custom.DecryptableItem DecryptableItem;CanRead:True;CanWrite:False;Microsoft.Azure.Cosmos.Encryption.Custom.DecryptableItem get_DecryptableItem();IsAbstract:False;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "Microsoft.Azure.Cosmos.Encryption.Custom.DecryptableItem get_DecryptableItem()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Encryption.Custom.DecryptableItem get_DecryptableItem();IsAbstract:False;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "System.IO.Stream get_StreamPayload()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.IO.Stream get_StreamPayload();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "System.IO.Stream StreamPayload": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": "System.IO.Stream StreamPayload;CanRead:True;CanWrite:False;System.IO.Stream get_StreamPayload();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "Void .ctor(System.IO.Stream)": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(System.IO.Stream)"
+        },
+        "Void Dispose()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void Dispose();IsAbstract:False;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:True;"
         }
       },
       "NestedTypes": {}

--- a/Microsoft.Azure.Cosmos.Encryption.Custom/tests/Microsoft.Azure.Cosmos.Encryption.Custom.Tests/Contracts/DotNetSDKEncryptionCustomAPI.net8.json
+++ b/Microsoft.Azure.Cosmos.Encryption.Custom/tests/Microsoft.Azure.Cosmos.Encryption.Custom.Tests/Contracts/DotNetSDKEncryptionCustomAPI.net8.json
@@ -610,7 +610,7 @@
           },
           "NestedTypes": {}
         },
-        "Microsoft.Azure.Cosmos.Encryption.Custom.EncryptableItemStream;Microsoft.Azure.Cosmos.Encryption.Custom.EncryptableItem;IsAbstract:False;IsSealed:True;IsInterface:False;IsEnum:False;IsClass:True;IsValueType:False;IsNested:False;IsGenericType:False;IsSerializable:False": {
+        "Microsoft.Azure.Cosmos.Encryption.Custom.StreamEncryptableItem;Microsoft.Azure.Cosmos.Encryption.Custom.EncryptableItem;IsAbstract:False;IsSealed:True;IsInterface:False;IsEnum:False;IsClass:True;IsValueType:False;IsNested:False;IsGenericType:False;IsSerializable:False": {
           "Subclasses": {},
           "Members": {
             "Microsoft.Azure.Cosmos.Encryption.Custom.DecryptableItem DecryptableItem": {
@@ -692,44 +692,6 @@
           "Type": "Constructor",
           "Attributes": [],
           "MethodInfo": "Void .ctor(T)"
-        }
-      },
-      "NestedTypes": {}
-    },
-    "Microsoft.Azure.Cosmos.Encryption.Custom.EncryptableItemStream;Microsoft.Azure.Cosmos.Encryption.Custom.EncryptableItem;IsAbstract:False;IsSealed:True;IsInterface:False;IsEnum:False;IsClass:True;IsValueType:False;IsNested:False;IsGenericType:False;IsSerializable:False": {
-      "Subclasses": {},
-      "Members": {
-        "Microsoft.Azure.Cosmos.Encryption.Custom.DecryptableItem DecryptableItem": {
-          "Type": "Property",
-          "Attributes": [],
-          "MethodInfo": "Microsoft.Azure.Cosmos.Encryption.Custom.DecryptableItem DecryptableItem;CanRead:True;CanWrite:False;Microsoft.Azure.Cosmos.Encryption.Custom.DecryptableItem get_DecryptableItem();IsAbstract:False;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
-        },
-        "Microsoft.Azure.Cosmos.Encryption.Custom.DecryptableItem get_DecryptableItem()": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Microsoft.Azure.Cosmos.Encryption.Custom.DecryptableItem get_DecryptableItem();IsAbstract:False;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
-        },
-        "System.IO.Stream get_StreamPayload()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
-          "Type": "Method",
-          "Attributes": [
-            "CompilerGeneratedAttribute"
-          ],
-          "MethodInfo": "System.IO.Stream get_StreamPayload();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
-        },
-        "System.IO.Stream StreamPayload": {
-          "Type": "Property",
-          "Attributes": [],
-          "MethodInfo": "System.IO.Stream StreamPayload;CanRead:True;CanWrite:False;System.IO.Stream get_StreamPayload();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
-        },
-        "Void .ctor(System.IO.Stream)": {
-          "Type": "Constructor",
-          "Attributes": [],
-          "MethodInfo": "Void .ctor(System.IO.Stream)"
-        },
-        "Void Dispose()": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "Void Dispose();IsAbstract:False;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:True;"
         }
       },
       "NestedTypes": {}
@@ -1136,6 +1098,44 @@
           "Type": "Method",
           "Attributes": [],
           "MethodInfo": "System.Threading.Tasks.Task`1[System.Byte[]] EncryptAsync(Byte[], System.String, System.String, System.Threading.CancellationToken);IsAbstract:True;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "Microsoft.Azure.Cosmos.Encryption.Custom.StreamEncryptableItem;Microsoft.Azure.Cosmos.Encryption.Custom.EncryptableItem;IsAbstract:False;IsSealed:True;IsInterface:False;IsEnum:False;IsClass:True;IsValueType:False;IsNested:False;IsGenericType:False;IsSerializable:False": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.Encryption.Custom.DecryptableItem DecryptableItem": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Encryption.Custom.DecryptableItem DecryptableItem;CanRead:True;CanWrite:False;Microsoft.Azure.Cosmos.Encryption.Custom.DecryptableItem get_DecryptableItem();IsAbstract:False;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "Microsoft.Azure.Cosmos.Encryption.Custom.DecryptableItem get_DecryptableItem()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Encryption.Custom.DecryptableItem get_DecryptableItem();IsAbstract:False;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "System.IO.Stream get_StreamPayload()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.IO.Stream get_StreamPayload();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "System.IO.Stream StreamPayload": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": "System.IO.Stream StreamPayload;CanRead:True;CanWrite:False;System.IO.Stream get_StreamPayload();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "Void .ctor(System.IO.Stream)": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(System.IO.Stream)"
+        },
+        "Void Dispose()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void Dispose();IsAbstract:False;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:True;"
         }
       },
       "NestedTypes": {}

--- a/Microsoft.Azure.Cosmos.Encryption.Custom/tests/Microsoft.Azure.Cosmos.Encryption.Custom.Tests/StreamEncryptableItemTests.cs
+++ b/Microsoft.Azure.Cosmos.Encryption.Custom/tests/Microsoft.Azure.Cosmos.Encryption.Custom.Tests/StreamEncryptableItemTests.cs
@@ -1,0 +1,140 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Encryption.Tests
+{
+    using System;
+    using System.IO;
+    using Microsoft.Azure.Cosmos;
+    using Microsoft.Azure.Cosmos.Encryption.Custom;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+    using Moq.Protected;
+    using Newtonsoft.Json.Linq;
+
+    [TestClass]
+    public class StreamEncryptableItemTests
+    {
+        [TestMethod]
+        public void Ctor_WithNullStream_ThrowsArgumentNullException()
+        {
+            ArgumentNullException exception = Assert.ThrowsException<ArgumentNullException>(() => new StreamEncryptableItem(null));
+            Assert.AreEqual("input", exception.ParamName);
+        }
+
+        [TestMethod]
+        public void StreamPayload_ReturnsOriginalStream()
+        {
+            using MemoryStream payload = new();
+            StreamEncryptableItem item = new(payload);
+
+            Assert.AreSame(payload, item.StreamPayload);
+        }
+
+        [TestMethod]
+        public void DecryptableItem_AccessBeforeInitialization_ThrowsInvalidOperationException()
+        {
+            StreamEncryptableItem item = new(new MemoryStream());
+
+            InvalidOperationException exception = Assert.ThrowsException<InvalidOperationException>(() => _ = item.DecryptableItem);
+            Assert.AreEqual("Decryptable content is not initialized.", exception.Message);
+        }
+
+        [TestMethod]
+        public void SetDecryptableItem_WhenDecryptableContentIsNull_ThrowsArgumentNullException()
+        {
+            StreamEncryptableItem item = new(new MemoryStream());
+            Mock<Encryptor> encryptorMock = new(MockBehavior.Loose);
+            CosmosSerializer serializer = CreateSerializerStub();
+
+            ArgumentNullException exception = Assert.ThrowsException<ArgumentNullException>(() => item.SetDecryptableItem(null, encryptorMock.Object, serializer));
+            Assert.AreEqual("decryptableContent", exception.ParamName);
+        }
+
+        [TestMethod]
+        public void SetDecryptableItem_WhenEncryptorIsNull_ThrowsArgumentNullException()
+        {
+            StreamEncryptableItem item = new(new MemoryStream());
+            CosmosSerializer serializer = CreateSerializerStub();
+            JToken content = new JObject();
+
+            ArgumentNullException exception = Assert.ThrowsException<ArgumentNullException>(() => item.SetDecryptableItem(content, null, serializer));
+            Assert.AreEqual("encryptor", exception.ParamName);
+        }
+
+        [TestMethod]
+        public void SetDecryptableItem_WhenSerializerIsNull_ThrowsArgumentNullException()
+        {
+            StreamEncryptableItem item = new(new MemoryStream());
+            Mock<Encryptor> encryptorMock = new(MockBehavior.Loose);
+            JToken content = new JObject();
+
+            ArgumentNullException exception = Assert.ThrowsException<ArgumentNullException>(() => item.SetDecryptableItem(content, encryptorMock.Object, null));
+            Assert.AreEqual("cosmosSerializer", exception.ParamName);
+        }
+
+        [TestMethod]
+        public void SetDecryptableItem_WhenCalledTwice_ThrowsInvalidOperationException()
+        {
+            StreamEncryptableItem item = new(new MemoryStream());
+            Mock<Encryptor> encryptorMock = new(MockBehavior.Loose);
+            CosmosSerializer serializer = CreateSerializerStub();
+            JToken content = new JObject();
+
+            item.SetDecryptableItem(content, encryptorMock.Object, serializer);
+
+            InvalidOperationException exception = Assert.ThrowsException<InvalidOperationException>(() => item.SetDecryptableItem(new JObject(), encryptorMock.Object, serializer));
+            Assert.AreEqual("Decryptable content is already initialized.", exception.Message);
+        }
+
+        [TestMethod]
+        public void SetDecryptableItem_WithValidInputs_InitializesDecryptableItem()
+        {
+            StreamEncryptableItem item = new(new MemoryStream());
+            Mock<Encryptor> encryptorMock = new(MockBehavior.Loose);
+            CosmosSerializer serializer = CreateSerializerStub();
+            JToken content = new JObject();
+
+            item.SetDecryptableItem(content, encryptorMock.Object, serializer);
+
+            DecryptableItem decryptableItem = item.DecryptableItem;
+            Assert.IsNotNull(decryptableItem);
+            Assert.IsInstanceOfType(decryptableItem, typeof(DecryptableItemCore));
+        }
+
+        [TestMethod]
+        public void ToStream_ReturnsUnderlyingStream()
+        {
+            using MemoryStream payload = new();
+            StreamEncryptableItem item = new(payload);
+            CosmosSerializer serializer = CreateSerializerStub();
+
+            Stream result = item.ToStream(serializer);
+
+            Assert.AreSame(payload, result);
+        }
+
+        [TestMethod]
+        public void Dispose_DisposesUnderlyingStream()
+        {
+            bool disposed = false;
+            Mock<Stream> payloadMock = new(MockBehavior.Loose);
+            payloadMock.Protected()
+                .Setup("Dispose", ItExpr.IsAny<bool>())
+                .Callback((bool _) => disposed = true);
+
+            StreamEncryptableItem item = new(payloadMock.Object);
+
+            item.Dispose();
+
+            Assert.IsTrue(disposed);
+            payloadMock.Protected().Verify("Dispose", Times.Once(), ItExpr.IsAny<bool>());
+        }
+
+        private static CosmosSerializer CreateSerializerStub()
+        {
+            return new Mock<CosmosSerializer>(MockBehavior.Strict).Object;
+        }
+    }
+}


### PR DESCRIPTION
# Pull Request Template

## Description

Renames `EncryptableItemStream` to `StreamEncryptableItem` to align with the naming convention, emphasizing that it is an encryptable item based on a stream.

## Type of change

- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)