### PR TITLE
[Query] Fixes EPK performance by providing partial partition key in the request

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Handler/RequestMessage.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/RequestMessage.cs
@@ -397,7 +397,7 @@ namespace Microsoft.Azure.Cosmos
                 }
             }
 
-            if (pkExists && partitionKeyRangeIdExists)
+            if (pkExists && partitionKeyRangeIdExists && this.OperationType != OperationType.Query)
             {
                 throw new ArgumentOutOfRangeException(RMResources.PartitionKeyAndPartitionKeyRangeRangeIdBothSpecified);
             }

--- a/Microsoft.Azure.Cosmos/src/RequestOptions/QueryRequestOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/RequestOptions/QueryRequestOptions.cs
@@ -279,11 +279,21 @@ namespace Microsoft.Azure.Cosmos
                 request.Headers.Add(HttpConstants.HttpHeaders.ResponseContinuationTokenLimitInKB, this.ResponseContinuationTokenLimitInKb.ToString());
             }
 
-            // All query APIs (GetItemQueryIterator, GetItemLinqQueryable and GetItemQueryStreamIterator) turn into ReadFeed operation if query text is null.
-            // In such a case, query pipelines are still involved (including QueryRequestOptions). In general backend only honors SupportedSerializationFormats
-            //  for OperationType Query but has a bug where it returns a binary response for ReadFeed API when partition key is also specified in the request.
             if (request.OperationType == OperationType.Query)
             {
+                // If a partition key is provided, set the logical partition key header for proper routing
+                // This is used for both full and partial (prefix) partition keys in hierarchical partitioning
+                // Only set the header if it hasn't been set already to avoid clobbering existing values
+                if (this.PartitionKey.HasValue &&
+                    !this.PartitionKey.Value.IsNone &&
+                    string.IsNullOrEmpty(request.Headers.CosmosMessageHeaders.PartitionKey))
+                {
+                    request.Headers.Add(HttpConstants.HttpHeaders.PartitionKey, this.PartitionKey.Value.InternalKey.ToJsonString());
+                }
+
+                // All query APIs (GetItemQueryIterator, GetItemLinqQueryable and GetItemQueryStreamIterator) turn into ReadFeed operation if query text is null.
+                // In such a case, query pipelines are still involved (including QueryRequestOptions). In general backend only honors SupportedSerializationFormats
+                //  for OperationType Query but has a bug where it returns a binary response for ReadFeed API when partition key is also specified in the request.
                 request.Headers.CosmosMessageHeaders.SupportedSerializationFormats = this.SupportedSerializationFormats?.ToString() ?? DocumentQueryExecutionContextBase.DefaultSupportedSerializationFormats;
             }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/QueryPartitionKeyTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/QueryPartitionKeyTest.cs
@@ -1,0 +1,437 @@
+namespace Microsoft.Azure.Cosmos.EmulatorTests.Query
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos;
+    using Microsoft.Azure.Cosmos.CosmosElements;
+    using Microsoft.Azure.Documents;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class QueryPartitionKeyTest : QueryTestsBase
+    {
+        private static readonly List<string> SampleDocuments = new List<string>
+        {
+            @"{""id"":""id0"",""operation"":""create"",""duration"":45,""tenant"":""tenant0"",""user"":""user0"",""session"":""session0""}",
+            @"{""id"":""id1"",""operation"":""update"",""duration"":23,""tenant"":""tenant0"",""user"":""user0"",""session"":""session1""}",
+            @"{""id"":""id2"",""operation"":""delete"",""duration"":67,""tenant"":""tenant0"",""user"":""user1"",""session"":""session0""}",
+            @"{""id"":""id3"",""operation"":""create"",""duration"":89,""tenant"":""tenant0"",""user"":""user1"",""session"":""session1""}",
+            @"{""id"":""id4"",""operation"":""update"",""duration"":12,""tenant"":""tenant1"",""user"":""user0"",""session"":""session0""}",
+            @"{""id"":""id5"",""operation"":""delete"",""duration"":56,""tenant"":""tenant1"",""user"":""user0"",""session"":""session1""}",
+            @"{""id"":""id6"",""operation"":""create"",""duration"":34,""tenant"":""tenant1"",""user"":""user1"",""session"":""session0""}",
+            @"{""id"":""id7"",""operation"":""update"",""duration"":78,""tenant"":""tenant1"",""user"":""user1"",""session"":""session1""}",
+            @"{""id"":""id8"",""operation"":""delete"",""duration"":91,""tenant"":""tenant2"",""user"":""user0"",""session"":""session0""}",
+            @"{""id"":""id9"",""operation"":""create"",""duration"":5,""tenant"":""tenant2"",""user"":""user1"",""session"":""session1""}",
+            @"{""id"":""id10"",""operation"":""update"",""duration"":42,""tenant"":""tenant0"",""user"":""user0"",""session"":""session2""}",
+            @"{""id"":""id11"",""operation"":""delete"",""duration"":73,""tenant"":""tenant1"",""user"":""user2"",""session"":""session0""}",
+            @"{""id"":""id12"",""operation"":""create"",""duration"":28,""tenant"":""tenant2"",""user"":""user0"",""session"":""session1""}",
+            @"{""id"":""id13"",""operation"":""update"",""duration"":61,""tenant"":""tenant0"",""user"":""user2"",""session"":""session2""}",
+            @"{""id"":""id14"",""operation"":""delete"",""duration"":15,""tenant"":""tenant1"",""user"":""user1"",""session"":""session2""}",
+        };
+
+        private static PartitionKeyDefinition HierarchicalPartitionKeyDefinition =>
+            new PartitionKeyDefinition
+            {
+                Paths = new Collection<string> { "/tenant", "/user", "/session" },
+                Kind = PartitionKind.MultiHash,
+                Version = Documents.PartitionKeyDefinitionVersion.V2
+            };
+
+        private static PartitionKeyDefinition SinglePartitionKeyDefinition =>
+            new PartitionKeyDefinition
+            {
+                Paths = new Collection<string> { "/tenant" },
+                Kind = PartitionKind.Hash,
+                Version = Documents.PartitionKeyDefinitionVersion.V2
+            };
+
+        [TestMethod]
+        public async Task TestSinglePartitionKeyContainer_Direct_SinglePartition()
+        {
+            await this.ExecuteTest(
+                SinglePartitionKeyDefinition,
+                ConnectionModes.Direct,
+                CollectionTypes.SinglePartition);
+        }
+
+        [TestMethod]
+        public async Task TestSinglePartitionKeyContainer_Gateway_SinglePartition()
+        {
+            await this.ExecuteTest(
+                SinglePartitionKeyDefinition,
+                ConnectionModes.Gateway,
+                CollectionTypes.SinglePartition);
+        }
+
+        [TestMethod]
+        public async Task TestSinglePartitionKeyContainer_Direct_MultiPartition()
+        {
+            await this.ExecuteTest(
+                SinglePartitionKeyDefinition,
+                ConnectionModes.Direct,
+                CollectionTypes.MultiPartition);
+        }
+
+        [TestMethod]
+        public async Task TestSinglePartitionKeyContainer_Gateway_MultiPartition()
+        {
+            await this.ExecuteTest(
+                SinglePartitionKeyDefinition,
+                ConnectionModes.Gateway,
+                CollectionTypes.MultiPartition);
+        }
+
+        [TestMethod]
+        public async Task TestHierarchicalPartitionKeyContainer_Direct_SinglePartition()
+        {
+            await this.ExecuteTest(
+                HierarchicalPartitionKeyDefinition,
+                ConnectionModes.Direct,
+                CollectionTypes.SinglePartition);
+        }
+
+        [TestMethod]
+        public async Task TestHierarchicalPartitionKeyContainer_Gateway_SinglePartition()
+        {
+            await this.ExecuteTest(
+                HierarchicalPartitionKeyDefinition,
+                ConnectionModes.Gateway,
+                CollectionTypes.SinglePartition);
+        }
+
+        [TestMethod]
+        public async Task TestHierarchicalPartitionKeyContainer_Direct_MultiPartition()
+        {
+            await this.ExecuteTest(
+                HierarchicalPartitionKeyDefinition,
+                ConnectionModes.Direct,
+                CollectionTypes.MultiPartition);
+        }
+
+        [TestMethod]
+        public async Task TestHierarchicalPartitionKeyContainer_Gateway_MultiPartition()
+        {
+            await this.ExecuteTest(
+                HierarchicalPartitionKeyDefinition,
+                ConnectionModes.Gateway,
+                CollectionTypes.MultiPartition);
+        }
+
+        private async Task ExecuteTest(PartitionKeyDefinition partitionKeyDefinition, ConnectionModes connectionMode, CollectionTypes collectionType)
+        {
+            await this.CreateIngestQueryDeleteAsync(
+                connectionMode,
+                collectionType,
+                SampleDocuments,
+                (container, documents) => this.ExecuteAllQueries(container, partitionKeyDefinition, documents),
+                partitionKeyDefinition,
+                IndexingPolicy);
+        }
+
+        private static Cosmos.IndexingPolicy IndexingPolicy =>
+            new Cosmos.IndexingPolicy
+            {
+                Automatic = true,
+                IndexingMode = Cosmos.IndexingMode.Consistent,
+                IncludedPaths = new Collection<Cosmos.IncludedPath>
+                {
+                    new Cosmos.IncludedPath
+                    {
+                        Path = "/*"
+                    }
+                }
+            };
+
+        private async Task ExecuteAllQueries(
+            Container container,
+            PartitionKeyDefinition partitionKeyDefinition,
+            IReadOnlyList<CosmosElements.CosmosObject> documents)
+        {
+            Console.WriteLine("\n=== Executing All Query Tests with Partition Keys ===\n");
+
+            // Queries must project full partition key values from the documents hit by the query.
+            // The projected pk values are used to validate that only documents with the specified partition key are returned.
+            List<string> queries = new List<string>
+            {
+                @"
+                SELECT *
+                FROM c",
+
+                @"
+                SELECT *
+                FROM c
+                WHERE STARTSWITH(c.tenant, 'tenant')",
+
+                @"
+                SELECT *
+                FROM c
+                WHERE c.operation = 'create' OR c.operation = 'delete'",
+
+                @"
+                SELECT
+                    COUNT(1) count,
+                    c.tenant,
+                    c.session,
+                    c.user
+                FROM c
+                GROUP BY c.tenant, c.session, c.user",
+
+                @"
+                SELECT *
+                FROM c
+                ORDER BY c.tenant",
+
+                @"
+                SELECT
+                    min(c.duration) AS minDuration,
+                    max(c.duration) AS maxDuration,
+                    sum(c.duration) AS sumDuration,
+                    c.tenant,
+                    c.session,
+                    c.user
+                FROM c
+                GROUP BY c.tenant, c.session, c.user
+                ORDER BY c.tenant"
+            };
+
+            // Step 1: Get distinct partition key values
+            Console.WriteLine("Step 1: Extracting distinct partition key values from documents...");
+            List<string[]> distinctPkValues = GetDistinctPartitionKeyValues(documents, partitionKeyDefinition);
+            Console.WriteLine($"Found {distinctPkValues.Count} distinct partition key value combinations\n");
+
+            // Step 2: For each distinct partition key value, execute all queries
+            for (int i = 0; i < distinctPkValues.Count; i++)
+            {
+                string[] pkValues = distinctPkValues[i];
+
+                Console.WriteLine($"\n====== Executing queries with Partition Key #{i + 1} ======");
+                Console.WriteLine($"Partition Key Values: [{string.Join(", ", pkValues)}]");
+                Console.WriteLine($"Partition Key Length: {pkValues.Length}");
+
+                // Build the partition key
+                Cosmos.PartitionKey partitionKey = BuildPartitionKey(pkValues);
+                Console.WriteLine($"PartitionKey: {partitionKey.ToJsonString()}\n");
+
+                for (int k = 0; k < queries.Count; k++)
+                {
+                    string query = queries[k];
+                    Console.WriteLine("------------");
+                    Console.WriteLine($"Query {k + 1}:{query}\n");
+
+                    QueryRequestOptions queryRequestOptions = new QueryRequestOptions
+                    {
+                        PartitionKey = partitionKey
+                    };
+
+                    FeedIterator<CosmosElement> iterator = container.GetItemQueryIterator<CosmosElement>(
+                        new QueryDefinition(query),
+                        requestOptions: queryRequestOptions);
+
+                    List<CosmosElement> results = new List<CosmosElement>();
+                    while (iterator.HasMoreResults)
+                    {
+                        FeedResponse<CosmosElement> response = await iterator.ReadNextAsync();
+                        results.AddRange(response);
+                    }
+
+                    Console.WriteLine($"Results: {results.Count} documents:");
+                    foreach (CosmosElement result in results)
+                    {
+                        Console.WriteLine($"    {result}");
+                    }
+
+                    // Validate partition key matches
+                    this.ValidateResultsMatchPartitionKey(results, pkValues, partitionKeyDefinition);
+                    Console.WriteLine("------------\n");
+                }
+            }
+
+            Console.WriteLine("\n=== All Queries Completed ===\n");
+        }
+
+        private static List<string[]> GetDistinctPartitionKeyValues(
+            IReadOnlyList<CosmosElements.CosmosObject> documents,
+            PartitionKeyDefinition partitionKeyDefinition)
+        {
+            HashSet<string> distinctValuesSet = new HashSet<string>();
+            List<string[]> distinctValuesList = new List<string[]>();
+            int pathCount = partitionKeyDefinition.Paths.Count;
+
+            foreach (CosmosObject document in documents)
+            {
+                string[] pkValues = ExtractPartitionKeyValues(document, partitionKeyDefinition);
+
+                if (pathCount == 1)
+                {
+                    // Single partition key: add the single value
+                    string key = string.Join("|", pkValues.Select(v => v ?? "<<null>>"));
+                    if (distinctValuesSet.Add(key))
+                    {
+                        distinctValuesList.Add(pkValues);
+                    }
+                }
+                else
+                {
+                    // Hierarchical partition key: generate all prefixes (1, 2, and 3 elements)
+                    for (int prefixLength = 1; prefixLength <= pathCount; prefixLength++)
+                    {
+                        string[] prefixValues = pkValues.Take(prefixLength).ToArray();
+                        string key = string.Join("|", prefixValues.Select(v => v ?? "<<null>>"));
+                        
+                        if (distinctValuesSet.Add(key))
+                        {
+                            distinctValuesList.Add(prefixValues);
+                        }
+                    }
+                }
+            }
+
+            return distinctValuesList;
+        }
+
+        private static Cosmos.PartitionKey BuildPartitionKey(string[] values)
+        {
+            if (values == null || values.Length == 0)
+            {
+                throw new ArgumentException("Values array must have at least one element", nameof(values));
+            }
+
+            if (values.Length > 3)
+            {
+                throw new ArgumentException("Values array cannot have more than 3 elements", nameof(values));
+            }
+
+            // Build the partition key from the values
+            PartitionKeyBuilder pkBuilder = new PartitionKeyBuilder();
+            
+            foreach (string value in values)
+            {
+                if (value == null)
+                {
+                    pkBuilder.AddNullValue();
+                }
+                else
+                {
+                    pkBuilder.Add(value);
+                }
+            }
+
+            return pkBuilder.Build();
+        }
+
+        private void ValidateResultsMatchPartitionKey(
+            List<CosmosElement> results,
+            string[] expectedPkValues,
+            PartitionKeyDefinition partitionKeyDefinition)
+        {
+            int validCount = 0;
+            int invalidCount = 0;
+
+            foreach (CosmosElement result in results)
+            {
+                if (result is CosmosObject cosmosObject)
+                {
+                    // Extract partition key values from the result
+                    string[] actualPkValues = ExtractPartitionKeyValues(cosmosObject, partitionKeyDefinition);
+
+                    if (actualPkValues != null)
+                    {
+                        // Check if the actual partition key values match the expected prefix
+                        bool matches = DoPartitionKeyValuesMatch(expectedPkValues, actualPkValues);
+
+                        if (matches)
+                        {
+                            validCount++;
+                        }
+                        else
+                        {
+                            invalidCount++;
+                            Console.WriteLine($"    WARNING: Document with PK values [{string.Join(", ", actualPkValues)}] does not match expected prefix [{string.Join(", ", expectedPkValues)}]");
+                        }
+                    }
+                }
+            }
+
+            Console.WriteLine($"\nValidation: {validCount} documents match partition key, {invalidCount} documents do not match");
+            
+            if (invalidCount > 0)
+            {
+                Assert.Fail($"Found {invalidCount} documents that do not match the specified partition key");
+            }
+        }
+
+        private static bool DoPartitionKeyValuesMatch(string[] expectedPkValues, string[] actualPkValues)
+        {
+            // The expected PK values can be a prefix of the actual PK values
+            // For example, if expected is ["tenant0"], it matches actual ["tenant0", "user0", "session0"]
+            // If expected is ["tenant0", "user0"], it matches actual ["tenant0", "user0", "session0"]
+            // If expected is ["tenant0", "user0", "session0"], it must match exactly
+
+            if (expectedPkValues.Length > actualPkValues.Length)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < expectedPkValues.Length; i++)
+            {
+                string expectedValue = expectedPkValues[i];
+                string actualValue = actualPkValues[i];
+
+                // Handle null comparison
+                if (expectedValue == null && actualValue == null)
+                {
+                    continue;
+                }
+
+                if (expectedValue == null || actualValue == null)
+                {
+                    return false;
+                }
+
+                if (!string.Equals(expectedValue, actualValue, StringComparison.Ordinal))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static string[] ExtractPartitionKeyValues(CosmosObject cosmosObject, PartitionKeyDefinition partitionKeyDefinition)
+        {
+            string[] values = new string[partitionKeyDefinition.Paths.Count];
+
+            for (int i = 0; i < partitionKeyDefinition.Paths.Count; i++)
+            {
+                string path = partitionKeyDefinition.Paths[i];
+                string propertyName = path.TrimStart('/');
+
+                if (cosmosObject.TryGetValue(propertyName, out CosmosElement element))
+                {
+                    if (element is CosmosString cosmosString)
+                    {
+                        values[i] = cosmosString.Value;
+                    }
+                    else if (element is CosmosNull)
+                    {
+                        values[i] = null;
+                    }
+                    else
+                    {
+                        // For other types, convert to string representation
+                        values[i] = element.ToString();
+                    }
+                }
+                else
+                {
+                    values[i] = null;
+                }
+            }
+
+            return values;
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosQueryRequestOptionsUniTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosQueryRequestOptionsUniTests.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Azure.Cosmos
     using System;
     using System.Collections.Generic;
     using System.Text;
+    using Microsoft.Azure.Documents;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     [TestClass]
@@ -22,5 +23,132 @@ namespace Microsoft.Azure.Cosmos
 
             Assert.IsNull(testMessage.Headers.ContinuationToken);
         }
+
+        [TestMethod]
+        public void PartitionKeyHeaderTest()
+        {
+            // Test with single partition key
+            QueryRequestOptions requestOption = new QueryRequestOptions
+            {
+                PartitionKey = new PartitionKeyBuilder().Add("value1").Build()
+            };
+
+            RequestMessage testMessage = CreateRequestMessage();
+            requestOption.PopulateRequestOptions(testMessage);
+
+            Assert.IsNotNull(testMessage.Headers.PartitionKey);
+            Assert.AreEqual("[\"value1\"]", testMessage.Headers.PartitionKey);
+
+            testMessage = CreateRequestMessage(readFeed: true);
+            requestOption.PopulateRequestOptions(testMessage);
+
+            Assert.IsNull(testMessage.Headers.PartitionKey);
+        }
+
+        [TestMethod]
+        public void PartialPartitionKeyHeaderTest()
+        {
+            // Test with partial partition key (1 out of 3 in hierarchical partition key)
+            QueryRequestOptions requestOption = new QueryRequestOptions
+            {
+                PartitionKey = new PartitionKeyBuilder().Add("tenant1").Build()
+            };
+
+            RequestMessage testMessage = CreateRequestMessage();
+            requestOption.PopulateRequestOptions(testMessage);
+
+            Assert.IsNotNull(testMessage.Headers.PartitionKey);
+            Assert.AreEqual("[\"tenant1\"]", testMessage.Headers.PartitionKey);
+        }
+
+        [TestMethod]
+        public void PartialPartitionKeyHeaderTest_TwoComponents()
+        {
+            // Test with partial partition key (2 out of 3 in hierarchical partition key)
+            QueryRequestOptions requestOption = new QueryRequestOptions
+            {
+                PartitionKey = new PartitionKeyBuilder().Add("tenant1").Add("user1").Build()
+            };
+
+            RequestMessage testMessage = CreateRequestMessage();
+            requestOption.PopulateRequestOptions(testMessage);
+
+            Assert.IsNotNull(testMessage.Headers.PartitionKey);
+            Assert.AreEqual("[\"tenant1\",\"user1\"]", testMessage.Headers.PartitionKey);
+        }
+
+        [TestMethod]
+        public void FullPartitionKeyHeaderTest()
+        {
+            // Test with full partition key (all 3 components in hierarchical partition key)
+            QueryRequestOptions requestOption = new QueryRequestOptions
+            {
+                PartitionKey = new PartitionKeyBuilder().Add("tenant1").Add("user1").Add("session1").Build()
+            };
+
+            RequestMessage testMessage = CreateRequestMessage();
+            requestOption.PopulateRequestOptions(testMessage);
+
+            Assert.IsNotNull(testMessage.Headers.PartitionKey);
+            Assert.AreEqual("[\"tenant1\",\"user1\",\"session1\"]", testMessage.Headers.PartitionKey);
+        }
+
+        [TestMethod]
+        public void NoPartitionKeyHeaderTest()
+        {
+            // Test without partition key
+            QueryRequestOptions requestOption = new QueryRequestOptions();
+
+            RequestMessage testMessage = CreateRequestMessage();
+            requestOption.PopulateRequestOptions(testMessage);
+
+            Assert.IsNull(testMessage.Headers.PartitionKey);
+        }
+
+        [TestMethod]
+        public void NonePartitionKeyHeaderTest()
+        {
+            // Test with PartitionKey.None
+            QueryRequestOptions requestOption = new QueryRequestOptions
+            {
+                PartitionKey = PartitionKey.None
+            };
+
+            RequestMessage testMessage = CreateRequestMessage();
+            requestOption.PopulateRequestOptions(testMessage);
+
+            Assert.IsNull(testMessage.Headers.PartitionKey);
+        }
+
+        [TestMethod]
+        public void PartitionKeyHeaderNotClobberedTest()
+        {
+            // Test that if the header is already present, PopulateRequestOptions doesn't clobber it
+            string existingHeaderValue = "[\"existingValue\"]";
+            
+            RequestMessage testMessage = CreateRequestMessage();
+            
+            // Pre-populate the header
+            testMessage.Headers.PartitionKey = existingHeaderValue;
+            
+            QueryRequestOptions requestOption = new QueryRequestOptions
+            {
+                PartitionKey = new PartitionKeyBuilder().Add("newValue").Build()
+            };
+            
+            requestOption.PopulateRequestOptions(testMessage);
+
+            // Verify that the existing header was NOT clobbered - it should remain unchanged
+            Assert.IsNotNull(testMessage.Headers.PartitionKey);
+            Assert.AreEqual(existingHeaderValue, testMessage.Headers.PartitionKey, 
+                "PopulateRequestOptions should not clobber an existing PartitionKey header");
+        }
+
+        private static RequestMessage CreateRequestMessage(bool readFeed = false) => 
+            new RequestMessage
+            {
+                ResourceType = ResourceType.Document,
+                OperationType = readFeed? OperationType.ReadFeed : OperationType.Query
+            };
     }
 }


### PR DESCRIPTION
# [Query] Fixes EPK performance by providing partial partition key in the request

## Description

The change provides partition key in the request header even when EPK routing is used. EPK routing is generally used when partial partition key is used for querying hierarchically partitioned container. As a result of this change, we could have query request having all 3 headers:
- Partition Key Range Id
- StartEPK, EndEPK
- Partition Key (logical partition key, partial or full)

The change only applies for query operations.

This allows backend to push the partition key (even when it's partial) to the index. This provides significant gains for containers where EPK indexing is not enabled (which applies to most containers).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #IssueNumber