### PR TITLE
[Internal] Query: Adds SubstringAfter/LastSubstringAfter/SubstringBefore/LastSubstringBefore to SDK

### DIFF
--- a/Microsoft.Azure.Cosmos/src/SqlObjects/SqlFunctionCallScalarExpression.cs
+++ b/Microsoft.Azure.Cosmos/src/SqlObjects/SqlFunctionCallScalarExpression.cs
@@ -103,6 +103,8 @@ namespace Microsoft.Azure.Cosmos.SqlObjects
             { Names.IsObject, Identifiers.IsObject },
             { Names.IsPrimitive, Identifiers.IsPrimitive },
             { Names.IsString, Identifiers.IsString },
+            { Names.LastSubstringAfter, Identifiers.LastSubstringAfter },
+            { Names.LastSubstringBefore, Identifiers.LastSubstringBefore },
             { Names.Left, Identifiers.Left },
             { Names.Length, Identifiers.Length },
             { Names.Like, Identifiers.Like },
@@ -145,9 +147,7 @@ namespace Microsoft.Azure.Cosmos.SqlObjects
             { Names.StringToObject, Identifiers.StringToObject },
             { Names.Substring, Identifiers.Substring },
             { Names.SubstringAfter, Identifiers.SubstringAfter },
-            { Names.SubstringAfterLast, Identifiers.SubstringAfterLast },
             { Names.SubstringBefore, Identifiers.SubstringBefore },
-            { Names.SubstringBeforeLast, Identifiers.SubstringBeforeLast },
             { Names.Sum, Identifiers.Sum },
             { Names.Tan, Identifiers.Tan },
             { Names.TicksToDateTime, Identifiers.TicksToDateTime },
@@ -355,6 +355,8 @@ namespace Microsoft.Azure.Cosmos.SqlObjects
             public const string IsPrimitive = "IS_PRIMITIVE";
             public const string IsString = "IS_STRING";
             public const string LastIndexOf = "LastIndexOf";
+            public const string LastSubstringAfter = "LastSubstringAfter";
+            public const string LastSubstringBefore = "LastSubstringBefore";
             public const string Left = "LEFT";
             public const string Length = "LENGTH";
             public const string Like = "LIKE";
@@ -404,9 +406,7 @@ namespace Microsoft.Azure.Cosmos.SqlObjects
             public const string StringToObject = "StringToObject";
             public const string Substring = "SUBSTRING";
             public const string SubstringAfter = "SubstringAfter";
-            public const string SubstringAfterLast = "SubstringAfterLast";
             public const string SubstringBefore = "SubstringBefore";
-            public const string SubstringBeforeLast = "SubstringBeforeLast";
             public const string Sum = "SUM";
             public const string Tan = "TAN";
             public const string TicksToDateTime = "TicksToDateTime";
@@ -537,6 +537,8 @@ namespace Microsoft.Azure.Cosmos.SqlObjects
             public static readonly SqlIdentifier IsPrimitive = SqlIdentifier.Create(Names.IsPrimitive);
             public static readonly SqlIdentifier IsString = SqlIdentifier.Create(Names.IsString);
             public static readonly SqlIdentifier LastIndexOf = SqlIdentifier.Create(Names.LastIndexOf);
+            public static readonly SqlIdentifier LastSubstringAfter = SqlIdentifier.Create(Names.LastSubstringAfter);
+            public static readonly SqlIdentifier LastSubstringBefore = SqlIdentifier.Create(Names.LastSubstringBefore);
             public static readonly SqlIdentifier Left = SqlIdentifier.Create(Names.Left);
             public static readonly SqlIdentifier Length = SqlIdentifier.Create(Names.Length);
             public static readonly SqlIdentifier Like = SqlIdentifier.Create(Names.Like);
@@ -586,9 +588,7 @@ namespace Microsoft.Azure.Cosmos.SqlObjects
             public static readonly SqlIdentifier StringToObject = SqlIdentifier.Create(Names.StringToObject);
             public static readonly SqlIdentifier Substring = SqlIdentifier.Create(Names.Substring);
             public static readonly SqlIdentifier SubstringAfter = SqlIdentifier.Create(Names.SubstringAfter);
-            public static readonly SqlIdentifier SubstringAfterLast = SqlIdentifier.Create(Names.SubstringAfterLast);
             public static readonly SqlIdentifier SubstringBefore = SqlIdentifier.Create(Names.SubstringBefore);
