### PR TITLE
[Internal] Release Agent: Adds documentation metadata update step

### DIFF
--- a/.github/agents/release-copilot-agent.agent.md
+++ b/.github/agents/release-copilot-agent.agent.md
@@ -336,6 +336,18 @@ After the PR is approved and merged:
 
 3. **Metadata update — `azure-docs-sdk-dotnet`:**
 
+   > **Prerequisite:** Only perform this step after the release PR has been **approved and merged**, and the SDK package has been **published to NuGet**. Verify both conditions before proceeding:
+   > ```powershell
+   > # Verify the release PR is merged
+   > $prState = gh pr view <PR_NUMBER> --repo Azure/azure-cosmos-dotnet-v3 --json state,mergedAt --jq '.state'
+   > if ($prState -ne 'MERGED') { Write-Error "Release PR is not yet merged. Aborting metadata update."; return }
+   >
+   > # Verify the NuGet package is available
+   > $nugetUrl = "https://api.nuget.org/v3-flatcontainer/microsoft.azure.cosmos/X.Y.Z/microsoft.azure.cosmos.X.Y.Z.nupkg"
+   > $nugetStatus = (Invoke-WebRequest -Uri $nugetUrl -Method Head -UseBasicParsing -ErrorAction SilentlyContinue).StatusCode
+   > if ($nugetStatus -ne 200) { Write-Error "NuGet package X.Y.Z is not yet available. Wait for the publish pipeline to complete."; return }
+   > ```
+
    Update the Cosmos DB metadata file in `MicrosoftDocs/azure-docs-sdk-dotnet` so the documentation site reflects the new release version. This work is done in a **separate worktree** to avoid disrupting the SDK repository.
 
    **3a. Get GitHub username:**
@@ -628,6 +640,18 @@ After the hotfix PR is merged:
    - Body: Copy changelog notes
 
 2. **Metadata update — `azure-docs-sdk-dotnet`:**
+
+   > **Prerequisite:** Only perform this step after the hotfix PR has been **approved and merged**, and the SDK package has been **published to NuGet**. Verify both conditions before proceeding:
+   > ```powershell
+   > # Verify the hotfix PR is merged
+   > $prState = gh pr view <PR_NUMBER> --repo Azure/azure-cosmos-dotnet-v3 --json state,mergedAt --jq '.state'
+   > if ($prState -ne 'MERGED') { Write-Error "Hotfix PR is not yet merged. Aborting metadata update."; return }
+   >
+   > # Verify the NuGet package is available
+   > $nugetUrl = "https://api.nuget.org/v3-flatcontainer/microsoft.azure.cosmos/X.Y.Z+1/microsoft.azure.cosmos.X.Y.Z+1.nupkg"
+   > $nugetStatus = (Invoke-WebRequest -Uri $nugetUrl -Method Head -UseBasicParsing -ErrorAction SilentlyContinue).StatusCode
+   > if ($nugetStatus -ne 200) { Write-Error "NuGet package X.Y.Z+1 is not yet available. Wait for the publish pipeline to complete."; return }
+   > ```
 
    Update the Cosmos DB metadata file so the documentation site reflects the hotfix version. This follows the same workflow as Minor Mode §2.8 step 3.
 


### PR DESCRIPTION
## Summary

Expands the release agent's post-merge metadata update from a 3-line stub into a full, executable workflow for both **Minor** and **Hotfix** modes.

## Changes

**File:** `.github/agents/release-copilot-agent.agent.md` (+132, -4)

### §2.8 Step 3 (Minor Mode) — Expanded metadata update
The agent now performs a complete docs metadata update after a minor release merge:
1. **Fork detection** — checks if the user already has a fork of `MicrosoftDocs/azure-docs-sdk-dotnet` before attempting to fork
2. **Fork or sync** — syncs existing fork or creates a new one
3. **Worktree clone** — clones into `../azure-docs-sdk-dotnet-worktree` to isolate docs work from the SDK repo
4. **File update** — updates `Version` and `ServiceDirectory` fields in `metadata/latest/Microsoft.Azure.Cosmos.json`
5. **PR creation** — creates a PR to upstream matching the [established format (PR #2526)](https://github.com/MicrosoftDocs/azure-docs-sdk-dotnet/pull/2526)
6. **Cleanup** — removes the worktree clone

### §3.11 (Hotfix Mode) — Added metadata update step
Mirrors the same workflow for hotfix releases (previously had no docs update step at all).

### Quick Start Summary
Added item 11 to the agent's capability list to reflect the new docs metadata update step.

## Motivation

Previously, the metadata update was a vague 3-line guidance note. This change makes it a first-class, automated step the release agent can execute end-to-end, ensuring documentation stays in sync with every SDK release.