### PR TITLE
[Internal] Client Telemetry: Fixes flaky PointSuccessOperationsTest

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/ClientTelemetry.cs
@@ -26,7 +26,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
     /// </summary>
     internal class ClientTelemetry : IDisposable
     {
-        private static readonly TimeSpan observingWindow = ClientTelemetryOptions.DefaultIntervalForTelemetryJob;
+        private static TimeSpan ObservingWindow => ClientTelemetryOptions.DefaultIntervalForTelemetryJob;
 
         private readonly ClientTelemetryProperties clientTelemetryInfo;
         private readonly ClientTelemetryProcessor processor;
@@ -119,7 +119,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                 userAgent: userAgent, 
                 connectionMode: connectionMode,
                 preferredRegions: preferredRegions,
-                aggregationIntervalInSec: (int)observingWindow.TotalSeconds);
+                aggregationIntervalInSec: (int)ObservingWindow.TotalSeconds);
 
             this.networkDataRecorder = new NetworkDataRecorder();
             this.cancellationTokenSource = new CancellationTokenSource();
@@ -141,7 +141,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
         /// <returns>Async Task</returns>
         private async Task EnrichAndSendAsync()
         {
-            DefaultTrace.TraceInformation("Telemetry Job Started with Observing window : {0}", observingWindow);
+            DefaultTrace.TraceInformation("Telemetry Job Started with Observing window : {0}", ObservingWindow);
 
             try
             {
@@ -153,7 +153,7 @@ namespace Microsoft.Azure.Cosmos.Telemetry
                         this.clientTelemetryInfo.GlobalDatabaseAccountName = accountProperties.Id;
                     }
 
-                    await Task.Delay(observingWindow, this.cancellationTokenSource.Token);
+                    await Task.Delay(ObservingWindow, this.cancellationTokenSource.Token);
 
                     this.clientTelemetryInfo.DateTimeUtc = DateTime.UtcNow.ToString(ClientTelemetryOptions.DateFormat);
                     this.clientTelemetryInfo.MachineId = VmMetadataApiHandler.GetMachineId();

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTests.cs
@@ -18,7 +18,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
     /// If you are making changes in this file please make sure you are adding similar test in <see cref="ClientTelemetryReleaseTests"/> also.
     /// </summary>
     [TestClass]
-    [TestCategory("Flaky")]
     [TestCategory("ClientTelemetryEmulator")]
     public class ClientTelemetryTests : ClientTelemetryTestsBase
     {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTestsBase.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ClientTelemetryTestsBase.cs
@@ -749,7 +749,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             HashSet<CacheRefreshInfo> cacheRefreshInfoSet = new HashSet<CacheRefreshInfo>();
             do
             {
-                this.eventSlim.Wait();
+                this.eventSlim.Wait(TimeSpan.FromSeconds(15));
+                this.eventSlim.Reset();
 
                 HashSet<OperationInfo> actualOperationSet = new HashSet<OperationInfo>();
                 HashSet<RequestInfo> requestInfoSet = new HashSet<RequestInfo>();
@@ -786,7 +787,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                         break;
                     }
 
-                    Assert.IsTrue(stopwatch.Elapsed.TotalMinutes < 1, $"The expected operation count({expectedOperationCount}) was never hit, Actual Operation Count is {actualOperationSet.Count}.  ActualInfo:{JsonConvert.SerializeObject(this.actualInfo)}");
+                    Assert.IsTrue(stopwatch.Elapsed.TotalMinutes < 2, $"The expected operation count({expectedOperationCount}) was never hit, Actual Operation Count is {actualOperationSet.Count}.  ActualInfo:{JsonConvert.SerializeObject(this.actualInfo)}");
                 }
             }
             while (localCopyOfActualInfo == null);


### PR DESCRIPTION
## Description

Fixes the flaky `PointSuccessOperationsTest` (9 failures in the last 30 days) by addressing three root causes in the telemetry test synchronization and a test-ordering hazard in production code.

## Root Causes

### 1. Busy-spin loop in `WaitAndAssert`
`ManualResetEventSlim` was never reset inside the polling loop. After the first telemetry signal, `Wait()` returned immediately every iteration, creating a tight CPU-burning spin that could starve the telemetry background task.

**Fix**: Added `eventSlim.Reset()` after each check so each iteration properly waits for a new telemetry payload.

### 2. No timeout on `eventSlim.Wait()`
If the telemetry background task failed to fire (e.g., thread pool starvation), the test hung indefinitely until the 5-minute `[Timeout]` killed it with no diagnostic message.

**Fix**: Added 15-second timeout to `eventSlim.Wait()`. Also increased the overall assertion timeout from 1 to 2 minutes for CI margin.

### 3. Static `observingWindow` capture
`ClientTelemetry.observingWindow` was `static readonly`, capturing `DefaultIntervalForTelemetryJob` (default: 10 minutes) at class-load time. If any other test loaded `ClientTelemetry` before `ClassInitialize` set the interval to 1 second, the telemetry window stayed at 10 minutes, causing guaranteed timeout.

**Fix**: Changed from `static readonly` field to a property that reads `DefaultIntervalForTelemetryJob` dynamically.

## Changes

| File | Change |
|------|--------|
| `ClientTelemetryTestsBase.cs` | 15s timeout on `Wait()`, `Reset()` after each check, 1-to-2 min overall timeout |
| `ClientTelemetry.cs` | `observingWindow` changed to `ObservingWindow` dynamic property |
| `ClientTelemetryTests.cs` | Removed `[TestCategory("Flaky")]` |

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
