### PR TITLE
[Internal] Specs: Adds OpenSpec configuration and feature specifications for all major SDK areas

### DIFF
--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,73 @@
+schema: spec-driven
+
+context: |
+  Tech stack: C# / .NET (LangVersion 10.0), Azure Cosmos DB SDK v3
+  Repository: azure-cosmos-dotnet-v3
+
+  Major components:
+  - Microsoft.Azure.Cosmos/ — core SDK client (production code)
+  - Microsoft.Azure.Cosmos.Encryption/ — client-side encryption extension
+  - Microsoft.Azure.Cosmos.Encryption.Custom/ — custom encryption extension
+  - Microsoft.Azure.Cosmos.Samples/ — runnable examples and usage patterns
+  - docs/ — general reference documentation (SdkDesign.md, etc.)
+
+  Build & test:
+  - Build: dotnet build Microsoft.Azure.Cosmos.sln
+  - Unit tests: dotnet test in test project folders under **/tests/
+  - Integration tests: require Windows Cosmos DB Emulator (see templates/emulator-setup.yml)
+  - CI pipelines: azure-pipelines-*.yml files at repo root
+
+  Versioning & feature flags:
+  - Versions managed in Directory.Build.props (do NOT change without explicit instruction)
+  - Preview features gated by PREVIEW define constant (IsPreview=true)
+  - Strong-name signed assemblies (35MSSharedLib1024.snk)
+
+  Architecture reference: docs/SdkDesign.md
+  Design guidelines: SdkDesignGuidelines.md
+  Central SDK guidelines: https://azure.github.io/azure-sdk/dotnet_introduction.html
+
+  Conventions:
+  - Public contract changes require API review (see SdkDesignGuidelines.md)
+  - Request options should not be sealed
+  - All public APIs must support unit testing and mocking
+  - Consistency with existing V3 public API takes priority over central SDK guidelines
+  - Never push directly to master — always use feature branches and PRs
+  - PR title format: [Internal] Category: (Adds|Fixes|Refactors|Removes) Description
+  - Use [Internal] prefix only for changes with NO customer-facing impact
+
+  SDK areas: routing, retry, query, changefeed, bulk, serialization,
+             encryption, telemetry, transport, diagnostics, client-config
+
+rules:
+  proposal:
+    - Include which SDK area this change affects (routing, retry, query, changefeed, bulk, serialization, encryption, telemetry, transport, diagnostics, client-config)
+    - State whether this is a preview or GA feature
+    - Link related GitHub issues with issue numbers
+    - Include a Non-goals section to clarify scope boundaries
+    - Note any service-side dependencies or minimum service version requirements
+
+  specs:
+    - Use EARS notation for behavioral requirements (WHEN <condition>, THEN the SDK SHALL <behavior>)
+    - Include full C# public API surface with XML doc comments
+    - Show a complete usage example a customer would write
+    - Make every acceptance criterion testable — each must map to at least one test case
+    - Specify error handling behavior using CosmosException (status codes, sub-status codes)
+    - Note backward compatibility impact and any breaking changes with migration guidance
+    - Include configuration precedence (per-request RequestOptions > client-wide CosmosClientOptions > environment variable > default)
+
+  design:
+    - Reference docs/SdkDesign.md for component architecture context
+    - Link to specific source files using relative paths (e.g., ../../Microsoft.Azure.Cosmos/src/Path/File.cs)
+    - Include Mermaid diagrams for request flow through SDK layers
+    - List all new and modified files with their responsibilities in a table
+    - Document alternatives considered with pros, cons, and rejection rationale
+    - Note thread safety and performance considerations
+
+  tasks:
+    - Separate tasks into implementation, contract updates, and documentation
+    - Include unit test tasks with specific test scenarios listed
+    - Include integration test tasks that specify emulator requirements
+    - Include baseline/golden-file test tasks for serialization stability (follow EndToEndTraceWriterBaselineTests pattern)
+    - Include a task to update ContractEnforcementTests baseline for any public API changes
+    - Include a task to update changelog.md
+    - Include a task to update .github/copilot-instructions.md if the feature affects AI assistant behavior

