### PR TITLE
[Internal] DTS: Adds IfMatchEtag (optimistic concurrency) support to DistributedWriteTransactions

### DIFF
--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperation.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperation.cs
@@ -23,7 +23,8 @@ namespace Microsoft.Azure.Cosmos
             string database,
             string container,
             PartitionKey partitionKey,
-            string id = null)
+            string id = null,
+            DistributedTransactionRequestOptions requestOptions = null)
         {
             this.OperationType = operationType;
             this.OperationIndex = operationIndex;
@@ -31,6 +32,7 @@ namespace Microsoft.Azure.Cosmos
             this.Database = database;
             this.Container = container;
             this.Id = id;
+            this.RequestOptions = requestOptions;
         }
 
         public PartitionKey PartitionKey { get; internal set; }
@@ -49,11 +51,13 @@ namespace Microsoft.Azure.Cosmos
 
         public string DatabaseResourceId { get; internal set; }
 
+        internal DistributedTransactionRequestOptions RequestOptions { get; }
+
         internal string PartitionKeyJson { get; set; }
 
         internal string SessionToken { get; set; }
 
-        internal string ETag { get; set; }
+        internal string ETag => this.RequestOptions?.IfMatchEtag;
 
         internal Stream ResourceStream { get; set; }
 
@@ -80,8 +84,9 @@ namespace Microsoft.Azure.Cosmos
             string database,
             string container,
             PartitionKey partitionKey,
-            T resource)
-            : base(operationType, operationIndex, database, container, partitionKey)
+            T resource,
+            DistributedTransactionRequestOptions requestOptions = null)
+            : base(operationType, operationIndex, database, container, partitionKey, id: null, requestOptions)
         {
             this.Resource = resource;
         }
@@ -93,8 +98,9 @@ namespace Microsoft.Azure.Cosmos
             string container,
             PartitionKey partitionKey,
             string id,
-            T resource)
-            : base(operationType, operationIndex, database, container, partitionKey, id)
+            T resource,
+            DistributedTransactionRequestOptions requestOptions = null)
+            : base(operationType, operationIndex, database, container, partitionKey, id, requestOptions)
         {
             this.Resource = resource;
         }

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionRequestOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionRequestOptions.cs
@@ -1,0 +1,18 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos
+{
+    /// <summary>
+    /// <see cref="RequestOptions"/> that apply to an operation within a <see cref="DistributedWriteTransaction"/>.
+    /// </summary>
+#if INTERNAL
+    public
+#else
+    internal
+#endif
+    class DistributedTransactionRequestOptions : RequestOptions
+    {
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedWriteTransaction.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedWriteTransaction.cs
@@ -24,12 +24,14 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="collection">The name of the container where the item will be created.</param>
         /// <param name="partitionKey">The partition key for the item.</param>
         /// <param name="resource">The resource to create.</param>
+        /// <param name="requestOptions">Options for the create operation.</param>
         /// <returns>The current <see cref="DistributedWriteTransaction"/> instance for method chaining.</returns>
         public abstract DistributedWriteTransaction CreateItem<T>(
             string database,
             string collection,
             PartitionKey partitionKey,
-            T resource);
+            T resource,
+            DistributedTransactionRequestOptions requestOptions = null);
 
         /// <summary>
         /// Adds a replace operation to the distributed transaction.
@@ -40,13 +42,15 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="partitionKey">The partition key for the item.</param>
         /// <param name="id">The unique identifier of the item to replace.</param>
         /// <param name="resource">The resource with updated values.</param>
+        /// <param name="requestOptions">Options for the replace operation.</param>
         /// <returns>The current <see cref="DistributedWriteTransaction"/> instance for method chaining.</returns>
         public abstract DistributedWriteTransaction ReplaceItem<T>(
             string database,
             string collection,
             PartitionKey partitionKey,
             string id,
-            T resource);
+            T resource,
+            DistributedTransactionRequestOptions requestOptions = null);
 
         /// <summary>
         /// Adds a delete operation to the distributed transaction.
@@ -55,12 +59,14 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="collection">The name of the container where the item exists.</param>
         /// <param name="partitionKey">The partition key for the item.</param>
         /// <param name="id">The unique identifier of the item to delete.</param>
+        /// <param name="requestOptions">Options for the delete operation.</param>
         /// <returns>The current <see cref="DistributedWriteTransaction"/> instance for method chaining.</returns>
         public abstract DistributedWriteTransaction DeleteItem(
             string database,
             string collection,
             PartitionKey partitionKey,
-            string id);
+            string id,
+            DistributedTransactionRequestOptions requestOptions = null);
 
         /// <summary>
         /// Adds a patch operation to the distributed transaction.
@@ -70,13 +76,15 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="partitionKey">The partition key for the item.</param>
         /// <param name="id">The unique identifier of the item to patch.</param>
         /// <param name="patchOperations">The list of <see cref="PatchOperation"/> to apply to the item.</param>
