### PR TITLE
[Internal] Testing: Refactors `AvailabilityStrategyNoTriggerTest` values to make test more reliable 

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosAvailabilityStrategyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosAvailabilityStrategyTests.cs
@@ -214,7 +214,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                         .Build(),
                 result:
                     FaultInjectionResultBuilder.GetResultBuilder(FaultInjectionServerErrorType.ResponseDelay)
-                        .WithDelay(TimeSpan.FromMilliseconds(300))
+                        .WithDelay(TimeSpan.FromMilliseconds(200))
                         .Build())
                 .WithDuration(TimeSpan.FromMinutes(90))
                 .Build();
@@ -228,7 +228,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                         .Build(),
                 result:
                     FaultInjectionResultBuilder.GetResultBuilder(FaultInjectionServerErrorType.ResponseDelay)
-                        .WithDelay(TimeSpan.FromMilliseconds(3000))
+                        .WithDelay(TimeSpan.FromMilliseconds(5000))
                         .Build())
                 .WithDuration(TimeSpan.FromMinutes(90))
                 .Build();


### PR DESCRIPTION
Changed values to make test more reliable

# Pull Request Template

## Description

This pull request makes minor adjustments to the test parameters in the `CosmosAvailabilityStrategyTests.cs` file to fine-tune the timing and thresholds used in the `AvailabilityStrategyNoTriggerTest`. These changes help to better calibrate the test scenarios for response delays and hedging thresholds.

Timing and threshold adjustments:

* Reduced the response delay from 300ms to 200ms in one fault injection scenario to make the test more responsive.
* Increased the response delay from 3000ms to 5000ms in another fault injection scenario for broader delay coverage.
* Lowered the cross-region hedging threshold from 300ms to 150ms to trigger hedging sooner in the test.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #IssueNumber