--- a/openspec/specs/README.md
+++ b/openspec/specs/README.md
@@ -1,0 +1,70 @@
+# Azure Cosmos DB .NET SDK — Feature Specifications
+
+This directory contains behavioral specifications for all major features of the Azure Cosmos DB .NET SDK v3. Each spec uses [EARS notation](https://en.wikipedia.org/wiki/Easy_Approach_to_Requirements_Syntax) (WHEN/THEN/SHALL) and structured scenarios that are testable, reviewable, and consumable by AI agents.
+
+## How to Use These Specs
+
+- **Before implementing a feature**: Read the relevant spec to understand requirements and edge cases
+- **During code review**: Validate PRs against the spec's scenarios and requirements
+- **For AI agents**: Reference specs as authoritative context for implementation, testing, and review tasks
+- **For onboarding**: Use specs to understand how each SDK feature is supposed to behave
+
+## Spec Format
+
+Each spec follows a consistent structure:
+- **Purpose**: What the feature does at a high level
+- **Requirements**: Behavioral requirements using RFC 2119 keywords (SHALL, MUST, SHOULD, MAY)
+- **Scenarios**: Concrete Given/When/Then examples for each requirement
+- **Key Source Files**: Links to implementation code
+
+## Index by Area
+
+### Data Operations
+| Spec | Description |
+|------|-------------|
+| [CRUD Operations](crud-operations/spec.md) | Point reads, creates, upserts, replaces, deletes, patches, ReadMany |
+| [Query Execution](query-execution/spec.md) | SQL queries, LINQ, cross-partition, pagination, FeedIterator |
+| [Change Feed](change-feed/spec.md) | Change feed iterator, processor, estimator, modes, start positions |
+| [Bulk and Batch](bulk-and-batch/spec.md) | TransactionalBatch (atomic) and bulk execution (throughput-optimized) |
+
+### Routing & Availability
+| Spec | Description |
+|------|-------------|
+| [Retry and Failover](retry-and-failover/spec.md) | Throttling retry (429), region failover, PPAF, Gone (410) handling |
+| [Cross-Region Hedging](cross-region-hedging/spec.md) | AvailabilityStrategy, threshold-based hedging, response selection |
+| [Partitioning](partitioning/spec.md) | Partition keys, hierarchical keys, FeedRange, partition routing |
+
+### Transport & Configuration
+| Spec | Description |
+|------|-------------|
+| [Transport and Connectivity](transport-and-connectivity/spec.md) | Gateway vs Direct mode, TCP tuning, endpoint discovery |
+| [Client Configuration](client-configuration/spec.md) | CosmosClient lifecycle, authentication, custom handlers, builder |
+| [Consistency and Session](consistency-and-session/spec.md) | Five consistency levels, session token management |
+
+### Serialization & Diagnostics
+| Spec | Description |
+|------|-------------|
+| [Serialization](serialization/spec.md) | CosmosSerializer, JSON.NET, System.Text.Json, LINQ serialization |
+| [Diagnostics and Tracing](diagnostics-and-tracing/spec.md) | CosmosDiagnostics, trace tree, OpenTelemetry, metrics |
+
+### Security
+| Spec | Description |
+|------|-------------|
+| [Client-Side Encryption](client-side-encryption/spec.md) | Encryption keys, policies, transparent encrypt/decrypt |
+| [Resource Management](resource-management/spec.md) | Database/container CRUD, throughput, indexing, TTL, vector/full-text search |
+
+## Creating New Specs
+
+For new features, use the OpenSpec workflow:
+```
+/opsx:propose <feature-name>
+```
+
+This creates a change folder in `openspec/changes/<feature-name>/` with proposal, specs, design, and tasks. When the feature ships and the change is archived, its delta specs merge into the appropriate spec file here.
+
+## Related Documentation
+
+- [SdkDesignGuidelines.md](../../SdkDesignGuidelines.md) — public API contract rules
+- [docs/SdkDesign.md](../../docs/SdkDesign.md) — SDK architecture overview
+- [docs/](../../docs/) — existing design documents
+- [openspec/config.yaml](../config.yaml) — OpenSpec project configuration and rules

--- a/openspec/specs/bulk-and-batch/spec.md
+++ b/openspec/specs/bulk-and-batch/spec.md
@@ -1,0 +1,128 @@
+# Bulk and Batch Operations
+
+## Purpose
+
+Transactional batch provides atomic multi-operation execution within a single partition key. Bulk execution mode optimizes throughput for high-volume ingestion and processing scenarios.
+
+## Requirements
+
+### Requirement: Transactional Batch
+The SDK SHALL execute multiple operations atomically within a single partition key scope.
+
+#### Scenario: Successful batch execution
+- GIVEN a transactional batch with multiple operations on the same partition key
+- WHEN `Container.CreateTransactionalBatch(partitionKey).CreateItem(a).UpsertItem(b).DeleteItem(cId).ExecuteAsync()` is called
+- THEN all operations succeed atomically
+- AND a `TransactionalBatchResponse` is returned with overall status code 200
+- AND individual operation results are accessible by index
+
+#### Scenario: Batch failure (atomicity)
+- GIVEN a batch where one operation would fail (e.g., creating a duplicate)
+- WHEN `ExecuteAsync()` is called
+- THEN ALL operations in the batch are rolled back
+- AND no partial state is persisted
+- AND the response status code indicates the failure
+
+#### Scenario: Mixed operation types
+- GIVEN a batch containing Create, Replace, Upsert, Patch, Delete, and Read operations
+- WHEN `ExecuteAsync()` is called
+- THEN all operations execute in the order they were added
+
+### Requirement: Batch Operation Types
+The SDK SHALL support all CRUD operation types within a transactional batch.
+
+#### Scenario: Batch create
+- GIVEN `batch.CreateItem<T>(item)`
+- WHEN the batch executes
+- THEN the item is created if it does not exist
+
+#### Scenario: Batch replace
+- GIVEN `batch.ReplaceItem<T>(id, item)`
+- WHEN the batch executes
+- THEN the existing item is fully replaced
+
+#### Scenario: Batch upsert
+- GIVEN `batch.UpsertItem<T>(item)`
+- WHEN the batch executes
+- THEN the item is created or replaced
+
+#### Scenario: Batch patch
+- GIVEN `batch.PatchItem(id, patchOperations)`
+- WHEN the batch executes
+- THEN partial modifications are applied to the item
+
+#### Scenario: Batch delete
+- GIVEN `batch.DeleteItem(id)`
+- WHEN the batch executes
+- THEN the item is removed
+
+#### Scenario: Batch read
+- GIVEN `batch.ReadItem(id)`
+- WHEN the batch executes
+- THEN the item's current state is returned in the operation result
+
+### Requirement: Batch with Stream
+The SDK SHALL support stream-based batch operations for zero-copy performance.
+
+#### Scenario: Stream-based create
+- GIVEN `batch.CreateItemStream(stream)`
+- WHEN the batch executes
+- THEN the item is created from the raw JSON stream without deserialization
+
+### Requirement: Batch Response Inspection
+The SDK SHALL provide access to individual operation results within a batch response.
+
+#### Scenario: Access individual results
+- GIVEN a completed batch response
+- WHEN `response.GetOperationResultAtIndex<T>(index)` is called
+- THEN the result for that specific operation is returned with its status code, resource, and ETag
+
+#### Scenario: Check overall success
+- GIVEN a completed batch response
+- WHEN `response.IsSuccessStatusCode` is checked
+- THEN it reflects whether all operations succeeded
+
+### Requirement: Batch Partition Key Constraint
+The SDK SHALL enforce that all operations in a batch target the same partition key.
+
+#### Scenario: Single partition key
+- GIVEN a batch created with `CreateTransactionalBatch(partitionKey)`
+- WHEN operations are added
+- THEN all operations are scoped to that partition key
+- AND cross-partition batches are not supported
+
+### Requirement: Bulk Execution Mode
+The SDK SHALL support a bulk execution mode that batches individual operations for higher throughput.
+
+#### Scenario: Enable bulk mode
+- GIVEN `CosmosClientOptions.AllowBulkExecution = true`
+- WHEN individual item operations (Create, Upsert, Replace, Delete, Read) are issued concurrently
+- THEN the SDK automatically groups operations into server-side batches
+- AND throughput is optimized at the cost of per-operation latency
+
+#### Scenario: Bulk with concurrent tasks
+- GIVEN bulk execution is enabled
+- WHEN hundreds of `CreateItemAsync` calls are made concurrently via `Task.WhenAll`
+- THEN the SDK internally batches these into optimal groups by partition key
+- AND each batch is sent as a single server request
+
+#### Scenario: Bulk retry behavior
+- GIVEN a bulk operation encounters a 429 (Throttled) response
+- WHEN the throttled batch is retried
+- THEN the SDK uses `BulkExecutionRetryPolicy` for retry logic
+- AND respects `MaxRetryAttemptsOnRateLimitedRequests` and `MaxRetryWaitTimeOnRateLimitedRequests`
+
+### Requirement: Batch Optimistic Concurrency
+The SDK SHALL support ETag-based concurrency within batch operations.
+
+#### Scenario: Conditional replace in batch
+- GIVEN `batch.ReplaceItem(id, item, new TransactionalBatchItemRequestOptions { IfMatchEtag = etag })`
+- WHEN the batch executes and the item's ETag does not match
+- THEN the entire batch fails with a precondition failure
+
+## Key Source Files
+- `Microsoft.Azure.Cosmos/src/Batch/TransactionalBatch.cs` — public batch API
+- `Microsoft.Azure.Cosmos/src/Batch/TransactionalBatchResponse.cs` — batch response
+- `Microsoft.Azure.Cosmos/src/Batch/BatchAsyncContainerExecutor.cs` — bulk execution orchestrator
+- `Microsoft.Azure.Cosmos/src/Batch/ItemBatchOperation.cs` — individual operation representation
+- `Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs` — `AllowBulkExecution` property

--- a/openspec/specs/bulk-and-batch/spec.md
+++ b/openspec/specs/bulk-and-batch/spec.md
@@ -9,116 +9,74 @@ Transactional batch provides atomic multi-operation execution within a single pa
 ### Requirement: Transactional Batch
 The SDK SHALL execute multiple operations atomically within a single partition key scope.
 
-#### Scenario: Successful batch execution
-- GIVEN a transactional batch with multiple operations on the same partition key
-- WHEN `Container.CreateTransactionalBatch(partitionKey).CreateItem(a).UpsertItem(b).DeleteItem(cId).ExecuteAsync()` is called
-- THEN all operations succeed atomically
-- AND a `TransactionalBatchResponse` is returned with overall status code 200
-- AND individual operation results are accessible by index
+#### Successful batch execution
+**When** `Container.CreateTransactionalBatch(partitionKey).CreateItem(a).UpsertItem(b).DeleteItem(cId).ExecuteAsync()` is called with multiple operations on the same partition key, the SDK shall execute all operations atomically, return a `TransactionalBatchResponse` with overall status code 200, and provide individual operation results accessible by index.
 
-#### Scenario: Batch failure (atomicity)
-- GIVEN a batch where one operation would fail (e.g., creating a duplicate)
-- WHEN `ExecuteAsync()` is called
-- THEN ALL operations in the batch are rolled back
-- AND no partial state is persisted
-- AND the response status code indicates the failure
+#### Batch failure (atomicity)
+**If** any operation in a transactional batch would fail (e.g., creating a duplicate), **then** the SDK shall roll back ALL operations in the batch, persist no partial state, and return a response status code indicating the failure.
 
-#### Scenario: Mixed operation types
-- GIVEN a batch containing Create, Replace, Upsert, Patch, Delete, and Read operations
-- WHEN `ExecuteAsync()` is called
-- THEN all operations execute in the order they were added
+#### Mixed operation types
+**When** `ExecuteAsync()` is called on a batch containing Create, Replace, Upsert, Patch, Delete, and Read operations, the SDK shall execute all operations in the order they were added.
 
 ### Requirement: Batch Operation Types
 The SDK SHALL support all CRUD operation types within a transactional batch.
 
-#### Scenario: Batch create
-- GIVEN `batch.CreateItem<T>(item)`
-- WHEN the batch executes
-- THEN the item is created if it does not exist
+#### Batch create
+**When** the batch executes with `batch.CreateItem<T>(item)`, the SDK shall create the item if it does not exist.
 
-#### Scenario: Batch replace
-- GIVEN `batch.ReplaceItem<T>(id, item)`
-- WHEN the batch executes
-- THEN the existing item is fully replaced
+#### Batch replace
+**When** the batch executes with `batch.ReplaceItem<T>(id, item)`, the SDK shall fully replace the existing item.
 
-#### Scenario: Batch upsert
-- GIVEN `batch.UpsertItem<T>(item)`
-- WHEN the batch executes
-- THEN the item is created or replaced
+#### Batch upsert
+**When** the batch executes with `batch.UpsertItem<T>(item)`, the SDK shall create or replace the item.
 
-#### Scenario: Batch patch
-- GIVEN `batch.PatchItem(id, patchOperations)`
-- WHEN the batch executes
-- THEN partial modifications are applied to the item
+#### Batch patch
+**When** the batch executes with `batch.PatchItem(id, patchOperations)`, the SDK shall apply partial modifications to the item.
 
-#### Scenario: Batch delete
-- GIVEN `batch.DeleteItem(id)`
-- WHEN the batch executes
-- THEN the item is removed
+#### Batch delete
+**When** the batch executes with `batch.DeleteItem(id)`, the SDK shall remove the item.
 
-#### Scenario: Batch read
-- GIVEN `batch.ReadItem(id)`
-- WHEN the batch executes
-- THEN the item's current state is returned in the operation result
+#### Batch read
+**When** the batch executes with `batch.ReadItem(id)`, the SDK shall return the item's current state in the operation result.
 
 ### Requirement: Batch with Stream
 The SDK SHALL support stream-based batch operations for zero-copy performance.
 
-#### Scenario: Stream-based create
-- GIVEN `batch.CreateItemStream(stream)`
-- WHEN the batch executes
-- THEN the item is created from the raw JSON stream without deserialization
+#### Stream-based create
+**When** the batch executes with `batch.CreateItemStream(stream)`, the SDK shall create the item from the raw JSON stream without deserialization.
 
 ### Requirement: Batch Response Inspection
 The SDK SHALL provide access to individual operation results within a batch response.
 
-#### Scenario: Access individual results
-- GIVEN a completed batch response
-- WHEN `response.GetOperationResultAtIndex<T>(index)` is called
-- THEN the result for that specific operation is returned with its status code, resource, and ETag
+#### Access individual results
+**When** `response.GetOperationResultAtIndex<T>(index)` is called on a completed batch response, the SDK shall return the result for that specific operation with its status code, resource, and ETag.
 
-#### Scenario: Check overall success
-- GIVEN a completed batch response
-- WHEN `response.IsSuccessStatusCode` is checked
-- THEN it reflects whether all operations succeeded
+#### Check overall success
+**When** `response.IsSuccessStatusCode` is checked on a completed batch response, the SDK shall reflect whether all operations succeeded.
 
 ### Requirement: Batch Partition Key Constraint
 The SDK SHALL enforce that all operations in a batch target the same partition key.
 
-#### Scenario: Single partition key
-- GIVEN a batch created with `CreateTransactionalBatch(partitionKey)`
-- WHEN operations are added
-- THEN all operations are scoped to that partition key
-- AND cross-partition batches are not supported
+#### Single partition key
+**When** a batch is created with `CreateTransactionalBatch(partitionKey)` and operations are added, the SDK shall scope all operations to that partition key and shall not support cross-partition batches.
 
 ### Requirement: Bulk Execution Mode
 The SDK SHALL support a bulk execution mode that batches individual operations for higher throughput.
 
-#### Scenario: Enable bulk mode
-- GIVEN `CosmosClientOptions.AllowBulkExecution = true`
-- WHEN individual item operations (Create, Upsert, Replace, Delete, Read) are issued concurrently
-- THEN the SDK automatically groups operations into server-side batches
-- AND throughput is optimized at the cost of per-operation latency
+#### Enable bulk mode
+**Where** `CosmosClientOptions.AllowBulkExecution = true`, **when** individual item operations (Create, Upsert, Replace, Delete, Read) are issued concurrently, the SDK shall automatically group operations into server-side batches and optimize throughput at the cost of per-operation latency.
 
-#### Scenario: Bulk with concurrent tasks
-- GIVEN bulk execution is enabled
-- WHEN hundreds of `CreateItemAsync` calls are made concurrently via `Task.WhenAll`
-- THEN the SDK internally batches these into optimal groups by partition key
-- AND each batch is sent as a single server request
+#### Bulk with concurrent tasks
+**While** bulk execution is enabled, **when** hundreds of `CreateItemAsync` calls are made concurrently via `Task.WhenAll`, the SDK shall internally batch these into optimal groups by partition key and send each batch as a single server request.
 
-#### Scenario: Bulk retry behavior
-- GIVEN a bulk operation encounters a 429 (Throttled) response
-- WHEN the throttled batch is retried
-- THEN the SDK uses `BulkExecutionRetryPolicy` for retry logic
-- AND respects `MaxRetryAttemptsOnRateLimitedRequests` and `MaxRetryWaitTimeOnRateLimitedRequests`
+#### Bulk retry behavior
+**If** a bulk operation encounters a 429 (Throttled) response, **then** the SDK shall use `BulkExecutionRetryPolicy` for retry logic and respect `MaxRetryAttemptsOnRateLimitedRequests` and `MaxRetryWaitTimeOnRateLimitedRequests`.
 
 ### Requirement: Batch Optimistic Concurrency
 The SDK SHALL support ETag-based concurrency within batch operations.
 
-#### Scenario: Conditional replace in batch
-- GIVEN `batch.ReplaceItem(id, item, new TransactionalBatchItemRequestOptions { IfMatchEtag = etag })`
-- WHEN the batch executes and the item's ETag does not match
-- THEN the entire batch fails with a precondition failure
+#### Conditional replace in batch
+**If** the item's ETag does not match when executing a batch with `batch.ReplaceItem(id, item, new TransactionalBatchItemRequestOptions { IfMatchEtag = etag })`, **then** the SDK shall fail the entire batch with a precondition failure.
 
 ## Key Source Files
 - `Microsoft.Azure.Cosmos/src/Batch/TransactionalBatch.cs` — public batch API

--- a/openspec/specs/change-feed/spec.md
+++ b/openspec/specs/change-feed/spec.md
@@ -9,131 +9,83 @@ Change feed provides an ordered stream of changes (creates, updates, and optiona
 ### Requirement: Change Feed Iterator
 The SDK SHALL provide a pull-based iterator for reading changes from a container.
 
-#### Scenario: Read all changes from beginning
-- GIVEN a container with existing items
-- WHEN `Container.GetChangeFeedIterator<T>(ChangeFeedStartFrom.Beginning(), ChangeFeedMode.Incremental)` is called
-- THEN all historical creates and updates are returned in order per partition
+#### Read all changes from beginning
+**When** `Container.GetChangeFeedIterator<T>(ChangeFeedStartFrom.Beginning(), ChangeFeedMode.Incremental)` is called on a container with existing items, the SDK shall return all historical creates and updates in order per partition.
 
-#### Scenario: Read changes from now
-- GIVEN a container
-- WHEN `Container.GetChangeFeedIterator<T>(ChangeFeedStartFrom.Now())` is called
-- THEN only changes occurring after this point are returned
+#### Read changes from now
+**When** `Container.GetChangeFeedIterator<T>(ChangeFeedStartFrom.Now())` is called, the SDK shall return only changes occurring after this point.
 
-#### Scenario: Read changes from specific time
-- GIVEN a UTC timestamp
-- WHEN `Container.GetChangeFeedIterator<T>(ChangeFeedStartFrom.Time(dateTimeUtc))` is called
-- THEN changes are returned starting from the first change after that timestamp (exclusive)
+#### Read changes from specific time
+**When** `Container.GetChangeFeedIterator<T>(ChangeFeedStartFrom.Time(dateTimeUtc))` is called with a UTC timestamp, the SDK shall return changes starting from the first change after that timestamp (exclusive).
 
-#### Scenario: Resume from continuation token
-- GIVEN a continuation token from a previous change feed read
-- WHEN `Container.GetChangeFeedIterator<T>(ChangeFeedStartFrom.ContinuationToken(token))` is called
-- THEN reading resumes from the saved position
+#### Resume from continuation token
+**When** `Container.GetChangeFeedIterator<T>(ChangeFeedStartFrom.ContinuationToken(token))` is called with a continuation token from a previous change feed read, the SDK shall resume reading from the saved position.
 
-#### Scenario: No new changes available
-- GIVEN no new changes since the last read
-- WHEN `ReadNextAsync()` is called
-- THEN a `FeedResponse<T>` is returned with status code 304 (Not Modified)
-- AND `HasMoreResults` remains true (change feed never completes)
+#### No new changes available
+**While** no new changes are available since the last read, **when** `ReadNextAsync()` is called, the SDK shall return a `FeedResponse<T>` with status code 304 (Not Modified) and `HasMoreResults` shall remain true (change feed never completes).
 
 ### Requirement: Change Feed Modes
 The SDK SHALL support multiple change feed modes with different fidelity levels.
 
-#### Scenario: Incremental mode (default)
-- GIVEN `ChangeFeedMode.Incremental` (or `LatestVersion`)
-- WHEN changes are read
-- THEN only the latest version of each item is returned
-- AND deletes are NOT included
+#### Incremental mode (default)
+**Where** `ChangeFeedMode.Incremental` (or `LatestVersion`) is used, **when** changes are read, the SDK shall return only the latest version of each item and shall not include deletes.
 
-#### Scenario: All Versions and Deletes mode
-- GIVEN `ChangeFeedMode.AllVersionsAndDeletes` (or `FullFidelity`)
-- WHEN changes are read
-- THEN all intermediate versions of each item are returned
-- AND delete events are included with metadata
-- AND the container MUST have a change feed retention policy configured
+#### All Versions and Deletes mode
+**Where** `ChangeFeedMode.AllVersionsAndDeletes` (or `FullFidelity`) is used, **when** changes are read, the SDK shall return all intermediate versions of each item and include delete events with metadata. The container MUST have a change feed retention policy configured.
 
 ### Requirement: Change Feed Processor
 The SDK SHALL provide a distributed change feed processing framework with automatic partition assignment and checkpointing.
 
-#### Scenario: Start processing
-- GIVEN a processor built with `Container.GetChangeFeedProcessorBuilder<T>(processorName, handler)`
-- AND configured with `.WithInstanceName(name).WithLeaseContainer(leaseContainer)`
-- WHEN `processor.StartAsync()` is called
-- THEN the processor begins polling for changes across all partitions
-- AND distributes work across instances sharing the same processor name
+#### Start processing
+**When** `processor.StartAsync()` is called on a processor built with `Container.GetChangeFeedProcessorBuilder<T>(processorName, handler)` and configured with `.WithInstanceName(name).WithLeaseContainer(leaseContainer)`, the SDK shall begin polling for changes across all partitions and distribute work across instances sharing the same processor name.
 
-#### Scenario: Automatic load balancing
-- GIVEN multiple processor instances with the same processor name
-- WHEN a new instance starts or an existing instance stops
-- THEN partition leases are automatically rebalanced across running instances
+#### Automatic load balancing
+**While** multiple processor instances share the same processor name, **when** a new instance starts or an existing instance stops, the SDK shall automatically rebalance partition leases across running instances.
 
-#### Scenario: Automatic checkpointing
-- GIVEN a `ChangesHandler<T>` delegate that completes successfully
-- WHEN the delegate returns without exception
-- THEN the checkpoint is automatically updated in the lease container
+#### Automatic checkpointing
+**When** a `ChangesHandler<T>` delegate returns without exception, the SDK shall automatically update the checkpoint in the lease container.
 
-#### Scenario: Manual checkpointing
-- GIVEN a processor built with `GetChangeFeedProcessorBuilderWithManualCheckpoint<T>`
-- WHEN the delegate is invoked with a `checkpointAsync` function
-- THEN the application controls when checkpoints are saved by calling `checkpointAsync()`
+#### Manual checkpointing
+**Where** a processor is built with `GetChangeFeedProcessorBuilderWithManualCheckpoint<T>`, **when** the delegate is invoked, the SDK shall provide a `checkpointAsync` function that allows the application to control when checkpoints are saved.
 
-#### Scenario: Handler failure
-- GIVEN a `ChangesHandler<T>` delegate that throws an exception
-- WHEN the exception propagates
-- THEN the change batch is retried from the last checkpoint
-- AND the lease is not advanced
+#### Handler failure
+**If** a `ChangesHandler<T>` delegate throws an exception, **then** the SDK shall retry the change batch from the last checkpoint and shall not advance the lease.
 
 ### Requirement: Change Feed Processor Configuration
 The SDK SHALL support configuring processor timing and behavior.
 
-#### Scenario: Poll interval
-- GIVEN `.WithPollInterval(TimeSpan.FromSeconds(5))` is configured
-- WHEN no new changes are available
-- THEN the processor waits 5 seconds before polling again (default: 1 second)
+#### Poll interval
+**Where** `.WithPollInterval(TimeSpan.FromSeconds(5))` is configured, **when** no new changes are available, the SDK shall wait 5 seconds before polling again (default: 1 second).
 
-#### Scenario: Max items per trigger
-- GIVEN `.WithMaxItems(100)` is configured
-- WHEN changes are available
-- THEN at most 100 items are passed per delegate invocation
+#### Max items per trigger
+**Where** `.WithMaxItems(100)` is configured, **when** changes are available, the SDK shall pass at most 100 items per delegate invocation.
 
-#### Scenario: Lease configuration
-- GIVEN custom lease timing via `.WithLeaseConfiguration(acquireInterval, expirationInterval, renewInterval)`
-- WHEN the processor runs
-- THEN leases are acquired at `acquireInterval` (default: 13s), renewed at `renewInterval` (default: 10s), and expire after `expirationInterval` (default: 60s)
+#### Lease configuration
+**Where** custom lease timing is configured via `.WithLeaseConfiguration(acquireInterval, expirationInterval, renewInterval)`, **when** the processor runs, the SDK shall acquire leases at `acquireInterval` (default: 13s), renew at `renewInterval` (default: 10s), and expire leases after `expirationInterval` (default: 60s).
 
-#### Scenario: Start from beginning
-- GIVEN `.WithStartFromBeginning()` is configured
-- WHEN the processor starts for the first time (no existing leases)
-- THEN processing begins from the earliest available changes
+#### Start from beginning
+**Where** `.WithStartFromBeginning()` is configured, **when** the processor starts for the first time (no existing leases), the SDK shall begin processing from the earliest available changes.
 
 ### Requirement: Change Feed Estimator
 The SDK SHALL provide a mechanism to estimate the number of pending changes.
 
-#### Scenario: Estimate remaining work
-- GIVEN an estimator built with `Container.GetChangeFeedEstimator(processorName, leaseContainer)`
-- WHEN `estimator.ReadNextAsync()` is called
-- THEN a `FeedResponse<ChangeFeedProcessorState>` is returned
-- AND each item contains the estimated lag per partition
+#### Estimate remaining work
+**When** `estimator.ReadNextAsync()` is called on an estimator built with `Container.GetChangeFeedEstimator(processorName, leaseContainer)`, the SDK shall return a `FeedResponse<ChangeFeedProcessorState>` where each item contains the estimated lag per partition.
 
 ### Requirement: Change Feed with FeedRange
 The SDK SHALL support reading changes from a specific subset of partitions.
 
-#### Scenario: Scoped to FeedRange
-- GIVEN a `FeedRange` obtained from `Container.GetFeedRangesAsync()`
-- WHEN `ChangeFeedStartFrom.Beginning(feedRange)` is used
-- THEN only changes within that partition range are returned
+#### Scoped to FeedRange
+**When** `ChangeFeedStartFrom.Beginning(feedRange)` is used with a `FeedRange` obtained from `Container.GetFeedRangesAsync()`, the SDK shall return only changes within that partition range.
 
 ### Requirement: Change Feed Ordering
 The SDK SHALL guarantee ordering within a logical partition.
 
-#### Scenario: Within-partition ordering
-- GIVEN multiple changes to items with the same partition key
-- WHEN changes are read via change feed
-- THEN changes appear in the order they were committed
+#### Within-partition ordering
+**When** changes to items with the same partition key are read via change feed, the SDK shall return changes in the order they were committed.
 
-#### Scenario: Cross-partition ordering
-- GIVEN changes across different partitions
-- WHEN changes are read
-- THEN ordering is guaranteed only within each partition, not across partitions
+#### Cross-partition ordering
+**When** changes across different partitions are read, the SDK shall guarantee ordering only within each partition, not across partitions.
 
 ## Key Source Files
 - `Microsoft.Azure.Cosmos/src/ChangeFeed/ChangeFeedIteratorCore.cs` — iterator implementation

--- a/openspec/specs/change-feed/spec.md
+++ b/openspec/specs/change-feed/spec.md
@@ -1,0 +1,144 @@
+# Change Feed
+
+## Purpose
+
+Change feed provides an ordered stream of changes (creates, updates, and optionally deletes) made to items in a container. It supports both pull-based iteration and push-based distributed processing.
+
+## Requirements
+
+### Requirement: Change Feed Iterator
+The SDK SHALL provide a pull-based iterator for reading changes from a container.
+
+#### Scenario: Read all changes from beginning
+- GIVEN a container with existing items
+- WHEN `Container.GetChangeFeedIterator<T>(ChangeFeedStartFrom.Beginning(), ChangeFeedMode.Incremental)` is called
+- THEN all historical creates and updates are returned in order per partition
+
+#### Scenario: Read changes from now
+- GIVEN a container
+- WHEN `Container.GetChangeFeedIterator<T>(ChangeFeedStartFrom.Now())` is called
+- THEN only changes occurring after this point are returned
+
+#### Scenario: Read changes from specific time
+- GIVEN a UTC timestamp
+- WHEN `Container.GetChangeFeedIterator<T>(ChangeFeedStartFrom.Time(dateTimeUtc))` is called
+- THEN changes are returned starting from the first change after that timestamp (exclusive)
+
+#### Scenario: Resume from continuation token
+- GIVEN a continuation token from a previous change feed read
+- WHEN `Container.GetChangeFeedIterator<T>(ChangeFeedStartFrom.ContinuationToken(token))` is called
+- THEN reading resumes from the saved position
+
+#### Scenario: No new changes available
+- GIVEN no new changes since the last read
+- WHEN `ReadNextAsync()` is called
+- THEN a `FeedResponse<T>` is returned with status code 304 (Not Modified)
+- AND `HasMoreResults` remains true (change feed never completes)
+
+### Requirement: Change Feed Modes
+The SDK SHALL support multiple change feed modes with different fidelity levels.
+
+#### Scenario: Incremental mode (default)
+- GIVEN `ChangeFeedMode.Incremental` (or `LatestVersion`)
+- WHEN changes are read
+- THEN only the latest version of each item is returned
+- AND deletes are NOT included
+
+#### Scenario: All Versions and Deletes mode
+- GIVEN `ChangeFeedMode.AllVersionsAndDeletes` (or `FullFidelity`)
+- WHEN changes are read
+- THEN all intermediate versions of each item are returned
+- AND delete events are included with metadata
+- AND the container MUST have a change feed retention policy configured
+
+### Requirement: Change Feed Processor
+The SDK SHALL provide a distributed change feed processing framework with automatic partition assignment and checkpointing.
+
+#### Scenario: Start processing
+- GIVEN a processor built with `Container.GetChangeFeedProcessorBuilder<T>(processorName, handler)`
+- AND configured with `.WithInstanceName(name).WithLeaseContainer(leaseContainer)`
+- WHEN `processor.StartAsync()` is called
+- THEN the processor begins polling for changes across all partitions
+- AND distributes work across instances sharing the same processor name
+
+#### Scenario: Automatic load balancing
+- GIVEN multiple processor instances with the same processor name
+- WHEN a new instance starts or an existing instance stops
+- THEN partition leases are automatically rebalanced across running instances
+
+#### Scenario: Automatic checkpointing
+- GIVEN a `ChangesHandler<T>` delegate that completes successfully
+- WHEN the delegate returns without exception
+- THEN the checkpoint is automatically updated in the lease container
+
+#### Scenario: Manual checkpointing
+- GIVEN a processor built with `GetChangeFeedProcessorBuilderWithManualCheckpoint<T>`
+- WHEN the delegate is invoked with a `checkpointAsync` function
+- THEN the application controls when checkpoints are saved by calling `checkpointAsync()`
+
+#### Scenario: Handler failure
+- GIVEN a `ChangesHandler<T>` delegate that throws an exception
+- WHEN the exception propagates
+- THEN the change batch is retried from the last checkpoint
+- AND the lease is not advanced
+
+### Requirement: Change Feed Processor Configuration
+The SDK SHALL support configuring processor timing and behavior.
+
+#### Scenario: Poll interval
+- GIVEN `.WithPollInterval(TimeSpan.FromSeconds(5))` is configured
+- WHEN no new changes are available
+- THEN the processor waits 5 seconds before polling again (default: 1 second)
+
+#### Scenario: Max items per trigger
+- GIVEN `.WithMaxItems(100)` is configured
+- WHEN changes are available
+- THEN at most 100 items are passed per delegate invocation
+
+#### Scenario: Lease configuration
+- GIVEN custom lease timing via `.WithLeaseConfiguration(acquireInterval, expirationInterval, renewInterval)`
+- WHEN the processor runs
+- THEN leases are acquired at `acquireInterval` (default: 13s), renewed at `renewInterval` (default: 10s), and expire after `expirationInterval` (default: 60s)
+
+#### Scenario: Start from beginning
+- GIVEN `.WithStartFromBeginning()` is configured
+- WHEN the processor starts for the first time (no existing leases)
+- THEN processing begins from the earliest available changes
+
+### Requirement: Change Feed Estimator
+The SDK SHALL provide a mechanism to estimate the number of pending changes.
+
+#### Scenario: Estimate remaining work
+- GIVEN an estimator built with `Container.GetChangeFeedEstimator(processorName, leaseContainer)`
+- WHEN `estimator.ReadNextAsync()` is called
+- THEN a `FeedResponse<ChangeFeedProcessorState>` is returned
+- AND each item contains the estimated lag per partition
+
+### Requirement: Change Feed with FeedRange
+The SDK SHALL support reading changes from a specific subset of partitions.
+
+#### Scenario: Scoped to FeedRange
+- GIVEN a `FeedRange` obtained from `Container.GetFeedRangesAsync()`
+- WHEN `ChangeFeedStartFrom.Beginning(feedRange)` is used
+- THEN only changes within that partition range are returned
+
+### Requirement: Change Feed Ordering
+The SDK SHALL guarantee ordering within a logical partition.
+
+#### Scenario: Within-partition ordering
+- GIVEN multiple changes to items with the same partition key
+- WHEN changes are read via change feed
+- THEN changes appear in the order they were committed
+
+#### Scenario: Cross-partition ordering
+- GIVEN changes across different partitions
+- WHEN changes are read
+- THEN ordering is guaranteed only within each partition, not across partitions
+
+## Key Source Files
+- `Microsoft.Azure.Cosmos/src/ChangeFeed/ChangeFeedIteratorCore.cs` — iterator implementation
+- `Microsoft.Azure.Cosmos/src/ChangeFeed/ChangeFeedStartFrom.cs` — start position types
+- `Microsoft.Azure.Cosmos/src/ChangeFeed/ChangeFeedMode.cs` — mode selection
+- `Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedProcessor.cs` — processor interface
+- `Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedProcessorBuilder.cs` — builder
+- `Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/` — lease management

--- a/openspec/specs/client-configuration/spec.md
+++ b/openspec/specs/client-configuration/spec.md
@@ -9,127 +9,83 @@
 ### Requirement: Client Construction
 The SDK SHALL support multiple authentication methods for constructing a CosmosClient.
 
-#### Scenario: Connection string
-- GIVEN a Cosmos DB connection string
-- WHEN `new CosmosClient(connectionString)` is called
-- THEN the client connects using the account endpoint and key from the string
+#### Connection string
+**When** `new CosmosClient(connectionString)` is called with a Cosmos DB connection string, the SDK shall connect using the account endpoint and key from the string.
 
-#### Scenario: Endpoint + key
-- GIVEN an account endpoint URI and account key
-- WHEN `new CosmosClient(endpoint, authKeyOrResourceToken)` is called
-- THEN the client authenticates with the master key
+#### Endpoint + key
+**When** `new CosmosClient(endpoint, authKeyOrResourceToken)` is called with an account endpoint URI and account key, the SDK shall authenticate with the master key.
 
-#### Scenario: Endpoint + TokenCredential (AAD)
-- GIVEN an account endpoint and an Azure `TokenCredential` (e.g., `DefaultAzureCredential`)
-- WHEN `new CosmosClient(endpoint, tokenCredential)` is called
-- THEN the client authenticates via Azure Active Directory
+#### Endpoint + TokenCredential (AAD)
+**When** `new CosmosClient(endpoint, tokenCredential)` is called with an account endpoint and an Azure `TokenCredential` (e.g., `DefaultAzureCredential`), the SDK shall authenticate via Azure Active Directory.
 
-#### Scenario: Token credential refresh
-- GIVEN `CosmosClientOptions.TokenCredentialBackgroundRefreshInterval` is set
-- WHEN the client is running
-- THEN the token is refreshed in the background at the specified interval
+#### Token credential refresh
+**Where** `CosmosClientOptions.TokenCredentialBackgroundRefreshInterval` is set, the SDK shall refresh the token in the background at the specified interval while the client is running.
 
-#### Scenario: Client options
-- GIVEN a `CosmosClientOptions` instance with custom settings
-- WHEN passed to any `CosmosClient` constructor
-- THEN all configured options are applied to the client
+#### Client options
+**When** a `CosmosClientOptions` instance with custom settings is passed to any `CosmosClient` constructor, the SDK shall apply all configured options to the client.
 
 ### Requirement: Client Lifecycle
 The SDK SHALL support proper resource cleanup when a client is disposed.
 
-#### Scenario: Dispose client
-- GIVEN a `CosmosClient` instance
-- WHEN `client.Dispose()` is called
-- THEN all connections are closed
-- AND all cached resources are released
-- AND the client MUST NOT be used after disposal
+#### Dispose client
+**When** `client.Dispose()` is called, the SDK shall close all connections, release all cached resources, and the client MUST NOT be used after disposal.
 
-#### Scenario: Singleton pattern
-- GIVEN a long-running application
-- WHEN the application creates a `CosmosClient`
-- THEN it SHOULD reuse the same instance for the application's lifetime
-- AND creating multiple clients to the same account is discouraged
+#### Singleton pattern
+**While** running in a long-running application, the SDK shall support reusing the same `CosmosClient` instance for the application's lifetime, and creating multiple clients to the same account is discouraged.
 
 ### Requirement: Region Configuration
 The SDK SHALL support configuring preferred regions for multi-region routing.
 
-#### Scenario: Single preferred region
-- GIVEN `CosmosClientOptions.ApplicationRegion = Regions.WestUS2`
-- WHEN requests are routed
-- THEN the SDK prefers the specified region
+#### Single preferred region
+**Where** `CosmosClientOptions.ApplicationRegion = Regions.WestUS2`, the SDK shall prefer the specified region when routing requests.
 
-#### Scenario: Ordered region list
-- GIVEN `CosmosClientOptions.ApplicationPreferredRegions = new List<string> { "East US", "West US 2", "Central US" }`
-- WHEN requests are routed
-- THEN regions are tried in the specified order for failover
+#### Ordered region list
+**Where** `CosmosClientOptions.ApplicationPreferredRegions = new List<string> { "East US", "West US 2", "Central US" }`, the SDK shall try regions in the specified order for failover when routing requests.
 
-#### Scenario: Region exclusion per request
-- GIVEN `RequestOptions.ExcludeRegions = new List<string> { "West US 2" }`
-- WHEN the request is routed
-- THEN "West US 2" is skipped in the routing preference
+#### Region exclusion per request
+**Where** `RequestOptions.ExcludeRegions = new List<string> { "West US 2" }`, the SDK shall skip "West US 2" in the routing preference when routing the request.
 
 ### Requirement: Custom Handler Pipeline
 The SDK SHALL support inserting custom request handlers into the processing pipeline.
 
-#### Scenario: Add custom handler
-- GIVEN a class extending `RequestHandler` with overridden `SendAsync`
-- AND added to `CosmosClientOptions.CustomHandlers`
-- WHEN requests are processed
-- THEN the custom handler is invoked in the pipeline before the transport handler
+#### Add custom handler
+**Where** a class extending `RequestHandler` with overridden `SendAsync` is added to `CosmosClientOptions.CustomHandlers`, the SDK shall invoke the custom handler in the pipeline before the transport handler when requests are processed.
 
-#### Scenario: Handler ordering
-- GIVEN multiple custom handlers in `CustomHandlers`
-- WHEN a request is processed
-- THEN handlers execute in the order they were added
+#### Handler ordering
+**Where** multiple custom handlers are in `CustomHandlers`, **when** a request is processed, the SDK shall execute handlers in the order they were added.
 
-#### Scenario: Handler access to request/response
-- GIVEN a custom `RequestHandler`
-- WHEN `SendAsync(RequestMessage, CancellationToken)` is invoked
-- THEN the handler can inspect and modify the `RequestMessage`
-- AND can inspect and modify the `ResponseMessage` returned from downstream
+#### Handler access to request/response
+**When** `SendAsync(RequestMessage, CancellationToken)` is invoked on a custom `RequestHandler`, the SDK shall allow the handler to inspect and modify the `RequestMessage` and to inspect and modify the `ResponseMessage` returned from downstream.
 
 ### Requirement: Resource Access Shortcuts
 The SDK SHALL provide convenient methods to access databases and containers.
 
-#### Scenario: Get database reference
-- GIVEN a known database ID
-- WHEN `client.GetDatabase("mydb")` is called
-- THEN a `Database` proxy is returned (no network call)
+#### Get database reference
+**When** `client.GetDatabase("mydb")` is called with a known database ID, the SDK shall return a `Database` proxy without making a network call.
 
-#### Scenario: Get container reference
-- GIVEN a known database and container ID
-- WHEN `client.GetContainer("mydb", "mycontainer")` is called
-- THEN a `Container` proxy is returned (no network call)
+#### Get container reference
+**When** `client.GetContainer("mydb", "mycontainer")` is called with a known database and container ID, the SDK shall return a `Container` proxy without making a network call.
 
 ### Requirement: Account Information
 The SDK SHALL support reading account-level properties.
 
-#### Scenario: Read account
-- GIVEN a connected client
-- WHEN `client.ReadAccountAsync()` is called
-- THEN `AccountProperties` is returned with available regions, consistency policy, and account metadata
+#### Read account
+**When** `client.ReadAccountAsync()` is called, the SDK shall return `AccountProperties` with available regions, consistency policy, and account metadata.
 
 ### Requirement: Fluent Builder (CosmosClientBuilder)
 The SDK SHALL provide a fluent builder for constructing clients.
 
-#### Scenario: Builder pattern
-- GIVEN `new CosmosClientBuilder(endpoint, key)`
-- WHEN `.WithConnectionModeDirect()`, `.WithApplicationRegion(region)`, `.WithBulkExecution(true)`, `.Build()` are chained
-- THEN a `CosmosClient` is constructed with the specified configuration
+#### Builder pattern
+**When** `new CosmosClientBuilder(endpoint, key)` is used with chained calls to `.WithConnectionModeDirect()`, `.WithApplicationRegion(region)`, `.WithBulkExecution(true)`, and `.Build()`, the SDK shall construct a `CosmosClient` with the specified configuration.
 
 ### Requirement: Content Response Control
 The SDK SHALL support controlling whether write responses include the resource body.
 
-#### Scenario: Client-level suppression
-- GIVEN `CosmosClientOptions.EnableContentResponseOnWrite = false`
-- WHEN write operations (Create, Replace, Upsert) are performed
-- THEN response bodies are not returned by default
-- AND request charge is reduced
+#### Client-level suppression
+**Where** `CosmosClientOptions.EnableContentResponseOnWrite = false`, **when** write operations (Create, Replace, Upsert) are performed, the SDK shall not return response bodies by default and request charge shall be reduced.
 
-#### Scenario: Per-request override
-- GIVEN `ItemRequestOptions.EnableContentResponseOnWrite = true`
-- WHEN a write operation is performed
-- THEN the response body is included regardless of client-level setting
+#### Per-request override
+**Where** `ItemRequestOptions.EnableContentResponseOnWrite = true`, **when** a write operation is performed, the SDK shall include the response body regardless of the client-level setting.
 
 ## Key Source Files
 - `Microsoft.Azure.Cosmos/src/CosmosClient.cs` — client entry point and lifecycle

--- a/openspec/specs/client-configuration/spec.md
+++ b/openspec/specs/client-configuration/spec.md
@@ -1,0 +1,140 @@
+# Client Configuration and Lifecycle
+
+## Purpose
+
+`CosmosClient` is the top-level entry point to the SDK. It manages connection lifecycle, configuration, custom handler pipelines, and authentication.
+
+## Requirements
+
+### Requirement: Client Construction
+The SDK SHALL support multiple authentication methods for constructing a CosmosClient.
+
+#### Scenario: Connection string
+- GIVEN a Cosmos DB connection string
+- WHEN `new CosmosClient(connectionString)` is called
+- THEN the client connects using the account endpoint and key from the string
+
+#### Scenario: Endpoint + key
+- GIVEN an account endpoint URI and account key
+- WHEN `new CosmosClient(endpoint, authKeyOrResourceToken)` is called
+- THEN the client authenticates with the master key
+
+#### Scenario: Endpoint + TokenCredential (AAD)
+- GIVEN an account endpoint and an Azure `TokenCredential` (e.g., `DefaultAzureCredential`)
+- WHEN `new CosmosClient(endpoint, tokenCredential)` is called
+- THEN the client authenticates via Azure Active Directory
+
+#### Scenario: Token credential refresh
+- GIVEN `CosmosClientOptions.TokenCredentialBackgroundRefreshInterval` is set
+- WHEN the client is running
+- THEN the token is refreshed in the background at the specified interval
+
+#### Scenario: Client options
+- GIVEN a `CosmosClientOptions` instance with custom settings
+- WHEN passed to any `CosmosClient` constructor
+- THEN all configured options are applied to the client
+
+### Requirement: Client Lifecycle
+The SDK SHALL support proper resource cleanup when a client is disposed.
+
+#### Scenario: Dispose client
+- GIVEN a `CosmosClient` instance
+- WHEN `client.Dispose()` is called
+- THEN all connections are closed
+- AND all cached resources are released
+- AND the client MUST NOT be used after disposal
+
+#### Scenario: Singleton pattern
+- GIVEN a long-running application
+- WHEN the application creates a `CosmosClient`
+- THEN it SHOULD reuse the same instance for the application's lifetime
+- AND creating multiple clients to the same account is discouraged
+
+### Requirement: Region Configuration
+The SDK SHALL support configuring preferred regions for multi-region routing.
+
+#### Scenario: Single preferred region
+- GIVEN `CosmosClientOptions.ApplicationRegion = Regions.WestUS2`
+- WHEN requests are routed
+- THEN the SDK prefers the specified region
+
+#### Scenario: Ordered region list
+- GIVEN `CosmosClientOptions.ApplicationPreferredRegions = new List<string> { "East US", "West US 2", "Central US" }`
+- WHEN requests are routed
+- THEN regions are tried in the specified order for failover
+
+#### Scenario: Region exclusion per request
+- GIVEN `RequestOptions.ExcludeRegions = new List<string> { "West US 2" }`
+- WHEN the request is routed
+- THEN "West US 2" is skipped in the routing preference
+
+### Requirement: Custom Handler Pipeline
+The SDK SHALL support inserting custom request handlers into the processing pipeline.
+
+#### Scenario: Add custom handler
+- GIVEN a class extending `RequestHandler` with overridden `SendAsync`
+- AND added to `CosmosClientOptions.CustomHandlers`
+- WHEN requests are processed
+- THEN the custom handler is invoked in the pipeline before the transport handler
+
+#### Scenario: Handler ordering
+- GIVEN multiple custom handlers in `CustomHandlers`
+- WHEN a request is processed
+- THEN handlers execute in the order they were added
+
+#### Scenario: Handler access to request/response
+- GIVEN a custom `RequestHandler`
+- WHEN `SendAsync(RequestMessage, CancellationToken)` is invoked
+- THEN the handler can inspect and modify the `RequestMessage`
+- AND can inspect and modify the `ResponseMessage` returned from downstream
+
+### Requirement: Resource Access Shortcuts
+The SDK SHALL provide convenient methods to access databases and containers.
+
+#### Scenario: Get database reference
+- GIVEN a known database ID
+- WHEN `client.GetDatabase("mydb")` is called
+- THEN a `Database` proxy is returned (no network call)
+
+#### Scenario: Get container reference
+- GIVEN a known database and container ID
+- WHEN `client.GetContainer("mydb", "mycontainer")` is called
+- THEN a `Container` proxy is returned (no network call)
+
+### Requirement: Account Information
+The SDK SHALL support reading account-level properties.
+
+#### Scenario: Read account
+- GIVEN a connected client
+- WHEN `client.ReadAccountAsync()` is called
+- THEN `AccountProperties` is returned with available regions, consistency policy, and account metadata
+
+### Requirement: Fluent Builder (CosmosClientBuilder)
+The SDK SHALL provide a fluent builder for constructing clients.
+
+#### Scenario: Builder pattern
+- GIVEN `new CosmosClientBuilder(endpoint, key)`
+- WHEN `.WithConnectionModeDirect()`, `.WithApplicationRegion(region)`, `.WithBulkExecution(true)`, `.Build()` are chained
+- THEN a `CosmosClient` is constructed with the specified configuration
+
+### Requirement: Content Response Control
+The SDK SHALL support controlling whether write responses include the resource body.
+
+#### Scenario: Client-level suppression
+- GIVEN `CosmosClientOptions.EnableContentResponseOnWrite = false`
+- WHEN write operations (Create, Replace, Upsert) are performed
+- THEN response bodies are not returned by default
+- AND request charge is reduced
+
+#### Scenario: Per-request override
+- GIVEN `ItemRequestOptions.EnableContentResponseOnWrite = true`
+- WHEN a write operation is performed
+- THEN the response body is included regardless of client-level setting
+
+## Key Source Files
+- `Microsoft.Azure.Cosmos/src/CosmosClient.cs` — client entry point and lifecycle
+- `Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs` — all client configuration
+- `Microsoft.Azure.Cosmos/src/Fluent/CosmosClientBuilder.cs` — fluent builder
+- `Microsoft.Azure.Cosmos/src/Handler/RequestHandler.cs` — custom handler base class
+- `Microsoft.Azure.Cosmos/src/Authorization/` — authentication providers
+- `Microsoft.Azure.Cosmos/src/Resource/ClientContextCore.cs` — internal client context

--- a/openspec/specs/client-side-encryption/spec.md
+++ b/openspec/specs/client-side-encryption/spec.md
@@ -1,0 +1,97 @@
+# Client-Side Encryption
+
+## Purpose
+
+Client-side encryption enables encrypting sensitive item properties before they are sent to the Cosmos DB service, ensuring data is encrypted at rest and in transit with customer-managed keys.
+
+## Requirements
+
+### Requirement: Client Encryption Key Management
+The SDK SHALL support creating and managing client encryption keys (CEKs) in the Cosmos DB account.
+
+#### Scenario: Create encryption key
+- GIVEN a database
+- WHEN `database.CreateClientEncryptionKeyAsync(new ClientEncryptionKeyProperties(keyId, algorithm, wrappedDataEncryptionKey, encryptionKeyWrapMetadata))` is called
+- THEN a client encryption key is created in the database
+- AND the key material is wrapped (encrypted) using the specified key wrap provider
+
+#### Scenario: Read encryption key
+- GIVEN an existing client encryption key
+- WHEN `database.GetClientEncryptionKey(keyId).ReadAsync()` is called
+- THEN the key properties are returned (metadata only, not raw key material)
+
+#### Scenario: Replace (rewrap) encryption key
+- GIVEN an existing client encryption key
+- WHEN `database.GetClientEncryptionKey(keyId).ReplaceAsync(updatedProperties)` is called
+- THEN the key is rewrapped with the new key wrap metadata (key rotation)
+
+### Requirement: Encryption Policy
+The SDK SHALL support defining encryption policies on containers to specify which properties are encrypted.
+
+#### Scenario: Define encryption policy
+- GIVEN `ContainerProperties.ClientEncryptionPolicy` with a list of `ClientEncryptionIncludedPath` entries
+- WHEN the container is created
+- THEN the specified property paths are encrypted on write and decrypted on read
+
+#### Scenario: Encryption path configuration
+- GIVEN a `ClientEncryptionIncludedPath` with `Path`, `ClientEncryptionKeyId`, `EncryptionType` (Deterministic or Randomized), and `EncryptionAlgorithm`
+- WHEN items are written to the container
+- THEN the property at the specified path is encrypted using the referenced CEK
+
+#### Scenario: Deterministic encryption
+- GIVEN `EncryptionType = "Deterministic"` for a path
+- WHEN the same value is encrypted multiple times
+- THEN the same ciphertext is produced
+- AND equality queries on the encrypted property are supported
+
+#### Scenario: Randomized encryption
+- GIVEN `EncryptionType = "Randomized"` for a path
+- WHEN the same value is encrypted multiple times
+- THEN different ciphertext is produced each time
+- AND equality queries on the encrypted property are NOT supported
+
+### Requirement: Key Wrap Providers
+The SDK SHALL support pluggable key wrap providers for wrapping/unwrapping data encryption keys.
+
+#### Scenario: Azure Key Vault provider
+- GIVEN `EncryptionKeyWrapMetadata` with type `"akv"` and an Azure Key Vault key URL
+- WHEN the encryption key is used
+- THEN the SDK uses Azure Key Vault to wrap/unwrap the data encryption key
+
+#### Scenario: Custom key wrap provider
+- GIVEN a custom `EncryptionKeyWrapProvider` implementation
+- WHEN registered with the encryption container
+- THEN the custom provider is used for all key wrap/unwrap operations
+
+### Requirement: Transparent Encryption/Decryption
+The SDK SHALL transparently encrypt and decrypt properties without requiring application code changes for standard CRUD operations.
+
+#### Scenario: Transparent encryption on write
+- GIVEN a container with an encryption policy
+- WHEN `Container.CreateItemAsync(item)` is called
+- THEN encrypted properties are automatically encrypted before sending to the service
+
+#### Scenario: Transparent decryption on read
+- GIVEN a container with encrypted properties
+- WHEN `Container.ReadItemAsync<T>(id, pk)` is called
+- THEN encrypted properties are automatically decrypted in the returned item
+
+### Requirement: Encryption with Cosmos Client Extensions
+The SDK SHALL provide encryption through separate extension packages.
+
+#### Scenario: Microsoft.Azure.Cosmos.Encryption package
+- GIVEN the `Microsoft.Azure.Cosmos.Encryption` NuGet package is referenced
+- WHEN `cosmosClient.WithEncryption(keyEncryptionKeyResolver, KeyEncryptionKeyResolverName.AzureKeyVault)` is called
+- THEN the client is configured for client-side encryption with Azure Key Vault
+
+#### Scenario: Microsoft.Azure.Cosmos.Encryption.Custom package
+- GIVEN the `Microsoft.Azure.Cosmos.Encryption.Custom` NuGet package is referenced
+- WHEN a custom `EncryptionKeyWrapProvider` is configured
+- THEN the client supports encryption with custom key management
+
+## Key Source Files
+- `Microsoft.Azure.Cosmos/src/Resource/ClientEncryptionKey/ClientEncryptionKey.cs` — key management API
+- `Microsoft.Azure.Cosmos/src/Resource/Settings/ClientEncryptionPolicy.cs` — encryption policy definition
+- `Microsoft.Azure.Cosmos/src/Resource/Settings/ClientEncryptionIncludedPath.cs` — encrypted path config
+- `Microsoft.Azure.Cosmos.Encryption/src/` — Azure Key Vault encryption extension
+- `Microsoft.Azure.Cosmos.Encryption.Custom/src/` — custom encryption extension

--- a/openspec/specs/client-side-encryption/spec.md
+++ b/openspec/specs/client-side-encryption/spec.md
@@ -9,85 +9,56 @@ Client-side encryption enables encrypting sensitive item properties before they 
 ### Requirement: Client Encryption Key Management
 The SDK SHALL support creating and managing client encryption keys (CEKs) in the Cosmos DB account.
 
-#### Scenario: Create encryption key
-- GIVEN a database
-- WHEN `database.CreateClientEncryptionKeyAsync(new ClientEncryptionKeyProperties(keyId, algorithm, wrappedDataEncryptionKey, encryptionKeyWrapMetadata))` is called
-- THEN a client encryption key is created in the database
-- AND the key material is wrapped (encrypted) using the specified key wrap provider
+#### Create encryption key
+**When** `database.CreateClientEncryptionKeyAsync(new ClientEncryptionKeyProperties(keyId, algorithm, wrappedDataEncryptionKey, encryptionKeyWrapMetadata))` is called, the SDK shall create a client encryption key in the database with the key material wrapped (encrypted) using the specified key wrap provider.
 
-#### Scenario: Read encryption key
-- GIVEN an existing client encryption key
-- WHEN `database.GetClientEncryptionKey(keyId).ReadAsync()` is called
-- THEN the key properties are returned (metadata only, not raw key material)
+#### Read encryption key
+**When** `database.GetClientEncryptionKey(keyId).ReadAsync()` is called for an existing client encryption key, the SDK shall return the key properties (metadata only, not raw key material).
 
-#### Scenario: Replace (rewrap) encryption key
-- GIVEN an existing client encryption key
-- WHEN `database.GetClientEncryptionKey(keyId).ReplaceAsync(updatedProperties)` is called
-- THEN the key is rewrapped with the new key wrap metadata (key rotation)
+#### Replace (rewrap) encryption key
+**When** `database.GetClientEncryptionKey(keyId).ReplaceAsync(updatedProperties)` is called for an existing client encryption key, the SDK shall rewrap the key with the new key wrap metadata (key rotation).
 
 ### Requirement: Encryption Policy
 The SDK SHALL support defining encryption policies on containers to specify which properties are encrypted.
 
-#### Scenario: Define encryption policy
-- GIVEN `ContainerProperties.ClientEncryptionPolicy` with a list of `ClientEncryptionIncludedPath` entries
-- WHEN the container is created
-- THEN the specified property paths are encrypted on write and decrypted on read
+#### Define encryption policy
+**Where** `ContainerProperties.ClientEncryptionPolicy` is configured with a list of `ClientEncryptionIncludedPath` entries, **when** the container is created, the SDK shall encrypt the specified property paths on write and decrypt them on read.
 
-#### Scenario: Encryption path configuration
-- GIVEN a `ClientEncryptionIncludedPath` with `Path`, `ClientEncryptionKeyId`, `EncryptionType` (Deterministic or Randomized), and `EncryptionAlgorithm`
-- WHEN items are written to the container
-- THEN the property at the specified path is encrypted using the referenced CEK
+#### Encryption path configuration
+**Where** a `ClientEncryptionIncludedPath` is configured with `Path`, `ClientEncryptionKeyId`, `EncryptionType` (Deterministic or Randomized), and `EncryptionAlgorithm`, **when** items are written to the container, the SDK shall encrypt the property at the specified path using the referenced CEK.
 
-#### Scenario: Deterministic encryption
-- GIVEN `EncryptionType = "Deterministic"` for a path
-- WHEN the same value is encrypted multiple times
-- THEN the same ciphertext is produced
-- AND equality queries on the encrypted property are supported
+#### Deterministic encryption
+**Where** `EncryptionType = "Deterministic"` is set for a path, **when** the same value is encrypted multiple times, the SDK shall produce the same ciphertext and support equality queries on the encrypted property.
 
-#### Scenario: Randomized encryption
-- GIVEN `EncryptionType = "Randomized"` for a path
-- WHEN the same value is encrypted multiple times
-- THEN different ciphertext is produced each time
-- AND equality queries on the encrypted property are NOT supported
+#### Randomized encryption
+**Where** `EncryptionType = "Randomized"` is set for a path, **when** the same value is encrypted multiple times, the SDK shall produce different ciphertext each time and shall NOT support equality queries on the encrypted property.
 
 ### Requirement: Key Wrap Providers
 The SDK SHALL support pluggable key wrap providers for wrapping/unwrapping data encryption keys.
 
-#### Scenario: Azure Key Vault provider
-- GIVEN `EncryptionKeyWrapMetadata` with type `"akv"` and an Azure Key Vault key URL
-- WHEN the encryption key is used
-- THEN the SDK uses Azure Key Vault to wrap/unwrap the data encryption key
+#### Azure Key Vault provider
+**Where** `EncryptionKeyWrapMetadata` is configured with type `"akv"` and an Azure Key Vault key URL, **when** the encryption key is used, the SDK shall use Azure Key Vault to wrap/unwrap the data encryption key.
 
-#### Scenario: Custom key wrap provider
-- GIVEN a custom `EncryptionKeyWrapProvider` implementation
-- WHEN registered with the encryption container
-- THEN the custom provider is used for all key wrap/unwrap operations
+#### Custom key wrap provider
+**Where** a custom `EncryptionKeyWrapProvider` implementation is registered with the encryption container, the SDK shall use the custom provider for all key wrap/unwrap operations.
 
 ### Requirement: Transparent Encryption/Decryption
 The SDK SHALL transparently encrypt and decrypt properties without requiring application code changes for standard CRUD operations.
 
-#### Scenario: Transparent encryption on write
-- GIVEN a container with an encryption policy
-- WHEN `Container.CreateItemAsync(item)` is called
-- THEN encrypted properties are automatically encrypted before sending to the service
+#### Transparent encryption on write
+**While** a container has an encryption policy configured, **when** `Container.CreateItemAsync(item)` is called, the SDK shall automatically encrypt the specified properties before sending to the service.
 
-#### Scenario: Transparent decryption on read
-- GIVEN a container with encrypted properties
-- WHEN `Container.ReadItemAsync<T>(id, pk)` is called
-- THEN encrypted properties are automatically decrypted in the returned item
+#### Transparent decryption on read
+**While** a container has encrypted properties, **when** `Container.ReadItemAsync<T>(id, pk)` is called, the SDK shall automatically decrypt the encrypted properties in the returned item.
 
 ### Requirement: Encryption with Cosmos Client Extensions
 The SDK SHALL provide encryption through separate extension packages.
 
-#### Scenario: Microsoft.Azure.Cosmos.Encryption package
-- GIVEN the `Microsoft.Azure.Cosmos.Encryption` NuGet package is referenced
-- WHEN `cosmosClient.WithEncryption(keyEncryptionKeyResolver, KeyEncryptionKeyResolverName.AzureKeyVault)` is called
-- THEN the client is configured for client-side encryption with Azure Key Vault
+#### Microsoft.Azure.Cosmos.Encryption package
+**Where** the `Microsoft.Azure.Cosmos.Encryption` NuGet package is referenced, **when** `cosmosClient.WithEncryption(keyEncryptionKeyResolver, KeyEncryptionKeyResolverName.AzureKeyVault)` is called, the SDK shall configure the client for client-side encryption with Azure Key Vault.
 
-#### Scenario: Microsoft.Azure.Cosmos.Encryption.Custom package
-- GIVEN the `Microsoft.Azure.Cosmos.Encryption.Custom` NuGet package is referenced
-- WHEN a custom `EncryptionKeyWrapProvider` is configured
-- THEN the client supports encryption with custom key management
+#### Microsoft.Azure.Cosmos.Encryption.Custom package
+**Where** the `Microsoft.Azure.Cosmos.Encryption.Custom` NuGet package is referenced, **when** a custom `EncryptionKeyWrapProvider` is configured, the SDK shall support encryption with custom key management.
 
 ## Key Source Files
 - `Microsoft.Azure.Cosmos/src/Resource/ClientEncryptionKey/ClientEncryptionKey.cs` — key management API

--- a/openspec/specs/consistency-and-session/spec.md
+++ b/openspec/specs/consistency-and-session/spec.md
@@ -9,101 +9,65 @@ The SDK supports five consistency levels and automatically manages session token
 ### Requirement: Consistency Level Configuration
 The SDK SHALL support overriding the account-level consistency at the client and request levels.
 
-#### Scenario: Client-level consistency override
-- GIVEN `CosmosClientOptions.ConsistencyLevel = ConsistencyLevel.Eventual`
-- WHEN requests are made through this client
-- THEN the Eventual consistency level is used by default for all requests
-- AND this MAY only weaken the account-level consistency, never strengthen it
+#### Client-level consistency override
+**Where** `CosmosClientOptions.ConsistencyLevel = ConsistencyLevel.Eventual`, **when** requests are made through this client, the SDK shall use the Eventual consistency level by default for all requests. This MAY only weaken the account-level consistency, never strengthen it.
 
-#### Scenario: Per-request consistency override
-- GIVEN `RequestOptions.ConsistencyLevel = ConsistencyLevel.Strong`
-- WHEN a specific request is made
-- THEN the Strong consistency level is used for that request only
+#### Per-request consistency override
+**Where** `RequestOptions.ConsistencyLevel = ConsistencyLevel.Strong`, **when** a specific request is made, the SDK shall use the Strong consistency level for that request only.
 
-#### Scenario: No override (account default)
-- GIVEN neither client-level nor request-level consistency is set
-- WHEN requests are made
-- THEN the account's default consistency level is used
+#### No override (account default)
+**Where** neither client-level nor request-level consistency is set, **when** requests are made, the SDK shall use the account's default consistency level.
 
 ### Requirement: Consistency Levels
 The SDK SHALL support all five Azure Cosmos DB consistency levels.
 
-#### Scenario: Strong consistency
-- GIVEN `ConsistencyLevel.Strong` is configured
-- WHEN a read is performed
-- THEN the most recent committed write is always returned
-- AND reads are linearizable
+#### Strong consistency
+**Where** `ConsistencyLevel.Strong` is configured, **when** a read is performed, the SDK shall always return the most recent committed write and ensure reads are linearizable.
 
-#### Scenario: Bounded staleness
-- GIVEN `ConsistencyLevel.BoundedStaleness` is configured
-- WHEN a read is performed
-- THEN the read is at most K versions or T seconds behind the latest write
+#### Bounded staleness
+**Where** `ConsistencyLevel.BoundedStaleness` is configured, **when** a read is performed, the SDK shall return data that is at most K versions or T seconds behind the latest write.
 
-#### Scenario: Session consistency (default)
-- GIVEN `ConsistencyLevel.Session` is configured (or account default is Session)
-- WHEN reads and writes are performed within the same session
-- THEN monotonic reads and read-your-writes are guaranteed within that session
+#### Session consistency (default)
+**Where** `ConsistencyLevel.Session` is configured (or account default is Session), **when** reads and writes are performed within the same session, the SDK shall guarantee monotonic reads and read-your-writes within that session.
 
-#### Scenario: Consistent prefix
-- GIVEN `ConsistencyLevel.ConsistentPrefix` is configured
-- WHEN reads are performed
-- THEN reads never see out-of-order writes (no gaps in write sequence)
+#### Consistent prefix
+**Where** `ConsistencyLevel.ConsistentPrefix` is configured, **when** reads are performed, the SDK shall ensure reads never see out-of-order writes (no gaps in write sequence).
 
-#### Scenario: Eventual consistency
-- GIVEN `ConsistencyLevel.Eventual` is configured
-- WHEN a read is performed
-- THEN the read returns data that will eventually converge to the latest write
+#### Eventual consistency
+**Where** `ConsistencyLevel.Eventual` is configured, **when** a read is performed, the SDK shall return data that will eventually converge to the latest write.
 
 ### Requirement: Session Token Management
 The SDK SHALL automatically manage session tokens to maintain session consistency guarantees.
 
-#### Scenario: Automatic session token capture
-- GIVEN a write operation completes
-- WHEN the response is received
-- THEN the SDK automatically captures and stores the session token from the response
-- AND associates it with the container and partition key range
+#### Automatic session token capture
+**When** a write operation completes and a response is received, the SDK shall automatically capture and store the session token from the response and associate it with the container and partition key range.
 
-#### Scenario: Automatic session token propagation
-- GIVEN a session token has been captured from a previous write
-- WHEN a subsequent read request is made to the same container
-- THEN the SDK automatically includes the stored session token in the request header
+#### Automatic session token propagation
+**While** a session token has been captured from a previous write, **when** a subsequent read request is made to the same container, the SDK shall automatically include the stored session token in the request header.
 
-#### Scenario: Session token across partitions
-- GIVEN writes to partition A and partition B
-- WHEN reads are performed
-- THEN each partition has its own session token
-- AND session consistency is maintained independently per partition
+#### Session token across partitions
+**When** writes are performed to multiple partitions and subsequent reads are performed, the SDK shall maintain a separate session token for each partition and ensure session consistency is maintained independently per partition.
 
-#### Scenario: Manual session token
-- GIVEN `RequestOptions.SessionToken` is explicitly set
-- WHEN the request is made
-- THEN the provided session token is used instead of the SDK-managed token
+#### Manual session token
+**Where** `RequestOptions.SessionToken` is explicitly set, **when** the request is made, the SDK shall use the provided session token instead of the SDK-managed token.
 
 ### Requirement: Session Container
 The SDK SHALL maintain an internal session container for token storage.
 
-#### Scenario: Token storage lifecycle
-- GIVEN a `CosmosClient` instance
-- WHEN operations are performed
-- THEN session tokens are stored in memory for the lifetime of the client
+#### Token storage lifecycle
+**While** a `CosmosClient` instance is active, **when** operations are performed, the SDK shall store session tokens in memory for the lifetime of the client.
 
-#### Scenario: Cross-client session continuity
-- GIVEN a session token obtained from one client's response
-- WHEN that token is passed to another client via `RequestOptions.SessionToken`
-- THEN the second client can achieve session-consistent reads relative to the first client's writes
+#### Cross-client session continuity
+**When** a session token obtained from one client's response is passed to another client via `RequestOptions.SessionToken`, the SDK shall enable the second client to achieve session-consistent reads relative to the first client's writes.
 
 ### Requirement: Consistency Weakening Validation
 The SDK SHALL only allow weakening the account-level consistency, not strengthening it.
 
-#### Scenario: Weaken from Strong to Session
-- GIVEN account-level consistency is Strong
-- WHEN `CosmosClientOptions.ConsistencyLevel = ConsistencyLevel.Session` is set
-- THEN the client uses Session consistency (valid weakening)
+#### Weaken from Strong to Session
+**Where** `CosmosClientOptions.ConsistencyLevel = ConsistencyLevel.Session` is set on an account with Strong consistency, the SDK shall use Session consistency as a valid weakening of the account-level consistency.
 
-#### Scenario: Attempt to strengthen
-- GIVEN account-level consistency is Eventual
-- WHEN `CosmosClientOptions.ConsistencyLevel = ConsistencyLevel.Strong` is set
-- THEN the service rejects the request with a 400 (Bad Request) error
+#### Attempt to strengthen
+**If** `CosmosClientOptions.ConsistencyLevel = ConsistencyLevel.Strong` is set on an account with Eventual consistency, **then** the SDK shall have the service reject the request with a 400 (Bad Request) error.
 
 ## Key Source Files
 - `Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs` — `ConsistencyLevel` property

--- a/openspec/specs/consistency-and-session/spec.md
+++ b/openspec/specs/consistency-and-session/spec.md
@@ -1,0 +1,113 @@
+# Consistency and Session Management
+
+## Purpose
+
+The SDK supports five consistency levels and automatically manages session tokens to ensure read-your-writes guarantees when using session consistency.
+
+## Requirements
+
+### Requirement: Consistency Level Configuration
+The SDK SHALL support overriding the account-level consistency at the client and request levels.
+
+#### Scenario: Client-level consistency override
+- GIVEN `CosmosClientOptions.ConsistencyLevel = ConsistencyLevel.Eventual`
+- WHEN requests are made through this client
+- THEN the Eventual consistency level is used by default for all requests
+- AND this MAY only weaken the account-level consistency, never strengthen it
+
+#### Scenario: Per-request consistency override
+- GIVEN `RequestOptions.ConsistencyLevel = ConsistencyLevel.Strong`
+- WHEN a specific request is made
+- THEN the Strong consistency level is used for that request only
+
+#### Scenario: No override (account default)
+- GIVEN neither client-level nor request-level consistency is set
+- WHEN requests are made
+- THEN the account's default consistency level is used
+
+### Requirement: Consistency Levels
+The SDK SHALL support all five Azure Cosmos DB consistency levels.
+
+#### Scenario: Strong consistency
+- GIVEN `ConsistencyLevel.Strong` is configured
+- WHEN a read is performed
+- THEN the most recent committed write is always returned
+- AND reads are linearizable
+
+#### Scenario: Bounded staleness
+- GIVEN `ConsistencyLevel.BoundedStaleness` is configured
+- WHEN a read is performed
+- THEN the read is at most K versions or T seconds behind the latest write
+
+#### Scenario: Session consistency (default)
+- GIVEN `ConsistencyLevel.Session` is configured (or account default is Session)
+- WHEN reads and writes are performed within the same session
+- THEN monotonic reads and read-your-writes are guaranteed within that session
+
+#### Scenario: Consistent prefix
+- GIVEN `ConsistencyLevel.ConsistentPrefix` is configured
+- WHEN reads are performed
+- THEN reads never see out-of-order writes (no gaps in write sequence)
+
+#### Scenario: Eventual consistency
+- GIVEN `ConsistencyLevel.Eventual` is configured
+- WHEN a read is performed
+- THEN the read returns data that will eventually converge to the latest write
+
+### Requirement: Session Token Management
+The SDK SHALL automatically manage session tokens to maintain session consistency guarantees.
+
+#### Scenario: Automatic session token capture
+- GIVEN a write operation completes
+- WHEN the response is received
+- THEN the SDK automatically captures and stores the session token from the response
+- AND associates it with the container and partition key range
+
+#### Scenario: Automatic session token propagation
+- GIVEN a session token has been captured from a previous write
+- WHEN a subsequent read request is made to the same container
+- THEN the SDK automatically includes the stored session token in the request header
+
+#### Scenario: Session token across partitions
+- GIVEN writes to partition A and partition B
+- WHEN reads are performed
+- THEN each partition has its own session token
+- AND session consistency is maintained independently per partition
+
+#### Scenario: Manual session token
+- GIVEN `RequestOptions.SessionToken` is explicitly set
+- WHEN the request is made
+- THEN the provided session token is used instead of the SDK-managed token
+
+### Requirement: Session Container
+The SDK SHALL maintain an internal session container for token storage.
+
+#### Scenario: Token storage lifecycle
+- GIVEN a `CosmosClient` instance
+- WHEN operations are performed
+- THEN session tokens are stored in memory for the lifetime of the client
+
+#### Scenario: Cross-client session continuity
+- GIVEN a session token obtained from one client's response
+- WHEN that token is passed to another client via `RequestOptions.SessionToken`
+- THEN the second client can achieve session-consistent reads relative to the first client's writes
+
+### Requirement: Consistency Weakening Validation
+The SDK SHALL only allow weakening the account-level consistency, not strengthening it.
+
+#### Scenario: Weaken from Strong to Session
+- GIVEN account-level consistency is Strong
+- WHEN `CosmosClientOptions.ConsistencyLevel = ConsistencyLevel.Session` is set
+- THEN the client uses Session consistency (valid weakening)
+
+#### Scenario: Attempt to strengthen
+- GIVEN account-level consistency is Eventual
+- WHEN `CosmosClientOptions.ConsistencyLevel = ConsistencyLevel.Strong` is set
+- THEN the service rejects the request with a 400 (Bad Request) error
+
+## Key Source Files
+- `Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs` — `ConsistencyLevel` property
+- `Microsoft.Azure.Cosmos/src/RequestOptions/RequestOptions.cs` — per-request consistency and session token
+- `Microsoft.Azure.Cosmos/src/SessionContainer.cs` — session token management
+- `Microsoft.Azure.Cosmos/src/SessionRetryOptions.cs` — session retry configuration
+- `Microsoft.Azure.Cosmos/src/GatewayStoreModel.cs` — session token propagation in gateway mode

--- a/openspec/specs/cross-region-hedging/spec.md
+++ b/openspec/specs/cross-region-hedging/spec.md
@@ -9,109 +9,68 @@ Cross-region request hedging improves read latency during regional degradation b
 ### Requirement: Availability Strategy Configuration
 The SDK SHALL provide a configurable availability strategy for cross-region hedging.
 
-#### Scenario: Enable hedging via client options
-- GIVEN `CosmosClientOptions.AvailabilityStrategy = AvailabilityStrategy.CrossRegionHedgingStrategy(threshold: TimeSpan.FromMilliseconds(1500), thresholdStep: TimeSpan.FromMilliseconds(500))`
-- AND `ApplicationPreferredRegions` is set with multiple regions
-- WHEN requests are made through this client
-- THEN hedging behavior is active for eligible operations
+#### Enable hedging via client options
+**Where** `CosmosClientOptions.AvailabilityStrategy = AvailabilityStrategy.CrossRegionHedgingStrategy(threshold: TimeSpan.FromMilliseconds(1500), thresholdStep: TimeSpan.FromMilliseconds(500))` and `ApplicationPreferredRegions` is set with multiple regions, **when** requests are made through this client, the SDK shall activate hedging behavior for eligible operations.
 
-#### Scenario: Disabled strategy
-- GIVEN `AvailabilityStrategy.DisabledStrategy()` or no strategy configured
-- WHEN requests are made
-- THEN no hedging occurs and requests go to a single region
+#### Disabled strategy
+**Where** `AvailabilityStrategy.DisabledStrategy()` is configured or no strategy is set, **when** requests are made, the SDK shall not perform hedging and shall send requests to a single region.
 
-#### Scenario: Per-request override
-- GIVEN a client-level availability strategy is configured
-- WHEN `RequestOptions.AvailabilityStrategy` is set on a specific request
-- THEN the per-request strategy overrides the client-level strategy for that request
+#### Per-request override
+**Where** a client-level availability strategy is configured, **when** `RequestOptions.AvailabilityStrategy` is set on a specific request, the SDK shall use the per-request strategy instead of the client-level strategy for that request.
 
-#### Scenario: No preferred regions
-- GIVEN `ApplicationPreferredRegions` is NOT set
-- WHEN an availability strategy is configured
-- THEN the SDK SHALL NOT apply any hedging behavior
+#### No preferred regions
+**If** `ApplicationPreferredRegions` is NOT set when an availability strategy is configured, **then** the SDK shall not apply any hedging behavior.
 
 ### Requirement: Hedging Trigger
 The SDK SHALL initiate hedged requests after the configured threshold elapses without a response.
 
-#### Scenario: Primary responds before threshold
-- GIVEN threshold is 1500ms
-- WHEN the primary region responds within 1500ms
-- THEN no hedged request is sent
-- AND the primary response is returned
+#### Primary responds before threshold
+**While** the hedging threshold is 1500ms, **when** the primary region responds within 1500ms, the SDK shall return the primary response without sending any hedged request.
 
-#### Scenario: Primary exceeds threshold
-- GIVEN threshold is 1500ms
-- WHEN the primary region has not responded after 1500ms
-- THEN a hedged request is sent to the next region in `ApplicationPreferredRegions`
+#### Primary exceeds threshold
+**While** the hedging threshold is 1500ms, **when** the primary region has not responded after 1500ms, the SDK shall send a hedged request to the next region in `ApplicationPreferredRegions`.
 
-#### Scenario: Subsequent hedges at thresholdStep intervals
-- GIVEN threshold is 1500ms and thresholdStep is 500ms
-- WHEN neither primary nor first hedge has responded
-- THEN a second hedge is sent at 2000ms (threshold + thresholdStep)
-- AND a third hedge is sent at 2500ms (threshold + 2 * thresholdStep)
-- AND hedging continues until all preferred regions are tried
+#### Subsequent hedges at thresholdStep intervals
+**While** the hedging threshold is 1500ms and thresholdStep is 500ms, **when** neither primary nor previous hedged requests have responded, the SDK shall send additional hedged requests at thresholdStep intervals (at 2000ms, 2500ms, and so on) until all preferred regions are tried.
 
 ### Requirement: Response Selection
 The SDK SHALL return the first final response received from any region.
 
-#### Scenario: Final status codes
-- GIVEN hedged requests are in flight to multiple regions
-- WHEN any region returns a status code in {1xx, 2xx, 3xx, 400, 401, 404/0, 409, 405, 412, 413}
-- THEN that response is considered final and returned to the caller
-- AND outstanding hedged requests are cancelled
+#### Final status codes
+**When** any region returns a status code in {1xx, 2xx, 3xx, 400, 401, 404/0, 409, 405, 412, 413} during hedged requests, the SDK shall consider that response final, return it to the caller, and cancel outstanding hedged requests.
 
-#### Scenario: Non-final responses
-- GIVEN all regions return non-final status codes (e.g., transient 5xx)
-- WHEN the last hedged request completes
-- THEN the last response received is returned to the caller
+#### Non-final responses
+**If** all regions return non-final status codes (e.g., transient 5xx) during hedged requests, **then** the SDK shall return the last response received to the caller.
 
 ### Requirement: Hedging Scope
 The SDK SHALL apply hedging based on operation type.
 
-#### Scenario: Read operations
-- GIVEN hedging is configured
-- WHEN a read operation is performed (ReadItem, Query, ReadMany, ChangeFeed)
-- THEN hedging is applied
+#### Read operations
+**Where** hedging is configured, **when** a read operation is performed (ReadItem, Query, ReadMany, ChangeFeed), the SDK shall apply hedging.
 
-#### Scenario: Write operations (single-master)
-- GIVEN a single-master account
-- WHEN a write operation is performed
-- THEN hedging sends requests to read regions (not the write region)
-- AND this enables reads from read replicas during write region degradation
+#### Write operations (single-master)
+**While** operating against a single-master account with hedging configured, **when** a write operation is performed, the SDK shall send hedged requests to read regions (not the write region), enabling reads from read replicas during write region degradation.
 
-#### Scenario: Write operations (multi-master)
-- GIVEN a multi-master account AND `enableMultiWriteRegionHedge = true`
-- WHEN a write operation is performed
-- THEN hedging sends requests to other write regions
-- AND the application is responsible for handling potential conflicts
+#### Write operations (multi-master)
+**While** operating against a multi-master account with `enableMultiWriteRegionHedge = true`, **when** a write operation is performed, the SDK shall send hedged requests to other write regions. The application is responsible for handling potential conflicts.
 
 ### Requirement: Independent Retry Per Hedge
 The SDK SHALL ensure each hedged request has its own independent retry policy.
 
-#### Scenario: Isolated retry chains
-- GIVEN a hedged request to Region 2 encounters a transient error
-- WHEN the retry policy evaluates the error
-- THEN Region 2's retry operates independently
-- AND the hedged request does NOT trigger cross-region retries (no hedging within hedging)
+#### Isolated retry chains
+**If** a hedged request to a secondary region encounters a transient error, **then** the SDK shall retry independently for that region without triggering cross-region retries (no hedging within hedging).
 
 ### Requirement: Hedging Diagnostics
 The SDK SHALL include hedging metadata in diagnostics output.
 
-#### Scenario: Diagnostics content
-- GIVEN a hedged request completes
-- WHEN `response.Diagnostics.ToString()` is called
-- THEN the output includes hedge configuration (threshold, thresholdStep)
-- AND a list of regions that received hedged requests
-- AND per-region response details (status code, latency)
+#### Diagnostics content
+**When** a hedged request completes and `response.Diagnostics.ToString()` is called, the SDK shall include hedge configuration (threshold, thresholdStep), a list of regions that received hedged requests, and per-region response details (status code, latency) in the output.
 
 ### Requirement: Default Hedging Configuration
 The SDK SHALL use sensible defaults when hedging is enabled without explicit thresholds.
 
-#### Scenario: Default threshold
-- GIVEN `AvailabilityStrategy.CrossRegionHedgingStrategy()` is called with default parameters
-- WHEN the SDK computes the threshold
-- THEN it uses `min(1000ms, RequestTimeout / 2)` as the threshold
-- AND 500ms as the thresholdStep
+#### Default threshold
+**Where** `AvailabilityStrategy.CrossRegionHedgingStrategy()` is called with default parameters, the SDK shall use `min(1000ms, RequestTimeout / 2)` as the threshold and 500ms as the thresholdStep.
 
 ## Key Source Files
 - `Microsoft.Azure.Cosmos/src/Routing/AvailabilityStrategy/AvailabilityStrategy.cs` — public factory

--- a/openspec/specs/cross-region-hedging/spec.md
+++ b/openspec/specs/cross-region-hedging/spec.md
@@ -1,0 +1,121 @@
+# Cross-Region Hedging
+
+## Purpose
+
+Cross-region request hedging improves read latency during regional degradation by sending parallel requests to multiple regions and returning the first successful response.
+
+## Requirements
+
+### Requirement: Availability Strategy Configuration
+The SDK SHALL provide a configurable availability strategy for cross-region hedging.
+
+#### Scenario: Enable hedging via client options
+- GIVEN `CosmosClientOptions.AvailabilityStrategy = AvailabilityStrategy.CrossRegionHedgingStrategy(threshold: TimeSpan.FromMilliseconds(1500), thresholdStep: TimeSpan.FromMilliseconds(500))`
+- AND `ApplicationPreferredRegions` is set with multiple regions
+- WHEN requests are made through this client
+- THEN hedging behavior is active for eligible operations
+
+#### Scenario: Disabled strategy
+- GIVEN `AvailabilityStrategy.DisabledStrategy()` or no strategy configured
+- WHEN requests are made
+- THEN no hedging occurs and requests go to a single region
+
+#### Scenario: Per-request override
+- GIVEN a client-level availability strategy is configured
+- WHEN `RequestOptions.AvailabilityStrategy` is set on a specific request
+- THEN the per-request strategy overrides the client-level strategy for that request
+
+#### Scenario: No preferred regions
+- GIVEN `ApplicationPreferredRegions` is NOT set
+- WHEN an availability strategy is configured
+- THEN the SDK SHALL NOT apply any hedging behavior
+
+### Requirement: Hedging Trigger
+The SDK SHALL initiate hedged requests after the configured threshold elapses without a response.
+
+#### Scenario: Primary responds before threshold
+- GIVEN threshold is 1500ms
+- WHEN the primary region responds within 1500ms
+- THEN no hedged request is sent
+- AND the primary response is returned
+
+#### Scenario: Primary exceeds threshold
+- GIVEN threshold is 1500ms
+- WHEN the primary region has not responded after 1500ms
+- THEN a hedged request is sent to the next region in `ApplicationPreferredRegions`
+
+#### Scenario: Subsequent hedges at thresholdStep intervals
+- GIVEN threshold is 1500ms and thresholdStep is 500ms
+- WHEN neither primary nor first hedge has responded
+- THEN a second hedge is sent at 2000ms (threshold + thresholdStep)
+- AND a third hedge is sent at 2500ms (threshold + 2 * thresholdStep)
+- AND hedging continues until all preferred regions are tried
+
+### Requirement: Response Selection
+The SDK SHALL return the first final response received from any region.
+
+#### Scenario: Final status codes
+- GIVEN hedged requests are in flight to multiple regions
+- WHEN any region returns a status code in {1xx, 2xx, 3xx, 400, 401, 404/0, 409, 405, 412, 413}
+- THEN that response is considered final and returned to the caller
+- AND outstanding hedged requests are cancelled
+
+#### Scenario: Non-final responses
+- GIVEN all regions return non-final status codes (e.g., transient 5xx)
+- WHEN the last hedged request completes
+- THEN the last response received is returned to the caller
+
+### Requirement: Hedging Scope
+The SDK SHALL apply hedging based on operation type.
+
+#### Scenario: Read operations
+- GIVEN hedging is configured
+- WHEN a read operation is performed (ReadItem, Query, ReadMany, ChangeFeed)
+- THEN hedging is applied
+
+#### Scenario: Write operations (single-master)
+- GIVEN a single-master account
+- WHEN a write operation is performed
+- THEN hedging sends requests to read regions (not the write region)
+- AND this enables reads from read replicas during write region degradation
+
+#### Scenario: Write operations (multi-master)
+- GIVEN a multi-master account AND `enableMultiWriteRegionHedge = true`
+- WHEN a write operation is performed
+- THEN hedging sends requests to other write regions
+- AND the application is responsible for handling potential conflicts
+
+### Requirement: Independent Retry Per Hedge
+The SDK SHALL ensure each hedged request has its own independent retry policy.
+
+#### Scenario: Isolated retry chains
+- GIVEN a hedged request to Region 2 encounters a transient error
+- WHEN the retry policy evaluates the error
+- THEN Region 2's retry operates independently
+- AND the hedged request does NOT trigger cross-region retries (no hedging within hedging)
+
+### Requirement: Hedging Diagnostics
+The SDK SHALL include hedging metadata in diagnostics output.
+
+#### Scenario: Diagnostics content
+- GIVEN a hedged request completes
+- WHEN `response.Diagnostics.ToString()` is called
+- THEN the output includes hedge configuration (threshold, thresholdStep)
+- AND a list of regions that received hedged requests
+- AND per-region response details (status code, latency)
+
+### Requirement: Default Hedging Configuration
+The SDK SHALL use sensible defaults when hedging is enabled without explicit thresholds.
+
+#### Scenario: Default threshold
+- GIVEN `AvailabilityStrategy.CrossRegionHedgingStrategy()` is called with default parameters
+- WHEN the SDK computes the threshold
+- THEN it uses `min(1000ms, RequestTimeout / 2)` as the threshold
+- AND 500ms as the thresholdStep
+
+## Key Source Files
+- `Microsoft.Azure.Cosmos/src/Routing/AvailabilityStrategy/AvailabilityStrategy.cs` — public factory
+- `Microsoft.Azure.Cosmos/src/Routing/AvailabilityStrategy/CrossRegionHedgingAvailabilityStrategy.cs` — hedging implementation
+- `Microsoft.Azure.Cosmos/src/Routing/AvailabilityStrategy/DisabledAvailabilityStrategy.cs` — no-op strategy
+- `Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs` — `AvailabilityStrategy` property
+- `Microsoft.Azure.Cosmos/src/RequestOptions/RequestOptions.cs` — per-request override

--- a/openspec/specs/crud-operations/spec.md
+++ b/openspec/specs/crud-operations/spec.md
@@ -1,0 +1,144 @@
+# CRUD Operations
+
+## Purpose
+
+Point operations for creating, reading, updating, replacing, and deleting individual items in Azure Cosmos DB containers. These are the foundational data-plane operations of the SDK.
+
+## Requirements
+
+### Requirement: Create Item
+The SDK SHALL create a new item in a container with a specified partition key.
+
+#### Scenario: Successful creation
+- GIVEN a container and a valid item with a partition key
+- WHEN `Container.CreateItemAsync<T>(item, partitionKey)` is called
+- THEN the item is persisted in the container
+- AND an `ItemResponse<T>` is returned with status code 201
+- AND the response includes the created resource, request charge, and diagnostics
+
+#### Scenario: Conflict on duplicate ID
+- GIVEN an item with the same ID and partition key already exists
+- WHEN `Container.CreateItemAsync<T>(item, partitionKey)` is called
+- THEN a `CosmosException` is thrown with status code 409 (Conflict)
+
+#### Scenario: Create with stream
+- GIVEN a valid JSON stream and partition key
+- WHEN `Container.CreateItemStreamAsync(stream, partitionKey)` is called
+- THEN a `ResponseMessage` is returned without deserialization overhead
+
+### Requirement: Read Item
+The SDK SHALL read a single item by its ID and partition key (point read).
+
+#### Scenario: Successful point read
+- GIVEN an existing item with known ID and partition key
+- WHEN `Container.ReadItemAsync<T>(id, partitionKey)` is called
+- THEN the item is returned in an `ItemResponse<T>` with status code 200
+- AND the response includes request charge, ETag, and diagnostics
+
+#### Scenario: Item not found
+- GIVEN no item exists with the specified ID and partition key
+- WHEN `Container.ReadItemAsync<T>(id, partitionKey)` is called
+- THEN a `CosmosException` is thrown with status code 404, sub-status code 0
+
+#### Scenario: Conditional read (If-None-Match)
+- GIVEN an item with a known ETag
+- WHEN `ReadItemAsync` is called with `ItemRequestOptions.IfNoneMatchEtag` set to that ETag
+- AND the item has not been modified
+- THEN a `CosmosException` is thrown with status code 304 (Not Modified)
+- AND no request charge is consumed for the read
+
+### Requirement: Replace Item
+The SDK SHALL replace an entire item identified by its ID and partition key.
+
+#### Scenario: Successful replace
+- GIVEN an existing item
+- WHEN `Container.ReplaceItemAsync<T>(item, id, partitionKey)` is called
+- THEN the item is fully replaced with the new content
+- AND an `ItemResponse<T>` is returned with status code 200
+
+#### Scenario: Optimistic concurrency with ETag
+- GIVEN an item with a known ETag
+- WHEN `ReplaceItemAsync` is called with `ItemRequestOptions.IfMatchEtag` set
+- AND the item has been modified by another client (ETag mismatch)
+- THEN a `CosmosException` is thrown with status code 412 (Precondition Failed)
+
+### Requirement: Upsert Item
+The SDK SHALL create or replace an item based on whether it already exists.
+
+#### Scenario: Item does not exist
+- GIVEN no item with the specified ID and partition key exists
+- WHEN `Container.UpsertItemAsync<T>(item, partitionKey)` is called
+- THEN the item is created
+- AND an `ItemResponse<T>` is returned with status code 201
+
+#### Scenario: Item already exists
+- GIVEN an item with the specified ID and partition key exists
+- WHEN `Container.UpsertItemAsync<T>(item, partitionKey)` is called
+- THEN the item is replaced with the new content
+- AND an `ItemResponse<T>` is returned with status code 200
+
+### Requirement: Delete Item
+The SDK SHALL delete an item by its ID and partition key.
+
+#### Scenario: Successful deletion
+- GIVEN an existing item
+- WHEN `Container.DeleteItemAsync<T>(id, partitionKey)` is called
+- THEN the item is removed from the container
+- AND an `ItemResponse<T>` is returned with status code 204
+
+#### Scenario: Delete non-existent item
+- GIVEN no item with the specified ID and partition key exists
+- WHEN `Container.DeleteItemAsync<T>(id, partitionKey)` is called
+- THEN a `CosmosException` is thrown with status code 404
+
+### Requirement: Patch Item
+The SDK SHALL apply partial modifications to an item without replacing the entire document.
+
+#### Scenario: Add a new property
+- GIVEN an existing item
+- WHEN `Container.PatchItemAsync<T>(id, partitionKey, patchOperations)` is called with `PatchOperation.Add("/newProp", value)`
+- THEN the property is added to the item
+- AND an `ItemResponse<T>` is returned with status code 200
+
+#### Scenario: Multiple patch operations
+- GIVEN an existing item
+- WHEN `PatchItemAsync` is called with multiple `PatchOperation` entries (Add, Remove, Replace, Set, Increment, Move)
+- THEN all operations are applied atomically in order
+
+#### Scenario: Conditional patch
+- GIVEN an existing item
+- WHEN `PatchItemAsync` is called with `PatchItemRequestOptions.FilterPredicate` set to a SQL-like condition
+- AND the condition evaluates to false
+- THEN a `CosmosException` is thrown with status code 412 (Precondition Failed)
+
+### Requirement: Read Many Items
+The SDK SHALL read multiple items by their (ID, partition key) pairs in a single request.
+
+#### Scenario: Successful ReadMany
+- GIVEN a list of (id, partitionKey) tuples
+- WHEN `Container.ReadManyItemsAsync<T>(items)` is called
+- THEN all found items are returned in a `FeedResponse<T>`
+- AND missing items are silently omitted from the response
+
+### Requirement: Content Response on Write
+The SDK SHALL support controlling whether write operations return the resource body.
+
+#### Scenario: Suppress content on create
+- GIVEN `ItemRequestOptions.EnableContentResponseOnWrite = false` or `CosmosClientOptions.EnableContentResponseOnWrite = false`
+- WHEN a create, replace, or upsert operation is performed
+- THEN the response does not include the resource body
+- AND request charge is reduced
+
+### Requirement: Priority-Based Execution
+The SDK SHALL support priority levels for point operations.
+
+#### Scenario: Low priority request
+- GIVEN `ItemRequestOptions.PriorityLevel = PriorityLevel.Low`
+- WHEN a point operation is performed during high load
+- THEN the service MAY deprioritize this request in favor of High priority requests
+
+## Key Source Files
+- `Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs` — public API definitions
+- `Microsoft.Azure.Cosmos/src/Resource/Container/ContainerCore.Items.cs` — implementation
+- `Microsoft.Azure.Cosmos/src/Patch/PatchOperation.cs` — patch operation types
+- `Microsoft.Azure.Cosmos/src/RequestOptions/ItemRequestOptions.cs` — per-request options

--- a/openspec/specs/crud-operations/spec.md
+++ b/openspec/specs/crud-operations/spec.md
@@ -9,133 +9,83 @@ Point operations for creating, reading, updating, replacing, and deleting indivi
 ### Requirement: Create Item
 The SDK SHALL create a new item in a container with a specified partition key.
 
-#### Scenario: Successful creation
-- GIVEN a container and a valid item with a partition key
-- WHEN `Container.CreateItemAsync<T>(item, partitionKey)` is called
-- THEN the item is persisted in the container
-- AND an `ItemResponse<T>` is returned with status code 201
-- AND the response includes the created resource, request charge, and diagnostics
+#### Successful creation
+**When** `Container.CreateItemAsync<T>(item, partitionKey)` is called with a valid item and partition key, the SDK shall persist the item in the container, return an `ItemResponse<T>` with status code 201, and include the created resource, request charge, and diagnostics in the response.
 
-#### Scenario: Conflict on duplicate ID
-- GIVEN an item with the same ID and partition key already exists
-- WHEN `Container.CreateItemAsync<T>(item, partitionKey)` is called
-- THEN a `CosmosException` is thrown with status code 409 (Conflict)
+#### Conflict on duplicate ID
+**If** an item with the same ID and partition key already exists when `Container.CreateItemAsync<T>(item, partitionKey)` is called, **then** the SDK shall throw a `CosmosException` with status code 409 (Conflict).
 
-#### Scenario: Create with stream
-- GIVEN a valid JSON stream and partition key
-- WHEN `Container.CreateItemStreamAsync(stream, partitionKey)` is called
-- THEN a `ResponseMessage` is returned without deserialization overhead
+#### Create with stream
+**When** `Container.CreateItemStreamAsync(stream, partitionKey)` is called with a valid JSON stream and partition key, the SDK shall return a `ResponseMessage` without deserialization overhead.
 
 ### Requirement: Read Item
 The SDK SHALL read a single item by its ID and partition key (point read).
 
-#### Scenario: Successful point read
-- GIVEN an existing item with known ID and partition key
-- WHEN `Container.ReadItemAsync<T>(id, partitionKey)` is called
-- THEN the item is returned in an `ItemResponse<T>` with status code 200
-- AND the response includes request charge, ETag, and diagnostics
+#### Successful point read
+**When** `Container.ReadItemAsync<T>(id, partitionKey)` is called for an existing item with known ID and partition key, the SDK shall return the item in an `ItemResponse<T>` with status code 200, including request charge, ETag, and diagnostics.
 
-#### Scenario: Item not found
-- GIVEN no item exists with the specified ID and partition key
-- WHEN `Container.ReadItemAsync<T>(id, partitionKey)` is called
-- THEN a `CosmosException` is thrown with status code 404, sub-status code 0
+#### Item not found
+**If** no item exists with the specified ID and partition key when `Container.ReadItemAsync<T>(id, partitionKey)` is called, **then** the SDK shall throw a `CosmosException` with status code 404, sub-status code 0.
 
-#### Scenario: Conditional read (If-None-Match)
-- GIVEN an item with a known ETag
-- WHEN `ReadItemAsync` is called with `ItemRequestOptions.IfNoneMatchEtag` set to that ETag
-- AND the item has not been modified
-- THEN a `CosmosException` is thrown with status code 304 (Not Modified)
-- AND no request charge is consumed for the read
+#### Conditional read (If-None-Match)
+**Where** `ItemRequestOptions.IfNoneMatchEtag` is set to a known ETag, **when** `ReadItemAsync` is called and the item has not been modified, the SDK shall throw a `CosmosException` with status code 304 (Not Modified) and consume no request charge for the read.
 
 ### Requirement: Replace Item
 The SDK SHALL replace an entire item identified by its ID and partition key.
 
-#### Scenario: Successful replace
-- GIVEN an existing item
-- WHEN `Container.ReplaceItemAsync<T>(item, id, partitionKey)` is called
-- THEN the item is fully replaced with the new content
-- AND an `ItemResponse<T>` is returned with status code 200
+#### Successful replace
+**When** `Container.ReplaceItemAsync<T>(item, id, partitionKey)` is called for an existing item, the SDK shall fully replace the item with the new content and return an `ItemResponse<T>` with status code 200.
 
-#### Scenario: Optimistic concurrency with ETag
-- GIVEN an item with a known ETag
-- WHEN `ReplaceItemAsync` is called with `ItemRequestOptions.IfMatchEtag` set
-- AND the item has been modified by another client (ETag mismatch)
-- THEN a `CosmosException` is thrown with status code 412 (Precondition Failed)
+#### Optimistic concurrency with ETag
+**If** `ReplaceItemAsync` is called with `ItemRequestOptions.IfMatchEtag` set and the item has been modified by another client (ETag mismatch), **then** the SDK shall throw a `CosmosException` with status code 412 (Precondition Failed).
 
 ### Requirement: Upsert Item
 The SDK SHALL create or replace an item based on whether it already exists.
 
-#### Scenario: Item does not exist
-- GIVEN no item with the specified ID and partition key exists
-- WHEN `Container.UpsertItemAsync<T>(item, partitionKey)` is called
-- THEN the item is created
-- AND an `ItemResponse<T>` is returned with status code 201
+#### Item does not exist
+**When** `Container.UpsertItemAsync<T>(item, partitionKey)` is called and no item with the specified ID and partition key exists, the SDK shall create the item and return an `ItemResponse<T>` with status code 201.
 
-#### Scenario: Item already exists
-- GIVEN an item with the specified ID and partition key exists
-- WHEN `Container.UpsertItemAsync<T>(item, partitionKey)` is called
-- THEN the item is replaced with the new content
-- AND an `ItemResponse<T>` is returned with status code 200
+#### Item already exists
+**When** `Container.UpsertItemAsync<T>(item, partitionKey)` is called and an item with the specified ID and partition key already exists, the SDK shall replace the item with the new content and return an `ItemResponse<T>` with status code 200.
 
 ### Requirement: Delete Item
 The SDK SHALL delete an item by its ID and partition key.
 
-#### Scenario: Successful deletion
-- GIVEN an existing item
-- WHEN `Container.DeleteItemAsync<T>(id, partitionKey)` is called
-- THEN the item is removed from the container
-- AND an `ItemResponse<T>` is returned with status code 204
+#### Successful deletion
+**When** `Container.DeleteItemAsync<T>(id, partitionKey)` is called for an existing item, the SDK shall remove the item from the container and return an `ItemResponse<T>` with status code 204.
 
-#### Scenario: Delete non-existent item
-- GIVEN no item with the specified ID and partition key exists
-- WHEN `Container.DeleteItemAsync<T>(id, partitionKey)` is called
-- THEN a `CosmosException` is thrown with status code 404
+#### Delete non-existent item
+**If** no item with the specified ID and partition key exists when `Container.DeleteItemAsync<T>(id, partitionKey)` is called, **then** the SDK shall throw a `CosmosException` with status code 404.
 
 ### Requirement: Patch Item
 The SDK SHALL apply partial modifications to an item without replacing the entire document.
 
-#### Scenario: Add a new property
-- GIVEN an existing item
-- WHEN `Container.PatchItemAsync<T>(id, partitionKey, patchOperations)` is called with `PatchOperation.Add("/newProp", value)`
-- THEN the property is added to the item
-- AND an `ItemResponse<T>` is returned with status code 200
+#### Add a new property
+**When** `Container.PatchItemAsync<T>(id, partitionKey, patchOperations)` is called with `PatchOperation.Add("/newProp", value)` for an existing item, the SDK shall add the property to the item and return an `ItemResponse<T>` with status code 200.
 
-#### Scenario: Multiple patch operations
-- GIVEN an existing item
-- WHEN `PatchItemAsync` is called with multiple `PatchOperation` entries (Add, Remove, Replace, Set, Increment, Move)
-- THEN all operations are applied atomically in order
+#### Multiple patch operations
+**When** `PatchItemAsync` is called with multiple `PatchOperation` entries (Add, Remove, Replace, Set, Increment, Move) for an existing item, the SDK shall apply all operations atomically in order.
 
-#### Scenario: Conditional patch
-- GIVEN an existing item
-- WHEN `PatchItemAsync` is called with `PatchItemRequestOptions.FilterPredicate` set to a SQL-like condition
-- AND the condition evaluates to false
-- THEN a `CosmosException` is thrown with status code 412 (Precondition Failed)
+#### Conditional patch
+**If** `PatchItemAsync` is called with `PatchItemRequestOptions.FilterPredicate` set to a SQL-like condition and the condition evaluates to false, **then** the SDK shall throw a `CosmosException` with status code 412 (Precondition Failed).
 
 ### Requirement: Read Many Items
 The SDK SHALL read multiple items by their (ID, partition key) pairs in a single request.
 
-#### Scenario: Successful ReadMany
-- GIVEN a list of (id, partitionKey) tuples
-- WHEN `Container.ReadManyItemsAsync<T>(items)` is called
-- THEN all found items are returned in a `FeedResponse<T>`
-- AND missing items are silently omitted from the response
+#### Successful ReadMany
+**When** `Container.ReadManyItemsAsync<T>(items)` is called with a list of (id, partitionKey) tuples, the SDK shall return all found items in a `FeedResponse<T>` and silently omit missing items from the response.
 
 ### Requirement: Content Response on Write
 The SDK SHALL support controlling whether write operations return the resource body.
 
-#### Scenario: Suppress content on create
-- GIVEN `ItemRequestOptions.EnableContentResponseOnWrite = false` or `CosmosClientOptions.EnableContentResponseOnWrite = false`
-- WHEN a create, replace, or upsert operation is performed
-- THEN the response does not include the resource body
-- AND request charge is reduced
+#### Suppress content on create
+**Where** `ItemRequestOptions.EnableContentResponseOnWrite = false` or `CosmosClientOptions.EnableContentResponseOnWrite = false`, **when** a create, replace, or upsert operation is performed, the SDK shall not include the resource body in the response and shall reduce the request charge.
 
 ### Requirement: Priority-Based Execution
 The SDK SHALL support priority levels for point operations.
 
-#### Scenario: Low priority request
-- GIVEN `ItemRequestOptions.PriorityLevel = PriorityLevel.Low`
-- WHEN a point operation is performed during high load
-- THEN the service MAY deprioritize this request in favor of High priority requests
+#### Low priority request
+**Where** `ItemRequestOptions.PriorityLevel = PriorityLevel.Low`, **when** a point operation is performed during high load, the service MAY deprioritize this request in favor of High priority requests.
 
 ## Key Source Files
 - `Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs` — public API definitions

--- a/openspec/specs/diagnostics-and-tracing/spec.md
+++ b/openspec/specs/diagnostics-and-tracing/spec.md
@@ -9,132 +9,83 @@ The SDK provides comprehensive diagnostics, distributed tracing, and metrics to 
 ### Requirement: CosmosDiagnostics
 The SDK SHALL capture diagnostics for every operation and expose them on response objects.
 
-#### Scenario: Access diagnostics
-- GIVEN any Cosmos DB operation completes (success or failure)
-- WHEN `response.Diagnostics` is accessed
-- THEN a `CosmosDiagnostics` object is returned containing operation-level metadata
+#### Access diagnostics
+**When** any Cosmos DB operation completes (success or failure) and `response.Diagnostics` is accessed, the SDK shall return a `CosmosDiagnostics` object containing operation-level metadata.
 
-#### Scenario: Client elapsed time
-- GIVEN a completed operation
-- WHEN `response.Diagnostics.GetClientElapsedTime()` is called
-- THEN the total client-side elapsed time is returned as a `TimeSpan`
+#### Client elapsed time
+**When** `response.Diagnostics.GetClientElapsedTime()` is called after a completed operation, the SDK shall return the total client-side elapsed time as a `TimeSpan`.
 
-#### Scenario: Contacted regions
-- GIVEN a completed operation
-- WHEN `response.Diagnostics.GetContactedRegions()` is called
-- THEN an `IReadOnlyList<(string regionName, Uri endpoint)>` is returned listing all regions contacted
+#### Contacted regions
+**When** `response.Diagnostics.GetContactedRegions()` is called after a completed operation, the SDK shall return an `IReadOnlyList<(string regionName, Uri endpoint)>` listing all regions contacted.
 
-#### Scenario: Failed request count
-- GIVEN a completed operation that involved retries
-- WHEN `response.Diagnostics.GetFailedRequestCount()` is called
-- THEN the number of failed attempts (before the final result) is returned
+#### Failed request count
+**While** a completed operation involved retries, **when** `response.Diagnostics.GetFailedRequestCount()` is called, the SDK shall return the number of failed attempts before the final result.
 
-#### Scenario: Lazy materialization
-- GIVEN a completed operation
-- WHEN `response.Diagnostics.ToString()` is called
-- THEN the full diagnostic JSON is materialized on demand (not eagerly computed)
-- AND the output includes the complete trace tree with all request details
+#### Lazy materialization
+**When** `response.Diagnostics.ToString()` is called after a completed operation, the SDK shall materialize the full diagnostic JSON on demand (not eagerly computed) and include the complete trace tree with all request details.
 
 ### Requirement: Trace Tree
 The SDK SHALL maintain a hierarchical trace tree for each operation capturing all internal steps.
 
-#### Scenario: Trace hierarchy
-- GIVEN an operation like `ReadItemAsync`
-- WHEN the operation completes
-- THEN the trace tree contains the top-level operation node
-- AND child nodes for each internal step (routing, transport, retry, serialization)
-- AND each node records name, start time, duration, component, and level
+#### Trace hierarchy
+**When** an operation like `ReadItemAsync` completes, the SDK shall produce a trace tree containing the top-level operation node, child nodes for each internal step (routing, transport, retry, serialization), and each node shall record name, start time, duration, component, and level.
 
-#### Scenario: Trace data
-- GIVEN a request was sent to the backend
-- WHEN the trace is examined
-- THEN `ClientSideRequestStatisticsTraceDatum` contains per-request details including:
-  - Status code and sub-status code
-  - Request charge (RU)
-  - Region and endpoint
-  - Request and response timestamps
-  - Transport-specific details (Direct: RNTBD stats, Gateway: HTTP stats)
+#### Trace data
+**When** a request is sent to the backend, the SDK shall include `ClientSideRequestStatisticsTraceDatum` in the trace containing per-request details including: status code and sub-status code, request charge (RU), region and endpoint, request and response timestamps, and transport-specific details (Direct: RNTBD stats, Gateway: HTTP stats).
 
 ### Requirement: OpenTelemetry Distributed Tracing
 The SDK SHALL emit OpenTelemetry-compatible traces for operation-level observability.
 
-#### Scenario: Enable distributed tracing
-- GIVEN `CosmosClientTelemetryOptions.DisableDistributedTracing = false` (default)
-- WHEN operations are performed
-- THEN the SDK emits activities on the `Azure.Cosmos.Operation` ActivitySource
+#### Enable distributed tracing
+**Where** `CosmosClientTelemetryOptions.DisableDistributedTracing = false` (default), **when** operations are performed, the SDK shall emit activities on the `Azure.Cosmos.Operation` ActivitySource.
 
-#### Scenario: Trace attributes
-- GIVEN distributed tracing is enabled
-- WHEN an operation activity is recorded
-- THEN it includes standard attributes: `db.system`, `db.name`, `db.collection.name`, `db.cosmosdb.operation_type`, `db.cosmosdb.status_code`, `db.cosmosdb.sub_status_code`, `db.cosmosdb.request_charge`
+#### Trace attributes
+**While** distributed tracing is enabled, **when** an operation activity is recorded, the SDK shall include standard attributes: `db.system`, `db.name`, `db.collection.name`, `db.cosmosdb.operation_type`, `db.cosmosdb.status_code`, `db.cosmosdb.sub_status_code`, `db.cosmosdb.request_charge`.
 
-#### Scenario: Latency threshold events
-- GIVEN a latency threshold is configured via `CosmosThresholdOptions`
-- WHEN an operation exceeds the threshold
-- THEN a `LatencyOverThreshold` event is emitted on the activity with full diagnostics
+#### Latency threshold events
+**Where** a latency threshold is configured via `CosmosThresholdOptions`, **when** an operation exceeds the threshold, the SDK shall emit a `LatencyOverThreshold` event on the activity with full diagnostics.
 
-#### Scenario: Failed request events
-- GIVEN a request fails with a non-retryable error
-- WHEN the operation completes
-- THEN a `FailedRequest` event is emitted on the activity
+#### Failed request events
+**If** a request fails with a non-retryable error, **then** the SDK shall emit a `FailedRequest` event on the activity when the operation completes.
 
-#### Scenario: Request-level diagnostics source
-- GIVEN an application subscribes to `Azure-Cosmos-Operation-Request-Diagnostics`
-- WHEN operations are performed
-- THEN detailed per-request diagnostics are emitted as events
+#### Request-level diagnostics source
+**Where** an application subscribes to `Azure-Cosmos-Operation-Request-Diagnostics`, **when** operations are performed, the SDK shall emit detailed per-request diagnostics as events.
 
 ### Requirement: Client Metrics
 The SDK SHALL emit OpenTelemetry-compatible metrics for quantitative monitoring.
 
-#### Scenario: Enable metrics
-- GIVEN `CosmosClientTelemetryOptions.IsClientMetricsEnabled = true`
-- WHEN operations are performed
-- THEN histograms are emitted on the `Azure.Cosmos.Client.Operation` meter
+#### Enable metrics
+**Where** `CosmosClientTelemetryOptions.IsClientMetricsEnabled = true`, **when** operations are performed, the SDK shall emit histograms on the `Azure.Cosmos.Client.Operation` meter.
 
-#### Scenario: Operation duration histogram
-- GIVEN metrics are enabled
-- WHEN operations complete
-- THEN `db.client.cosmosdb.request.duration` records operation latency in seconds
-- AND uses histogram buckets: 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5, 10
+#### Operation duration histogram
+**While** metrics are enabled, **when** operations complete, the SDK shall record operation latency in seconds via `db.client.cosmosdb.request.duration` using histogram buckets: 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5, 10.
 
-#### Scenario: Request/response body size
-- GIVEN metrics are enabled
-- WHEN operations complete
-- THEN `db.client.cosmosdb.request.body.size` and `db.client.cosmosdb.response.body.size` record payload sizes
+#### Request/response body size
+**While** metrics are enabled, **when** operations complete, the SDK shall record payload sizes via `db.client.cosmosdb.request.body.size` and `db.client.cosmosdb.response.body.size`.
 
-#### Scenario: Service duration (Direct mode only)
-- GIVEN metrics are enabled and Direct mode is used
-- WHEN operations complete
-- THEN `db.client.cosmosdb.request.service_duration` records backend processing time
+#### Service duration (Direct mode only)
+**While** metrics are enabled and Direct mode is used, **when** operations complete, the SDK shall record backend processing time via `db.client.cosmosdb.request.service_duration`.
 
 ### Requirement: Threshold-Based Diagnostics
 The SDK SHALL support configurable thresholds for automatic diagnostics capture.
 
-#### Scenario: Configure thresholds
-- GIVEN `CosmosThresholdOptions` is configured with latency thresholds per operation type
-- WHEN an operation exceeds its threshold
-- THEN diagnostics are automatically captured and emitted as telemetry events
+#### Configure thresholds
+**Where** `CosmosThresholdOptions` is configured with latency thresholds per operation type, **when** an operation exceeds its threshold, the SDK shall automatically capture diagnostics and emit them as telemetry events.
 
-#### Scenario: Per-request threshold override
-- GIVEN `RequestOptions.CosmosThresholdOptions` is set
-- WHEN the request exceeds the per-request threshold
-- THEN the per-request threshold takes precedence over the client-level threshold
+#### Per-request threshold override
+**Where** `RequestOptions.CosmosThresholdOptions` is set, **when** the request exceeds the per-request threshold, the SDK shall use the per-request threshold taking precedence over the client-level threshold.
 
 ### Requirement: Diagnostics in Exceptions
 The SDK SHALL include diagnostics in exception objects.
 
-#### Scenario: Exception diagnostics
-- GIVEN an operation throws a `CosmosException`
-- WHEN `exception.Diagnostics` is accessed
-- THEN full diagnostics are available including all retry attempts and failure details
+#### Exception diagnostics
+**If** an operation throws a `CosmosException`, **then** the SDK shall provide full diagnostics via `exception.Diagnostics` including all retry attempts and failure details.
 
 ### Requirement: Query Metrics
 The SDK SHALL expose server-side query metrics when available.
 
-#### Scenario: Access query metrics
-- GIVEN a query operation completes
-- WHEN `response.Diagnostics.GetQueryMetrics()` is called
-- THEN `ServerSideCumulativeMetrics` is returned with server-side execution time, RU, and document count
+#### Access query metrics
+**When** `response.Diagnostics.GetQueryMetrics()` is called after a query operation completes, the SDK shall return `ServerSideCumulativeMetrics` with server-side execution time, RU, and document count.
 
 ## Key Source Files
 - `Microsoft.Azure.Cosmos/src/Diagnostics/CosmosDiagnostics.cs` — abstract diagnostics base

--- a/openspec/specs/diagnostics-and-tracing/spec.md
+++ b/openspec/specs/diagnostics-and-tracing/spec.md
@@ -1,0 +1,145 @@
+# Diagnostics and Tracing
+
+## Purpose
+
+The SDK provides comprehensive diagnostics, distributed tracing, and metrics to enable observability of Cosmos DB operations for debugging, monitoring, and performance analysis.
+
+## Requirements
+
+### Requirement: CosmosDiagnostics
+The SDK SHALL capture diagnostics for every operation and expose them on response objects.
+
+#### Scenario: Access diagnostics
+- GIVEN any Cosmos DB operation completes (success or failure)
+- WHEN `response.Diagnostics` is accessed
+- THEN a `CosmosDiagnostics` object is returned containing operation-level metadata
+
+#### Scenario: Client elapsed time
+- GIVEN a completed operation
+- WHEN `response.Diagnostics.GetClientElapsedTime()` is called
+- THEN the total client-side elapsed time is returned as a `TimeSpan`
+
+#### Scenario: Contacted regions
+- GIVEN a completed operation
+- WHEN `response.Diagnostics.GetContactedRegions()` is called
+- THEN an `IReadOnlyList<(string regionName, Uri endpoint)>` is returned listing all regions contacted
+
+#### Scenario: Failed request count
+- GIVEN a completed operation that involved retries
+- WHEN `response.Diagnostics.GetFailedRequestCount()` is called
+- THEN the number of failed attempts (before the final result) is returned
+
+#### Scenario: Lazy materialization
+- GIVEN a completed operation
+- WHEN `response.Diagnostics.ToString()` is called
+- THEN the full diagnostic JSON is materialized on demand (not eagerly computed)
+- AND the output includes the complete trace tree with all request details
+
+### Requirement: Trace Tree
+The SDK SHALL maintain a hierarchical trace tree for each operation capturing all internal steps.
+
+#### Scenario: Trace hierarchy
+- GIVEN an operation like `ReadItemAsync`
+- WHEN the operation completes
+- THEN the trace tree contains the top-level operation node
+- AND child nodes for each internal step (routing, transport, retry, serialization)
+- AND each node records name, start time, duration, component, and level
+
+#### Scenario: Trace data
+- GIVEN a request was sent to the backend
+- WHEN the trace is examined
+- THEN `ClientSideRequestStatisticsTraceDatum` contains per-request details including:
+  - Status code and sub-status code
+  - Request charge (RU)
+  - Region and endpoint
+  - Request and response timestamps
+  - Transport-specific details (Direct: RNTBD stats, Gateway: HTTP stats)
+
+### Requirement: OpenTelemetry Distributed Tracing
+The SDK SHALL emit OpenTelemetry-compatible traces for operation-level observability.
+
+#### Scenario: Enable distributed tracing
+- GIVEN `CosmosClientTelemetryOptions.DisableDistributedTracing = false` (default)
+- WHEN operations are performed
+- THEN the SDK emits activities on the `Azure.Cosmos.Operation` ActivitySource
+
+#### Scenario: Trace attributes
+- GIVEN distributed tracing is enabled
+- WHEN an operation activity is recorded
+- THEN it includes standard attributes: `db.system`, `db.name`, `db.collection.name`, `db.cosmosdb.operation_type`, `db.cosmosdb.status_code`, `db.cosmosdb.sub_status_code`, `db.cosmosdb.request_charge`
+
+#### Scenario: Latency threshold events
+- GIVEN a latency threshold is configured via `CosmosThresholdOptions`
+- WHEN an operation exceeds the threshold
+- THEN a `LatencyOverThreshold` event is emitted on the activity with full diagnostics
+
+#### Scenario: Failed request events
+- GIVEN a request fails with a non-retryable error
+- WHEN the operation completes
+- THEN a `FailedRequest` event is emitted on the activity
+
+#### Scenario: Request-level diagnostics source
+- GIVEN an application subscribes to `Azure-Cosmos-Operation-Request-Diagnostics`
+- WHEN operations are performed
+- THEN detailed per-request diagnostics are emitted as events
+
+### Requirement: Client Metrics
+The SDK SHALL emit OpenTelemetry-compatible metrics for quantitative monitoring.
+
+#### Scenario: Enable metrics
+- GIVEN `CosmosClientTelemetryOptions.IsClientMetricsEnabled = true`
+- WHEN operations are performed
+- THEN histograms are emitted on the `Azure.Cosmos.Client.Operation` meter
+
+#### Scenario: Operation duration histogram
+- GIVEN metrics are enabled
+- WHEN operations complete
+- THEN `db.client.cosmosdb.request.duration` records operation latency in seconds
+- AND uses histogram buckets: 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1, 5, 10
+
+#### Scenario: Request/response body size
+- GIVEN metrics are enabled
+- WHEN operations complete
+- THEN `db.client.cosmosdb.request.body.size` and `db.client.cosmosdb.response.body.size` record payload sizes
+
+#### Scenario: Service duration (Direct mode only)
+- GIVEN metrics are enabled and Direct mode is used
+- WHEN operations complete
+- THEN `db.client.cosmosdb.request.service_duration` records backend processing time
+
+### Requirement: Threshold-Based Diagnostics
+The SDK SHALL support configurable thresholds for automatic diagnostics capture.
+
+#### Scenario: Configure thresholds
+- GIVEN `CosmosThresholdOptions` is configured with latency thresholds per operation type
+- WHEN an operation exceeds its threshold
+- THEN diagnostics are automatically captured and emitted as telemetry events
+
+#### Scenario: Per-request threshold override
+- GIVEN `RequestOptions.CosmosThresholdOptions` is set
+- WHEN the request exceeds the per-request threshold
+- THEN the per-request threshold takes precedence over the client-level threshold
+
+### Requirement: Diagnostics in Exceptions
+The SDK SHALL include diagnostics in exception objects.
+
+#### Scenario: Exception diagnostics
+- GIVEN an operation throws a `CosmosException`
+- WHEN `exception.Diagnostics` is accessed
+- THEN full diagnostics are available including all retry attempts and failure details
+
+### Requirement: Query Metrics
+The SDK SHALL expose server-side query metrics when available.
+
+#### Scenario: Access query metrics
+- GIVEN a query operation completes
+- WHEN `response.Diagnostics.GetQueryMetrics()` is called
+- THEN `ServerSideCumulativeMetrics` is returned with server-side execution time, RU, and document count
+
+## Key Source Files
+- `Microsoft.Azure.Cosmos/src/Diagnostics/CosmosDiagnostics.cs` — abstract diagnostics base
+- `Microsoft.Azure.Cosmos/src/Diagnostics/CosmosTraceDiagnostics.cs` — trace-based implementation
+- `Microsoft.Azure.Cosmos/src/Tracing/Trace.cs` — hierarchical trace node
+- `Microsoft.Azure.Cosmos/src/Tracing/TraceData/ClientSideRequestStatisticsTraceDatum.cs` — per-request stats
+- `Microsoft.Azure.Cosmos/src/Telemetry/OpenTelemetry/` — OpenTelemetry integration
+- `Microsoft.Azure.Cosmos/src/CosmosClientTelemetryOptions.cs` — telemetry configuration

--- a/openspec/specs/partitioning/spec.md
+++ b/openspec/specs/partitioning/spec.md
@@ -9,96 +9,62 @@ Partitioning is the fundamental data distribution mechanism in Azure Cosmos DB. 
 ### Requirement: Partition Key Specification
 The SDK SHALL support specifying partition keys for all item-level operations.
 
-#### Scenario: Single partition key
-- GIVEN a container with a partition key path `/tenantId`
-- WHEN `new PartitionKey("tenant-1")` is provided to an operation
-- THEN the request is routed to the correct physical partition
+#### Single partition key
+**When** `new PartitionKey("tenant-1")` is provided to an operation on a container with partition key path `/tenantId`, the SDK shall route the request to the correct physical partition.
 
-#### Scenario: Partition key from item
-- GIVEN an item with the partition key property populated
-- WHEN `Container.CreateItemAsync(item)` is called without an explicit partition key
-- THEN the SDK extracts the partition key from the item using the container's partition key definition
+#### Partition key from item
+**When** `Container.CreateItemAsync(item)` is called without an explicit partition key, the SDK shall extract the partition key from the item using the container's partition key definition.
 
-#### Scenario: None partition key
-- GIVEN an item that does not have a partition key property (or it is null)
-- WHEN `PartitionKey.None` is used
-- THEN the item is stored in the system-defined "none" partition
+#### None partition key
+**When** `PartitionKey.None` is used for an item that does not have a partition key property (or it is null), the SDK shall store the item in the system-defined "none" partition.
 
 ### Requirement: Hierarchical Partition Keys
 The SDK SHALL support hierarchical (multi-level) partition keys.
 
-#### Scenario: Build hierarchical key
-- GIVEN a container with partition key paths `["/tenantId", "/userId", "/sessionId"]`
-- WHEN `new PartitionKeyBuilder().Add("tenant-1").Add("user-1").Add("session-1").Build()` is called
-- THEN a hierarchical partition key is created for routing
+#### Build hierarchical key
+**When** `new PartitionKeyBuilder().Add("tenant-1").Add("user-1").Add("session-1").Build()` is called for a container with partition key paths `["/tenantId", "/userId", "/sessionId"]`, the SDK shall create a hierarchical partition key for routing.
 
-#### Scenario: Partial partition key for queries
-- GIVEN a hierarchical partition key container
-- WHEN a query is executed with only the first level partition key (e.g., tenantId only)
-- THEN the query fans out to all sub-partitions under that prefix
+#### Partial partition key for queries
+**While** using a hierarchical partition key container, **when** a query is executed with only the first level partition key (e.g., tenantId only), the SDK shall fan out the query to all sub-partitions under that prefix.
 
-#### Scenario: Full hierarchical key for point operations
-- GIVEN a hierarchical partition key container
-- WHEN a point operation (Read, Replace, Delete) is performed
-- THEN the full hierarchical key MUST be provided
+#### Full hierarchical key for point operations
+**While** using a hierarchical partition key container, **when** a point operation (Read, Replace, Delete) is performed, the full hierarchical key MUST be provided.
 
 ### Requirement: Feed Ranges
 The SDK SHALL support FeedRange for parallel processing across partitions.
 
-#### Scenario: Get all feed ranges
-- GIVEN a container
-- WHEN `Container.GetFeedRangesAsync()` is called
-- THEN a list of `FeedRange` objects is returned, each representing a partition key range
+#### Get all feed ranges
+**When** `Container.GetFeedRangesAsync()` is called, the SDK shall return a list of `FeedRange` objects, each representing a partition key range.
 
-#### Scenario: Use feed range for change feed
-- GIVEN a `FeedRange` from `GetFeedRangesAsync()`
-- WHEN `ChangeFeedStartFrom.Beginning(feedRange)` is used
-- THEN only changes within that partition range are returned
+#### Use feed range for change feed
+**When** `ChangeFeedStartFrom.Beginning(feedRange)` is used with a `FeedRange` from `GetFeedRangesAsync()`, the SDK shall return only changes within that partition range.
 
-#### Scenario: Use feed range for query
-- GIVEN a `FeedRange`
-- WHEN a query is executed with `QueryRequestOptions.FeedRange` set
-- THEN the query only executes against the specified partition range
+#### Use feed range for query
+**When** a query is executed with `QueryRequestOptions.FeedRange` set to a specific `FeedRange`, the SDK shall execute the query only against the specified partition range.
 
-#### Scenario: FeedRange from partition key
-- GIVEN a partition key value
-- WHEN `FeedRange.FromPartitionKey(partitionKey)` is called
-- THEN a `FeedRange` scoped to that single logical partition is returned
+#### FeedRange from partition key
+**When** `FeedRange.FromPartitionKey(partitionKey)` is called, the SDK shall return a `FeedRange` scoped to that single logical partition.
 
 ### Requirement: Partition Key Range Caching
 The SDK SHALL cache partition key range information to avoid repeated metadata lookups.
 
-#### Scenario: Cache hit
-- GIVEN a partition key range has been resolved previously
-- WHEN a new request targets the same partition
-- THEN the cached routing information is used without a metadata call
+#### Cache hit
+**While** a partition key range has been resolved previously, **when** a new request targets the same partition, the SDK shall use the cached routing information without a metadata call.
 
-#### Scenario: Cache invalidation on 410 Gone
-- GIVEN the service returns 410 (Gone) with sub-status 1002 (PartitionKeyRangeGone)
-- WHEN the SDK handles this response
-- THEN the partition key range cache is invalidated
-- AND the operation is retried with refreshed routing
+#### Cache invalidation on 410 Gone
+**If** the service returns 410 (Gone) with sub-status 1002 (PartitionKeyRangeGone), **then** the SDK shall invalidate the partition key range cache and retry the operation with refreshed routing.
 
-#### Scenario: Partition split
-- GIVEN a physical partition is split by the service
-- WHEN a request targets the old partition range
-- THEN the SDK receives a 410 response
-- AND refreshes the routing map to discover the new partition ranges
-- AND retries the operation against the correct new partition
+#### Partition split
+**If** a physical partition is split by the service and a request targets the old partition range, **then** the SDK shall handle the 410 response, refresh the routing map to discover the new partition ranges, and retry the operation against the correct new partition.
 
 ### Requirement: Cross-Partition Operations
 The SDK SHALL support operations that span multiple partitions.
 
-#### Scenario: Cross-partition query
-- GIVEN a query without a partition key filter
-- WHEN the query is executed
-- THEN the SDK fans out the query to all partitions
-- AND merges results according to the query's ORDER BY requirements
+#### Cross-partition query
+**When** a query without a partition key filter is executed, the SDK shall fan out the query to all partitions and merge results according to the query's ORDER BY requirements.
 
-#### Scenario: Change feed across all partitions
-- GIVEN `ChangeFeedStartFrom.Beginning()` without a FeedRange
-- WHEN the change feed iterator is used
-- THEN changes from all partitions are returned
+#### Change feed across all partitions
+**When** `ChangeFeedStartFrom.Beginning()` is used without a FeedRange, the SDK shall return changes from all partitions via the change feed iterator.
 
 ## Key Source Files
 - `Microsoft.Azure.Cosmos/src/PartitionKey.cs` — partition key value type

--- a/openspec/specs/partitioning/spec.md
+++ b/openspec/specs/partitioning/spec.md
@@ -1,0 +1,109 @@
+# Partitioning
+
+## Purpose
+
+Partitioning is the fundamental data distribution mechanism in Azure Cosmos DB. The SDK handles partition key routing, hierarchical partition keys, and feed ranges for parallel processing.
+
+## Requirements
+
+### Requirement: Partition Key Specification
+The SDK SHALL support specifying partition keys for all item-level operations.
+
+#### Scenario: Single partition key
+- GIVEN a container with a partition key path `/tenantId`
+- WHEN `new PartitionKey("tenant-1")` is provided to an operation
+- THEN the request is routed to the correct physical partition
+
+#### Scenario: Partition key from item
+- GIVEN an item with the partition key property populated
+- WHEN `Container.CreateItemAsync(item)` is called without an explicit partition key
+- THEN the SDK extracts the partition key from the item using the container's partition key definition
+
+#### Scenario: None partition key
+- GIVEN an item that does not have a partition key property (or it is null)
+- WHEN `PartitionKey.None` is used
+- THEN the item is stored in the system-defined "none" partition
+
+### Requirement: Hierarchical Partition Keys
+The SDK SHALL support hierarchical (multi-level) partition keys.
+
+#### Scenario: Build hierarchical key
+- GIVEN a container with partition key paths `["/tenantId", "/userId", "/sessionId"]`
+- WHEN `new PartitionKeyBuilder().Add("tenant-1").Add("user-1").Add("session-1").Build()` is called
+- THEN a hierarchical partition key is created for routing
+
+#### Scenario: Partial partition key for queries
+- GIVEN a hierarchical partition key container
+- WHEN a query is executed with only the first level partition key (e.g., tenantId only)
+- THEN the query fans out to all sub-partitions under that prefix
+
+#### Scenario: Full hierarchical key for point operations
+- GIVEN a hierarchical partition key container
+- WHEN a point operation (Read, Replace, Delete) is performed
+- THEN the full hierarchical key MUST be provided
+
+### Requirement: Feed Ranges
+The SDK SHALL support FeedRange for parallel processing across partitions.
+
+#### Scenario: Get all feed ranges
+- GIVEN a container
+- WHEN `Container.GetFeedRangesAsync()` is called
+- THEN a list of `FeedRange` objects is returned, each representing a partition key range
+
+#### Scenario: Use feed range for change feed
+- GIVEN a `FeedRange` from `GetFeedRangesAsync()`
+- WHEN `ChangeFeedStartFrom.Beginning(feedRange)` is used
+- THEN only changes within that partition range are returned
+
+#### Scenario: Use feed range for query
+- GIVEN a `FeedRange`
+- WHEN a query is executed with `QueryRequestOptions.FeedRange` set
+- THEN the query only executes against the specified partition range
+
+#### Scenario: FeedRange from partition key
+- GIVEN a partition key value
+- WHEN `FeedRange.FromPartitionKey(partitionKey)` is called
+- THEN a `FeedRange` scoped to that single logical partition is returned
+
+### Requirement: Partition Key Range Caching
+The SDK SHALL cache partition key range information to avoid repeated metadata lookups.
+
+#### Scenario: Cache hit
+- GIVEN a partition key range has been resolved previously
+- WHEN a new request targets the same partition
+- THEN the cached routing information is used without a metadata call
+
+#### Scenario: Cache invalidation on 410 Gone
+- GIVEN the service returns 410 (Gone) with sub-status 1002 (PartitionKeyRangeGone)
+- WHEN the SDK handles this response
+- THEN the partition key range cache is invalidated
+- AND the operation is retried with refreshed routing
+
+#### Scenario: Partition split
+- GIVEN a physical partition is split by the service
+- WHEN a request targets the old partition range
+- THEN the SDK receives a 410 response
+- AND refreshes the routing map to discover the new partition ranges
+- AND retries the operation against the correct new partition
+
+### Requirement: Cross-Partition Operations
+The SDK SHALL support operations that span multiple partitions.
+
+#### Scenario: Cross-partition query
+- GIVEN a query without a partition key filter
+- WHEN the query is executed
+- THEN the SDK fans out the query to all partitions
+- AND merges results according to the query's ORDER BY requirements
+
+#### Scenario: Change feed across all partitions
+- GIVEN `ChangeFeedStartFrom.Beginning()` without a FeedRange
+- WHEN the change feed iterator is used
+- THEN changes from all partitions are returned
+
+## Key Source Files
+- `Microsoft.Azure.Cosmos/src/PartitionKey.cs` — partition key value type
+- `Microsoft.Azure.Cosmos/src/PartitionKeyBuilder.cs` — hierarchical partition key builder
+- `Microsoft.Azure.Cosmos/src/FeedRange/FeedRange.cs` — feed range abstraction
+- `Microsoft.Azure.Cosmos/src/Routing/PartitionKeyRangeCache.cs` — range caching
+- `Microsoft.Azure.Cosmos/src/Routing/CollectionRoutingMap.cs` — partition routing
+- `Microsoft.Azure.Cosmos/src/Routing/PartitionRoutingHelper.cs` — routing utilities

--- a/openspec/specs/query-execution/spec.md
+++ b/openspec/specs/query-execution/spec.md
@@ -1,0 +1,106 @@
+# Query Execution
+
+## Purpose
+
+SQL and LINQ query execution against Azure Cosmos DB containers, including cross-partition queries, pagination via FeedIterator, and query optimization features.
+
+## Requirements
+
+### Requirement: SQL Query Execution
+The SDK SHALL execute parameterized SQL queries against containers and return results via FeedIterator.
+
+#### Scenario: Single-partition query
+- GIVEN a container with items and a query targeting a single partition key
+- WHEN `Container.GetItemQueryIterator<T>(queryDefinition, requestOptions: new QueryRequestOptions { PartitionKey = pk })` is called
+- THEN results are fetched from a single partition
+- AND returned via `FeedIterator<T>` with pagination support
+
+#### Scenario: Cross-partition query
+- GIVEN a query without a partition key filter
+- WHEN `Container.GetItemQueryIterator<T>(queryDefinition)` is called
+- THEN the SDK SHALL fan out the query to all partitions
+- AND merge results according to the query's ordering requirements
+
+#### Scenario: Parameterized query
+- GIVEN a `QueryDefinition` with parameters
+- WHEN `new QueryDefinition("SELECT * FROM c WHERE c.status = @status").WithParameter("@status", "active")` is used
+- THEN parameters are safely bound to prevent injection
+
+### Requirement: FeedIterator Pagination
+The SDK SHALL provide page-by-page iteration over query results with continuation token support.
+
+#### Scenario: Iterating all pages
+- GIVEN a FeedIterator with `HasMoreResults = true`
+- WHEN `ReadNextAsync()` is called repeatedly
+- THEN each call returns a `FeedResponse<T>` containing a page of items
+- AND `HasMoreResults` becomes false when all results are consumed
+
+#### Scenario: Resume with continuation token
+- GIVEN a `FeedResponse<T>` with a non-null `ContinuationToken`
+- WHEN a new `GetItemQueryIterator<T>` is created with that continuation token
+- THEN iteration resumes from where it left off
+
+#### Scenario: Page size control
+- GIVEN `QueryRequestOptions.MaxItemCount` is set to N
+- WHEN `ReadNextAsync()` is called
+- THEN each page contains at most N items (may contain fewer)
+
+### Requirement: Stream-Based Query
+The SDK SHALL support stream-based query execution for zero-copy scenarios.
+
+#### Scenario: Stream query
+- GIVEN a query
+- WHEN `Container.GetItemQueryStreamIterator(queryDefinition)` is called
+- THEN results are returned as `ResponseMessage` with raw JSON stream
+- AND no deserialization is performed by the SDK
+
+### Requirement: LINQ Query Support
+The SDK SHALL support LINQ-to-SQL translation for type-safe queries.
+
+#### Scenario: LINQ query
+- GIVEN a container with typed items
+- WHEN `Container.GetItemLinqQueryable<T>().Where(x => x.Status == "active").ToFeedIterator()` is called
+- THEN the LINQ expression is translated to a Cosmos SQL query
+- AND results are returned via `FeedIterator<T>`
+
+### Requirement: Query Configuration
+The SDK SHALL support query-level configuration via QueryRequestOptions.
+
+#### Scenario: Max concurrency
+- GIVEN `QueryRequestOptions.MaxConcurrency` is set to N
+- WHEN a cross-partition query is executed
+- THEN at most N partitions are queried concurrently
+
+#### Scenario: Index metrics
+- GIVEN `QueryRequestOptions.PopulateIndexMetrics = true`
+- WHEN a query is executed
+- THEN `FeedResponse<T>.Headers["x-ms-cosmos-index-utilization"]` contains index usage statistics
+
+#### Scenario: Consistency level override
+- GIVEN `QueryRequestOptions.ConsistencyLevel` is set
+- WHEN a query is executed
+- THEN the specified consistency level is used for that query only
+
+### Requirement: ReadMany Optimization
+The SDK SHALL provide an optimized multi-item read for known (id, partitionKey) pairs.
+
+#### Scenario: Batch point reads
+- GIVEN a list of `(id, partitionKey)` tuples
+- WHEN `Container.ReadManyItemsAsync<T>(items)` is called
+- THEN all items are returned in a single `FeedResponse<T>`
+- AND the operation is optimized as a single server roundtrip where possible
+
+### Requirement: Query Metrics
+The SDK SHALL expose server-side query metrics when available.
+
+#### Scenario: Retrieve query metrics
+- GIVEN a completed query page
+- WHEN `FeedResponse<T>.Diagnostics.GetQueryMetrics()` is called
+- THEN `ServerSideCumulativeMetrics` is returned with RU charge, execution time, document count, and index hit metrics
+
+## Key Source Files
+- `Microsoft.Azure.Cosmos/src/Query/v3Query/QueryDefinition.cs` — query definition with parameters
+- `Microsoft.Azure.Cosmos/src/Query/v3Query/QueryIterator.cs` — query iterator implementation
+- `Microsoft.Azure.Cosmos/src/Resource/FeedIterators/FeedIterator.cs` — abstract FeedIterator
+- `Microsoft.Azure.Cosmos/src/Linq/` — LINQ-to-SQL translation
+- `Microsoft.Azure.Cosmos/src/RequestOptions/QueryRequestOptions.cs` — query configuration

--- a/openspec/specs/query-execution/spec.md
+++ b/openspec/specs/query-execution/spec.md
@@ -9,94 +9,62 @@ SQL and LINQ query execution against Azure Cosmos DB containers, including cross
 ### Requirement: SQL Query Execution
 The SDK SHALL execute parameterized SQL queries against containers and return results via FeedIterator.
 
-#### Scenario: Single-partition query
-- GIVEN a container with items and a query targeting a single partition key
-- WHEN `Container.GetItemQueryIterator<T>(queryDefinition, requestOptions: new QueryRequestOptions { PartitionKey = pk })` is called
-- THEN results are fetched from a single partition
-- AND returned via `FeedIterator<T>` with pagination support
+#### Single-partition query
+**When** `Container.GetItemQueryIterator<T>(queryDefinition, requestOptions: new QueryRequestOptions { PartitionKey = pk })` is called with a query targeting a single partition key, the SDK shall fetch results from a single partition and return them via `FeedIterator<T>` with pagination support.
 
-#### Scenario: Cross-partition query
-- GIVEN a query without a partition key filter
-- WHEN `Container.GetItemQueryIterator<T>(queryDefinition)` is called
-- THEN the SDK SHALL fan out the query to all partitions
-- AND merge results according to the query's ordering requirements
+#### Cross-partition query
+**When** `Container.GetItemQueryIterator<T>(queryDefinition)` is called with a query without a partition key filter, the SDK shall fan out the query to all partitions and merge results according to the query's ordering requirements.
 
-#### Scenario: Parameterized query
-- GIVEN a `QueryDefinition` with parameters
-- WHEN `new QueryDefinition("SELECT * FROM c WHERE c.status = @status").WithParameter("@status", "active")` is used
-- THEN parameters are safely bound to prevent injection
+#### Parameterized query
+**When** `new QueryDefinition("SELECT * FROM c WHERE c.status = @status").WithParameter("@status", "active")` is used, the SDK shall safely bind parameters to prevent injection.
 
 ### Requirement: FeedIterator Pagination
 The SDK SHALL provide page-by-page iteration over query results with continuation token support.
 
-#### Scenario: Iterating all pages
-- GIVEN a FeedIterator with `HasMoreResults = true`
-- WHEN `ReadNextAsync()` is called repeatedly
-- THEN each call returns a `FeedResponse<T>` containing a page of items
-- AND `HasMoreResults` becomes false when all results are consumed
+#### Iterating all pages
+**While** a FeedIterator has `HasMoreResults = true`, **when** `ReadNextAsync()` is called repeatedly, the SDK shall return a `FeedResponse<T>` containing a page of items for each call and set `HasMoreResults` to false when all results are consumed.
 
-#### Scenario: Resume with continuation token
-- GIVEN a `FeedResponse<T>` with a non-null `ContinuationToken`
-- WHEN a new `GetItemQueryIterator<T>` is created with that continuation token
-- THEN iteration resumes from where it left off
+#### Resume with continuation token
+**When** a new `GetItemQueryIterator<T>` is created with a non-null `ContinuationToken` from a previous `FeedResponse<T>`, the SDK shall resume iteration from where it left off.
 
-#### Scenario: Page size control
-- GIVEN `QueryRequestOptions.MaxItemCount` is set to N
-- WHEN `ReadNextAsync()` is called
-- THEN each page contains at most N items (may contain fewer)
+#### Page size control
+**Where** `QueryRequestOptions.MaxItemCount` is set to N, **when** `ReadNextAsync()` is called, the SDK shall return each page containing at most N items (may contain fewer).
 
 ### Requirement: Stream-Based Query
 The SDK SHALL support stream-based query execution for zero-copy scenarios.
 
-#### Scenario: Stream query
-- GIVEN a query
-- WHEN `Container.GetItemQueryStreamIterator(queryDefinition)` is called
-- THEN results are returned as `ResponseMessage` with raw JSON stream
-- AND no deserialization is performed by the SDK
+#### Stream query
+**When** `Container.GetItemQueryStreamIterator(queryDefinition)` is called, the SDK shall return results as `ResponseMessage` with raw JSON stream and perform no deserialization.
 
 ### Requirement: LINQ Query Support
 The SDK SHALL support LINQ-to-SQL translation for type-safe queries.
 
-#### Scenario: LINQ query
-- GIVEN a container with typed items
-- WHEN `Container.GetItemLinqQueryable<T>().Where(x => x.Status == "active").ToFeedIterator()` is called
-- THEN the LINQ expression is translated to a Cosmos SQL query
-- AND results are returned via `FeedIterator<T>`
+#### LINQ query
+**When** `Container.GetItemLinqQueryable<T>().Where(x => x.Status == "active").ToFeedIterator()` is called, the SDK shall translate the LINQ expression to a Cosmos SQL query and return results via `FeedIterator<T>`.
 
 ### Requirement: Query Configuration
 The SDK SHALL support query-level configuration via QueryRequestOptions.
 
-#### Scenario: Max concurrency
-- GIVEN `QueryRequestOptions.MaxConcurrency` is set to N
-- WHEN a cross-partition query is executed
-- THEN at most N partitions are queried concurrently
+#### Max concurrency
+**Where** `QueryRequestOptions.MaxConcurrency` is set to N, **when** a cross-partition query is executed, the SDK shall query at most N partitions concurrently.
 
-#### Scenario: Index metrics
-- GIVEN `QueryRequestOptions.PopulateIndexMetrics = true`
-- WHEN a query is executed
-- THEN `FeedResponse<T>.Headers["x-ms-cosmos-index-utilization"]` contains index usage statistics
+#### Index metrics
+**Where** `QueryRequestOptions.PopulateIndexMetrics = true`, **when** a query is executed, the SDK shall populate `FeedResponse<T>.Headers["x-ms-cosmos-index-utilization"]` with index usage statistics.
 
-#### Scenario: Consistency level override
-- GIVEN `QueryRequestOptions.ConsistencyLevel` is set
-- WHEN a query is executed
-- THEN the specified consistency level is used for that query only
+#### Consistency level override
+**Where** `QueryRequestOptions.ConsistencyLevel` is set, **when** a query is executed, the SDK shall use the specified consistency level for that query only.
 
 ### Requirement: ReadMany Optimization
 The SDK SHALL provide an optimized multi-item read for known (id, partitionKey) pairs.
 
-#### Scenario: Batch point reads
-- GIVEN a list of `(id, partitionKey)` tuples
-- WHEN `Container.ReadManyItemsAsync<T>(items)` is called
-- THEN all items are returned in a single `FeedResponse<T>`
-- AND the operation is optimized as a single server roundtrip where possible
+#### Batch point reads
+**When** `Container.ReadManyItemsAsync<T>(items)` is called with a list of `(id, partitionKey)` tuples, the SDK shall return all items in a single `FeedResponse<T>` and optimize the operation as a single server roundtrip where possible.
 
 ### Requirement: Query Metrics
 The SDK SHALL expose server-side query metrics when available.
 
-#### Scenario: Retrieve query metrics
-- GIVEN a completed query page
-- WHEN `FeedResponse<T>.Diagnostics.GetQueryMetrics()` is called
-- THEN `ServerSideCumulativeMetrics` is returned with RU charge, execution time, document count, and index hit metrics
+#### Retrieve query metrics
+**When** `FeedResponse<T>.Diagnostics.GetQueryMetrics()` is called after a completed query page, the SDK shall return `ServerSideCumulativeMetrics` with RU charge, execution time, document count, and index hit metrics.
 
 ## Key Source Files
 - `Microsoft.Azure.Cosmos/src/Query/v3Query/QueryDefinition.cs` — query definition with parameters

--- a/openspec/specs/resource-management/spec.md
+++ b/openspec/specs/resource-management/spec.md
@@ -1,0 +1,187 @@
+# Resource Management
+
+## Purpose
+
+The SDK provides management operations for databases, containers, throughput, indexing policies, and container-level features like vector search, full-text search, and conflict resolution.
+
+## Requirements
+
+### Requirement: Database Management
+The SDK SHALL support creating, reading, and deleting databases.
+
+#### Scenario: Create database
+- GIVEN a Cosmos DB account
+- WHEN `CosmosClient.CreateDatabaseAsync("mydb")` is called
+- THEN a new database is created
+- AND a `DatabaseResponse` is returned with status code 201
+
+#### Scenario: Create if not exists
+- GIVEN a database name
+- WHEN `CosmosClient.CreateDatabaseIfNotExistsAsync("mydb")` is called
+- THEN the database is created if it doesn't exist (201)
+- OR the existing database reference is returned (200)
+
+#### Scenario: Read database
+- GIVEN an existing database
+- WHEN `database.ReadAsync()` is called
+- THEN `DatabaseProperties` are returned with the database metadata
+
+#### Scenario: Delete database
+- GIVEN an existing database
+- WHEN `database.DeleteAsync()` is called
+- THEN the database and all its containers are permanently deleted
+
+### Requirement: Container Management
+The SDK SHALL support creating, reading, replacing, and deleting containers.
+
+#### Scenario: Create container
+- GIVEN a database
+- WHEN `database.CreateContainerAsync(new ContainerProperties("mycontainer", "/partitionKey"))` is called
+- THEN a new container is created with the specified partition key
+- AND a `ContainerResponse` is returned with status code 201
+
+#### Scenario: Create with throughput
+- GIVEN `ThroughputProperties.CreateManualThroughput(400)` or `ThroughputProperties.CreateAutoscaleThroughput(4000)`
+- WHEN `CreateContainerAsync(properties, throughput)` is called
+- THEN the container is created with the specified throughput mode
+
+#### Scenario: Replace container properties
+- GIVEN an existing container
+- WHEN `container.ReplaceContainerAsync(updatedProperties)` is called
+- THEN the container properties are updated (e.g., indexing policy, default TTL)
+
+#### Scenario: Delete container
+- GIVEN an existing container
+- WHEN `container.DeleteContainerAsync()` is called
+- THEN the container and all its items are permanently deleted
+
+### Requirement: Throughput Management
+The SDK SHALL support reading and updating throughput for databases and containers.
+
+#### Scenario: Read throughput
+- GIVEN a container with provisioned throughput
+- WHEN `container.ReadThroughputAsync()` is called
+- THEN `ThroughputProperties` is returned with current RU/s settings
+
+#### Scenario: Replace throughput
+- GIVEN a container with manual throughput
+- WHEN `container.ReplaceThroughputAsync(ThroughputProperties.CreateManualThroughput(800))` is called
+- THEN the throughput is updated to 800 RU/s
+
+#### Scenario: Autoscale throughput
+- GIVEN a container configured with autoscale
+- WHEN `container.ReadThroughputAsync()` is called
+- THEN the response includes `AutoscaleMaxThroughput` and current provisioned throughput
+
+### Requirement: Indexing Policy Configuration
+The SDK SHALL support configuring indexing policies on containers.
+
+#### Scenario: Default indexing
+- GIVEN no indexing policy is specified
+- WHEN a container is created
+- THEN all properties are automatically indexed (default behavior)
+
+#### Scenario: Custom included paths
+- GIVEN `IndexingPolicy.IncludedPaths` contains specific paths
+- WHEN the container is created or updated
+- THEN only the specified paths are indexed
+
+#### Scenario: Excluded paths
+- GIVEN `IndexingPolicy.ExcludedPaths` contains specific paths
+- WHEN items are ingested
+- THEN the excluded paths are not indexed
+
+#### Scenario: Composite indexes
+- GIVEN `IndexingPolicy.CompositeIndexes` is configured
+- WHEN queries with multi-property ORDER BY are executed
+- THEN the composite index is used for efficient sorting
+
+#### Scenario: Spatial indexes
+- GIVEN spatial index paths are configured
+- WHEN geospatial queries (ST_DISTANCE, ST_WITHIN, etc.) are executed
+- THEN the spatial index is used for efficient geo queries
+
+### Requirement: Vector Embedding Policy
+The SDK SHALL support configuring vector embedding policies for vector search.
+
+#### Scenario: Configure vector embedding
+- GIVEN `ContainerProperties.VectorEmbeddingPolicy` is set with vector paths, dimensions, data type, and distance function
+- WHEN the container is created
+- THEN vector search is enabled for the specified paths
+
+#### Scenario: Vector index types
+- GIVEN `VectorIndexPath` with `VectorIndexType` (Flat, QuantizedFlat, DiskANN)
+- WHEN configured in the indexing policy
+- THEN the appropriate vector index is created
+
+### Requirement: Full-Text Search Policy
+The SDK SHALL support configuring full-text search policies.
+
+#### Scenario: Configure full-text paths
+- GIVEN `ContainerProperties.FullTextPolicy` with `FullTextPath` entries
+- WHEN the container is created
+- THEN full-text search is enabled for the specified paths
+
+### Requirement: Time-to-Live (TTL)
+The SDK SHALL support configuring item expiration via TTL.
+
+#### Scenario: Container-level TTL
+- GIVEN `ContainerProperties.DefaultTimeToLive = 3600` (seconds)
+- WHEN items are created without an explicit TTL
+- THEN items expire 3600 seconds after their last modification
+
+#### Scenario: Item-level TTL override
+- GIVEN a container with default TTL enabled
+- WHEN an item is created with a `ttl` property set to a specific value
+- THEN that item's TTL overrides the container default
+
+#### Scenario: Disable TTL for specific item
+- GIVEN a container with default TTL
+- WHEN an item is created with `ttl = -1`
+- THEN that item never expires
+
+### Requirement: Conflict Resolution Policy
+The SDK SHALL support configuring conflict resolution for multi-region writes.
+
+#### Scenario: Last-writer-wins (default)
+- GIVEN `ConflictResolutionPolicy.Mode = ConflictResolutionMode.LastWriterWins`
+- WHEN concurrent writes conflict
+- THEN the write with the highest `_ts` (or custom conflict resolution path) wins
+
+#### Scenario: Custom stored procedure
+- GIVEN `ConflictResolutionPolicy.Mode = ConflictResolutionMode.Custom` with a stored procedure path
+- WHEN conflicts occur
+- THEN the specified stored procedure is invoked to resolve the conflict
+
+### Requirement: Stored Procedures, UDFs, and Triggers
+The SDK SHALL support managing server-side programmability artifacts.
+
+#### Scenario: Create stored procedure
+- GIVEN JavaScript function body
+- WHEN `container.Scripts.CreateStoredProcedureAsync(properties)` is called
+- THEN the stored procedure is registered in the container
+
+#### Scenario: Execute stored procedure
+- GIVEN a registered stored procedure
+- WHEN `container.Scripts.ExecuteStoredProcedureAsync<T>(sprocId, partitionKey, parameters)` is called
+- THEN the stored procedure executes server-side within the partition scope
+
+#### Scenario: Create user-defined function
+- GIVEN JavaScript function body
+- WHEN `container.Scripts.CreateUserDefinedFunctionAsync(properties)` is called
+- THEN the UDF is registered and available for use in queries
+
+#### Scenario: Create trigger
+- GIVEN trigger properties with type (Pre/Post) and operation
+- WHEN `container.Scripts.CreateTriggerAsync(properties)` is called
+- THEN the trigger is registered and fires on the specified operation type
+
+## Key Source Files
+- `Microsoft.Azure.Cosmos/src/Resource/Database/Database.cs` — database management API
+- `Microsoft.Azure.Cosmos/src/Resource/Container/Container.cs` — container management API
+- `Microsoft.Azure.Cosmos/src/Resource/Settings/ContainerProperties.cs` — container properties
+- `Microsoft.Azure.Cosmos/src/Resource/Settings/IndexingPolicy.cs` — indexing configuration
+- `Microsoft.Azure.Cosmos/src/Resource/Settings/VectorEmbeddingPolicy.cs` — vector search config
+- `Microsoft.Azure.Cosmos/src/Resource/Settings/FullTextPolicy.cs` — full-text search config
+- `Microsoft.Azure.Cosmos/src/Resource/Settings/ConflictResolutionPolicy.cs` — conflict resolution
+- `Microsoft.Azure.Cosmos/src/Resource/Scripts/Scripts.cs` — stored procedures, UDFs, triggers

--- a/openspec/specs/resource-management/spec.md
+++ b/openspec/specs/resource-management/spec.md
@@ -9,172 +9,113 @@ The SDK provides management operations for databases, containers, throughput, in
 ### Requirement: Database Management
 The SDK SHALL support creating, reading, and deleting databases.
 
-#### Scenario: Create database
-- GIVEN a Cosmos DB account
-- WHEN `CosmosClient.CreateDatabaseAsync("mydb")` is called
-- THEN a new database is created
-- AND a `DatabaseResponse` is returned with status code 201
+#### Create database
+**When** `CosmosClient.CreateDatabaseAsync("mydb")` is called, the SDK shall create a new database and return a `DatabaseResponse` with status code 201.
 
-#### Scenario: Create if not exists
-- GIVEN a database name
-- WHEN `CosmosClient.CreateDatabaseIfNotExistsAsync("mydb")` is called
-- THEN the database is created if it doesn't exist (201)
-- OR the existing database reference is returned (200)
+#### Create if not exists
+**When** `CosmosClient.CreateDatabaseIfNotExistsAsync("mydb")` is called, the SDK shall create the database if it doesn't exist (201) or return the existing database reference (200).
 
-#### Scenario: Read database
-- GIVEN an existing database
-- WHEN `database.ReadAsync()` is called
-- THEN `DatabaseProperties` are returned with the database metadata
+#### Read database
+**When** `database.ReadAsync()` is called on an existing database, the SDK shall return `DatabaseProperties` with the database metadata.
 
-#### Scenario: Delete database
-- GIVEN an existing database
-- WHEN `database.DeleteAsync()` is called
-- THEN the database and all its containers are permanently deleted
+#### Delete database
+**When** `database.DeleteAsync()` is called on an existing database, the SDK shall permanently delete the database and all its containers.
 
 ### Requirement: Container Management
 The SDK SHALL support creating, reading, replacing, and deleting containers.
 
-#### Scenario: Create container
-- GIVEN a database
-- WHEN `database.CreateContainerAsync(new ContainerProperties("mycontainer", "/partitionKey"))` is called
-- THEN a new container is created with the specified partition key
-- AND a `ContainerResponse` is returned with status code 201
+#### Create container
+**When** `database.CreateContainerAsync(new ContainerProperties("mycontainer", "/partitionKey"))` is called, the SDK shall create a new container with the specified partition key and return a `ContainerResponse` with status code 201.
 
-#### Scenario: Create with throughput
-- GIVEN `ThroughputProperties.CreateManualThroughput(400)` or `ThroughputProperties.CreateAutoscaleThroughput(4000)`
-- WHEN `CreateContainerAsync(properties, throughput)` is called
-- THEN the container is created with the specified throughput mode
+#### Create with throughput
+**When** `CreateContainerAsync(properties, throughput)` is called with `ThroughputProperties.CreateManualThroughput(400)` or `ThroughputProperties.CreateAutoscaleThroughput(4000)`, the SDK shall create the container with the specified throughput mode.
 
-#### Scenario: Replace container properties
-- GIVEN an existing container
-- WHEN `container.ReplaceContainerAsync(updatedProperties)` is called
-- THEN the container properties are updated (e.g., indexing policy, default TTL)
+#### Replace container properties
+**When** `container.ReplaceContainerAsync(updatedProperties)` is called on an existing container, the SDK shall update the container properties (e.g., indexing policy, default TTL).
 
-#### Scenario: Delete container
-- GIVEN an existing container
-- WHEN `container.DeleteContainerAsync()` is called
-- THEN the container and all its items are permanently deleted
+#### Delete container
+**When** `container.DeleteContainerAsync()` is called on an existing container, the SDK shall permanently delete the container and all its items.
 
 ### Requirement: Throughput Management
 The SDK SHALL support reading and updating throughput for databases and containers.
 
-#### Scenario: Read throughput
-- GIVEN a container with provisioned throughput
-- WHEN `container.ReadThroughputAsync()` is called
-- THEN `ThroughputProperties` is returned with current RU/s settings
+#### Read throughput
+**When** `container.ReadThroughputAsync()` is called on a container with provisioned throughput, the SDK shall return `ThroughputProperties` with current RU/s settings.
 
-#### Scenario: Replace throughput
-- GIVEN a container with manual throughput
-- WHEN `container.ReplaceThroughputAsync(ThroughputProperties.CreateManualThroughput(800))` is called
-- THEN the throughput is updated to 800 RU/s
+#### Replace throughput
+**When** `container.ReplaceThroughputAsync(ThroughputProperties.CreateManualThroughput(800))` is called on a container with manual throughput, the SDK shall update the throughput to 800 RU/s.
 
-#### Scenario: Autoscale throughput
-- GIVEN a container configured with autoscale
-- WHEN `container.ReadThroughputAsync()` is called
-- THEN the response includes `AutoscaleMaxThroughput` and current provisioned throughput
+#### Autoscale throughput
+**While** a container is configured with autoscale, **when** `container.ReadThroughputAsync()` is called, the SDK shall return the response including `AutoscaleMaxThroughput` and current provisioned throughput.
 
 ### Requirement: Indexing Policy Configuration
 The SDK SHALL support configuring indexing policies on containers.
 
-#### Scenario: Default indexing
-- GIVEN no indexing policy is specified
-- WHEN a container is created
-- THEN all properties are automatically indexed (default behavior)
+#### Default indexing
+**When** a container is created without specifying an indexing policy, the SDK shall automatically index all properties (default behavior).
 
-#### Scenario: Custom included paths
-- GIVEN `IndexingPolicy.IncludedPaths` contains specific paths
-- WHEN the container is created or updated
-- THEN only the specified paths are indexed
+#### Custom included paths
+**Where** `IndexingPolicy.IncludedPaths` contains specific paths, **when** the container is created or updated, the SDK shall index only the specified paths.
 
-#### Scenario: Excluded paths
-- GIVEN `IndexingPolicy.ExcludedPaths` contains specific paths
-- WHEN items are ingested
-- THEN the excluded paths are not indexed
+#### Excluded paths
+**Where** `IndexingPolicy.ExcludedPaths` contains specific paths, **when** items are ingested, the SDK shall not index the excluded paths.
 
-#### Scenario: Composite indexes
-- GIVEN `IndexingPolicy.CompositeIndexes` is configured
-- WHEN queries with multi-property ORDER BY are executed
-- THEN the composite index is used for efficient sorting
+#### Composite indexes
+**Where** `IndexingPolicy.CompositeIndexes` is configured, **when** queries with multi-property ORDER BY are executed, the SDK shall use the composite index for efficient sorting.
 
-#### Scenario: Spatial indexes
-- GIVEN spatial index paths are configured
-- WHEN geospatial queries (ST_DISTANCE, ST_WITHIN, etc.) are executed
-- THEN the spatial index is used for efficient geo queries
+#### Spatial indexes
+**Where** spatial index paths are configured, **when** geospatial queries (ST_DISTANCE, ST_WITHIN, etc.) are executed, the SDK shall use the spatial index for efficient geo queries.
 
 ### Requirement: Vector Embedding Policy
 The SDK SHALL support configuring vector embedding policies for vector search.
 
-#### Scenario: Configure vector embedding
-- GIVEN `ContainerProperties.VectorEmbeddingPolicy` is set with vector paths, dimensions, data type, and distance function
-- WHEN the container is created
-- THEN vector search is enabled for the specified paths
+#### Configure vector embedding
+**Where** `ContainerProperties.VectorEmbeddingPolicy` is set with vector paths, dimensions, data type, and distance function, **when** the container is created, the SDK shall enable vector search for the specified paths.
 
-#### Scenario: Vector index types
-- GIVEN `VectorIndexPath` with `VectorIndexType` (Flat, QuantizedFlat, DiskANN)
-- WHEN configured in the indexing policy
-- THEN the appropriate vector index is created
+#### Vector index types
+**Where** `VectorIndexPath` with `VectorIndexType` (Flat, QuantizedFlat, DiskANN) is configured in the indexing policy, the SDK shall create the appropriate vector index.
 
 ### Requirement: Full-Text Search Policy
 The SDK SHALL support configuring full-text search policies.
 
-#### Scenario: Configure full-text paths
-- GIVEN `ContainerProperties.FullTextPolicy` with `FullTextPath` entries
-- WHEN the container is created
-- THEN full-text search is enabled for the specified paths
+#### Configure full-text paths
+**Where** `ContainerProperties.FullTextPolicy` is set with `FullTextPath` entries, **when** the container is created, the SDK shall enable full-text search for the specified paths.
 
 ### Requirement: Time-to-Live (TTL)
 The SDK SHALL support configuring item expiration via TTL.
 
-#### Scenario: Container-level TTL
-- GIVEN `ContainerProperties.DefaultTimeToLive = 3600` (seconds)
-- WHEN items are created without an explicit TTL
-- THEN items expire 3600 seconds after their last modification
+#### Container-level TTL
+**Where** `ContainerProperties.DefaultTimeToLive = 3600` (seconds), **when** items are created without an explicit TTL, the SDK shall expire items 3600 seconds after their last modification.
 
-#### Scenario: Item-level TTL override
-- GIVEN a container with default TTL enabled
-- WHEN an item is created with a `ttl` property set to a specific value
-- THEN that item's TTL overrides the container default
+#### Item-level TTL override
+**While** a container has default TTL enabled, **when** an item is created with a `ttl` property set to a specific value, the SDK shall use that item's TTL overriding the container default.
 
-#### Scenario: Disable TTL for specific item
-- GIVEN a container with default TTL
-- WHEN an item is created with `ttl = -1`
-- THEN that item never expires
+#### Disable TTL for specific item
+**While** a container has default TTL, **when** an item is created with `ttl = -1`, the SDK shall ensure that item never expires.
 
 ### Requirement: Conflict Resolution Policy
 The SDK SHALL support configuring conflict resolution for multi-region writes.
 
-#### Scenario: Last-writer-wins (default)
-- GIVEN `ConflictResolutionPolicy.Mode = ConflictResolutionMode.LastWriterWins`
-- WHEN concurrent writes conflict
-- THEN the write with the highest `_ts` (or custom conflict resolution path) wins
+#### Last-writer-wins (default)
+**Where** `ConflictResolutionPolicy.Mode = ConflictResolutionMode.LastWriterWins`, **when** concurrent writes conflict, the SDK shall resolve the conflict so the write with the highest `_ts` (or custom conflict resolution path) wins.
 
-#### Scenario: Custom stored procedure
-- GIVEN `ConflictResolutionPolicy.Mode = ConflictResolutionMode.Custom` with a stored procedure path
-- WHEN conflicts occur
-- THEN the specified stored procedure is invoked to resolve the conflict
+#### Custom stored procedure
+**Where** `ConflictResolutionPolicy.Mode = ConflictResolutionMode.Custom` with a stored procedure path, **when** conflicts occur, the SDK shall invoke the specified stored procedure to resolve the conflict.
 
 ### Requirement: Stored Procedures, UDFs, and Triggers
 The SDK SHALL support managing server-side programmability artifacts.
 
-#### Scenario: Create stored procedure
-- GIVEN JavaScript function body
-- WHEN `container.Scripts.CreateStoredProcedureAsync(properties)` is called
-- THEN the stored procedure is registered in the container
+#### Create stored procedure
+**When** `container.Scripts.CreateStoredProcedureAsync(properties)` is called with a JavaScript function body, the SDK shall register the stored procedure in the container.
 
-#### Scenario: Execute stored procedure
-- GIVEN a registered stored procedure
-- WHEN `container.Scripts.ExecuteStoredProcedureAsync<T>(sprocId, partitionKey, parameters)` is called
-- THEN the stored procedure executes server-side within the partition scope
+#### Execute stored procedure
+**When** `container.Scripts.ExecuteStoredProcedureAsync<T>(sprocId, partitionKey, parameters)` is called with a registered stored procedure, the SDK shall execute the stored procedure server-side within the partition scope.
 
-#### Scenario: Create user-defined function
-- GIVEN JavaScript function body
-- WHEN `container.Scripts.CreateUserDefinedFunctionAsync(properties)` is called
-- THEN the UDF is registered and available for use in queries
+#### Create user-defined function
+**When** `container.Scripts.CreateUserDefinedFunctionAsync(properties)` is called with a JavaScript function body, the SDK shall register the UDF and make it available for use in queries.
 
-#### Scenario: Create trigger
-- GIVEN trigger properties with type (Pre/Post) and operation
-- WHEN `container.Scripts.CreateTriggerAsync(properties)` is called
-- THEN the trigger is registered and fires on the specified operation type
+#### Create trigger
+**When** `container.Scripts.CreateTriggerAsync(properties)` is called with trigger properties specifying type (Pre/Post) and operation, the SDK shall register the trigger and fire it on the specified operation type.
 
 ## Key Source Files
 - `Microsoft.Azure.Cosmos/src/Resource/Database/Database.cs` — database management API

--- a/openspec/specs/retry-and-failover/spec.md
+++ b/openspec/specs/retry-and-failover/spec.md
@@ -9,117 +9,71 @@ The SDK's retry and failover layer handles transient errors, throttling (429), s
 ### Requirement: Throttling Retry (429)
 The SDK SHALL automatically retry requests that receive a 429 (Too Many Requests) response with exponential backoff.
 
-#### Scenario: Retry on throttle
-- GIVEN a request that receives a 429 response
-- WHEN the SDK evaluates the response
-- THEN the request is retried after waiting for the duration specified in the `x-ms-retry-after-ms` header
-- AND retries continue up to `CosmosClientOptions.MaxRetryAttemptsOnRateLimitedRequests` times (default: 9)
+#### Retry on throttle
+**When** a request receives a 429 response, the SDK shall retry the request after waiting for the duration specified in the `x-ms-retry-after-ms` header, continuing retries up to `CosmosClientOptions.MaxRetryAttemptsOnRateLimitedRequests` times (default: 9).
 
-#### Scenario: Max retry time exceeded
-- GIVEN throttling retries have been attempted
-- WHEN the cumulative wait time exceeds `CosmosClientOptions.MaxRetryWaitTimeOnRateLimitedRequests` (default: 30 seconds)
-- THEN the SDK stops retrying and returns the 429 response to the caller
+#### Max retry time exceeded
+**If** the cumulative wait time for throttling retries exceeds `CosmosClientOptions.MaxRetryWaitTimeOnRateLimitedRequests` (default: 30 seconds), **then** the SDK shall stop retrying and return the 429 response to the caller.
 
-#### Scenario: Custom retry configuration
-- GIVEN `CosmosClientOptions.MaxRetryAttemptsOnRateLimitedRequests = 3` and `MaxRetryWaitTimeOnRateLimitedRequests = TimeSpan.FromSeconds(10)`
-- WHEN a request is continuously throttled
-- THEN at most 3 retries are attempted within a 10-second window
+#### Custom retry configuration
+**Where** `CosmosClientOptions.MaxRetryAttemptsOnRateLimitedRequests = 3` and `MaxRetryWaitTimeOnRateLimitedRequests = TimeSpan.FromSeconds(10)`, **when** a request is continuously throttled, the SDK shall attempt at most 3 retries within a 10-second window.
 
 ### Requirement: Region Failover on Endpoint Unavailability
 The SDK SHALL fail over to the next preferred region when an endpoint becomes unavailable.
 
-#### Scenario: Service unavailable (503)
-- GIVEN a request receives a 503 (Service Unavailable) response
-- WHEN the SDK evaluates the response
-- THEN the current endpoint is marked unavailable
-- AND the request is retried on the next region in `ApplicationPreferredRegions`
-- AND at most 1 service-unavailable retry is attempted per region
+#### Service unavailable (503)
+**When** a request receives a 503 (Service Unavailable) response, the SDK shall mark the current endpoint as unavailable, retry the request on the next region in `ApplicationPreferredRegions`, and attempt at most 1 service-unavailable retry per region.
 
-#### Scenario: Write forbidden (403/3)
-- GIVEN a write request receives a 403 with sub-status code 3 (WriteForbidden)
-- WHEN the SDK evaluates the response
-- THEN the current write endpoint is marked unavailable
-- AND the request is retried on the next preferred write region
+#### Write forbidden (403/3)
+**When** a write request receives a 403 with sub-status code 3 (WriteForbidden), the SDK shall mark the current write endpoint as unavailable and retry the request on the next preferred write region.
 
-#### Scenario: Request timeout (408)
-- GIVEN a request receives a 408 (Request Timeout)
-- WHEN the SDK evaluates the response
-- THEN the partition key range is marked unavailable in the current region
-- AND the request is retried on the next preferred region
+#### Request timeout (408)
+**When** a request receives a 408 (Request Timeout), the SDK shall mark the partition key range as unavailable in the current region and retry the request on the next preferred region.
 
-#### Scenario: HTTP request exception
-- GIVEN a request fails with an `HttpRequestException` (network-level failure)
-- WHEN the SDK evaluates the exception
-- THEN the partition is marked unavailable
-- AND the request is retried on the next preferred region
+#### HTTP request exception
+**When** a request fails with an `HttpRequestException` (network-level failure), the SDK shall mark the partition as unavailable and retry the request on the next preferred region.
 
-#### Scenario: Maximum failover retries
-- GIVEN the SDK has attempted failover retries
-- WHEN the retry count reaches 120
-- THEN no further retries are attempted and the error is returned to the caller
+#### Maximum failover retries
+**If** the failover retry count reaches 120, **then** the SDK shall stop retrying and return the error to the caller.
 
 ### Requirement: Gone (410) Handling
 The SDK SHALL handle 410 (Gone) responses by refreshing routing information.
 
-#### Scenario: Partition key range gone
-- GIVEN a request receives 410 with sub-status 1002 (PartitionKeyRangeGone)
-- WHEN the SDK evaluates the response
-- THEN the partition key range cache is invalidated
-- AND the request is retried with refreshed routing information
+#### Partition key range gone
+**When** a request receives a 410 with sub-status 1002 (PartitionKeyRangeGone), the SDK shall invalidate the partition key range cache and retry the request with refreshed routing information.
 
-#### Scenario: Name cache stale
-- GIVEN a request receives 410 with sub-status indicating stale cache
-- WHEN the SDK evaluates the response
-- THEN the collection cache is refreshed
-- AND the request is retried
+#### Name cache stale
+**When** a request receives a 410 with sub-status indicating a stale cache, the SDK shall refresh the collection cache and retry the request.
 
 ### Requirement: Per-Partition Automatic Failover (PPAF)
 The SDK SHALL support per-partition-level failover for Direct mode connections.
 
-#### Scenario: Partition-level 503 in single-master
-- GIVEN a write request to a specific partition receives 503
-- AND the account is single-master with `ApplicationPreferredRegions` configured
-- WHEN the SDK evaluates the response
-- THEN that specific partition is marked unavailable in the current region
-- AND the retry targets the next region in `ApplicationPreferredRegions` for that partition only
+#### Partition-level 503 in single-master
+**While** the account is single-master with `ApplicationPreferredRegions` configured, **when** a write request to a specific partition receives a 503, the SDK shall mark that specific partition as unavailable in the current region and retry targeting the next region in `ApplicationPreferredRegions` for that partition only.
 
-#### Scenario: System resource unavailable (429/3092)
-- GIVEN a request receives 429 with sub-status code 3092 (SystemResourceUnavailable)
-- WHEN the SDK evaluates the response
-- THEN this is treated as a 503-equivalent
-- AND partition-level failover is triggered to the next region
+#### System resource unavailable (429/3092)
+**When** a request receives a 429 with sub-status code 3092 (SystemResourceUnavailable), the SDK shall treat this as a 503-equivalent and trigger partition-level failover to the next region.
 
-#### Scenario: PPAF does not affect other partitions
-- GIVEN partition A is marked unavailable in Region 1
-- WHEN a request for partition B is made
-- THEN partition B's request is routed to Region 1 normally
-- AND only partition A's requests are routed to Region 2
+#### PPAF does not affect other partitions
+**While** partition A is marked unavailable in Region 1, **when** a request for partition B is made, the SDK shall route partition B's request to Region 1 normally and route only partition A's requests to Region 2.
 
 ### Requirement: Retry Wait Time
 The SDK SHALL wait an appropriate interval between failover retries.
 
-#### Scenario: Failover retry delay
-- GIVEN a region failover is triggered
-- WHEN the SDK prepares to retry on the next region
-- THEN it waits 1000 milliseconds before sending the retry
+#### Failover retry delay
+**When** a region failover is triggered, the SDK shall wait 1000 milliseconds before sending the retry to the next region.
 
 ### Requirement: Retry Policy Independence
 The SDK SHALL ensure each retry scope operates independently.
 
-#### Scenario: Independent retry chains
-- GIVEN a request is being retried due to region failover
-- WHEN the retry request encounters a new transient error
-- THEN the new error is evaluated independently by the retry policy
-- AND the original retry context is preserved
+#### Independent retry chains
+**While** a request is being retried due to region failover, **when** the retry request encounters a new transient error, the SDK shall evaluate the new error independently by the retry policy and preserve the original retry context.
 
 ### Requirement: Excluded Regions
 The SDK SHALL support excluding specific regions from request routing.
 
-#### Scenario: Exclude region via RequestOptions
-- GIVEN `RequestOptions.ExcludeRegions` contains "West US 2"
-- WHEN a request is routed
-- THEN "West US 2" is not considered for that request
-- AND the next available region in the preferred list is used
+#### Exclude region via RequestOptions
+**Where** `RequestOptions.ExcludeRegions` contains "West US 2", **when** a request is routed, the SDK shall not consider "West US 2" for that request and use the next available region in the preferred list.
 
 ## Key Source Files
 - `Microsoft.Azure.Cosmos/src/ClientRetryPolicy.cs` — main retry orchestrator

--- a/openspec/specs/retry-and-failover/spec.md
+++ b/openspec/specs/retry-and-failover/spec.md
@@ -1,0 +1,130 @@
+# Retry and Failover
+
+## Purpose
+
+The SDK's retry and failover layer handles transient errors, throttling (429), service unavailability (503), and cross-region failover to maintain high availability and resilience.
+
+## Requirements
+
+### Requirement: Throttling Retry (429)
+The SDK SHALL automatically retry requests that receive a 429 (Too Many Requests) response with exponential backoff.
+
+#### Scenario: Retry on throttle
+- GIVEN a request that receives a 429 response
+- WHEN the SDK evaluates the response
+- THEN the request is retried after waiting for the duration specified in the `x-ms-retry-after-ms` header
+- AND retries continue up to `CosmosClientOptions.MaxRetryAttemptsOnRateLimitedRequests` times (default: 9)
+
+#### Scenario: Max retry time exceeded
+- GIVEN throttling retries have been attempted
+- WHEN the cumulative wait time exceeds `CosmosClientOptions.MaxRetryWaitTimeOnRateLimitedRequests` (default: 30 seconds)
+- THEN the SDK stops retrying and returns the 429 response to the caller
+
+#### Scenario: Custom retry configuration
+- GIVEN `CosmosClientOptions.MaxRetryAttemptsOnRateLimitedRequests = 3` and `MaxRetryWaitTimeOnRateLimitedRequests = TimeSpan.FromSeconds(10)`
+- WHEN a request is continuously throttled
+- THEN at most 3 retries are attempted within a 10-second window
+
+### Requirement: Region Failover on Endpoint Unavailability
+The SDK SHALL fail over to the next preferred region when an endpoint becomes unavailable.
+
+#### Scenario: Service unavailable (503)
+- GIVEN a request receives a 503 (Service Unavailable) response
+- WHEN the SDK evaluates the response
+- THEN the current endpoint is marked unavailable
+- AND the request is retried on the next region in `ApplicationPreferredRegions`
+- AND at most 1 service-unavailable retry is attempted per region
+
+#### Scenario: Write forbidden (403/3)
+- GIVEN a write request receives a 403 with sub-status code 3 (WriteForbidden)
+- WHEN the SDK evaluates the response
+- THEN the current write endpoint is marked unavailable
+- AND the request is retried on the next preferred write region
+
+#### Scenario: Request timeout (408)
+- GIVEN a request receives a 408 (Request Timeout)
+- WHEN the SDK evaluates the response
+- THEN the partition key range is marked unavailable in the current region
+- AND the request is retried on the next preferred region
+
+#### Scenario: HTTP request exception
+- GIVEN a request fails with an `HttpRequestException` (network-level failure)
+- WHEN the SDK evaluates the exception
+- THEN the partition is marked unavailable
+- AND the request is retried on the next preferred region
+
+#### Scenario: Maximum failover retries
+- GIVEN the SDK has attempted failover retries
+- WHEN the retry count reaches 120
+- THEN no further retries are attempted and the error is returned to the caller
+
+### Requirement: Gone (410) Handling
+The SDK SHALL handle 410 (Gone) responses by refreshing routing information.
+
+#### Scenario: Partition key range gone
+- GIVEN a request receives 410 with sub-status 1002 (PartitionKeyRangeGone)
+- WHEN the SDK evaluates the response
+- THEN the partition key range cache is invalidated
+- AND the request is retried with refreshed routing information
+
+#### Scenario: Name cache stale
+- GIVEN a request receives 410 with sub-status indicating stale cache
+- WHEN the SDK evaluates the response
+- THEN the collection cache is refreshed
+- AND the request is retried
+
+### Requirement: Per-Partition Automatic Failover (PPAF)
+The SDK SHALL support per-partition-level failover for Direct mode connections.
+
+#### Scenario: Partition-level 503 in single-master
+- GIVEN a write request to a specific partition receives 503
+- AND the account is single-master with `ApplicationPreferredRegions` configured
+- WHEN the SDK evaluates the response
+- THEN that specific partition is marked unavailable in the current region
+- AND the retry targets the next region in `ApplicationPreferredRegions` for that partition only
+
+#### Scenario: System resource unavailable (429/3092)
+- GIVEN a request receives 429 with sub-status code 3092 (SystemResourceUnavailable)
+- WHEN the SDK evaluates the response
+- THEN this is treated as a 503-equivalent
+- AND partition-level failover is triggered to the next region
+
+#### Scenario: PPAF does not affect other partitions
+- GIVEN partition A is marked unavailable in Region 1
+- WHEN a request for partition B is made
+- THEN partition B's request is routed to Region 1 normally
+- AND only partition A's requests are routed to Region 2
+
+### Requirement: Retry Wait Time
+The SDK SHALL wait an appropriate interval between failover retries.
+
+#### Scenario: Failover retry delay
+- GIVEN a region failover is triggered
+- WHEN the SDK prepares to retry on the next region
+- THEN it waits 1000 milliseconds before sending the retry
+
+### Requirement: Retry Policy Independence
+The SDK SHALL ensure each retry scope operates independently.
+
+#### Scenario: Independent retry chains
+- GIVEN a request is being retried due to region failover
+- WHEN the retry request encounters a new transient error
+- THEN the new error is evaluated independently by the retry policy
+- AND the original retry context is preserved
+
+### Requirement: Excluded Regions
+The SDK SHALL support excluding specific regions from request routing.
+
+#### Scenario: Exclude region via RequestOptions
+- GIVEN `RequestOptions.ExcludeRegions` contains "West US 2"
+- WHEN a request is routed
+- THEN "West US 2" is not considered for that request
+- AND the next available region in the preferred list is used
+
+## Key Source Files
+- `Microsoft.Azure.Cosmos/src/ClientRetryPolicy.cs` — main retry orchestrator
+- `Microsoft.Azure.Cosmos/src/RetryPolicy.cs` — factory for ClientRetryPolicy
+- `Microsoft.Azure.Cosmos/src/ResourceThrottleRetryPolicy.cs` — 429 throttle retry
+- `Microsoft.Azure.Cosmos/src/Routing/GlobalEndpointManager.cs` — region endpoint management
+- `Microsoft.Azure.Cosmos/src/Routing/GlobalPartitionEndpointManager.cs` — per-partition failover (PPAF)
+- `Microsoft.Azure.Cosmos/src/Handler/RetryHandler.cs` — handler pipeline retry integration

--- a/openspec/specs/serialization/spec.md
+++ b/openspec/specs/serialization/spec.md
@@ -1,0 +1,105 @@
+# Serialization
+
+## Purpose
+
+The SDK's serialization layer handles conversion between .NET objects and JSON for Cosmos DB operations, supporting multiple JSON libraries and custom serializers.
+
+## Requirements
+
+### Requirement: Default Serializer
+The SDK SHALL use Newtonsoft.Json (JSON.NET) as the default serializer.
+
+#### Scenario: Default behavior
+- GIVEN no custom serializer is configured
+- WHEN items are created, read, or queried
+- THEN `CosmosJsonDotNetSerializer` is used for serialization and deserialization
+
+### Requirement: Custom Serializer
+The SDK SHALL support plugging in a custom serializer that extends `CosmosSerializer`.
+
+#### Scenario: Custom serializer via options
+- GIVEN `CosmosClientOptions.Serializer` is set to a custom `CosmosSerializer` implementation
+- WHEN items are serialized or deserialized
+- THEN the custom serializer's `ToStream<T>()` and `FromStream<T>()` methods are used
+
+#### Scenario: CosmosSerializer contract
+- GIVEN a class extending `CosmosSerializer`
+- WHEN it is provided to the client
+- THEN it MUST implement `Stream ToStream<T>(T input)` and `T FromStream<T>(Stream stream)`
+
+### Requirement: System.Text.Json Support
+The SDK SHALL support System.Text.Json as an alternative serializer.
+
+#### Scenario: Enable System.Text.Json
+- GIVEN `CosmosClientOptions.UseSystemTextJsonSerializerWithOptions` is set to a `JsonSerializerOptions` instance
+- WHEN items are serialized or deserialized
+- THEN `CosmosSystemTextJsonSerializer` is used
+
+### Requirement: Serialization Options
+The SDK SHALL support configuring serialization behavior via `CosmosSerializationOptions`.
+
+#### Scenario: Ignore null values
+- GIVEN `CosmosClientOptions.SerializerOptions = new CosmosSerializationOptions { IgnoreNullValues = true }`
+- WHEN an item with null properties is serialized
+- THEN null properties are omitted from the JSON output
+
+#### Scenario: Indented output
+- GIVEN `CosmosSerializationOptions.Indented = true`
+- WHEN an item is serialized
+- THEN the JSON output is formatted with indentation
+
+#### Scenario: Camel case property names
+- GIVEN `CosmosSerializationOptions.PropertyNamingPolicy = CosmosPropertyNamingPolicy.CamelCase`
+- WHEN an item with PascalCase property names is serialized
+- THEN property names are converted to camelCase in the JSON output
+
+### Requirement: Mutual Exclusivity of Serializer Settings
+The SDK SHALL enforce that only one serializer configuration is active.
+
+#### Scenario: Multiple serializer settings
+- GIVEN two or more of `Serializer`, `SerializerOptions`, and `UseSystemTextJsonSerializerWithOptions` are set
+- WHEN the client is constructed
+- THEN an `ArgumentException` is thrown
+
+### Requirement: LINQ Serialization Support
+The SDK SHALL support custom member name resolution for LINQ queries via `CosmosLinqSerializer`.
+
+#### Scenario: LINQ with custom serializer
+- GIVEN a `CosmosLinqSerializer` implementation that maps `MyProperty` to `my_property`
+- WHEN a LINQ query references `x.MyProperty`
+- THEN the generated SQL uses `c["my_property"]`
+
+### Requirement: Stream Operations
+The SDK SHALL support stream-based operations that bypass serialization.
+
+#### Scenario: Stream create
+- GIVEN `Container.CreateItemStreamAsync(stream, partitionKey)` is called
+- WHEN the operation is processed
+- THEN the raw stream is sent directly to the service without SDK-side serialization
+
+#### Scenario: Stream read
+- GIVEN `Container.ReadItemStreamAsync(id, partitionKey)` is called
+- WHEN the response is received
+- THEN a `ResponseMessage` is returned with the raw JSON stream
+- AND no deserialization is performed
+
+### Requirement: Internal vs User Serialization
+The SDK SHALL separate internal serialization (system properties, metadata) from user content serialization.
+
+#### Scenario: System properties
+- GIVEN an item response from the service
+- WHEN system properties (`id`, `_rid`, `_ts`, `_etag`, `_self`) are deserialized
+- THEN the SDK uses its internal serializer regardless of the user-configured serializer
+
+#### Scenario: User content
+- GIVEN an item response from the service
+- WHEN the user's item content is deserialized
+- THEN the user-configured serializer is used
+
+## Key Source Files
+- `Microsoft.Azure.Cosmos/src/Serializer/CosmosSerializer.cs` — abstract base serializer
+- `Microsoft.Azure.Cosmos/src/Serializer/CosmosJsonDotNetSerializer.cs` — default JSON.NET serializer
+- `Microsoft.Azure.Cosmos/src/Serializer/CosmosSystemTextJsonSerializer.cs` — System.Text.Json serializer
+- `Microsoft.Azure.Cosmos/src/Serializer/CosmosSerializerCore.cs` — core serialization logic
+- `Microsoft.Azure.Cosmos/src/Serializer/CosmosLinqSerializer.cs` — LINQ member name resolution
+- `Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs` — serializer configuration properties

--- a/openspec/specs/serialization/spec.md
+++ b/openspec/specs/serialization/spec.md
@@ -9,92 +9,65 @@ The SDK's serialization layer handles conversion between .NET objects and JSON f
 ### Requirement: Default Serializer
 The SDK SHALL use Newtonsoft.Json (JSON.NET) as the default serializer.
 
-#### Scenario: Default behavior
-- GIVEN no custom serializer is configured
-- WHEN items are created, read, or queried
-- THEN `CosmosJsonDotNetSerializer` is used for serialization and deserialization
+#### Default behavior
+**While** no custom serializer is configured, **when** items are created, read, or queried, the SDK shall use `CosmosJsonDotNetSerializer` for serialization and deserialization.
 
 ### Requirement: Custom Serializer
 The SDK SHALL support plugging in a custom serializer that extends `CosmosSerializer`.
 
-#### Scenario: Custom serializer via options
-- GIVEN `CosmosClientOptions.Serializer` is set to a custom `CosmosSerializer` implementation
-- WHEN items are serialized or deserialized
-- THEN the custom serializer's `ToStream<T>()` and `FromStream<T>()` methods are used
+#### Custom serializer via options
+**Where** `CosmosClientOptions.Serializer` is set to a custom `CosmosSerializer` implementation, **when** items are serialized or deserialized, the SDK shall use the custom serializer's `ToStream<T>()` and `FromStream<T>()` methods.
 
-#### Scenario: CosmosSerializer contract
-- GIVEN a class extending `CosmosSerializer`
-- WHEN it is provided to the client
-- THEN it MUST implement `Stream ToStream<T>(T input)` and `T FromStream<T>(Stream stream)`
+#### CosmosSerializer contract
+**When** a class extending `CosmosSerializer` is provided to the client, the SDK shall require it to implement `Stream ToStream<T>(T input)` and `T FromStream<T>(Stream stream)`.
 
 ### Requirement: System.Text.Json Support
 The SDK SHALL support System.Text.Json as an alternative serializer.
 
-#### Scenario: Enable System.Text.Json
-- GIVEN `CosmosClientOptions.UseSystemTextJsonSerializerWithOptions` is set to a `JsonSerializerOptions` instance
-- WHEN items are serialized or deserialized
-- THEN `CosmosSystemTextJsonSerializer` is used
+#### Enable System.Text.Json
+**Where** `CosmosClientOptions.UseSystemTextJsonSerializerWithOptions` is set to a `JsonSerializerOptions` instance, **when** items are serialized or deserialized, the SDK shall use `CosmosSystemTextJsonSerializer`.
 
 ### Requirement: Serialization Options
 The SDK SHALL support configuring serialization behavior via `CosmosSerializationOptions`.
 
-#### Scenario: Ignore null values
-- GIVEN `CosmosClientOptions.SerializerOptions = new CosmosSerializationOptions { IgnoreNullValues = true }`
-- WHEN an item with null properties is serialized
-- THEN null properties are omitted from the JSON output
+#### Ignore null values
+**Where** `CosmosClientOptions.SerializerOptions = new CosmosSerializationOptions { IgnoreNullValues = true }`, **when** an item with null properties is serialized, the SDK shall omit null properties from the JSON output.
 
-#### Scenario: Indented output
-- GIVEN `CosmosSerializationOptions.Indented = true`
-- WHEN an item is serialized
-- THEN the JSON output is formatted with indentation
+#### Indented output
+**Where** `CosmosSerializationOptions.Indented = true`, **when** an item is serialized, the SDK shall format the JSON output with indentation.
 
-#### Scenario: Camel case property names
-- GIVEN `CosmosSerializationOptions.PropertyNamingPolicy = CosmosPropertyNamingPolicy.CamelCase`
-- WHEN an item with PascalCase property names is serialized
-- THEN property names are converted to camelCase in the JSON output
+#### Camel case property names
+**Where** `CosmosSerializationOptions.PropertyNamingPolicy = CosmosPropertyNamingPolicy.CamelCase`, **when** an item with PascalCase property names is serialized, the SDK shall convert property names to camelCase in the JSON output.
 
 ### Requirement: Mutual Exclusivity of Serializer Settings
 The SDK SHALL enforce that only one serializer configuration is active.
 
-#### Scenario: Multiple serializer settings
-- GIVEN two or more of `Serializer`, `SerializerOptions`, and `UseSystemTextJsonSerializerWithOptions` are set
-- WHEN the client is constructed
-- THEN an `ArgumentException` is thrown
+#### Multiple serializer settings
+**If** two or more of `Serializer`, `SerializerOptions`, and `UseSystemTextJsonSerializerWithOptions` are set, **then** the SDK shall throw an `ArgumentException` when the client is constructed.
 
 ### Requirement: LINQ Serialization Support
 The SDK SHALL support custom member name resolution for LINQ queries via `CosmosLinqSerializer`.
 
-#### Scenario: LINQ with custom serializer
-- GIVEN a `CosmosLinqSerializer` implementation that maps `MyProperty` to `my_property`
-- WHEN a LINQ query references `x.MyProperty`
-- THEN the generated SQL uses `c["my_property"]`
+#### LINQ with custom serializer
+**Where** a `CosmosLinqSerializer` implementation maps `MyProperty` to `my_property`, **when** a LINQ query references `x.MyProperty`, the SDK shall generate SQL using `c["my_property"]`.
 
 ### Requirement: Stream Operations
 The SDK SHALL support stream-based operations that bypass serialization.
 
-#### Scenario: Stream create
-- GIVEN `Container.CreateItemStreamAsync(stream, partitionKey)` is called
-- WHEN the operation is processed
-- THEN the raw stream is sent directly to the service without SDK-side serialization
+#### Stream create
+**When** `Container.CreateItemStreamAsync(stream, partitionKey)` is called, the SDK shall send the raw stream directly to the service without SDK-side serialization.
 
-#### Scenario: Stream read
-- GIVEN `Container.ReadItemStreamAsync(id, partitionKey)` is called
-- WHEN the response is received
-- THEN a `ResponseMessage` is returned with the raw JSON stream
-- AND no deserialization is performed
+#### Stream read
+**When** `Container.ReadItemStreamAsync(id, partitionKey)` is called, the SDK shall return a `ResponseMessage` with the raw JSON stream and perform no deserialization.
 
 ### Requirement: Internal vs User Serialization
 The SDK SHALL separate internal serialization (system properties, metadata) from user content serialization.
 
-#### Scenario: System properties
-- GIVEN an item response from the service
-- WHEN system properties (`id`, `_rid`, `_ts`, `_etag`, `_self`) are deserialized
-- THEN the SDK uses its internal serializer regardless of the user-configured serializer
+#### System properties
+**When** system properties (`id`, `_rid`, `_ts`, `_etag`, `_self`) are deserialized from an item response, the SDK shall use its internal serializer regardless of the user-configured serializer.
 
-#### Scenario: User content
-- GIVEN an item response from the service
-- WHEN the user's item content is deserialized
-- THEN the user-configured serializer is used
+#### User content
+**When** the user's item content is deserialized from an item response, the SDK shall use the user-configured serializer.
 
 ## Key Source Files
 - `Microsoft.Azure.Cosmos/src/Serializer/CosmosSerializer.cs` — abstract base serializer

--- a/openspec/specs/transport-and-connectivity/spec.md
+++ b/openspec/specs/transport-and-connectivity/spec.md
@@ -9,133 +9,86 @@ The SDK supports two transport modes — Gateway (HTTPS) and Direct (TCP) — wi
 ### Requirement: Connection Mode Selection
 The SDK SHALL support two connection modes with distinct transport characteristics.
 
-#### Scenario: Gateway mode
-- GIVEN `CosmosClientOptions.ConnectionMode = ConnectionMode.Gateway`
-- WHEN requests are made
-- THEN all requests are routed through the Cosmos DB gateway proxy via HTTPS (port 443)
-- AND the protocol is forced to HTTPS regardless of other settings
+#### Gateway mode
+**Where** `CosmosClientOptions.ConnectionMode = ConnectionMode.Gateway`, **when** requests are made, the SDK shall route all requests through the Cosmos DB gateway proxy via HTTPS (port 443) and force the protocol to HTTPS regardless of other settings.
 
-#### Scenario: Direct mode (default)
-- GIVEN `CosmosClientOptions.ConnectionMode = ConnectionMode.Direct` (or not specified, as Direct is the default)
-- WHEN requests are made
-- THEN data-plane requests use direct TCP connections to backend replicas
-- AND metadata requests still use the gateway
+#### Direct mode (default)
+**Where** `CosmosClientOptions.ConnectionMode = ConnectionMode.Direct` (or not specified, as Direct is the default), **when** requests are made, the SDK shall use direct TCP connections to backend replicas for data-plane requests and use the gateway for metadata requests.
 
 ### Requirement: Gateway Mode Configuration
 The SDK SHALL support configuring HTTP connection behavior for Gateway mode.
 
-#### Scenario: Max connection limit
-- GIVEN `CosmosClientOptions.GatewayModeMaxConnectionLimit = 100`
-- WHEN multiple concurrent requests are made in Gateway mode
-- THEN at most 100 simultaneous HTTP connections are maintained (default: 50)
+#### Max connection limit
+**Where** `CosmosClientOptions.GatewayModeMaxConnectionLimit = 100`, **when** multiple concurrent requests are made in Gateway mode, the SDK shall maintain at most 100 simultaneous HTTP connections (default: 50).
 
-#### Scenario: Custom HttpClient
-- GIVEN `CosmosClientOptions.HttpClientFactory` is set
-- WHEN the SDK creates HTTP connections
-- THEN it uses the provided HttpClient factory
-- AND `GatewayModeMaxConnectionLimit` and `WebProxy` settings are ignored
+#### Custom HttpClient
+**Where** `CosmosClientOptions.HttpClientFactory` is set, **when** the SDK creates HTTP connections, the SDK shall use the provided HttpClient factory and ignore `GatewayModeMaxConnectionLimit` and `WebProxy` settings.
 
-#### Scenario: Web proxy
-- GIVEN `CosmosClientOptions.WebProxy` is set
-- WHEN requests are made in Gateway mode
-- THEN HTTP traffic is routed through the specified proxy
+#### Web proxy
+**Where** `CosmosClientOptions.WebProxy` is set, **when** requests are made in Gateway mode, the SDK shall route HTTP traffic through the specified proxy.
 
 ### Requirement: Direct Mode TCP Configuration
 The SDK SHALL support fine-grained TCP connection tuning for Direct mode.
 
-#### Scenario: Idle connection timeout
-- GIVEN `CosmosClientOptions.IdleTcpConnectionTimeout = TimeSpan.FromMinutes(20)`
-- WHEN a TCP connection is idle for 20 minutes
-- THEN it is closed to free resources (minimum: 10 minutes)
+#### Idle connection timeout
+**Where** `CosmosClientOptions.IdleTcpConnectionTimeout = TimeSpan.FromMinutes(20)`, **when** a TCP connection is idle for 20 minutes, the SDK shall close it to free resources (minimum: 10 minutes).
 
-#### Scenario: Connection open timeout
-- GIVEN `CosmosClientOptions.OpenTcpConnectionTimeout = TimeSpan.FromSeconds(10)`
-- WHEN establishing a new TCP connection
-- THEN the connection attempt times out after 10 seconds (default: 5 seconds)
+#### Connection open timeout
+**Where** `CosmosClientOptions.OpenTcpConnectionTimeout = TimeSpan.FromSeconds(10)`, **when** establishing a new TCP connection, the SDK shall time out the connection attempt after 10 seconds (default: 5 seconds).
 
-#### Scenario: Max requests per connection
-- GIVEN `CosmosClientOptions.MaxRequestsPerTcpConnection = 50`
-- WHEN concurrent requests are sent over TCP
-- THEN at most 50 requests are multiplexed per TCP connection (default: 30)
+#### Max requests per connection
+**Where** `CosmosClientOptions.MaxRequestsPerTcpConnection = 50`, **when** concurrent requests are sent over TCP, the SDK shall multiplex at most 50 requests per TCP connection (default: 30).
 
-#### Scenario: Max connections per endpoint
-- GIVEN `CosmosClientOptions.MaxTcpConnectionsPerEndpoint = 32`
-- WHEN connecting to a backend node
-- THEN at most 32 TCP connections are established to that endpoint
+#### Max connections per endpoint
+**Where** `CosmosClientOptions.MaxTcpConnectionsPerEndpoint = 32`, **when** connecting to a backend node, the SDK shall establish at most 32 TCP connections to that endpoint.
 
-#### Scenario: Port reuse mode
-- GIVEN `CosmosClientOptions.PortReuseMode` is set
-- WHEN new TCP connections are created
-- THEN the specified port reuse strategy is applied
+#### Port reuse mode
+**Where** `CosmosClientOptions.PortReuseMode` is set, **when** new TCP connections are created, the SDK shall apply the specified port reuse strategy.
 
 ### Requirement: Request Timeout
 The SDK SHALL enforce a configurable timeout for individual requests.
 
-#### Scenario: Default timeout
-- GIVEN no timeout is configured
-- WHEN a request is made
-- THEN it times out after 6 seconds (default `RequestTimeout`)
+#### Default timeout
+**While** no timeout is configured, **when** a request is made, the SDK shall time out after 6 seconds (default `RequestTimeout`).
 
-#### Scenario: Custom timeout
-- GIVEN `CosmosClientOptions.RequestTimeout = TimeSpan.FromSeconds(15)`
-- WHEN a request exceeds 15 seconds
-- THEN a `CosmosException` with status 408 (RequestTimeout) is thrown
+#### Custom timeout
+**Where** `CosmosClientOptions.RequestTimeout = TimeSpan.FromSeconds(15)`, **when** a request exceeds 15 seconds, the SDK shall throw a `CosmosException` with status 408 (RequestTimeout).
 
 ### Requirement: Endpoint Discovery
 The SDK SHALL automatically discover and connect to available service endpoints.
 
-#### Scenario: Automatic region discovery
-- GIVEN `CosmosClientOptions.LimitToEndpoint = false` (default)
-- WHEN the client is initialized
-- THEN the SDK queries the account for available regions
-- AND populates the endpoint cache
+#### Automatic region discovery
+**Where** `CosmosClientOptions.LimitToEndpoint = false` (default), **when** the client is initialized, the SDK shall query the account for available regions and populate the endpoint cache.
 
-#### Scenario: Limit to single endpoint
-- GIVEN `CosmosClientOptions.LimitToEndpoint = true`
-- WHEN the client is initialized
-- THEN only the provided endpoint URI is used
-- AND no region discovery is performed
-- AND `ApplicationRegion` and `ApplicationPreferredRegions` MUST NOT be set
+#### Limit to single endpoint
+**Where** `CosmosClientOptions.LimitToEndpoint = true`, **when** the client is initialized, the SDK shall use only the provided endpoint URI, perform no region discovery, and require that `ApplicationRegion` and `ApplicationPreferredRegions` are not set.
 
-#### Scenario: TCP connection endpoint rediscovery
-- GIVEN `CosmosClientOptions.EnableTcpConnectionEndpointRediscovery = true` (default)
-- WHEN a TCP connection is reset
-- THEN the SDK refreshes the endpoint address cache
-- AND establishes connections to newly discovered endpoints
+#### TCP connection endpoint rediscovery
+**Where** `CosmosClientOptions.EnableTcpConnectionEndpointRediscovery = true` (default), **when** a TCP connection is reset, the SDK shall refresh the endpoint address cache and establish connections to newly discovered endpoints.
 
 ### Requirement: Custom Initialization Endpoints
 The SDK SHALL support custom endpoints for account initialization in geo-failover scenarios.
 
-#### Scenario: Custom init endpoints
-- GIVEN `CosmosClientOptions.AccountInitializationCustomEndpoints` contains fallback URIs
-- WHEN the primary account endpoint is unreachable during initialization
-- THEN the SDK attempts to initialize from the custom endpoints
+#### Custom init endpoints
+**Where** `CosmosClientOptions.AccountInitializationCustomEndpoints` contains fallback URIs, **if** the primary account endpoint is unreachable during initialization, **then** the SDK shall attempt to initialize from the custom endpoints.
 
 ### Requirement: SSL/TLS Configuration
 The SDK SHALL support custom certificate validation for Direct mode.
 
-#### Scenario: Custom certificate validation
-- GIVEN `CosmosClientOptions.ServerCertificateCustomValidationCallback` is set
-- WHEN a TLS connection is established
-- THEN the custom callback is invoked for certificate validation
+#### Custom certificate validation
+**Where** `CosmosClientOptions.ServerCertificateCustomValidationCallback` is set, **when** a TLS connection is established, the SDK shall invoke the custom callback for certificate validation.
 
 ### Requirement: Mutual Exclusivity of Settings
 The SDK SHALL enforce that conflicting connection settings cannot be used together.
 
-#### Scenario: WebProxy with HttpClientFactory
-- GIVEN both `WebProxy` and `HttpClientFactory` are set
-- WHEN the client is constructed
-- THEN an `ArgumentException` is thrown
+#### WebProxy with HttpClientFactory
+**If** both `WebProxy` and `HttpClientFactory` are set, **then** the SDK shall throw an `ArgumentException` when the client is constructed.
 
-#### Scenario: ApplicationRegion with ApplicationPreferredRegions
-- GIVEN both `ApplicationRegion` and `ApplicationPreferredRegions` are set
-- WHEN the client is constructed
-- THEN an `ArgumentException` is thrown
+#### ApplicationRegion with ApplicationPreferredRegions
+**If** both `ApplicationRegion` and `ApplicationPreferredRegions` are set, **then** the SDK shall throw an `ArgumentException` when the client is constructed.
 
-#### Scenario: LimitToEndpoint with regions
-- GIVEN `LimitToEndpoint = true` and either region setting is configured
-- WHEN the client is constructed
-- THEN an `ArgumentException` is thrown
+#### LimitToEndpoint with regions
+**If** `LimitToEndpoint = true` and either region setting is configured, **then** the SDK shall throw an `ArgumentException` when the client is constructed.
 
 ## Key Source Files
 - `Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs` — all connection configuration

--- a/openspec/specs/transport-and-connectivity/spec.md
+++ b/openspec/specs/transport-and-connectivity/spec.md
@@ -1,0 +1,145 @@
+# Transport and Connectivity
+
+## Purpose
+
+The SDK supports two transport modes — Gateway (HTTPS) and Direct (TCP) — with configurable connection management, pooling, and endpoint discovery.
+
+## Requirements
+
+### Requirement: Connection Mode Selection
+The SDK SHALL support two connection modes with distinct transport characteristics.
+
+#### Scenario: Gateway mode
+- GIVEN `CosmosClientOptions.ConnectionMode = ConnectionMode.Gateway`
+- WHEN requests are made
+- THEN all requests are routed through the Cosmos DB gateway proxy via HTTPS (port 443)
+- AND the protocol is forced to HTTPS regardless of other settings
+
+#### Scenario: Direct mode (default)
+- GIVEN `CosmosClientOptions.ConnectionMode = ConnectionMode.Direct` (or not specified, as Direct is the default)
+- WHEN requests are made
+- THEN data-plane requests use direct TCP connections to backend replicas
+- AND metadata requests still use the gateway
+
+### Requirement: Gateway Mode Configuration
+The SDK SHALL support configuring HTTP connection behavior for Gateway mode.
+
+#### Scenario: Max connection limit
+- GIVEN `CosmosClientOptions.GatewayModeMaxConnectionLimit = 100`
+- WHEN multiple concurrent requests are made in Gateway mode
+- THEN at most 100 simultaneous HTTP connections are maintained (default: 50)
+
+#### Scenario: Custom HttpClient
+- GIVEN `CosmosClientOptions.HttpClientFactory` is set
+- WHEN the SDK creates HTTP connections
+- THEN it uses the provided HttpClient factory
+- AND `GatewayModeMaxConnectionLimit` and `WebProxy` settings are ignored
+
+#### Scenario: Web proxy
+- GIVEN `CosmosClientOptions.WebProxy` is set
+- WHEN requests are made in Gateway mode
+- THEN HTTP traffic is routed through the specified proxy
+
+### Requirement: Direct Mode TCP Configuration
+The SDK SHALL support fine-grained TCP connection tuning for Direct mode.
+
+#### Scenario: Idle connection timeout
+- GIVEN `CosmosClientOptions.IdleTcpConnectionTimeout = TimeSpan.FromMinutes(20)`
+- WHEN a TCP connection is idle for 20 minutes
+- THEN it is closed to free resources (minimum: 10 minutes)
+
+#### Scenario: Connection open timeout
+- GIVEN `CosmosClientOptions.OpenTcpConnectionTimeout = TimeSpan.FromSeconds(10)`
+- WHEN establishing a new TCP connection
+- THEN the connection attempt times out after 10 seconds (default: 5 seconds)
+
+#### Scenario: Max requests per connection
+- GIVEN `CosmosClientOptions.MaxRequestsPerTcpConnection = 50`
+- WHEN concurrent requests are sent over TCP
+- THEN at most 50 requests are multiplexed per TCP connection (default: 30)
+
+#### Scenario: Max connections per endpoint
+- GIVEN `CosmosClientOptions.MaxTcpConnectionsPerEndpoint = 32`
+- WHEN connecting to a backend node
+- THEN at most 32 TCP connections are established to that endpoint
+
+#### Scenario: Port reuse mode
+- GIVEN `CosmosClientOptions.PortReuseMode` is set
+- WHEN new TCP connections are created
+- THEN the specified port reuse strategy is applied
+
+### Requirement: Request Timeout
+The SDK SHALL enforce a configurable timeout for individual requests.
+
+#### Scenario: Default timeout
+- GIVEN no timeout is configured
+- WHEN a request is made
+- THEN it times out after 6 seconds (default `RequestTimeout`)
+
+#### Scenario: Custom timeout
+- GIVEN `CosmosClientOptions.RequestTimeout = TimeSpan.FromSeconds(15)`
+- WHEN a request exceeds 15 seconds
+- THEN a `CosmosException` with status 408 (RequestTimeout) is thrown
+
+### Requirement: Endpoint Discovery
+The SDK SHALL automatically discover and connect to available service endpoints.
+
+#### Scenario: Automatic region discovery
+- GIVEN `CosmosClientOptions.LimitToEndpoint = false` (default)
+- WHEN the client is initialized
+- THEN the SDK queries the account for available regions
+- AND populates the endpoint cache
+
+#### Scenario: Limit to single endpoint
+- GIVEN `CosmosClientOptions.LimitToEndpoint = true`
+- WHEN the client is initialized
+- THEN only the provided endpoint URI is used
+- AND no region discovery is performed
+- AND `ApplicationRegion` and `ApplicationPreferredRegions` MUST NOT be set
+
+#### Scenario: TCP connection endpoint rediscovery
+- GIVEN `CosmosClientOptions.EnableTcpConnectionEndpointRediscovery = true` (default)
+- WHEN a TCP connection is reset
+- THEN the SDK refreshes the endpoint address cache
+- AND establishes connections to newly discovered endpoints
+
+### Requirement: Custom Initialization Endpoints
+The SDK SHALL support custom endpoints for account initialization in geo-failover scenarios.
+
+#### Scenario: Custom init endpoints
+- GIVEN `CosmosClientOptions.AccountInitializationCustomEndpoints` contains fallback URIs
+- WHEN the primary account endpoint is unreachable during initialization
+- THEN the SDK attempts to initialize from the custom endpoints
+
+### Requirement: SSL/TLS Configuration
+The SDK SHALL support custom certificate validation for Direct mode.
+
+#### Scenario: Custom certificate validation
+- GIVEN `CosmosClientOptions.ServerCertificateCustomValidationCallback` is set
+- WHEN a TLS connection is established
+- THEN the custom callback is invoked for certificate validation
+
+### Requirement: Mutual Exclusivity of Settings
+The SDK SHALL enforce that conflicting connection settings cannot be used together.
+
+#### Scenario: WebProxy with HttpClientFactory
+- GIVEN both `WebProxy` and `HttpClientFactory` are set
+- WHEN the client is constructed
+- THEN an `ArgumentException` is thrown
+
+#### Scenario: ApplicationRegion with ApplicationPreferredRegions
+- GIVEN both `ApplicationRegion` and `ApplicationPreferredRegions` are set
+- WHEN the client is constructed
+- THEN an `ArgumentException` is thrown
+
+#### Scenario: LimitToEndpoint with regions
+- GIVEN `LimitToEndpoint = true` and either region setting is configured
+- WHEN the client is constructed
+- THEN an `ArgumentException` is thrown
+
+## Key Source Files
+- `Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs` — all connection configuration
+- `Microsoft.Azure.Cosmos/src/GatewayStoreModel.cs` — gateway mode transport
+- `Microsoft.Azure.Cosmos/src/Handler/TransportHandler.cs` — handler pipeline transport layer
+- `Microsoft.Azure.Cosmos/src/Routing/GlobalEndpointManager.cs` — endpoint discovery and management
+- `Microsoft.Azure.Cosmos/src/Routing/LocationCache.cs` — region endpoint caching


### PR DESCRIPTION
## Description

Configures the OpenSpec framework with SDK-specific context and creates behavioral specifications for all 14 major feature areas of the Azure Cosmos DB .NET SDK v3.

### What's included

**OpenSpec Configuration** (openspec/config.yaml):
- SDK tech stack, components, build/test commands
- Versioning and feature flag conventions
- Per-artifact rules for proposals, specs, design docs, and tasks
- EARS notation and SDK-specific requirements for each artifact type

**14 Feature Specifications** (openspec/specs/):

| Area | Specs |
|------|-------|
| Data Operations | CRUD operations, query execution, change feed, bulk and batch |
| Routing and Availability | Retry and failover, cross-region hedging, partitioning |
| Transport and Config | Transport and connectivity, client configuration, consistency and session |
| Serialization and Diagnostics | Serialization, diagnostics and tracing |
| Security and Management | Client-side encryption, resource management |

**Index** (openspec/specs/README.md): Navigable index of all specs organized by area.

### Spec format

All specs use:
- EARS notation for behavioral requirements (WHEN condition, THEN the SDK SHALL behavior)
- Given/When/Then scenarios for each requirement
- Key source file references linking specs to implementation code

### Purpose

These specs serve as the source of truth for SDK behavior, enabling:
- Consistent feature documentation across 50+ public API surfaces
- AI agent context for implementation, testing, and code review tasks
- Onboarding material for new team members
- PR validation against acceptance criteria

### Related

- Builds on the exploration document in the feature/spec-based-development-exploration branch
- Uses the diagnostics compaction spec as a format reference

## Type of change

- [x] Documentation / specification changes (no code impact)
