### PR TITLE
[FaultInjection] FaultInjection: Fixes naming typos and XML documentation

### DIFF
--- a/Microsoft.Azure.Cosmos/FaultInjection/src/FaultInjectionEndpoint.cs
+++ b/Microsoft.Azure.Cosmos/FaultInjection/src/FaultInjectionEndpoint.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection
         /// <param name="databaseName">The database name.</param>
         /// <param name="containerName">The container name.</param>
         /// <param name="feedRange">The <see cref="FeedRange"/>.</param>
-        /// <param name="includePrimary">Indicates wether primary replica can be used</param>
+        /// <param name="includePrimary">Indicates whether primary replica can be used</param>
         /// <param name="replicaCount">Replica count.</param>
         public FaultInjectionEndpoint(
             string databaseName,
@@ -63,7 +63,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection
         }
 
         /// <summary>
-        /// Gets the replica count. Used to inidcate how many physical addresses can be applied to the fault injection rule.
+        /// Gets the replica count. Used to indicate how many physical addresses can be applied to the fault injection rule.
         /// </summary>
         /// <returns>an int, the replica count</returns>
         public int GetReplicaCount()
@@ -71,7 +71,11 @@ namespace Microsoft.Azure.Cosmos.FaultInjection
             return this.replicaCount; 
         }
 
-        public string GetResoureName()
+        /// <summary>
+        /// Gets the resource name in the format dbs/{databaseName}/colls/{containerName}.
+        /// </summary>
+        /// <returns>The resource name.</returns>
+        public string GetResourceName()
         {
             return $"dbs/{this.databaseName}/colls/{this.containerName}";
         }
