### PR TITLE
Docs: Adds immediate-action triggers to IssueFixAgent

### DIFF
--- a/.github/agents/issue-fix-agent.agent.md
+++ b/.github/agents/issue-fix-agent.agent.md
@@ -4928,6 +4928,20 @@ commit_format:
     - "Reference issue number in body if applicable"
     - "Sign-off required for external contributors"
     
+  copilot_attribution:
+    requirement: "All Copilot-assisted commits MUST include co-author trailer"
+    format: |
+      Co-authored-by: Copilot Autofix powered by GitHub Advanced Security <copilot-autofix-noreply@github.com>
+    example: |
+      Fix: Dictionary.Any() now uses OBJECTTOARRAY instead of JOIN
+      
+      The LINQ translator was treating Dictionary<K,V> as a generic
+      IEnumerable, generating incorrect SQL with JOIN.
+      
+      Fixes #5547
+      
+      Co-authored-by: Copilot Autofix powered by GitHub Advanced Security <copilot-autofix-noreply@github.com>
+    
   full_example: |
     Fix: Dictionary.Any() now uses OBJECTTOARRAY instead of JOIN
     


### PR DESCRIPTION
## Description

Updates to IssueFixAgent plan based on session learnings.

### Changes:
1. **Immediate-action triggers** - Agent should not wait or ask permission when next action is clear
2. **PR comment monitoring** - Immediately address review comments

### New rules added:
- "Do NOT wait or ask permission when next action is clear"
- "Do NOT ask 'want me to do X?' - just execute if conditions are met"
- "CI passes on draft PR → immediately mark ready for review"
- "PR review comment received → immediately address or respond"

## Type of change
Documentation update