### PR TITLE
[Internal] Tests: Fixes AppCancellationDuringHedging with deterministic synchronization

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/AvailabilityStrategyUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/AvailabilityStrategyUnitTests.cs
@@ -281,8 +281,8 @@
         {
             // Arrange
             CrossRegionHedgingAvailabilityStrategy availabilityStrategy = new CrossRegionHedgingAvailabilityStrategy(
-                threshold: TimeSpan.FromMilliseconds(10),
-                thresholdStep: TimeSpan.FromMilliseconds(10));
+                threshold: TimeSpan.FromMilliseconds(100),
+                thresholdStep: TimeSpan.FromMilliseconds(100));
 
             using RequestMessage request = CreateReadRequest();
             using CosmosClient mockCosmosClient = CreateMockClientWithRegions(3);
@@ -296,19 +296,16 @@
 
                 if (callNumber == 1)
                 {
-                    // First request: cancel the app token after a brief delay
+                    // First request: cancel the app token immediately
                     // This simulates an e2e timeout scenario
-                    _ = Task.Delay(15).ContinueWith(_ => appCts.Cancel());
+                    appCts.Cancel();
+                }
 
-                    // Then wait - this will be cancelled
-                    try
-                    {
-                        await Task.Delay(TimeSpan.FromSeconds(30), ct);
-                    }
-                    catch (OperationCanceledException)
-                    {
-                        throw;
-                    }
+                // All requests block deterministically until cancelled via the token
+                TaskCompletionSource<ResponseMessage> tcs = new TaskCompletionSource<ResponseMessage>();
+                using (ct.Register(() => tcs.TrySetCanceled(ct)))
+                {
+                    await tcs.Task;
                 }
 
                 return new ResponseMessage(HttpStatusCode.OK);


### PR DESCRIPTION
## Summary

Replaces timing-dependent cancellation pattern with deterministic `TaskCompletionSource` + `ct.Register()` approach in the `AppCancellationDuringHedging_DoesNotSpawnNewHedgeRequests` test.

## Root Cause

The test used a 10ms threshold with a 15ms cancellation delay, giving only 5ms margin. `Task.Delay` precision at these scales is unreliable on loaded CI agents, causing the test to fail ~4% of the time.

## Fix

- Cancel the app token **immediately** on the first request (deterministic)
- All requests block via `TaskCompletionSource` until cancelled via the cancellation token
- No more timing dependencies — the test is now fully deterministic

## Test Fixed (95.89% pass rate — 29 failures in 30 days)
- `AppCancellationDuringHedging_DoesNotSpawnNewHedgeRequests`

## Impact
- **29 flaky failures eliminated**
- Split from #5643 for independent validation