@@ -84,7 +88,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection
         {
             return String.Format(
                 "\"FaultInjectionEndpoint\":{{ \"ResourceName\": \"{0}\", \"FeedRange\": \"{1}\", \"IncludePrimary\": \"{2}\", \"ReplicaCount\": \"{3}\"}}",
-                this.GetResoureName(),
+                this.GetResourceName(),
                 this.feedRange,
                 this.includePrimary,
                 this.replicaCount);

--- a/Microsoft.Azure.Cosmos/FaultInjection/src/FaultInjectionServerErrorResultBuilder.cs
+++ b/Microsoft.Azure.Cosmos/FaultInjection/src/FaultInjectionServerErrorResultBuilder.cs
@@ -44,7 +44,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection
         /// Only used RESPONSE_DELAY and CONNECTION_DELAY.
         /// 
         /// For <see cref="FaultInjectionServerErrorType.SendDelay"/>, it is the delay added before the request is sent.
-        /// For <see cref="FaultInjectionServerErrorType.ResponseDelay"/>, it is the delay added after the response is recieved.
+        /// For <see cref="FaultInjectionServerErrorType.ResponseDelay"/>, it is the delay added after the response is received.
         /// For <see cref="FaultInjectionServerErrorType.ConnectionDelay"/>, it is the delay added before the connection is established.
         /// 
         /// </summary>

--- a/Microsoft.Azure.Cosmos/FaultInjection/src/FaultInjector.cs
+++ b/Microsoft.Azure.Cosmos/FaultInjection/src/FaultInjector.cs
@@ -24,7 +24,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection
 
         /// <summary>
         /// Gets the fault injection rule id for the given activity id
-        /// If multible FaultInjectionRules are applied to the same activity, the first rule applied will be returned
+        /// If multiple FaultInjectionRules are applied to the same activity, the first rule applied will be returned
         /// </summary>
         /// <param name="activityId"></param>
         /// <returns>the fault injection rule id</returns>

--- a/Microsoft.Azure.Cosmos/FaultInjection/src/implementation/FaultInjectionApplicationContext.cs
+++ b/Microsoft.Azure.Cosmos/FaultInjection/src/implementation/FaultInjectionApplicationContext.cs
@@ -68,12 +68,13 @@ namespace Microsoft.Azure.Cosmos.FaultInjection
 
         /// <summary>
         /// Gets the fault injection rule id for the given activity id
-        /// If multible FaultInjectionRules are applied to the same activity, the first rule applied will be returned
+        /// If multiple FaultInjectionRules are applied to the same activity, the first rule applied will be returned
         /// </summary>
         /// <returns>the fault injection rule id</returns>
         public bool TryGetRuleExecutionByActivityId(Guid activityId, out (DateTime, string) execution)
         {
-            if (this.executionsByActivityId.TryGetValue(activityId, out List<(DateTime, string)>? ruleExecutions))
+            if (this.executionsByActivityId.TryGetValue(activityId, out List<(DateTime, string)>? ruleExecutions)
+                && ruleExecutions.Count > 0)
             {
                 execution = ruleExecutions[0];
                 return true;

--- a/Microsoft.Azure.Cosmos/FaultInjection/src/implementation/FaultInjectionCustomServerErrorResultInternal.cs
+++ b/Microsoft.Azure.Cosmos/FaultInjection/src/implementation/FaultInjectionCustomServerErrorResultInternal.cs
@@ -174,7 +174,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection
             {
                 Version = isProxyCall ? new Version(2, 0) : new Version(1, 1),
                 StatusCode = (HttpStatusCode)this.statusCode,
-                Content = new FaultInjectionServerErrorResultInternal.FauntInjectionHttpContent(
+                Content = new FaultInjectionServerErrorResultInternal.FaultInjectionHttpContent(
                     new MemoryStream(
                         isProxyCall
                             ? FaultInjectionServerErrorResultInternal.FaultInjectionResponseEncoding.GetBytes(

--- a/Microsoft.Azure.Cosmos/FaultInjection/src/implementation/FaultInjectionRuleProcessor.cs
+++ b/Microsoft.Azure.Cosmos/FaultInjection/src/implementation/FaultInjectionRuleProcessor.cs
@@ -1,4 +1,4 @@
-﻿//------------------------------------------------------------
+//------------------------------------------------------------
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 //------------------------------------------------------------
 namespace Microsoft.Azure.Cosmos.FaultInjection
@@ -149,7 +149,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection
                 {
                     DocumentServiceRequest request = DocumentServiceRequest.CreateFromName(
                        operationType: OperationType.Read,
-                       resourceFullName: rule.GetCondition().GetEndpoint().GetResoureName(),
+                       resourceFullName: rule.GetCondition().GetEndpoint().GetResourceName(),
                        resourceType: ResourceType.Document,
                        authorizationTokenType: AuthorizationTokenType.PrimaryMasterKey);
 
@@ -250,7 +250,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection
                 {
                     DocumentServiceRequest request = DocumentServiceRequest.CreateFromName(
                        operationType: OperationType.Read,
-                       resourceFullName: rule.GetCondition().GetEndpoint().GetResoureName(),
+                       resourceFullName: rule.GetCondition().GetEndpoint().GetResourceName(),
                        resourceType: ResourceType.Document,
                        authorizationTokenType: AuthorizationTokenType.PrimaryMasterKey);
 
@@ -431,7 +431,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection
             FeedRangeInternal feedRangeInternal = (FeedRangeInternal)addressEndpoints.GetFeedRange();
             DocumentServiceRequest request = DocumentServiceRequest.CreateFromName(
                     operationType: OperationType.Read,
-                    resourceFullName: addressEndpoints.GetResoureName(),
+                    resourceFullName: addressEndpoints.GetResourceName(),
                     resourceType: ResourceType.Document,
                     authorizationTokenType: AuthorizationTokenType.PrimaryMasterKey);
 
@@ -478,7 +478,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection
 
             DocumentServiceRequest request = DocumentServiceRequest.CreateFromName(
                     operationType: OperationType.Read,
-                    resourceFullName: condition.GetEndpoint().GetResoureName(),
+                    resourceFullName: condition.GetEndpoint().GetResourceName(),
                     resourceType: ResourceType.Document,
                     authorizationTokenType: AuthorizationTokenType.PrimaryMasterKey);
 

--- a/Microsoft.Azure.Cosmos/FaultInjection/src/implementation/FaultInjectionServerErrorResultInternal.cs
+++ b/Microsoft.Azure.Cosmos/FaultInjection/src/implementation/FaultInjectionServerErrorResultInternal.cs
@@ -1,4 +1,4 @@
-﻿//------------------------------------------------------------
+//------------------------------------------------------------
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 //------------------------------------------------------------
 namespace Microsoft.Azure.Cosmos.FaultInjection
@@ -321,7 +321,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection
                             ? new Version(2, 0)
                             : new Version(1, 1),
                         StatusCode = HttpStatusCode.Gone,
-                        Content = new FauntInjectionHttpContent(
+                        Content = new FaultInjectionHttpContent(
                         new MemoryStream(
                             isProxyCall
                                 ? FaultInjectionResponseEncoding.GetBytes(
@@ -345,7 +345,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection
                             ? new Version(2, 0)
                             : new Version(1, 1),
                         StatusCode = HttpStatusCode.TooManyRequests,
-                        Content = new FauntInjectionHttpContent(
+                        Content = new FaultInjectionHttpContent(
                             new MemoryStream(
                                 isProxyCall
                                     ? FaultInjectionResponseEncoding.GetBytes(
@@ -371,7 +371,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection
                             ? new Version(2, 0)
                             : new Version(1, 1),
                         StatusCode = HttpStatusCode.RequestTimeout,
-                        Content = new FauntInjectionHttpContent(
+                        Content = new FaultInjectionHttpContent(
                             new MemoryStream(
                                 isProxyCall
                                     ? FaultInjectionResponseEncoding.GetBytes(
@@ -396,7 +396,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection
                             ? new Version(2, 0)
                             : new Version(1, 1),
                         StatusCode = HttpStatusCode.InternalServerError,
-                        Content = new FauntInjectionHttpContent(
+                        Content = new FaultInjectionHttpContent(
                             new MemoryStream(
                                 isProxyCall
                                     ? FaultInjectionResponseEncoding.GetBytes(
@@ -422,7 +422,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection
                             ? new Version(2, 0)
                             : new Version(1, 1),
                         StatusCode = HttpStatusCode.NotFound,
-                        Content = new FauntInjectionHttpContent(
+                        Content = new FaultInjectionHttpContent(
                             new MemoryStream(
                                 isProxyCall
                                     ? FaultInjectionResponseEncoding.GetBytes(
@@ -448,7 +448,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection
                             ? new Version(2, 0)
                             : new Version(1, 1),
                         StatusCode = HttpStatusCode.Gone,
-                        Content = new FauntInjectionHttpContent(
+                        Content = new FaultInjectionHttpContent(
                             new MemoryStream(
                                 isProxyCall
                                     ? FaultInjectionResponseEncoding.GetBytes(
@@ -473,7 +473,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection
                             ? new Version(2, 0)
                             : new Version(1, 1),
                         StatusCode = HttpStatusCode.Gone,
-                        Content = new FauntInjectionHttpContent(
+                        Content = new FaultInjectionHttpContent(
                             new MemoryStream(
                                 isProxyCall
                                     ? FaultInjectionResponseEncoding.GetBytes(
@@ -498,7 +498,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection
                             ? new Version(2, 0)
                             : new Version(1, 1),
                         StatusCode = HttpStatusCode.ServiceUnavailable,
-                        Content = new FauntInjectionHttpContent(
+                        Content = new FaultInjectionHttpContent(
                             new MemoryStream(
                                 isProxyCall
                                     ? FaultInjectionResponseEncoding.GetBytes(
@@ -523,7 +523,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection
                             ? new Version(2, 0)
                             : new Version(1, 1),
                         StatusCode = HttpStatusCode.Forbidden,
-                        Content = new FauntInjectionHttpContent(
+                        Content = new FaultInjectionHttpContent(
                             new MemoryStream(
                                 isProxyCall
                                     ? FaultInjectionResponseEncoding.GetBytes(
@@ -548,7 +548,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection
                             ? new Version(2, 0)
                             : new Version(1, 1),
                         StatusCode = HttpStatusCode.Gone,
-                        Content = new FauntInjectionHttpContent(
+                        Content = new FaultInjectionHttpContent(
                             new MemoryStream(
                                 isProxyCall
                                     ? FaultInjectionResponseEncoding.GetBytes(
@@ -571,7 +571,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection
                             ? new Version(2, 0)
                             : new Version(1, 1),
                         StatusCode = HttpStatusCode.Unauthorized,
-                        Content = new FauntInjectionHttpContent(
+                        Content = new FaultInjectionHttpContent(
                             new MemoryStream(
                                 isProxyCall
                                     ? FaultInjectionResponseEncoding.GetBytes(
@@ -588,7 +588,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection
                             ? new Version(2, 0)
                             : new Version(1, 1),
                         StatusCode = HttpStatusCode.Unauthorized,
-                        Content = new FauntInjectionHttpContent(
+                        Content = new FaultInjectionHttpContent(
                             new MemoryStream(
                                 isProxyCall
                                     ? FaultInjectionResponseEncoding.GetBytes(
@@ -641,11 +641,11 @@ namespace Microsoft.Azure.Cosmos.FaultInjection
             return $"{{\"code\": \"{statusCode}:{subStatusCode}\",\"message\":\"Fault Injection Server Error: {message}, rule: {faultInjectionRuleId}\"}}";
         }
 
-        internal class FauntInjectionHttpContent : HttpContent
+        internal class FaultInjectionHttpContent : HttpContent
         {
             private readonly Stream content;
 
-            public FauntInjectionHttpContent(Stream content)
+            public FaultInjectionHttpContent(Stream content)
             {
                 this.content = content;
             }

--- a/Microsoft.Azure.Cosmos/FaultInjection/tests/FaultInjectionUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/FaultInjection/tests/FaultInjectionUnitTests.cs
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
             //Test FaultInjectionEndpoint
             PartitionKey test = new PartitionKey("test");
             Assert.AreEqual(FeedRange.FromPartitionKey(test).ToString(), faultInjectionRule.GetCondition().GetEndpoint().GetFeedRange().ToString());
-            Assert.AreEqual("dbs/db/colls/col", faultInjectionRule.GetCondition().GetEndpoint().GetResoureName());
+            Assert.AreEqual("dbs/db/colls/col", faultInjectionRule.GetCondition().GetEndpoint().GetResourceName());
             Assert.AreEqual(3, faultInjectionRule.GetCondition().GetEndpoint().GetReplicaCount());
             Assert.IsTrue(faultInjectionRule.GetCondition().GetEndpoint().IsIncludePrimary());
 


### PR DESCRIPTION
## Summary

This PR fixes all naming typos and XML documentation issues in the FaultInjection library identified during pre-release analysis.

### Changes

**1. Rename `FauntInjectionHttpContent` to `FaultInjectionHttpContent` (#5657)**
- Internal class had "Faunt" instead of "Fault" — 14 references in `FaultInjectionServerErrorResultInternal.cs` and 1 reference in `FaultInjectionCustomServerErrorResultInternal.cs`.

**2. Rename `GetResoureName()` to `GetResourceName()` (#5658)**
- Public method on `FaultInjectionEndpoint` had typo "Resoure" instead of "Resource".
- Updated all 6 call sites (endpoint, rule processor, unit test).
- Added XML documentation to the method.
- **Note:** This is a public API breaking change, acceptable since the library is still in beta.

**3. Fix XML documentation typos (#5659)**
- `FaultInjectionEndpoint.cs`: "wether" → "whether", "inidcate" → "indicate"
- `FaultInjectionServerErrorResultBuilder.cs`: "recieved" → "received"
- `FaultInjector.cs`: "multible" → "multiple"
- `FaultInjectionApplicationContext.cs`: "multible" → "multiple"

**4. Add bounds check in `TryGetRuleExecutionByActivityId` (#5664)**
- Added `ruleExecutions.Count > 0` check before accessing `ruleExecutions[0]` to prevent potential `ArgumentOutOfRangeException`.

### Testing
- Build verified locally with `dotnet build`

Parent tracking issue: #5652