+        /// <param name="requestOptions">Options for the patch operation</param>
         /// <returns>The current <see cref="DistributedWriteTransaction"/> instance for method chaining.</returns>
         public abstract DistributedWriteTransaction PatchItem(
             string database,
             string collection,
             PartitionKey partitionKey,
             string id,
-            IReadOnlyList<PatchOperation> patchOperations);
+            IReadOnlyList<PatchOperation> patchOperations,
+            DistributedTransactionRequestOptions requestOptions = null);
 
         /// <summary>
         /// Adds an upsert operation to the distributed transaction.
@@ -87,11 +95,13 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="collection">The name of the container where the item will be upserted.</param>
         /// <param name="partitionKey">The partition key for the item.</param>
         /// <param name="resource">The resource to upsert.</param>
+        /// <param name="requestOptions">Options for the upsert operation.</param>
         /// <returns>The current <see cref="DistributedWriteTransaction"/> instance for method chaining.</returns>
         public abstract DistributedWriteTransaction UpsertItem<T>(
             string database,
             string collection,
             PartitionKey partitionKey,
-            T resource);
+            T resource,
+            DistributedTransactionRequestOptions requestOptions = null);
     }
 }

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedWriteTransactionCore.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedWriteTransactionCore.cs
@@ -22,7 +22,12 @@ namespace Microsoft.Azure.Cosmos
             this.operations = new List<DistributedTransactionOperation>();
         }
 
-        public override DistributedWriteTransaction CreateItem<T>(string database, string collection, PartitionKey partitionKey, T resource)
+        public override DistributedWriteTransaction CreateItem<T>(
+            string database,
+            string collection,
+            PartitionKey partitionKey,
+            T resource,
+            DistributedTransactionRequestOptions requestOptions = null)
         {
             DistributedWriteTransactionCore.ValidateContainerReference(database, collection);
             DistributedWriteTransactionCore.ValidateResource(resource);
@@ -34,11 +39,18 @@ namespace Microsoft.Azure.Cosmos
                     database,
                     collection,
                     partitionKey,
-                    resource));
+                    resource,
+                    requestOptions));
             return this;
         }
 
-        public override DistributedWriteTransaction ReplaceItem<T>(string database, string collection, PartitionKey partitionKey, string id, T resource)
+        public override DistributedWriteTransaction ReplaceItem<T>(
+            string database,
+            string collection,
+            PartitionKey partitionKey,
+            string id,
+            T resource,
+            DistributedTransactionRequestOptions requestOptions = null)
         {
             DistributedWriteTransactionCore.ValidateContainerReference(database, collection);
             DistributedWriteTransactionCore.ValidateItemId(id);
@@ -52,11 +64,17 @@ namespace Microsoft.Azure.Cosmos
                     collection,
                     partitionKey,
                     id,
-                    resource));
+                    resource,
+                    requestOptions));
             return this;
         }
 
-        public override DistributedWriteTransaction DeleteItem(string database, string collection, PartitionKey partitionKey, string id)
+        public override DistributedWriteTransaction DeleteItem(
+            string database,
+            string collection,
+            PartitionKey partitionKey,
+            string id,
+            DistributedTransactionRequestOptions requestOptions = null)
         {
             DistributedWriteTransactionCore.ValidateContainerReference(database, collection);
             DistributedWriteTransactionCore.ValidateItemId(id);
@@ -68,7 +86,8 @@ namespace Microsoft.Azure.Cosmos
                     database,
                     collection,
                     partitionKey,
-                    id: id));
+                    id: id,
+                    requestOptions));
             return this;
         }
 
@@ -77,7 +96,8 @@ namespace Microsoft.Azure.Cosmos
             string collection,
             PartitionKey partitionKey,
             string id,
-            IReadOnlyList<PatchOperation> patchOperations)
+            IReadOnlyList<PatchOperation> patchOperations,
+            DistributedTransactionRequestOptions requestOptions = null)
         {
             DistributedWriteTransactionCore.ValidateContainerReference(database, collection);
             DistributedWriteTransactionCore.ValidateItemId(id);
@@ -96,11 +116,18 @@ namespace Microsoft.Azure.Cosmos
                     database,
                     collection,
                     partitionKey,
-                    resource: patchSpec));
+                    id,
+                    resource: patchSpec,
+                    requestOptions));
             return this;
         }
 
-        public override DistributedWriteTransaction UpsertItem<T>(string database, string collection, PartitionKey partitionKey, T resource)
+        public override DistributedWriteTransaction UpsertItem<T>(
+            string database,
+            string collection,
+            PartitionKey partitionKey,
+            T resource,
+            DistributedTransactionRequestOptions requestOptions = null)
         {
             DistributedWriteTransactionCore.ValidateContainerReference(database, collection);
             DistributedWriteTransactionCore.ValidateResource(resource);
@@ -112,7 +139,8 @@ namespace Microsoft.Azure.Cosmos
                     database,
                     collection,
                     partitionKey,
-                    resource));
+                    resource,
+                    requestOptions));
             return this;
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/DistributedTransaction/DistributedTransactionE2ETests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/DistributedTransaction/DistributedTransactionE2ETests.cs
@@ -276,6 +276,204 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             response.Dispose();
         }
 
+        [TestMethod]
+        public async Task ValidateReplaceItemWithIfMatchEtagSerializedToRequest()
+        {
+            // Arrange
+            ToDoActivity doc = ToDoActivity.CreateRandomToDoActivity();
+            string expectedEtag = "\"test-etag-replace\"";
+
+            DistributedTransactionTestHandler handler = CreateMockHandler(
+                HttpStatusCode.OK,
+                CreateMockSuccessResponse(operationCount: 1));
+
+            using CosmosClient client = TestCommon.CreateCosmosClient(
+                clientOptions: new CosmosClientOptions
+                {
+                    CustomHandlers = { handler },
+                    ConnectionMode = ConnectionMode.Gateway
+                });
+
+            // Act
+            DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
+                .ReplaceItem(
+                    this.database.Id,
+                    this.container.Id,
+                    new PartitionKey(doc.pk),
+                    doc.id,
+                    doc,
+                    new DistributedTransactionRequestOptions { IfMatchEtag = expectedEtag })
+                .CommitTransactionAsync(CancellationToken.None);
+
+            // Assert
+            Assert.IsTrue(response.IsSuccessStatusCode);
+            using JsonDocument requestJson = JsonDocument.Parse(handler.CapturedRequestBody);
+            JsonElement operation = requestJson.RootElement.GetProperty("operations")[0];
+            Assert.IsTrue(operation.TryGetProperty("id", out JsonElement idElement), "id field should be present for replace operation");
+            Assert.AreEqual(doc.id, idElement.GetString());
+            Assert.IsTrue(operation.TryGetProperty("etag", out JsonElement etagElement), "etag field should be present when IfMatchEtag is set");
+            Assert.AreEqual(expectedEtag, etagElement.GetString());
+
+            response.Dispose();
+        }
+
+        [TestMethod]
+        public async Task ValidateDeleteItemWithIfMatchEtagSerializedToRequest()
+        {
+            // Arrange
+            string expectedEtag = "\"test-etag-delete\"";
+
+            DistributedTransactionTestHandler handler = CreateMockHandler(
+                HttpStatusCode.OK,
+                CreateMockSuccessResponse(operationCount: 1));
+
+            using CosmosClient client = TestCommon.CreateCosmosClient(
+                clientOptions: new CosmosClientOptions
+                {
+                    CustomHandlers = { handler },
+                    ConnectionMode = ConnectionMode.Gateway
+                });
+
+            // Act
+            DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
+                .DeleteItem(
+                    this.database.Id,
+                    this.container.Id,
+                    new PartitionKey("delete-pk"),
+                    "delete-id",
+                    new DistributedTransactionRequestOptions { IfMatchEtag = expectedEtag })
+                .CommitTransactionAsync(CancellationToken.None);
+
+            // Assert
+            Assert.IsTrue(response.IsSuccessStatusCode);
+            using JsonDocument requestJson = JsonDocument.Parse(handler.CapturedRequestBody);
+            JsonElement operation = requestJson.RootElement.GetProperty("operations")[0];
+            Assert.IsTrue(operation.TryGetProperty("id", out JsonElement idElement), "id field should be present for delete operation");
+            Assert.AreEqual("delete-id", idElement.GetString());
+            Assert.IsTrue(operation.TryGetProperty("etag", out JsonElement etagElement), "etag field should be present when IfMatchEtag is set");
+            Assert.AreEqual(expectedEtag, etagElement.GetString());
+
+            response.Dispose();
+        }
+
+        [TestMethod]
+        public async Task ValidatePatchItemWithIfMatchEtagSerializedToRequest()
+        {
+            // Arrange
+            string expectedEtag = "\"test-etag-patch\"";
+            IReadOnlyList<PatchOperation> patchOps = new[] { PatchOperation.Add("/description", "patched") };
+
+            DistributedTransactionTestHandler handler = CreateMockHandler(
+                HttpStatusCode.OK,
+                CreateMockSuccessResponse(operationCount: 1));
+
+            using CosmosClient client = TestCommon.CreateCosmosClient(
+                clientOptions: new CosmosClientOptions
+                {
+                    CustomHandlers = { handler },
+                    ConnectionMode = ConnectionMode.Gateway
+                });
+
+            // Act
+            DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
+                .PatchItem(
+                    this.database.Id,
+                    this.container.Id,
+                    new PartitionKey("patch-pk"),
+                    "patch-id",
+                    patchOps,
+                    new DistributedTransactionRequestOptions { IfMatchEtag = expectedEtag })
+                .CommitTransactionAsync(CancellationToken.None);
+
+            // Assert
+            Assert.IsTrue(response.IsSuccessStatusCode);
+            using JsonDocument requestJson = JsonDocument.Parse(handler.CapturedRequestBody);
+            JsonElement operation = requestJson.RootElement.GetProperty("operations")[0];
+            Assert.IsTrue(operation.TryGetProperty("id", out JsonElement idElement), "id field should be present for patch operation");
+            Assert.AreEqual("patch-id", idElement.GetString());
+            Assert.IsTrue(operation.TryGetProperty("etag", out JsonElement etagElement), "etag field should be present when IfMatchEtag is set");
+            Assert.AreEqual(expectedEtag, etagElement.GetString());
+
+            response.Dispose();
+        }
+
+        [TestMethod]
+        public async Task ValidatePreconditionFailedResponse()
+        {
+            // Arrange
+            string mockErrorResponse = @"{
+                ""operationResponses"": [{
+                    ""index"": 0,
+                    ""statuscode"": 412,
+                    ""substatuscode"": 0
+                }]
+            }";
+
+            DistributedTransactionTestHandler handler = CreateMockHandler(HttpStatusCode.PreconditionFailed, mockErrorResponse);
+            using CosmosClient client = TestCommon.CreateCosmosClient(
+                clientOptions: new CosmosClientOptions
+                {
+                    CustomHandlers = { handler },
+                    ConnectionMode = ConnectionMode.Gateway
+                });
+
+            ToDoActivity doc = ToDoActivity.CreateRandomToDoActivity();
+
+            // Act
+            DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
+                .ReplaceItem(
+                    this.database.Id,
+                    this.container.Id,
+                    new PartitionKey(doc.pk),
+                    doc.id,
+                    doc,
+                    new DistributedTransactionRequestOptions { IfMatchEtag = "\"stale-etag\"" })
+                .CommitTransactionAsync(CancellationToken.None);
+
+            // Assert
+            Assert.AreEqual(HttpStatusCode.PreconditionFailed, response.StatusCode);
+            Assert.IsFalse(response.IsSuccessStatusCode);
+            Assert.AreEqual(1, response.Count);
+            Assert.AreEqual(HttpStatusCode.PreconditionFailed, response[0].StatusCode);
+
+            response.Dispose();
+        }
+
+        [TestMethod]
+        public async Task ValidateOperationsWithoutIfMatchEtagDoNotSerializeEtagField()
+        {
+            // Arrange
+            ToDoActivity createDoc = ToDoActivity.CreateRandomToDoActivity();
+            ToDoActivity replaceDoc = ToDoActivity.CreateRandomToDoActivity();
+
+            DistributedTransactionTestHandler handler = CreateMockHandler(
+                HttpStatusCode.OK,
+                CreateMockSuccessResponse(operationCount: 2));
+
+            using CosmosClient client = TestCommon.CreateCosmosClient(
+                clientOptions: new CosmosClientOptions
+                {
+                    CustomHandlers = { handler },
+                    ConnectionMode = ConnectionMode.Gateway
+                });
+
+            // Act — no IfMatchEtag provided
+            DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
+                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(createDoc.pk), createDoc)
+                .ReplaceItem(this.database.Id, this.container.Id, new PartitionKey(replaceDoc.pk), replaceDoc.id, replaceDoc)
+                .CommitTransactionAsync(CancellationToken.None);
+
+            // Assert — no etag field should be serialized when IfMatchEtag is not set
+            using JsonDocument requestJson = JsonDocument.Parse(handler.CapturedRequestBody);
+            JsonElement operations = requestJson.RootElement.GetProperty("operations");
+            foreach (JsonElement operation in operations.EnumerateArray())
+            {
+                Assert.IsFalse(operation.TryGetProperty("etag", out _), "etag field should not be present when IfMatchEtag is not set");
+            }
+
+            response.Dispose();
+        }
+
         #region Helper Methods
 
         private static DistributedTransactionTestHandler CreateMockHandler(HttpStatusCode statusCode, string responseBody)


### PR DESCRIPTION
# Pull Request Template

## Description

- Introduces `DistributedTransactionItemRequestOptions`, a `RequestOptions` subclass for use with DistributedWriteTransaction operations.
- Adds an optional requestOptions parameter to write API callers can supply an ETag for optimistic concurrency control.
- ETag from `requestOptions.IfMatchEtag` is propagated to the underlying`  DistributedTransactionOperation` before it is enqueued
- E2E tests covering ETag serialization for Replace, Delete, and Patch, as well as precondition-failure (412) handling and null requestOptions scenarios

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber