### PR TITLE
FFCF: Adds PreviousImageRetentionPolicy to ContainerProperties

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/ContainerProperties.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/ContainerProperties.cs
@@ -87,6 +87,9 @@ namespace Microsoft.Azure.Cosmos
         [JsonProperty(PropertyName = "fullTextPolicy", NullValueHandling = NullValueHandling.Ignore)]
         private FullTextPolicy fullTextPolicyInternal;
 
+        [JsonProperty(PropertyName = "previousImageRetentionPolicy", NullValueHandling = NullValueHandling.Ignore)]
+        private PreviousImageRetentionPolicy? previousImageRetentionPolicyInternal;
+
         /// <summary>
         /// This contains additional values for scenarios where the SDK is not aware of new fields. 
         /// This ensures that if resource is read and updated none of the fields will be lost in the process.
@@ -396,6 +399,30 @@ namespace Microsoft.Azure.Cosmos
                 return this.changeFeedPolicyInternal;
             }
             set => this.changeFeedPolicyInternal = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the <see cref="Cosmos.PreviousImageRetentionPolicy"/> associated with the container from the Azure Cosmos DB service.
+        /// </summary>
+        /// <value>
+        /// The previous image retention policy associated with the container.
+        /// </value>
+        /// <remarks>
+        /// <para>
+        /// The <see cref="Cosmos.PreviousImageRetentionPolicy"/> controls whether the previous image of a document 
+        /// is retained during change feed operations for replace and/or delete operations.
+        /// </para>
+        /// </remarks>
+        [JsonIgnore]
+#if PREVIEW
+        public
+#else
+        internal
+#endif
+        PreviousImageRetentionPolicy? PreviousImageRetentionPolicy
+        {
+            get => this.previousImageRetentionPolicyInternal;
+            set => this.previousImageRetentionPolicyInternal = value;
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/PreviousImageRetentionPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/PreviousImageRetentionPolicy.cs
@@ -1,0 +1,41 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos
+{
+    using System;
+
+    /// <summary>
+    /// Specifies the previous image retention policy for a container in the Azure Cosmos DB service.
+    /// This policy controls whether the previous image of a document is retained during change feed operations.
+    /// </summary>
+    [Flags]
+#if PREVIEW
+    public
+#else
+    internal
+#endif
+    enum PreviousImageRetentionPolicy
+    {
+        /// <summary>
+        /// Previous image retention is disabled.
+        /// </summary>
+        Disabled = 0x00,
+
+        /// <summary>
+        /// Previous image retention is enabled for replace operations.
+        /// </summary>
+        EnabledForReplaceOperation = 0x01,
+
+        /// <summary>
+        /// Previous image retention is enabled for delete operations.
+        /// </summary>
+        EnabledForDeleteOperation = 0x02,
+
+        /// <summary>
+        /// Previous image retention is enabled for all operations (replace and delete).
+        /// </summary>
+        EnabledForAllOperations = EnabledForReplaceOperation | EnabledForDeleteOperation
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetPreviewSDKAPI.net6.json
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetPreviewSDKAPI.net6.json
@@ -326,10 +326,27 @@
           "Attributes": [],
           "MethodInfo": "Microsoft.Azure.Cosmos.ChangeFeedPolicy get_ChangeFeedPolicy();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
         },
+        "System.Nullable`1[Microsoft.Azure.Cosmos.PreviousImageRetentionPolicy] get_PreviousImageRetentionPolicy()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Nullable`1[Microsoft.Azure.Cosmos.PreviousImageRetentionPolicy] get_PreviousImageRetentionPolicy();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "System.Nullable`1[Microsoft.Azure.Cosmos.PreviousImageRetentionPolicy] PreviousImageRetentionPolicy[Newtonsoft.Json.JsonIgnoreAttribute()]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonIgnoreAttribute"
+          ],
+          "MethodInfo": "System.Nullable`1[Microsoft.Azure.Cosmos.PreviousImageRetentionPolicy] PreviousImageRetentionPolicy;CanRead:True;CanWrite:True;System.Nullable`1[Microsoft.Azure.Cosmos.PreviousImageRetentionPolicy] get_PreviousImageRetentionPolicy();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;Void set_PreviousImageRetentionPolicy(System.Nullable`1[Microsoft.Azure.Cosmos.PreviousImageRetentionPolicy]);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
         "Void set_ChangeFeedPolicy(Microsoft.Azure.Cosmos.ChangeFeedPolicy)": {
           "Type": "Method",
           "Attributes": [],
           "MethodInfo": "Void set_ChangeFeedPolicy(Microsoft.Azure.Cosmos.ChangeFeedPolicy);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "Void set_PreviousImageRetentionPolicy(System.Nullable`1[Microsoft.Azure.Cosmos.PreviousImageRetentionPolicy])": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Void set_PreviousImageRetentionPolicy(System.Nullable`1[Microsoft.Azure.Cosmos.PreviousImageRetentionPolicy]);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
         }
       },
       "NestedTypes": {}
