### PR TITLE
[Internal] Docs: Add PR body formatting guidance to agent plan

### DIFF
--- a/.github/agents/issue-fix-agent.agent.md
+++ b/.github/agents/issue-fix-agent.agent.md
@@ -5664,6 +5664,35 @@ gh_cli_workarounds:
     problem: "`gh pr edit --title` may fail with GraphQL warning"
     workaround: |
       gh api repos/{owner}/{repo}/pulls/{pr_number} -X PATCH -f title="New Title"
+
+  pr_body_formatting_corrupted:
+    problem: "PR description loses newlines, emojis corrupted (e.g., 🤖 becomes Γëí╞Æ├▒├╗)"
+    symptoms:
+      - "All content appears on single line"
+      - "Markdown headers not rendered"
+      - "Unicode characters corrupted"
+    causes:
+      - "Using Out-File without proper encoding"
+      - "PowerShell string handling stripping newlines"
+      - "gh pr create/edit with inline --body argument"
+    workaround: |
+      # 1. Write body to file with UTF8 no BOM encoding:
+      $body | Set-Content -Path "body.md" -Encoding UTF8
+      
+      # 2. Use gh api with -F to read from file:
+      gh api repos/{owner}/{repo}/pulls/{pr_number} -X PATCH -F body=@body.md
+      
+      # 3. For new PRs, use --body-file (not --body):
+      gh pr create --draft --title "..." --body-file body.md
+    verification: |
+      # After update, verify formatting preserved:
+      gh api repos/{owner}/{repo}/pulls/{pr_number} --jq '.body' | Select-Object -First 5
+      # Should show proper line breaks and headers
+    prevention:
+      - "NEVER use inline --body with multi-line content"
+      - "ALWAYS write to file first, then use -F body=@file or --body-file"
+      - "ALWAYS use UTF8 encoding (Set-Content -Encoding UTF8)"
+      - "VERIFY formatting after every PR create/update"
 ```
 
 ### 18.19 Sequence Diagrams in PRs


### PR DESCRIPTION
## Description

🤖 **This PR was authored by GitHub Copilot**

Adds documentation for the recurring issue where PR descriptions lose formatting.

## Problem
PR body content gets corrupted:
- Newlines stripped (all content on one line)
- Emojis corrupted (🤖 becomes Γëí╞Æ├▒├╗)
- Markdown headers not rendered

## Root Causes
- PowerShell encoding issues with Out-File
- Using inline `--body` argument instead of `--body-file`
- String handling stripping newlines

## Workaround Added
```powershell
# 1. Write body to file with UTF8 encoding:
$body | Set-Content -Path "body.md" -Encoding UTF8

# 2. Use gh api with -F to read from file:
gh api repos/{owner}/{repo}/pulls/{pr_number} -X PATCH -F body=@body.md
```

## Prevention Rules
- NEVER use inline `--body` with multi-line content
- ALWAYS write to file first
- ALWAYS use UTF8 encoding
- VERIFY formatting after every PR create/update

---
*Generated by GitHub Copilot CLI Agent*