-            public static readonly SqlIdentifier SubstringBeforeLast = SqlIdentifier.Create(Names.SubstringBeforeLast);
             public static readonly SqlIdentifier Sum = SqlIdentifier.Create(Names.Sum);
             public static readonly SqlIdentifier Tan = SqlIdentifier.Create(Names.Tan);
             public static readonly SqlIdentifier TicksToDateTime = SqlIdentifier.Create(Names.TicksToDateTime);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BaselineTest/TestBaseline/SqlObjectVisitorBaselineTests.SqlFunctionCalls.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BaselineTest/TestBaseline/SqlObjectVisitorBaselineTests.SqlFunctionCalls.xml
@@ -2875,6 +2875,74 @@ LastIndexOf(
   </Result>
   <Result>
     <Input>
+      <Description>LastSubstringAfter</Description>
+      <SqlObject><![CDATA[{
+  "Name": {
+    "Value": "LastSubstringAfter"
+  },
+  "Arguments": [
+    {
+      "Literal": {
+        "Value": "Hello world"
+      }
+    },
+    {
+      "Literal": {
+        "Value": "o"
+      }
+    }
+  ],
+  "IsUdf": false
+}]]></SqlObject>
+    </Input>
+    <Output>
+      <TextOutput><![CDATA[LastSubstringAfter("Hello world", "o")]]></TextOutput>
+      <PrettyPrint><![CDATA[
+LastSubstringAfter(
+    "Hello world", 
+    "o"
+)
+]]></PrettyPrint>
+      <HashCode>441842242</HashCode>
+      <ObfusctedQuery><![CDATA[LastSubstringAfter("str1__11", "o")]]></ObfusctedQuery>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>LastSubstringBefore</Description>
+      <SqlObject><![CDATA[{
+  "Name": {
+    "Value": "LastSubstringBefore"
+  },
+  "Arguments": [
+    {
+      "Literal": {
+        "Value": "Hello world"
+      }
+    },
+    {
+      "Literal": {
+        "Value": "o"
+      }
+    }
+  ],
+  "IsUdf": false
+}]]></SqlObject>
+    </Input>
+    <Output>
+      <TextOutput><![CDATA[LastSubstringBefore("Hello world", "o")]]></TextOutput>
+      <PrettyPrint><![CDATA[
+LastSubstringBefore(
+    "Hello world", 
+    "o"
+)
+]]></PrettyPrint>
+      <HashCode>1887256552</HashCode>
+      <ObfusctedQuery><![CDATA[LastSubstringBefore("str1__11", "o")]]></ObfusctedQuery>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
       <Description>LEFT</Description>
       <SqlObject><![CDATA[{
   "Name": {
@@ -4363,40 +4431,6 @@ SubstringAfter(
   </Result>
   <Result>
     <Input>
-      <Description>SubstringAfterLast</Description>
-      <SqlObject><![CDATA[{
-  "Name": {
-    "Value": "SubstringAfterLast"
-  },
-  "Arguments": [
-    {
-      "Literal": {
-        "Value": "Hello world"
-      }
-    },
-    {
-      "Literal": {
-        "Value": "o"
-      }
-    }
-  ],
-  "IsUdf": false
-}]]></SqlObject>
-    </Input>
-    <Output>
-      <TextOutput><![CDATA[SubstringAfterLast("Hello world", "o")]]></TextOutput>
-      <PrettyPrint><![CDATA[
-SubstringAfterLast(
-    "Hello world", 
-    "o"
-)
-]]></PrettyPrint>
-      <HashCode>263341754</HashCode>
-      <ObfusctedQuery><![CDATA[SubstringAfterLast("str1__11", "o")]]></ObfusctedQuery>
-    </Output>
-  </Result>
-  <Result>
-    <Input>
       <Description>SubstringBefore</Description>
       <SqlObject><![CDATA[{
   "Name": {
@@ -4427,40 +4461,6 @@ SubstringBefore(
 ]]></PrettyPrint>
       <HashCode>516840642</HashCode>
       <ObfusctedQuery><![CDATA[SubstringBefore("str1__11", "o")]]></ObfusctedQuery>
-    </Output>
-  </Result>
-  <Result>
-    <Input>
-      <Description>SubstringBeforeLast</Description>
-      <SqlObject><![CDATA[{
-  "Name": {
-    "Value": "SubstringBeforeLast"
-  },
-  "Arguments": [
-    {
-      "Literal": {
-        "Value": "Hello world"
-      }
-    },
-    {
-      "Literal": {
-        "Value": "o"
-      }
-    }
-  ],
-  "IsUdf": false
-}]]></SqlObject>
-    </Input>
-    <Output>
-      <TextOutput><![CDATA[SubstringBeforeLast("Hello world", "o")]]></TextOutput>
-      <PrettyPrint><![CDATA[
-SubstringBeforeLast(
-    "Hello world", 
-    "o"
-)
-]]></PrettyPrint>
-      <HashCode>1171747440</HashCode>
-      <ObfusctedQuery><![CDATA[SubstringBeforeLast("str1__11", "o")]]></ObfusctedQuery>
     </Output>
   </Result>
   <Result>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/SqlObjects/SqlObjectVisitorBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/SqlObjects/SqlObjectVisitorBaselineTests.cs
@@ -797,6 +797,18 @@ namespace Microsoft.Azure.Cosmos.Test.SqlObjects
                     SqlLiteralScalarExpression.Create(SqlStringLiteral.Create("ABCDABCDABC")),
                     SqlLiteralScalarExpression.Create(SqlStringLiteral.Create("ABC")))),
                 new SqlObjectVisitorInput(
+                SqlFunctionCallScalarExpression.Names.LastSubstringAfter,
+                SqlFunctionCallScalarExpression.CreateBuiltin(
+                    SqlFunctionCallScalarExpression.Identifiers.LastSubstringAfter,
+                    SqlLiteralScalarExpression.Create(SqlStringLiteral.Create("Hello world")),
+                    SqlLiteralScalarExpression.Create(SqlStringLiteral.Create("o")))),
+                new SqlObjectVisitorInput(
+                SqlFunctionCallScalarExpression.Names.LastSubstringBefore,
+                SqlFunctionCallScalarExpression.CreateBuiltin(
+                    SqlFunctionCallScalarExpression.Identifiers.LastSubstringBefore,
+                    SqlLiteralScalarExpression.Create(SqlStringLiteral.Create("Hello world")),
+                    SqlLiteralScalarExpression.Create(SqlStringLiteral.Create("o")))),
+                new SqlObjectVisitorInput(
                 SqlFunctionCallScalarExpression.Names.Left,
                 SqlFunctionCallScalarExpression.CreateBuiltin(
                     SqlFunctionCallScalarExpression.Identifiers.Left,
@@ -1069,21 +1081,9 @@ namespace Microsoft.Azure.Cosmos.Test.SqlObjects
                     SqlLiteralScalarExpression.Create(SqlStringLiteral.Create("Hello world")),
                     SqlLiteralScalarExpression.Create(SqlStringLiteral.Create("o")))),
                 new SqlObjectVisitorInput(
-                SqlFunctionCallScalarExpression.Names.SubstringAfterLast,
-                SqlFunctionCallScalarExpression.CreateBuiltin(
-                    SqlFunctionCallScalarExpression.Identifiers.SubstringAfterLast,
-                    SqlLiteralScalarExpression.Create(SqlStringLiteral.Create("Hello world")),
-                    SqlLiteralScalarExpression.Create(SqlStringLiteral.Create("o")))),
-                new SqlObjectVisitorInput(
                 SqlFunctionCallScalarExpression.Names.SubstringBefore,
                 SqlFunctionCallScalarExpression.CreateBuiltin(
                     SqlFunctionCallScalarExpression.Identifiers.SubstringBefore,
-                    SqlLiteralScalarExpression.Create(SqlStringLiteral.Create("Hello world")),
-                    SqlLiteralScalarExpression.Create(SqlStringLiteral.Create("o")))),
-                new SqlObjectVisitorInput(
-                SqlFunctionCallScalarExpression.Names.SubstringBeforeLast,
-                SqlFunctionCallScalarExpression.CreateBuiltin(
-                    SqlFunctionCallScalarExpression.Identifiers.SubstringBeforeLast,
                     SqlLiteralScalarExpression.Create(SqlStringLiteral.Create("Hello world")),
                     SqlLiteralScalarExpression.Create(SqlStringLiteral.Create("o")))),
                 new SqlObjectVisitorInput(


### PR DESCRIPTION
# 4 new system functions

**SubstringAfter**
Returns the part of a string expression after the first occurrence of another string expression.

```
SubstringAfter("", "") = "";
SubstringAfter("abcde", "bc") = "de";
```


**SubstringBefore**
Returns the part of a string expression before the first occurrence of another string expression.

```
SubstringBefore("", "") = "";
SubstringBefore("abcde", "bc") = "a";
```


**LastSubstringAfter**
Returns the part of a string expression after the last occurrence of another string expression.

```
LastSubstringAfter("", "") = "";
LastSubstringAfter("abcdeabcde", "bc") = "de";
```


**LastSubstringBefore**
Returns the part of a string expression before the last occurrence of another string expression.

```
LastSubstringBefore("", "") = "";
LastSubstringBefore("abcdeabcde", "bc") = "abcdea";
```

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber