### PR TITLE
Hedging: Fixes ArgumentNullException in CrossRegionHedgingAvailabilityStrategy caused by abandoned tasks receiving wrong CancellationToken

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/AvailabilityStrategyUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/AvailabilityStrategyUnitTests.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
     using System.IO;
+    using System.Net;
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
@@ -95,6 +96,123 @@
                        availabilityStrategy.ExecuteAvailabilityStrategyAsync(sender, mockCosmosClient, request, cts.Token));
         }
 
-       
+        /// <summary>
+        /// Reproduces the ArgumentNullException reported by customers in 
+        /// CrossRegionHedgingAvailabilityStrategy.RequestSenderAndResultCheckAsync.
+        /// 
+        /// Root cause: When a hedge request completes successfully before the primary,
+        /// ExecuteAvailabilityStrategyAsync returns immediately. The primary request task
+        /// is still running because the sender receives the ORIGINAL cancellation token 
+        /// (not the linked CTS token), so it is NOT cancelled. After the method returns,
+        /// the using blocks dispose the CancellationTokenSource and CloneableStream, and
+        /// the using block in CloneAndSendAsync disposes the cloned RequestMessage.
+        /// The abandoned task eventually faults and is never observed, producing the 
+        /// TaskScheduler_UnobservedTaskException with ArgumentNullException that customers see.
+        ///
+        /// This test directly verifies that when a hedge succeeds and the method returns,
+        /// the abandoned primary task is properly cancelled and does not leave the cloned 
+        /// request in a disposed state while the sender is still using it.
+        /// </summary>
+        [TestMethod]
+        public async Task CloneAndSendAsync_DisposesClonedRequest_CausesNullReferenceOnAbandonedTask()
+        {
+            // Arrange
+            CrossRegionHedgingAvailabilityStrategy availabilityStrategy =
+                new CrossRegionHedgingAvailabilityStrategy(
+                    threshold: TimeSpan.FromMilliseconds(100),
+                    thresholdStep: TimeSpan.FromMilliseconds(50));
+
+            RequestMessage request = new RequestMessage(
+                HttpMethod.Get,
+                new Uri("/dbs/testdb/colls/testcontainer/docs/testId", UriKind.Relative))
+            {
+                ResourceType = ResourceType.Document,
+                OperationType = OperationType.Read,
+            };
+
+            AccountProperties databaseAccount = new AccountProperties()
+            {
+                ReadLocationsInternal = new Collection<AccountRegion>()
+                {
+                    new AccountRegion() { Name = "US East", Endpoint = new Uri("https://location1.documents.azure.com").ToString() },
+                    new AccountRegion() { Name = "US West", Endpoint = new Uri("https://location2.documents.azure.com").ToString() },
+                    new AccountRegion() { Name = "US Central", Endpoint = new Uri("https://location3.documents.azure.com").ToString() },
+                }
+            };
+
+            using CosmosClient mockCosmosClient = MockCosmosUtil.CreateMockCosmosClient();
+            mockCosmosClient.DocumentClient.GlobalEndpointManager.InitializeAccountPropertiesAndStartBackgroundRefresh(databaseAccount);
+
+            int callCount = 0;
+            TaskCompletionSource<bool> primarySenderEntered = new TaskCompletionSource<bool>();
+            bool primaryTokenWasCancelled = false;
+
+            Func<RequestMessage, CancellationToken, Task<ResponseMessage>> sender =
+                async (req, token) =>
+                {
+                    int currentCall = Interlocked.Increment(ref callCount);
+
+                    if (currentCall == 1)
+                    {
+                        // Signal that the primary sender has started
+                        primarySenderEntered.TrySetResult(true);
+
+                        // Simulate a slow primary request. Use a polling loop so we
+                        // can cleanly detect cancellation without throwing, to isolate
+                        // the test assertion from cancellation exception handling.
+                        int elapsed = 0;
+                        while (elapsed < 10000 && !token.IsCancellationRequested)
+                        {
+                            await Task.Delay(50);
+                            elapsed += 50;
+                        }
+
+                        if (token.IsCancellationRequested)
+                        {
+                            primaryTokenWasCancelled = true;
+                            // Return a transient response instead of throwing,
+                            // so the task completes cleanly and we can assert
+                            // just on the cancellation behavior.
+                            return new ResponseMessage(HttpStatusCode.ServiceUnavailable, requestMessage: req);
+                        }
+
+                        return new ResponseMessage(HttpStatusCode.OK, requestMessage: req);
+                    }
+
+                    // Hedge request: return success immediately
+                    return new ResponseMessage(HttpStatusCode.OK, requestMessage: req);
+                };
+
+            // Act
+            ResponseMessage result = await availabilityStrategy.ExecuteAvailabilityStrategyAsync(
+                sender,
+                mockCosmosClient,
+                request,
+                CancellationToken.None);
+
+            // The hedge succeeded, so we should get a 200 OK
+            Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
+
+            // Verify the primary sender was invoked
+            await primarySenderEntered.Task;
+
+            // Wait a bit for things to settle
+            await Task.Delay(500);
+
+            // CRITICAL ASSERTION: The primary request's sender should have received 
+            // a cancellation token that gets cancelled when the hedge succeeds.
+            // In the current buggy code, it receives the ORIGINAL CancellationToken.None
+            // which is NEVER cancelled, so the primary task keeps running indefinitely.
+            // This is what leads to the abandoned task and the unobserved exception.
+            Assert.IsTrue(
+                primaryTokenWasCancelled,
+                "The primary request's sender was invoked with a cancellation token that " +
+                "was NOT cancelled when the hedge succeeded. This means the primary task " +
+                "continues running after ExecuteAvailabilityStrategyAsync returns, and when " +
+                "it eventually completes, the using block in CloneAndSendAsync disposes the " +
+                "cloned request, causing the ArgumentNullException that customers reported. " +
+                "The sender should receive the linked CancellationToken so it gets cancelled " +
+                "when a hedge succeeds.");
+        }
     }
 }