@@ -1333,6 +1350,37 @@
             "CompilerGeneratedAttribute"
           ],
           "MethodInfo": "Void set_IncludeRegion(System.Nullable`1[System.Boolean]);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "Microsoft.Azure.Cosmos.PreviousImageRetentionPolicy;System.Enum;IsAbstract:False;IsSealed:True;IsInterface:False;IsEnum:True;IsClass:False;IsValueType:True;IsNested:False;IsGenericType:False;IsSerializable:True": {
+      "Subclasses": {},
+      "Members": {
+        "Int32 value__": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": "Int32 value__;IsInitOnly:False;IsStatic:False;"
+        },
+        "Microsoft.Azure.Cosmos.PreviousImageRetentionPolicy Disabled": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.PreviousImageRetentionPolicy Disabled;IsInitOnly:False;IsStatic:True;"
+        },
+        "Microsoft.Azure.Cosmos.PreviousImageRetentionPolicy EnabledForAllOperations": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.PreviousImageRetentionPolicy EnabledForAllOperations;IsInitOnly:False;IsStatic:True;"
+        },
+        "Microsoft.Azure.Cosmos.PreviousImageRetentionPolicy EnabledForDeleteOperation": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.PreviousImageRetentionPolicy EnabledForDeleteOperation;IsInitOnly:False;IsStatic:True;"
+        },
+        "Microsoft.Azure.Cosmos.PreviousImageRetentionPolicy EnabledForReplaceOperation": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.PreviousImageRetentionPolicy EnabledForReplaceOperation;IsInitOnly:False;IsStatic:True;"
         }
       },
       "NestedTypes": {}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/SettingsContractTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/SettingsContractTests.cs
