### PR TITLE
Performance: Cache URL-encoded AAD authorization signature

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Authorization/AuthorizationTokenProviderTokenCredential.cs
+++ b/Microsoft.Azure.Cosmos/src/Authorization/AuthorizationTokenProviderTokenCredential.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Azure.Cosmos
 {
     using System;
     using System.Globalization;
+    using System.Threading;
     using System.Threading.Tasks;
     using global::Azure.Core;
     using Microsoft.Azure.Cosmos.Core.Trace;
@@ -20,6 +21,14 @@ namespace Microsoft.Azure.Cosmos
         private bool isDisposed = false;
 
         internal readonly TokenCredential tokenCredential;
+
+        // Cache the URL-encoded AAD authorization signature to avoid redundant
+        // HttpUtility.UrlEncode calls for the same token. The AAD token is refreshed
+        // in the background every ~30 minutes, but GenerateAadAuthorizationSignature
+        // is called on every Cosmos DB request. Caching eliminates per-request
+        // URL-encoding overhead (~8.9μs and 6KB allocation per call).
+        private string cachedAadToken;
+        private string cachedAadAuthorizationSignature;
 
         public AuthorizationTokenProviderTokenCredential(
             TokenCredential tokenCredential,
@@ -42,7 +51,7 @@ namespace Microsoft.Azure.Cosmos
         {
             using (Trace trace = Trace.GetRootTrace(nameof(GetUserAuthorizationTokenAsync), TraceComponent.Authorization, TraceLevel.Info))
             {
-                string token = AuthorizationTokenProviderTokenCredential.GenerateAadAuthorizationSignature(
+                string token = this.GetOrCreateAadAuthorizationSignature(
                     await this.tokenCredentialCache.GetTokenAsync(trace));
                 return (token, default);
             }
@@ -56,7 +65,7 @@ namespace Microsoft.Azure.Cosmos
             AuthorizationTokenType tokenType,
             ITrace trace)
         {
-            return AuthorizationTokenProviderTokenCredential.GenerateAadAuthorizationSignature(
+            return this.GetOrCreateAadAuthorizationSignature(
                     await this.tokenCredentialCache.GetTokenAsync(trace));
         }
 
@@ -68,7 +77,7 @@ namespace Microsoft.Azure.Cosmos
         {
             using (Trace trace = Trace.GetRootTrace(nameof(GetUserAuthorizationTokenAsync), TraceComponent.Authorization, TraceLevel.Info))
             {
-                string token = AuthorizationTokenProviderTokenCredential.GenerateAadAuthorizationSignature(
+                string token = this.GetOrCreateAadAuthorizationSignature(
                     await this.tokenCredentialCache.GetTokenAsync(trace));
 
                 headersCollection.Add(HttpConstants.HttpHeaders.Authorization, token);
@@ -106,6 +115,20 @@ namespace Microsoft.Azure.Cosmos
                 Constants.Properties.AadToken,
                 Constants.Properties.TokenVersion,
                 aadToken));
+        }
+
+        internal string GetOrCreateAadAuthorizationSignature(string aadToken)
+        {
+            string currentCachedToken = Volatile.Read(ref this.cachedAadToken);
+            if (ReferenceEquals(aadToken, currentCachedToken))
+            {
+                return Volatile.Read(ref this.cachedAadAuthorizationSignature);
+            }
+
+            string signature = AuthorizationTokenProviderTokenCredential.GenerateAadAuthorizationSignature(aadToken);
+            Volatile.Write(ref this.cachedAadAuthorizationSignature, signature);
+            Volatile.Write(ref this.cachedAadToken, aadToken);
+            return signature;
         }
 
         public override void Dispose()

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosAuthorizationTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosAuthorizationTests.cs
@@ -138,6 +138,49 @@ namespace Microsoft.Azure.Cosmos.Tests
             }
         }
 
+        [TestMethod]
+        public void AadAuthorizationSignatureCaching_ReturnsCachedResultForSameToken()
+        {
+            using AuthorizationTokenProviderTokenCredential provider = new AuthorizationTokenProviderTokenCredential(
+                new Mock<TokenCredential>().Object,
+                CosmosAuthorizationTests.AccountEndpoint,
+                backgroundTokenCredentialRefreshInterval: TimeSpan.FromSeconds(1));
+
+            string token = "test-aad-token-value";
+
+            string result1 = provider.GetOrCreateAadAuthorizationSignature(token);
+            string result2 = provider.GetOrCreateAadAuthorizationSignature(token);
+
+            // Same reference means the cached value was returned (not recomputed)
+            Assert.AreSame(result1, result2, "Expected cached signature to be returned for the same token reference.");
+
+            // Verify the result matches the uncached static method
+            string expected = AuthorizationTokenProviderTokenCredential.GenerateAadAuthorizationSignature(token);
+            Assert.AreEqual(expected, result1);
+        }
+
+        [TestMethod]
+        public void AadAuthorizationSignatureCaching_RecomputesForNewToken()
+        {
+            using AuthorizationTokenProviderTokenCredential provider = new AuthorizationTokenProviderTokenCredential(
+                new Mock<TokenCredential>().Object,
+                CosmosAuthorizationTests.AccountEndpoint,
+                backgroundTokenCredentialRefreshInterval: TimeSpan.FromSeconds(1));
+
+            string token1 = "first-aad-token";
+            string token2 = "second-aad-token";
+
+            string result1 = provider.GetOrCreateAadAuthorizationSignature(token1);
+            string result2 = provider.GetOrCreateAadAuthorizationSignature(token2);
+
+            Assert.AreNotEqual(result1, result2, "Different tokens should produce different signatures.");
+
+            string expected1 = AuthorizationTokenProviderTokenCredential.GenerateAadAuthorizationSignature(token1);
+            string expected2 = AuthorizationTokenProviderTokenCredential.GenerateAadAuthorizationSignature(token2);
+            Assert.AreEqual(expected1, result1);
+            Assert.AreEqual(expected2, result2);
+        }
+
         [DataTestMethod]
         [DataRow("https://env-override/.default", "https://env-override/.default", DisplayName = "EnvVarOverride")]
         [DataRow("https://cosmos.azure.com/.default", "https://cosmos.azure.com/.default", DisplayName = "EnvVarOverride_Fabric")]


### PR DESCRIPTION
## Description

The AAD token credential path calls HttpUtility.UrlEncode on the full authorization string (~1.5KB JWT) on every Cosmos DB request, even though the underlying AAD token is cached and only refreshes every ~30 minutes.

At high throughput (thousands of requests/sec), HttpUtility.IsSafe character-by-character scanning accounts for significant amount of CPU. Benchmarks show 8.9μs and 6KB allocation per call, while the cached path is 1.7ns with zero allocations.

This change caches the URL-encoded result alongside the token using Volatile reads/writes for lock-free thread safety. The static GenerateAadAuthorizationSignature method is preserved for backward compatibility.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)