### PR DESCRIPTION
## Issue
Customers reported ArgumentNullException (surfaced as TaskScheduler_UnobservedTaskException) originating from [CrossRegionHedgingAvailabilityStrategy.RequestSenderAndResultCheckAsync](vscode-file://vscode-app/c:/Users/ntripician/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html). Two distinct stack traces were observed:

Stack trace 1 — ArgumentNullException at [RequestMessage.set_Content](vscode-file://vscode-app/c:/Users/ntripician/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) → CheckDisposed():

```
System.ArgumentNullException: Value cannot be null. (Parameter 'source')
   at Microsoft.Azure.Cosmos.RequestMessage.set_Content(Stream value)
   at Microsoft.Azure.Cosmos.RequestMessage.CheckDisposed()
   at Microsoft.Azure.Cosmos.RequestInvokerHandler.BaseSendAsync(RequestMessage request, CancellationToken cancellationToken)
```

Stack trace 2 — NullReferenceException at RequestInvokerHandler.SendAsync:

```
System.NullReferenceException: Object reference not set to an instance of an object.
   at Microsoft.Azure.Cosmos.Handlers.RequestInvokerHandler.SendAsync(RequestMessage request, CancellationToken cancellationToken)
   at Microsoft.Azure.Cosmos.CrossRegionHedgingAvailabilityStrategy.RequestSenderAndResultCheckAsync(...)
```

Both exceptions are unobserved and only surface through TaskScheduler.UnobservedTaskException — they don't crash the application but pollute logs and indicate a resource lifecycle bug.

## Root Cause
In [ExecuteAvailabilityStrategyAsync](vscode-file://vscode-app/c:/Users/ntripician/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), the SDK races a primary request against hedged requests across regions using [Task.WhenAny](vscode-file://vscode-app/c:/Users/ntripician/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html). When a hedge completes successfully, the method calls [cancellationTokenSource.Cancel()](vscode-file://vscode-app/c:/Users/ntripician/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) and returns the winning response immediately.

The bug is in how [CloneAndSendAsync](vscode-file://vscode-app/c:/Users/ntripician/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) was invoked:

```csharp
// BEFORE (buggy)
Task<HedgingResponse> requestTask = this.CloneAndSendAsync(
    ...
    cancellationToken: cancellationToken,        // ← original caller's token (e.g., CancellationToken.None)
    cancellationTokenSource: cancellationTokenSource);
```

The sender delegate inside [CloneAndSendAsync](vscode-file://vscode-app/c:/Users/ntripician/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) received the original caller's [CancellationToken](vscode-file://vscode-app/c:/Users/ntripician/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (often [CancellationToken.None](vscode-file://vscode-app/c:/Users/ntripician/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)) instead of [cancellationTokenSource.Token](vscode-file://vscode-app/c:/Users/ntripician/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (the linked CTS token). This caused the following chain of events:

1. Primary request starts — sender receives [CancellationToken.None](vscode-file://vscode-app/c:/Users/ntripician/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
2. Hedge request completes successfully — [cancellationTokenSource.Cancel()](vscode-file://vscode-app/c:/Users/ntripician/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) fires
3. Primary task is NOT cancelled — it holds [CancellationToken.None](vscode-file://vscode-app/c:/Users/ntripician/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html), which is never signaled
4. [ExecuteAvailabilityStrategyAsync](vscode-file://vscode-app/c:/Users/ntripician/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) returns — its using blocks dispose:
[CancellationTokenSource](vscode-file://vscode-app/c:/Users/ntripician/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (the linked CTS)
[CloneableStream](vscode-file://vscode-app/c:/Users/ntripician/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) (the shared cloned body)
5. Abandoned primary task eventually completes — its [CloneAndSendAsync](vscode-file://vscode-app/c:/Users/ntripician/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) using block disposes the cloned [RequestMessage](vscode-file://vscode-app/c:/Users/ntripician/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
6. Downstream code accesses the disposed request → ArgumentNullException / NullReferenceException
Exception is never observed → surfaces as TaskScheduler_UnobservedTaskException

## Fix
Change 1: Pass the linked CTS token to the sender ([CrossRegionHedgingAvailabilityStrategy.cs:176](vscode-file://vscode-app/c:/Users/ntripician/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html))

```csharp
// AFTER (fixed)
Task<HedgingResponse> requestTask = this.CloneAndSendAsync(
    ...
    cancellationToken: cancellationTokenSource.Token,   // ← linked token, cancelled when hedge succeeds
    cancellationTokenSource: cancellationTokenSource);
```

This ensures that when a hedge succeeds and [cancellationTokenSource.Cancel()](vscode-file://vscode-app/c:/Users/ntripician/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) fires, all outstanding sender delegates observe the cancellation and exit promptly. There are no more abandoned tasks running with stale tokens.

Change 2: Replace using with try/finally for cloned request disposal ([CrossRegionHedgingAvailabilityStrategy.cs:270-297](vscode-file://vscode-app/c:/Users/ntripician/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html))

```csharp
// BEFORE
using (clonedRequest = request.Clone(trace, clonedBody))
{
    return await this.RequestSenderAndResultCheckAsync(...);
}

// AFTER
RequestMessage clonedRequest = request.Clone(trace, clonedBody);
try
{
    return await this.RequestSenderAndResultCheckAsync(...);
}
finally
{
    clonedRequest.Dispose();
}
```
This makes the disposal lifecycle explicit and avoids the pattern of declaring the variable outside the using scope, which was confusing and made the ownership semantics unclear.

## Testing
Added [CloneAndSendAsync_DisposesClonedRequest_CausesNullReferenceOnAbandonedTask](vscode-file://vscode-app/c:/Users/ntripician/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) unit test that:

1. Sets up 3 regions with a primary sender that simulates a slow request (polls for cancellation in a loop)
2. Configures a hedge sender that returns [200 OK](vscode-file://vscode-app/c:/Users/ntripician/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) immediately
3. Passes [CancellationToken.None](vscode-file://vscode-app/c:/Users/ntripician/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) as the caller's token (matching real-world usage)
4. Asserts that the primary sender's cancellation token was cancelled when the hedge succeeded
This test fails on the original code (the primary sender receives [CancellationToken.None](vscode-file://vscode-app/c:/Users/ntripician/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) which is never cancelled) and passes with the fix (the primary sender receives [cancellationTokenSource.Token](vscode-file://vscode-app/c:/Users/ntripician/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) which gets cancelled when the hedge succeeds).

## Impact
- Before fix: Any hedging scenario where a hedge succeeds before the primary request produces an abandoned task that eventually faults with an unobserved exception. High-throughput multi-region workloads would see frequent TaskScheduler_UnobservedTaskException entries.
- After fix: Abandoned tasks are promptly cancelled, resources are cleaned up in the correct order, and no unobserved exceptions occur.


## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)

## Closing issues

To automatically close an issue: closes #IssueNumber