### PR TITLE
[Internal] Tests: Adds DoNotParallelize to DistributedTransaction E2E tests

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/DistributedTransaction/DistributedTransactionE2ETests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/DistributedTransaction/DistributedTransactionE2ETests.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
     using PartitionKey = Cosmos.PartitionKey;
 
     [TestClass]
+    [DoNotParallelize]
     public class DistributedTransactionE2ETests : BaseCosmosClientHelper
     {   
         private const string IdempotencyTokenHeader = HttpConstants.HttpHeaders.IdempotencyToken;


### PR DESCRIPTION
## Summary

Adds `[DoNotParallelize]` attribute to `DistributedTransactionE2ETests` to prevent concurrent test execution contention on the emulator.

## Root Cause

All 4 tests share a `TestInitialize` that creates a new container via `BaseCosmosClientHelper.TestInit()` (which calls `DeleteAllDatabasesAsync`). Concurrent test execution caused resource contention on the emulator, resulting in consistent ~4% failure rate across all 4 tests.

## Tests Fixed (95.82% pass rate each — 16 failures each in 30 days)
- `ValidateConflictResponseReturnsErrorStatus`
- `ValidateHappyPathRequestAndResponse`
- `ValidateMixedOperationsRequestStructure`
- `ValidateResponseDeserializesCorrectly`

## Impact
- **64 total flaky failures eliminated** (4 × 16)
- Split from #5643 for independent validation