### PR TITLE
[Internal] Tests: Adds clean-up method to ensure created databases are deleted

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CFP/AllVersionsAndDeletes/BuilderWithCustomSerializerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CFP/AllVersionsAndDeletes/BuilderWithCustomSerializerTests.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.CFP.AllVersionsAndDeletes
     [TestCategory("ChangeFeedProcessor")]
     public class BuilderWithCustomSerializerTests
     {
-        internal CosmosClient client;
+        internal CosmosClient cosmosClient;
         internal Database database;
 
         [TestCleanup]
@@ -41,10 +41,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.CFP.AllVersionsAndDeletes
             {
                 // Ignore exceptions during cleanup
             }
-            finally
-            {
-                this.client?.Dispose();
-            }
+            
+            this.cosmosClient?.Dispose();
         }
 
             [TestMethod]
@@ -817,11 +815,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.CFP.AllVersionsAndDeletes
                 }
             };
 
-            CosmosClient cosmosClient = isMultiMaster 
+            this.cosmosClient = isMultiMaster 
                         ? new CosmosClient(accountEndpoint, options) 
                         : new CosmosClient(defaultEndpoint, authKey, options);
     
-            this.database = await cosmosClient.CreateDatabaseIfNotExistsAsync(id: Guid.NewGuid().ToString());
+            this.database = await this.cosmosClient.CreateDatabaseIfNotExistsAsync(id: Guid.NewGuid().ToString());
             Container leaseContainer = await this.database.CreateContainerIfNotExistsAsync(containerProperties: new ContainerProperties(id: "leases", partitionKeyPath: "/id"));
             ContainerInternal monitoredContainer = await this.CreateMonitoredContainer(ChangeFeedMode.AllVersionsAndDeletes, this.database);
             ManualResetEvent allDocsProcessed = new ManualResetEvent(false);
@@ -946,8 +944,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.CFP.AllVersionsAndDeletes
             {
                 await  this.database.DeleteAsync();
             }
-
-            cosmosClient?.Dispose();
         }
 
         private static async Task RevertLeaseDocumentsToLegacyWithNoMode(


### PR DESCRIPTION
# Pull Request Template

## Description


This pull request ensures that created databases to the live account are deleted. On our multimaster test account there are many redundant databases that have not been cleaned up that can be traced back to this test. This change ensures that the databases created for this test are deleted after the test is complete. This should help save on costs.

Resource management improvements:

* Added `client` and `database` as internal instance variables to the test class, allowing for consistent access and disposal throughout the test lifecycle.
* Implemented a `[TestCleanup]` method that deletes the test database (if it exists) and disposes of the Cosmos client, handling exceptions gracefully to avoid test failures due to cleanup issues.

Test code consistency:

* Updated test methods to assign the created database to `this.database` and to use the instance variable instead of local variables, ensuring that the cleanup method can properly dispose of resources. [[1]](diffhunk://#diff-5b8e740df9df73b4ff1179be9cf42b611977cfa5de6f5f7824abb82fb9a7770fL801-R826) [[2]](diffhunk://#diff-5b8e740df9df73b4ff1179be9cf42b611977cfa5de6f5f7824abb82fb9a7770fL922-R947)

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #IssueNumber