@@ -1116,7 +1116,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         [TestMethod]
         public void PreviousImageRetentionPolicySerialization()
         {
-            ContainerProperties containerSettings = new ContainerProperties("TestContainer", "/partitionKey");
+            ContainerProperties containerSettings = new ContainerProperties("TestContainer1", "/partitionKey");
             string serialization = JsonConvert.SerializeObject(containerSettings);
             Assert.IsFalse(serialization.Contains("previousImageRetentionPolicy"), "Previous Image Retention Policy should not be included by default");
 
@@ -1133,7 +1133,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         [TestMethod]
         public void PreviousImageRetentionPolicySerialization_Disabled()
         {
-            ContainerProperties containerSettings = new ContainerProperties("TestContainer", "/partitionKey");
+            ContainerProperties containerSettings = new ContainerProperties("TestContainer2", "/partitionKey");
             containerSettings.PreviousImageRetentionPolicy = Cosmos.PreviousImageRetentionPolicy.Disabled;
             
             string serializationWithValues = JsonConvert.SerializeObject(containerSettings);
@@ -1149,7 +1149,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         public void PreviousImageRetentionPolicySerialization_IndividualFlags()
         {
             // Test EnabledForReplaceOperation
-            ContainerProperties containerSettings = new ContainerProperties("TestContainer", "/partitionKey");
+            ContainerProperties containerSettings = new ContainerProperties("TestContainer3", "/partitionKey");
             containerSettings.PreviousImageRetentionPolicy = Cosmos.PreviousImageRetentionPolicy.EnabledForReplaceOperation;
             
             string serialization = JsonConvert.SerializeObject(containerSettings);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/SettingsContractTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/SettingsContractTests.cs
@@ -1117,11 +1117,11 @@ namespace Microsoft.Azure.Cosmos.Tests
         public void PreviousImageRetentionPolicySerialization()
         {
             ContainerProperties containerSettings = new ContainerProperties("TestContainer1", "/partitionKey");
-            string serialization = JsonConvert.SerializeObject(containerSettings);
+            string serialization = SettingsContractTests.CosmosSerialize(containerSettings);
             Assert.IsFalse(serialization.Contains("previousImageRetentionPolicy"), "Previous Image Retention Policy should not be included by default");
 
             containerSettings.PreviousImageRetentionPolicy = Cosmos.PreviousImageRetentionPolicy.EnabledForAllOperations;
-            string serializationWithValues = JsonConvert.SerializeObject(containerSettings);
+            string serializationWithValues = SettingsContractTests.CosmosSerialize(containerSettings);
             Assert.IsTrue(serializationWithValues.Contains("previousImageRetentionPolicy"), "Previous Image Retention Policy should be included");
 
             JObject parsed = JObject.Parse(serializationWithValues);
@@ -1136,7 +1136,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             ContainerProperties containerSettings = new ContainerProperties("TestContainer2", "/partitionKey");
             containerSettings.PreviousImageRetentionPolicy = Cosmos.PreviousImageRetentionPolicy.Disabled;
             
-            string serializationWithValues = JsonConvert.SerializeObject(containerSettings);
+            string serializationWithValues = SettingsContractTests.CosmosSerialize(containerSettings);
             Assert.IsTrue(serializationWithValues.Contains("previousImageRetentionPolicy"), "Previous Image Retention Policy should be included when explicitly set");
 
             JObject parsed = JObject.Parse(serializationWithValues);
@@ -1152,21 +1152,21 @@ namespace Microsoft.Azure.Cosmos.Tests
             ContainerProperties containerSettings = new ContainerProperties("TestContainer3", "/partitionKey");
             containerSettings.PreviousImageRetentionPolicy = Cosmos.PreviousImageRetentionPolicy.EnabledForReplaceOperation;
             
-            string serialization = JsonConvert.SerializeObject(containerSettings);
+            string serialization = SettingsContractTests.CosmosSerialize(containerSettings);
             JObject parsed = JObject.Parse(serialization);
             Assert.AreEqual(1, parsed["previousImageRetentionPolicy"].Value<int>(), "EnabledForReplaceOperation should serialize to 1");
 
             // Test EnabledForDeleteOperation
             containerSettings.PreviousImageRetentionPolicy = Cosmos.PreviousImageRetentionPolicy.EnabledForDeleteOperation;
             
-            serialization = JsonConvert.SerializeObject(containerSettings);
+            serialization = SettingsContractTests.CosmosSerialize(containerSettings);
             parsed = JObject.Parse(serialization);
             Assert.AreEqual(2, parsed["previousImageRetentionPolicy"].Value<int>(), "EnabledForDeleteOperation should serialize to 2");
 
             // Test EnabledForAllOperations (combined flags)
             containerSettings.PreviousImageRetentionPolicy = Cosmos.PreviousImageRetentionPolicy.EnabledForAllOperations;
             
-            serialization = JsonConvert.SerializeObject(containerSettings);
+            serialization = SettingsContractTests.CosmosSerialize(containerSettings);
             parsed = JObject.Parse(serialization);
             Assert.AreEqual(3, parsed["previousImageRetentionPolicy"].Value<int>(), "EnabledForAllOperations should serialize to 3");
         }
@@ -1176,19 +1176,19 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             // Test deserialization of all enum values
             string jsonWithDisabled = "{\"id\":\"TestContainer\",\"partitionKey\":{\"paths\":[\"/pk\"],\"kind\":\"Hash\"},\"previousImageRetentionPolicy\":0}";
-            ContainerProperties containerDisabled = JsonConvert.DeserializeObject<ContainerProperties>(jsonWithDisabled);
+            ContainerProperties containerDisabled = SettingsContractTests.CosmosDeserialize<ContainerProperties>(jsonWithDisabled);
             Assert.AreEqual(Cosmos.PreviousImageRetentionPolicy.Disabled, containerDisabled.PreviousImageRetentionPolicy);
 
             string jsonWithReplace = "{\"id\":\"TestContainer\",\"partitionKey\":{\"paths\":[\"/pk\"],\"kind\":\"Hash\"},\"previousImageRetentionPolicy\":1}";
-            ContainerProperties containerReplace = JsonConvert.DeserializeObject<ContainerProperties>(jsonWithReplace);
+            ContainerProperties containerReplace = SettingsContractTests.CosmosDeserialize<ContainerProperties>(jsonWithReplace);
             Assert.AreEqual(Cosmos.PreviousImageRetentionPolicy.EnabledForReplaceOperation, containerReplace.PreviousImageRetentionPolicy);
 
             string jsonWithDelete = "{\"id\":\"TestContainer\",\"partitionKey\":{\"paths\":[\"/pk\"],\"kind\":\"Hash\"},\"previousImageRetentionPolicy\":2}";
-            ContainerProperties containerDelete = JsonConvert.DeserializeObject<ContainerProperties>(jsonWithDelete);
+            ContainerProperties containerDelete = SettingsContractTests.CosmosDeserialize<ContainerProperties>(jsonWithDelete);
             Assert.AreEqual(Cosmos.PreviousImageRetentionPolicy.EnabledForDeleteOperation, containerDelete.PreviousImageRetentionPolicy);
 
             string jsonWithAll = "{\"id\":\"TestContainer\",\"partitionKey\":{\"paths\":[\"/pk\"],\"kind\":\"Hash\"},\"previousImageRetentionPolicy\":3}";
-            ContainerProperties containerAll = JsonConvert.DeserializeObject<ContainerProperties>(jsonWithAll);
+            ContainerProperties containerAll = SettingsContractTests.CosmosDeserialize<ContainerProperties>(jsonWithAll);
             Assert.AreEqual(Cosmos.PreviousImageRetentionPolicy.EnabledForAllOperations, containerAll.PreviousImageRetentionPolicy);
         }
 
@@ -1197,7 +1197,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             // Test that containers without the property deserialize correctly (backwards compatibility)
             string jsonWithoutPolicy = "{\"id\":\"TestContainer\",\"partitionKey\":{\"paths\":[\"/pk\"],\"kind\":\"Hash\"}}";
-            ContainerProperties container = JsonConvert.DeserializeObject<ContainerProperties>(jsonWithoutPolicy);
+            ContainerProperties container = SettingsContractTests.CosmosDeserialize<ContainerProperties>(jsonWithoutPolicy);
             Assert.IsNull(container.PreviousImageRetentionPolicy, "PreviousImageRetentionPolicy should be null when not present in JSON");
         }
 


### PR DESCRIPTION
This PR adds a new PreviousImageRetentionPolicy property to ContainerProperties that allows users to configure whether previous images of documents are retained during change feed operations for replace and/or delete operations.
Changes

New Files
•	Microsoft.Azure.Cosmos\src\Resource\Settings\PreviousImageRetentionPolicy.cs - New flags enum with values:
      •	Disabled (0x00) - Previous image retention is disabled
      •	EnabledForReplaceOperation (0x01) - Retain previous image for replace operations
      •	EnabledForDeleteOperation (0x02) - Retain previous image for delete operations
      •	EnabledForAllOperations (0x03) - Retain previous image for both replace and delete operations

Additional Details: https://microsoft-my.sharepoint.com/:w:/p/grander/EYle3g6_YrlHkMIM2fxp3P8Bk2ejj3WkhNCFHsMuaEtc_A?e=GuI46T&wdOrigin=TEAMS-MAGLEV.null_ns.rwc&wdExp=TEAMS-TREATMENT&wdhostclicktime=1770677883263&web=1 

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber