### PR TITLE
[Internal] Availability Strategy: Fixes outdated Cross Region Request Hedging documentation

### DIFF
--- a/docs/Cross Region Request Hedging.md
+++ b/docs/Cross Region Request Hedging.md
@@ -1,10 +1,12 @@
-# Reliability achieve low end to end latency for read request with cross region hedging
+# Cross Region Request Hedging
 
-The ability to specify a Cross Region Hedging Availability Strategy is a new feature in the Cosmos SDK that enables the sending of redundant parallel requests to multiple regions during high latency periods. This feature can lower latency and improve availability in scenarios where a particular region is slow or temporarily unavailable, but it may incur more cost in terms of request units when parallel cross-region requests are required. 
+The Cross Region Hedging Availability Strategy is a feature in the Cosmos SDK that enables the sending of redundant parallel requests to multiple regions during high latency periods. This feature can lower latency and improve availability in scenarios where a particular region is slow or temporarily unavailable, but it may incur more cost in terms of request units when parallel cross-region requests are required.
 
-When the cross region hedging strategy is enabled, the SDK will send the first request to the primary region. If there is no response from the backend before the threshold time, then the SDK will begin sending hedged requests to the regions in order of the `ApplicationPreferredRegions` list. After the first hedged request is sent out, the hedged requests will continue to be fired off one by one after waiting for the time specified in the threshold step. Once a response is received from one of the requests, the availability strategy will check to see if the result is considered final. If the result is final, then it is returned. If not, the SDK will skip the remaining threshold/threshold step time and send out the next hedged request. If all hedged requests are sent out and no final response is received, the SDK will return the last response it received. 
+When the cross region hedging strategy is enabled, the SDK will send the first request to the primary region. If there is no response from the backend before the threshold time, then the SDK will begin sending hedged requests to the regions in order of the preferred regions list. After the first hedged request is sent out, the hedged requests will continue to be fired off one by one after waiting for the time specified in the threshold step. Once a response is received from one of the requests, the availability strategy will check to see if the result is considered final. If the result is final, then it is returned. If not, the SDK will skip the remaining threshold/threshold step time and send out the next hedged request. If all hedged requests are sent out and no final response is received, the SDK will return the last response it received.
 
 The `AvailabilityStrategy` operates on the `RequestInvokerHandler` level meaning that each hedged request will go through its own [handler pipeline](https://github.com/Azure/azure-cosmos-dotnet-v3/blob/master/docs/SdkDesign.md#handler-pipeline), including the `ClientRetryPolicy`. This means that the hedged requests will be retried independently of each other. Note that the hedged requests are restricted to the region they are sent out in so no cross region retries will be made, only local retries. The primary request however, will behave as a normal request.
+
+> **Note:** Hedging requires at least two available regions. If only a single region endpoint is available, the SDK will skip hedging and send the request normally.
 
 ## APIs
 
@@ -53,10 +55,10 @@ CosmosClient client = new CosmosClient(
 //Send one request out with a more aggressive threshold
 ItemRequestOptions requestOptions = new ItemRequestOptions()
 {
-    AvailabilityStrategyOptions = AvailabilityStrategy.CrossRegionHedgingStrategy(
+    AvailabilityStrategy = AvailabilityStrategy.CrossRegionHedgingStrategy(
         threshold: TimeSpan.FromSeconds(1),
         thresholdStep: TimeSpan.FromSeconds(.5)
-     ))
+     )
 };
 ```
 
@@ -66,15 +68,15 @@ ItemRequestOptions requestOptions = new ItemRequestOptions()
 //Send one request out without an AvailabilityStrategy
 ItemRequestOptions requestOptions = new ItemRequestOptions()
 {
-    AvailabilityStrategyOptions = AvailabilityStrategy.DisabledStrategy()
+    AvailabilityStrategy = AvailabilityStrategy.DisabledStrategy()
 };
 ```
 
-When enabled at the `CosmosClient` level, the availability strategy applies to all read requests unless explicitly disabled per request: ReadItem, Queries (single and cross partition), ReadMany, and ChangeFeed.
+When enabled at the `CosmosClient` level, the availability strategy applies to all document-level read requests unless explicitly disabled per request. This includes ReadItem, Queries (single and cross partition), ReadMany, and ChangeFeed. Hedging does not apply to container, database, or other non-document resource operations.
 
 ## Hedging for Write Requests
 
-Availability strategies can also be used for write requests. This feature is not enabled by default, but can be enabled by setting the `enableMultiWriteRegionHedge` parameter to `true` when creating the `CrossRegionHedgingStrategy`. This will allow the SDK to send out hedged requests for write requests as well. This feature can only be used for accounts where multi region writes are enabled. Like read requssts, the SDK will only hedge for document requests, not container, database, or other write requests. Please note that all conflict resolution must be handled by the client application. Write request hedging otherwise preforms the same as read request hedging.
+Availability strategies can also be used for write requests. This feature is not enabled by default, but can be enabled by setting the `enableMultiWriteRegionHedge` parameter to `true` when creating the `CrossRegionHedgingStrategy`. This will allow the SDK to send out hedged requests for write requests as well. This feature can only be used for accounts where multi region writes are enabled. Like read requests, the SDK will only hedge for document requests, not container, database, or other write requests. Please note that all conflict resolution must be handled by the client application, and applications should be prepared to handle additional 409 (Conflict) and 412 (Precondition Failed) errors. Applications may also not be able to be deterministic on Create vs Replace in the case of Upsert operations. Write request hedging otherwise performs the same as read request hedging.
 
 ```csharp
 CosmosClientOptions options = new CosmosClientOptions()
@@ -96,42 +98,42 @@ CosmosClient client = new CosmosClient(
 
 ## Diagnostics
 
-In the diagnostics data there are two new areas of note `Hedge Config` and `Hedge Context` that will appear when using this feature. `Hedge Config` shows what the configured availability strategy used is, along with whether hedging for write requests are enabled. `Hedge Context` shows all the regions requests were sent to. To find what region the request was sent to, look for the `StoreResponse` in the diagnostics data. A full example of a hedged request can be seen [here](https://github.com/Azure/azure-cosmos-dotnet-v3/tree/master/Microsoft.Azure.Cosmos.Samples/Usage/Hedging/ReadRequestDiagnosticsExample.json).
+In the diagnostics data there are three areas of note that will appear when hedging occurs: `Hedge Config`, `Hedge Context`, and `Response Region`. `Hedge Config` shows the configured availability strategy parameters, including the threshold, threshold step, and whether hedging for write requests is enabled. `Hedge Context` lists all the regions that requests were sent to. `Response Region` indicates which region's response was ultimately returned to the caller. A full example of a hedged request can be seen [here](https://github.com/Azure/azure-cosmos-dotnet-v3/tree/master/Microsoft.Azure.Cosmos.Samples/Usage/Hedging/ReadRequestDiagnosticsExample.json).
 
 ```json
 "Summary": {
         "DirectCalls": {
-            "(200, 0)": 2
+            "(200, 0)": 1
         },
         "GatewayCalls": {
-            "(200, 0)": 4,
-            "(304, 0)": 1
+            "(200, 0)": 1
         }
     },
     "name": "ReadItemAsync",
-    "start datetime": "2024-10-09T21:26:22.101Z",
-    "duration in milliseconds": 1188.7136,
+    "start datetime": "2025-05-09T16:15:21.287Z",
+    "duration in milliseconds": 1131.2238,
     "data": {
         "Client Configuration": {
-            "Client Created Time Utc": "2024-10-09T21:26:22.0996575Z",
-            "MachineId": "hashedMachineName",
+            "Client Created Time Utc": "2025-05-09T16:15:19.8917662Z",
+            "MachineId": "hashedMachineName:94d755e6-4bd9-6d68-c9d4-22b4d44d5b96",
             "NumberOfClientsCreated": 1,
             "NumberOfActiveClients": 1,
             "ConnectionMode": "Direct",
-            "User Agent": "cosmos-netstandard-sdk/3.44.0|2|X64|Microsoft Windows 10.0.22631|.NET 6.0.35|L|",
+            "User Agent": "cosmos-netstandard-sdk/3.49.0|2|X64|Microsoft Windows 10.0.26100|.NET 6.0.36|L|",
             "ConnectionConfig": {
                 "gw": "(cps:50, urto:6, p:False, httpf: False)",
                 "rntbd": "(cto: 5, icto: -1, mrpc: 30, mcpe: 65535, erd: True, pr: ReuseUnicastPort)",
                 "other": "(ed:False, be:False)"
             },
-            "ConsistencyConfig": "(consistency: NotSet, prgns:[Central US, North Central US], apprgn: )",
+            "ConsistencyConfig": "(consistency: NotSet, prgns:[West US 3, West US], apprgn: )",
             "ProcessorCount": 12
         },
         "Hedge Config": "t:100ms, s:50ms, w:False",
         "Hedge Context": [
-            "Central US",
-            "North Central US"
+            "West US 3",
+            "West US"
         ],
+        "Response Region": "West US"
     }
 ```
 
@@ -181,3 +183,24 @@ graph TD
     P -- No, But this is the final hedge request --> C
     
 ```
+
+## SDK Default Hedging with Per-Partition Automatic Failover (PPAF)
+
+When Per-Partition Automatic Failover (PPAF) is enabled on the account and the client does not have an explicitly configured `AvailabilityStrategy`, the SDK will automatically enable a default hedging strategy. This default strategy uses the following thresholds:
+
+- **Threshold**: `min(1000ms, RequestTimeout / 2)`
+- **Threshold Step**: `500ms`
+- **Write Hedging**: Disabled
+
+If the request timeout is set to 0 (invalid), the SDK falls back to a default threshold of 1000ms.
+
+This SDK-default hedging strategy is only applied when no client-level `AvailabilityStrategy` is explicitly configured. If a user sets their own `AvailabilityStrategy`, it takes precedence over the PPAF default. Similarly, the SDK-default strategy is automatically removed if PPAF is later disabled on the account.
+
+## Availability Strategy Resolution Order
+
+The SDK resolves which `AvailabilityStrategy` to use in the following priority order:
+
+1. **Request-level** `RequestOptions.AvailabilityStrategy` (per-request override, highest priority)
+2. **Client-level** `CosmosClientOptions.AvailabilityStrategy` (applies to all requests)
+3. **SDK Default** (automatically applied when PPAF is enabled and no explicit strategy is configured)
+4. **None** (hedging disabled)


### PR DESCRIPTION
## Changes

Updates the Cross Region Request Hedging documentation to reflect the current SDK behavior.

### Bug Fixes
- Fixed incorrect property name: AvailabilityStrategyOptions to AvailabilityStrategy
- Fixed syntax error: extra closing parenthesis in code example
- Fixed typos: requssts to requests, preforms to performs

### Content Updates
- Updated title
- Added Response Region diagnostic field
- Updated diagnostics JSON to SDK 3.49.0
- Added PPAF default hedging section
- Added Availability Strategy resolution order
- Clarified document-level operations only
- Added multi-region requirement note
- Expanded write hedging caveats