### PR TITLE
ChangeFeed: Add health monitor notifications to PartitionLoadBalancerCore

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedProcessorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedProcessorCore.cs
@@ -146,7 +146,8 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
                 partitionController,
                 this.documentServiceLeaseStoreManager.LeaseContainer,
                 loadBalancingStrategy,
-                this.changeFeedLeaseOptions.LeaseAcquireInterval);
+                this.changeFeedLeaseOptions.LeaseAcquireInterval,
+                this.changeFeedProcessorOptions.HealthMonitor);
             return new PartitionManagerCore(bootstrapper, partitionController, partitionLoadBalancer);
         }
     }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/PartitionLoadBalancerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/PartitionLoadBalancerTests.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
     {
         private readonly DocumentServiceLeaseContainer leaseContainer = Mock.Of<DocumentServiceLeaseContainer>();
         private readonly LoadBalancingStrategy strategy = Mock.Of<LoadBalancingStrategy>();
+        private readonly ChangeFeedProcessorHealthMonitor monitor = Mock.Of<ChangeFeedProcessorHealthMonitor>();
 
         [TestMethod]
         public async Task AddLease_ThrowsException_LeaseAddingContinues()
@@ -26,7 +27,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
 
             // long acquire interval to ensure that only 1 load balancing iteration is performed in a test run
             TimeSpan leaseAcquireInterval = TimeSpan.FromHours(1);
-            PartitionLoadBalancerCore loadBalancer = new PartitionLoadBalancerCore(controller, this.leaseContainer, this.strategy, leaseAcquireInterval);
+            PartitionLoadBalancerCore loadBalancer = new PartitionLoadBalancerCore(controller, this.leaseContainer, this.strategy, leaseAcquireInterval, this.monitor);
 
             Mock.Get(this.strategy)
                 .Setup(s => s.SelectLeasesToTake(It.IsAny<IEnumerable<DocumentServiceLease>>()))
@@ -46,6 +47,30 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
                 .Verify(m => m.GetAllLeasesAsync(), Times.Once);
 
             Assert.AreEqual(2, controller.HitCount);
+
+            // Verify that the monitor was notified of errors
+            Mock.Get(this.monitor)
+                .Verify(m => m.NotifyErrorAsync(It.IsAny<string>(), It.IsAny<Exception>()), Times.Exactly(2));
+        }
+
+        [TestMethod]
+        public async Task GetAllLeases_ThrowsException_MonitorNotified()
+        {
+            PartitionController controller = Mock.Of<PartitionController>();
+
+            TimeSpan leaseAcquireInterval = TimeSpan.FromHours(1);
+            PartitionLoadBalancerCore loadBalancer = new PartitionLoadBalancerCore(controller, this.leaseContainer, this.strategy, leaseAcquireInterval, this.monitor);
+
+            Mock.Get(this.leaseContainer)
+                .Setup(m => m.GetAllLeasesAsync())
+                .ThrowsAsync(new InvalidOperationException("Test exception"));
+
+            loadBalancer.Start();
+            await loadBalancer.StopAsync();
+
+            // Verify that the monitor was notified of the error
+            Mock.Get(this.monitor)
+                .Verify(m => m.NotifyErrorAsync("PartitionLoadBalancer", It.IsAny<Exception>()), Times.Once);
         }
 
         private class FailingPartitionController : PartitionController


### PR DESCRIPTION
## Description

Fixes #3453

During Load Balancing process, errors that occur on lease acquisition or load balancer iteration were not being reported to the Notifications API (ChangeFeedProcessorHealthMonitor).

### Changes

- Add `ChangeFeedProcessorHealthMonitor` to `PartitionLoadBalancerCore` constructor
- Call `monitor.NotifyErrorAsync()` when individual lease acquisition fails (with lease token)
- Call `monitor.NotifyErrorAsync()` when load balancer iteration fails (with "PartitionLoadBalancer" identifier)
- Update `ChangeFeedProcessorCore` to pass the health monitor to the load balancer
- Add test to verify monitor is notified on errors

### Pattern followed

This follows the same pattern already used in `PartitionControllerCore` which receives the health monitor and calls `NotifyErrorAsync` on failures.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Closing issues

closes #3453