### PR TITLE
[Internal] PPAF: Fixes write hedging RU amplification from PPAF cache poisoning

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ClientRetryPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/ClientRetryPolicy.cs
@@ -179,12 +179,6 @@ namespace Microsoft.Azure.Cosmos
                 return shouldRetryResult;
             }
 
-            // When a hedged PPAF write request succeeds (2xx), update the partition-level
-            // failover cache to mark the primary endpoint as unavailable. This ensures
-            // future requests for this partition route directly to the successful region
-            // instead of going through the primary and hedging again.
-            this.TryUpdatePPAFCacheOnSuccessfulHedge(cosmosResponseMessage);
-
             // Today, the only scenario where we would treat a throttling (429) exception as service unavailable is when we
             // get 429 (TooManyRequests) with sub status code 3092 (System Resource Not Available). Note that this is applicable
             // for write requests targeted to a multiple master account. In such case, the 429/3092 will be treated as 503. The
@@ -633,45 +627,6 @@ namespace Microsoft.Azure.Cosmos
                 && this.documentServiceRequest.Properties.TryGetValue(
                     CrossRegionHedgingAvailabilityStrategy.SuppressPPAFCacheUpdateKey, out object value)
                 && value is true;
-        }
-
-        /// <summary>
-        /// When a hedged PPAF write request receives a successful response (status &lt; 400),
-        /// updates the partition-level failover cache to mark the primary write endpoint as
-        /// unavailable. This causes future requests for the same partition to route directly
-        /// to the region where the hedge succeeded, avoiding unnecessary hedging round-trips.
-        /// </summary>
-        /// <param name="response">The response message from the hedged request.</param>
-        private void TryUpdatePPAFCacheOnSuccessfulHedge(ResponseMessage response)
-        {
-            if (response == null
-                || (int)response.StatusCode >= (int)HttpStatusCode.BadRequest
-                || this.documentServiceRequest?.Properties == null)
-            {
-                return;
-            }
-
-            if (!this.documentServiceRequest.Properties.TryGetValue(
-                    CrossRegionHedgingAvailabilityStrategy.PPAFHedgePrimaryEndpointKey, out object primaryEndpointObj)
-                || primaryEndpointObj is not Uri primaryEndpoint)
-            {
-                return;
-            }
-
-            // Temporarily set the request's routed endpoint to the primary so that
-            // TryMarkEndpointUnavailableForPartitionKeyRange records the primary as
-            // the failed location, routing future requests to the successful hedge region.
-            Uri originalEndpoint = this.documentServiceRequest.RequestContext?.LocationEndpointToRoute;
-            this.documentServiceRequest.RequestContext.RouteToLocation(primaryEndpoint);
-
-            this.partitionKeyRangeLocationCache.TryMarkEndpointUnavailableForPartitionKeyRange(
-                this.documentServiceRequest);
-
-            // Restore the original endpoint for clean request state
-            if (originalEndpoint != null)
-            {
-                this.documentServiceRequest.RequestContext.RouteToLocation(originalEndpoint);
-            }
         }
 
         private sealed class RetryContext

--- a/Microsoft.Azure.Cosmos/src/ClientRetryPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/ClientRetryPolicy.cs
@@ -144,7 +144,8 @@ namespace Microsoft.Azure.Cosmos
                     this.failoverRetryCount,
                     this.locationEndpoint?.ToString() ?? string.Empty);
 
-                if (this.partitionKeyRangeLocationCache.IncrementRequestFailureCounterAndCheckIfPartitionCanFailover(
+                if (!this.ShouldSuppressPPAFCacheUpdate()
+                    && this.partitionKeyRangeLocationCache.IncrementRequestFailureCounterAndCheckIfPartitionCanFailover(
                         this.documentServiceRequest))
                 {
                     // In the event of a (ppaf + write operation) or (ppcb + read or multi-master write operation) getting timed
@@ -270,7 +271,8 @@ namespace Microsoft.Azure.Cosmos
                 && subStatusCode == SubStatusCodes.WriteForbidden)
             {
                 // It's a write forbidden so it safe to retry
-                if (this.partitionKeyRangeLocationCache.TryMarkEndpointUnavailableForPartitionKeyRange(
+                if (!this.ShouldSuppressPPAFCacheUpdate()
+                    && this.partitionKeyRangeLocationCache.TryMarkEndpointUnavailableForPartitionKeyRange(
                      this.documentServiceRequest))
                 {
                     return ShouldRetryResult.RetryAfter(TimeSpan.Zero);
@@ -553,6 +555,7 @@ namespace Microsoft.Azure.Cosmos
             bool isSystemResourceUnavailableForWrite)
         {
             if (this.documentServiceRequest != null
+                && !this.ShouldSuppressPPAFCacheUpdate()
                 && (isSystemResourceUnavailableForWrite
                 || this.IsRequestEligibleForPerPartitionAutomaticFailover()
                 || this.IsRequestEligibleForPartitionLevelCircuitBreaker()))
@@ -608,6 +611,22 @@ namespace Microsoft.Azure.Cosmos
         {
             return this.partitionKeyRangeLocationCache.IsRequestEligibleForPartitionLevelCircuitBreaker(this.documentServiceRequest)
                         && this.partitionKeyRangeLocationCache.IncrementRequestFailureCounterAndCheckIfPartitionCanFailover(this.documentServiceRequest);
+        }
+
+        /// <summary>
+        /// Checks whether the current request is a PPAF write hedge request that should
+        /// suppress partition-level failover cache updates. Hedged (non-primary) write
+        /// requests set <see cref="CrossRegionHedgingAvailabilityStrategy.SuppressPPAFCacheUpdateKey"/>
+        /// on the request properties to prevent transient errors from poisoning the PPAF
+        /// cache and causing cascading hedge requests that amplify RU consumption.
+        /// </summary>
+        /// <returns>True if PPAF cache updates should be suppressed for this request.</returns>
+        private bool ShouldSuppressPPAFCacheUpdate()
+        {
+            return this.documentServiceRequest?.Properties != null
+                && this.documentServiceRequest.Properties.TryGetValue(
+                    CrossRegionHedgingAvailabilityStrategy.SuppressPPAFCacheUpdateKey, out object value)
+                && value is true;
         }
 
         private sealed class RetryContext

--- a/Microsoft.Azure.Cosmos/src/ClientRetryPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/ClientRetryPolicy.cs
@@ -179,6 +179,12 @@ namespace Microsoft.Azure.Cosmos
                 return shouldRetryResult;
             }
 
+            // When a hedged PPAF write request succeeds (2xx), update the partition-level
+            // failover cache to mark the primary endpoint as unavailable. This ensures
+            // future requests for this partition route directly to the successful region
+            // instead of going through the primary and hedging again.
+            this.TryUpdatePPAFCacheOnSuccessfulHedge(cosmosResponseMessage);
+
             // Today, the only scenario where we would treat a throttling (429) exception as service unavailable is when we
             // get 429 (TooManyRequests) with sub status code 3092 (System Resource Not Available). Note that this is applicable
             // for write requests targeted to a multiple master account. In such case, the 429/3092 will be treated as 503. The
@@ -627,6 +633,45 @@ namespace Microsoft.Azure.Cosmos
                 && this.documentServiceRequest.Properties.TryGetValue(
                     CrossRegionHedgingAvailabilityStrategy.SuppressPPAFCacheUpdateKey, out object value)
                 && value is true;
+        }
+
+        /// <summary>
+        /// When a hedged PPAF write request receives a successful response (status &lt; 400),
+        /// updates the partition-level failover cache to mark the primary write endpoint as
+        /// unavailable. This causes future requests for the same partition to route directly
+        /// to the region where the hedge succeeded, avoiding unnecessary hedging round-trips.
+        /// </summary>
+        /// <param name="response">The response message from the hedged request.</param>
+        private void TryUpdatePPAFCacheOnSuccessfulHedge(ResponseMessage response)
+        {
+            if (response == null
+                || (int)response.StatusCode >= (int)HttpStatusCode.BadRequest
+                || this.documentServiceRequest?.Properties == null)
+            {
+                return;
+            }
+
+            if (!this.documentServiceRequest.Properties.TryGetValue(
+                    CrossRegionHedgingAvailabilityStrategy.PPAFHedgePrimaryEndpointKey, out object primaryEndpointObj)
+                || primaryEndpointObj is not Uri primaryEndpoint)
+            {
+                return;
+            }
+
+            // Temporarily set the request's routed endpoint to the primary so that
+            // TryMarkEndpointUnavailableForPartitionKeyRange records the primary as
+            // the failed location, routing future requests to the successful hedge region.
+            Uri originalEndpoint = this.documentServiceRequest.RequestContext?.LocationEndpointToRoute;
+            this.documentServiceRequest.RequestContext.RouteToLocation(primaryEndpoint);
+
+            this.partitionKeyRangeLocationCache.TryMarkEndpointUnavailableForPartitionKeyRange(
+                this.documentServiceRequest);
+
+            // Restore the original endpoint for clean request state
+            if (originalEndpoint != null)
+            {
+                this.documentServiceRequest.RequestContext.RouteToLocation(originalEndpoint);
+            }
         }
 
         private sealed class RetryContext

--- a/Microsoft.Azure.Cosmos/src/Routing/AvailabilityStrategy/CrossRegionHedgingAvailabilityStrategy.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/AvailabilityStrategy/CrossRegionHedgingAvailabilityStrategy.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Azure.Cosmos
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Core.Trace;
     using Microsoft.Azure.Cosmos.Diagnostics;
+    using Microsoft.Azure.Cosmos.Routing;
     using Microsoft.Azure.Cosmos.Tracing;
     using Microsoft.Azure.Documents;
 
@@ -214,7 +215,8 @@ namespace Microsoft.Azure.Cosmos
                                         requestNumber: requestNumber,
                                         trace: trace,
                                         hedgeRequestsCancellationTokenSource: hedgeRequestsCancellationTokenSource,
-                                        ppafPrimaryWriteEndpoint: ppafPrimaryWriteEndpoint);
+                                        ppafPrimaryWriteEndpoint: ppafPrimaryWriteEndpoint,
+                                        partitionKeyRangeLocationCache: client.DocumentClient.PartitionKeyRangeLocation);
 
                                 requestTasks.Add(requestTask);
                                 requestTasks.Add(hedgeTimer);
@@ -347,7 +349,8 @@ namespace Microsoft.Azure.Cosmos
             int requestNumber,
             ITrace trace,
             CancellationTokenSource hedgeRequestsCancellationTokenSource,
-            Uri ppafPrimaryWriteEndpoint)
+            Uri ppafPrimaryWriteEndpoint,
+            GlobalPartitionEndpointManager partitionKeyRangeLocationCache)
         {
             RequestMessage clonedRequest;
 
@@ -384,7 +387,8 @@ namespace Microsoft.Azure.Cosmos
                     clonedRequest,
                     hedgeRegions.ElementAt(requestNumber),
                     hedgeRequestsCancellationTokenSource, 
-                    trace);
+                    trace,
+                    partitionKeyRangeLocationCache);
             }
         }
 
@@ -393,11 +397,23 @@ namespace Microsoft.Azure.Cosmos
             RequestMessage request,
             string targetRegionName,
             CancellationTokenSource hedgeRequestsCancellationTokenSource,
-            ITrace trace)
+            ITrace trace,
+            GlobalPartitionEndpointManager partitionKeyRangeLocationCache)
         {
             try
             {
                 ResponseMessage response = await sender.Invoke(request, hedgeRequestsCancellationTokenSource.Token);
+
+                // ShouldRetryAsync is only called on error responses (AbstractRetryHandler
+                // short-circuits on success), so the PPAF cache update for successful hedged
+                // writes must happen here, outside the retry policy pipeline.
+                if (response.IsSuccessStatusCode)
+                {
+                    CrossRegionHedgingAvailabilityStrategy.TryUpdatePPAFCacheOnSuccessfulHedge(
+                        request,
+                        partitionKeyRangeLocationCache);
+                }
+
                 if (IsFinalResult((int)response.StatusCode, (int)response.Headers.SubStatusCode))
                 {
                     if (!hedgeRequestsCancellationTokenSource.IsCancellationRequested)
@@ -448,6 +464,48 @@ namespace Microsoft.Azure.Cosmos
             //after enforcing the consistency model
             //All other errors should be treated as possibly transient errors
             return statusCode == (int)HttpStatusCode.NotFound && subStatusCode == (int)SubStatusCodes.Unknown;
+        }
+
+        /// <summary>
+        /// When a hedged PPAF write request receives a successful response, updates the
+        /// partition-level failover cache to mark the primary write endpoint as unavailable.
+        /// This causes future requests for the same partition to route directly to the region
+        /// where the hedge succeeded, avoiding unnecessary hedging round-trips.
+        /// This must be called from the hedging strategy (not from ClientRetryPolicy.ShouldRetryAsync)
+        /// because AbstractRetryHandler short-circuits on success and never invokes ShouldRetryAsync
+        /// for successful responses.
+        /// </summary>
+        private static void TryUpdatePPAFCacheOnSuccessfulHedge(
+            RequestMessage request,
+            GlobalPartitionEndpointManager partitionKeyRangeLocationCache)
+        {
+            if (request?.DocumentServiceRequest?.Properties == null
+                || partitionKeyRangeLocationCache == null)
+            {
+                return;
+            }
+
+            if (!request.DocumentServiceRequest.Properties.TryGetValue(
+                    CrossRegionHedgingAvailabilityStrategy.PPAFHedgePrimaryEndpointKey, out object primaryEndpointObj)
+                || primaryEndpointObj is not Uri primaryEndpoint)
+            {
+                return;
+            }
+
+            // Temporarily set the request's routed endpoint to the primary so that
+            // TryMarkEndpointUnavailableForPartitionKeyRange records the primary as
+            // the failed location, routing future requests to the successful hedge region.
+            Uri originalEndpoint = request.DocumentServiceRequest.RequestContext?.LocationEndpointToRoute;
+            request.DocumentServiceRequest.RequestContext.RouteToLocation(primaryEndpoint);
+
+            partitionKeyRangeLocationCache.TryMarkEndpointUnavailableForPartitionKeyRange(
+                request.DocumentServiceRequest);
+
+            // Restore the original endpoint for clean request state
+            if (originalEndpoint != null)
+            {
+                request.DocumentServiceRequest.RequestContext.RouteToLocation(originalEndpoint);
+            }
         }
 
         private sealed class HedgingResponse

--- a/Microsoft.Azure.Cosmos/src/Routing/AvailabilityStrategy/CrossRegionHedgingAvailabilityStrategy.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/AvailabilityStrategy/CrossRegionHedgingAvailabilityStrategy.cs
@@ -30,9 +30,18 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Internal property key set on hedged (non-primary) write requests when PPAF is enabled.
         /// When present, the ClientRetryPolicy will skip updating the per-partition failover cache
-        /// to prevent speculative hedge responses from poisoning the cache and causing RU amplification.
+        /// on error responses to prevent speculative hedge responses from poisoning the cache and
+        /// causing RU amplification. On successful (2xx) responses, the cache IS updated to record
+        /// that the primary region should be failed over for this partition.
         /// </summary>
         internal const string SuppressPPAFCacheUpdateKey = "x-ms-suppress-ppaf-cache-update";
+
+        /// <summary>
+        /// Internal property key storing the primary write endpoint URI on hedged PPAF write requests.
+        /// When a hedged request succeeds, the ClientRetryPolicy uses this to mark the primary endpoint
+        /// as unavailable for the partition, so future requests route directly to the successful region.
+        /// </summary>
+        internal const string PPAFHedgePrimaryEndpointKey = "x-ms-ppaf-hedge-primary-endpoint";
 
         /// <summary>
         /// Latency threshold which activates the first region hedging 
@@ -178,6 +187,13 @@ namespace Microsoft.Azure.Cosmos
 
                     List<Task> requestTasks = new List<Task>(hedgeRegions.Count + 1);
 
+                    // Capture the primary write endpoint for PPAF write hedging. When a hedged
+                    // request succeeds, this is used to mark the primary as unavailable in the
+                    // PPAF cache so future requests route directly to the successful region.
+                    Uri ppafPrimaryWriteEndpoint = this.ppafEnabled && !isReadRequest
+                        ? client.DocumentClient.GlobalEndpointManager.WriteEndpoints[0]
+                        : null;
+
                     HedgingResponse hedgeResponse = null;
 
                     //Send out hedged requests
@@ -197,7 +213,8 @@ namespace Microsoft.Azure.Cosmos
                                         hedgeRegions: hedgeRegions,
                                         requestNumber: requestNumber,
                                         trace: trace,
-                                        hedgeRequestsCancellationTokenSource: hedgeRequestsCancellationTokenSource);
+                                        hedgeRequestsCancellationTokenSource: hedgeRequestsCancellationTokenSource,
+                                        ppafPrimaryWriteEndpoint: ppafPrimaryWriteEndpoint);
 
                                 requestTasks.Add(requestTask);
                                 requestTasks.Add(hedgeTimer);
@@ -329,7 +346,8 @@ namespace Microsoft.Azure.Cosmos
             IReadOnlyCollection<string> hedgeRegions,
             int requestNumber,
             ITrace trace,
-            CancellationTokenSource hedgeRequestsCancellationTokenSource)
+            CancellationTokenSource hedgeRequestsCancellationTokenSource,
+            Uri ppafPrimaryWriteEndpoint)
         {
             RequestMessage clonedRequest;
 
@@ -347,13 +365,17 @@ namespace Microsoft.Azure.Cosmos
                     clonedRequest.RequestOptions.ExcludeRegions = excludeRegions;
 
                     // For PPAF write hedging: suppress partition-level failover cache updates
-                    // on hedged (non-primary) requests. Without this, hedged request errors
+                    // on hedged (non-primary) error responses. Without this, hedged request errors
                     // poison the PPAF cache, causing all subsequent requests for the same
                     // partition to think the primary region failed over—triggering more hedging
-                    // and amplifying RU consumption.
-                    if (this.ppafEnabled && !OperationTypeExtensions.IsReadOperation(request.OperationType))
+                    // and amplifying RU consumption. On success, the primary endpoint is used
+                    // to update the cache so future requests route directly to the successful region.
+                    if (this.ppafEnabled
+                        && !OperationTypeExtensions.IsReadOperation(request.OperationType)
+                        && ppafPrimaryWriteEndpoint != null)
                     {
                         clonedRequest.Properties[CrossRegionHedgingAvailabilityStrategy.SuppressPPAFCacheUpdateKey] = true;
+                        clonedRequest.Properties[CrossRegionHedgingAvailabilityStrategy.PPAFHedgePrimaryEndpointKey] = ppafPrimaryWriteEndpoint;
                     }
                 }
 

--- a/Microsoft.Azure.Cosmos/src/Routing/AvailabilityStrategy/CrossRegionHedgingAvailabilityStrategy.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/AvailabilityStrategy/CrossRegionHedgingAvailabilityStrategy.cs
@@ -468,9 +468,7 @@ namespace Microsoft.Azure.Cosmos
 
         /// <summary>
         /// When a hedged PPAF write request receives a successful response, updates the
-        /// partition-level failover cache to mark the primary write endpoint as unavailable.
-        /// This causes future requests for the same partition to route directly to the region
-        /// where the hedge succeeded, avoiding unnecessary hedging round-trips.
+        /// partition-level failover cache to route directly to the successful region.
         /// This must be called from the hedging strategy (not from ClientRetryPolicy.ShouldRetryAsync)
         /// because AbstractRetryHandler short-circuits on success and never invokes ShouldRetryAsync
         /// for successful responses.
@@ -485,6 +483,12 @@ namespace Microsoft.Azure.Cosmos
                 return;
             }
 
+            // Only update the PPAF write cache for write requests
+            if (OperationTypeExtensions.IsReadOperation(request.OperationType))
+            {
+                return;
+            }
+
             if (!request.DocumentServiceRequest.Properties.TryGetValue(
                     CrossRegionHedgingAvailabilityStrategy.PPAFHedgePrimaryEndpointKey, out object primaryEndpointObj)
                 || primaryEndpointObj is not Uri primaryEndpoint)
@@ -492,20 +496,21 @@ namespace Microsoft.Azure.Cosmos
                 return;
             }
 
-            // Temporarily set the request's routed endpoint to the primary so that
-            // TryMarkEndpointUnavailableForPartitionKeyRange records the primary as
-            // the failed location, routing future requests to the successful hedge region.
-            Uri originalEndpoint = request.DocumentServiceRequest.RequestContext?.LocationEndpointToRoute;
-            request.DocumentServiceRequest.RequestContext.RouteToLocation(primaryEndpoint);
-
-            partitionKeyRangeLocationCache.TryMarkEndpointUnavailableForPartitionKeyRange(
-                request.DocumentServiceRequest);
-
-            // Restore the original endpoint for clean request state
-            if (originalEndpoint != null)
+            // The successful endpoint is the one the hedged request was routed to
+            Uri successfulEndpoint = request.DocumentServiceRequest.RequestContext?.LocationEndpointToRoute;
+            if (successfulEndpoint == null)
             {
-                request.DocumentServiceRequest.RequestContext.RouteToLocation(originalEndpoint);
+                return;
             }
+
+            // Directly set the cache to point to the successful endpoint rather than
+            // marking the primary as failed and iterating sequentially. This ensures
+            // that in multi-region scenarios (e.g., Primary=A, Read=B, Read=C where C
+            // succeeds), the cache points to C, not B.
+            partitionKeyRangeLocationCache.TrySetPartitionLevelLocationOverrideForSuccessfulHedge(
+                request.DocumentServiceRequest,
+                primaryEndpoint,
+                successfulEndpoint);
         }
 
         private sealed class HedgingResponse

--- a/Microsoft.Azure.Cosmos/src/Routing/AvailabilityStrategy/CrossRegionHedgingAvailabilityStrategy.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/AvailabilityStrategy/CrossRegionHedgingAvailabilityStrategy.cs
@@ -28,6 +28,13 @@ namespace Microsoft.Azure.Cosmos
         private const string ResponseRegion = "Response Region";
 
         /// <summary>
+        /// Internal property key set on hedged (non-primary) write requests when PPAF is enabled.
+        /// When present, the ClientRetryPolicy will skip updating the per-partition failover cache
+        /// to prevent speculative hedge responses from poisoning the cache and causing RU amplification.
+        /// </summary>
+        internal const string SuppressPPAFCacheUpdateKey = "x-ms-suppress-ppaf-cache-update";
+
+        /// <summary>
         /// Latency threshold which activates the first region hedging 
         /// </summary>
         public TimeSpan Threshold { get; private set; }
@@ -338,6 +345,16 @@ namespace Microsoft.Azure.Cosmos
                     List<string> excludeRegions = new List<string>(hedgeRegions);
                     excludeRegions.RemoveAt(requestNumber);
                     clonedRequest.RequestOptions.ExcludeRegions = excludeRegions;
+
+                    // For PPAF write hedging: suppress partition-level failover cache updates
+                    // on hedged (non-primary) requests. Without this, hedged request errors
+                    // poison the PPAF cache, causing all subsequent requests for the same
+                    // partition to think the primary region failed over—triggering more hedging
+                    // and amplifying RU consumption.
+                    if (this.ppafEnabled && !OperationTypeExtensions.IsReadOperation(request.OperationType))
+                    {
+                        clonedRequest.Properties[CrossRegionHedgingAvailabilityStrategy.SuppressPPAFCacheUpdateKey] = true;
+                    }
                 }
 
                 return await this.RequestSenderAndResultCheckAsync(

--- a/Microsoft.Azure.Cosmos/src/Routing/GlobalPartitionEndpointManager.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GlobalPartitionEndpointManager.cs
@@ -26,6 +26,21 @@ namespace Microsoft.Azure.Cosmos.Routing
             DocumentServiceRequest request);
 
         /// <summary>
+        /// Directly sets the partition-level write failover cache to route to a known successful
+        /// endpoint. Used by the hedging strategy when a hedged write succeeds at a non-primary
+        /// region, so that future requests for the same partition route directly to that region
+        /// rather than iterating through endpoints sequentially.
+        /// </summary>
+        /// <param name="request">The document service request containing partition key range context.</param>
+        /// <param name="primaryEndpoint">The primary write endpoint that should be marked as failed.</param>
+        /// <param name="successfulEndpoint">The endpoint where the hedged write succeeded.</param>
+        /// <returns>True if the cache was updated, false otherwise.</returns>
+        public abstract bool TrySetPartitionLevelLocationOverrideForSuccessfulHedge(
+            DocumentServiceRequest request,
+            Uri primaryEndpoint,
+            Uri successfulEndpoint);
+
+        /// <summary>
         /// Increments the failure counter for the specified partition and checks if the partition can fail over.
         /// This method is used to determine if a partition should be failed over based on the number of request failures.
         /// </summary>

--- a/Microsoft.Azure.Cosmos/src/Routing/GlobalPartitionEndpointManagerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GlobalPartitionEndpointManagerCore.cs
@@ -208,6 +208,51 @@ namespace Microsoft.Azure.Cosmos.Routing
         }
 
         /// <inheritdoc/>
+        public override bool TrySetPartitionLevelLocationOverrideForSuccessfulHedge(
+            DocumentServiceRequest request,
+            Uri primaryEndpoint,
+            Uri successfulEndpoint)
+        {
+            if (!this.IsRequestEligibleForPartitionFailover(
+                request,
+                shouldValidateFailedLocation: false,
+                out PartitionKeyRange? partitionKeyRange,
+                out Uri? _))
+            {
+                return false;
+            }
+
+            if (partitionKeyRange == null
+                || primaryEndpoint == null
+                || successfulEndpoint == null)
+            {
+                return false;
+            }
+
+            if (!this.IsRequestEligibleForPerPartitionAutomaticFailover(request))
+            {
+                return false;
+            }
+
+            PartitionKeyRangeFailoverInfo partitionFailover = this.PartitionKeyRangeToLocationForWrite.Value.GetOrAdd(
+                partitionKeyRange,
+                (_) => new PartitionKeyRangeFailoverInfo(
+                    request.RequestContext.ResolvedCollectionRid,
+                    primaryEndpoint));
+
+            partitionFailover.SetLocationOnSuccess(primaryEndpoint, successfulEndpoint);
+
+            DefaultTrace.TraceInformation(
+                "Partition level override set directly to successful hedge region for {0}. PartitionKeyRange: {1}, primaryEndpoint: {2}, successfulEndpoint: {3}",
+                request.OperationType,
+                partitionKeyRange,
+                primaryEndpoint,
+                successfulEndpoint);
+
+            return true;
+        }
+
+        /// <inheritdoc/>
         public override bool IncrementRequestFailureCounterAndCheckIfPartitionCanFailover(
             DocumentServiceRequest request)
         {
@@ -702,6 +747,20 @@ namespace Microsoft.Azure.Cosmos.Routing
                 }
 
                 return false;
+            }
+
+            /// <summary>
+            /// Directly sets the current failover location to a known successful endpoint.
+            /// Marks the primary endpoint as failed so sequential failover logic won't
+            /// circle back to it. Used when a hedged write succeeds at a specific region.
+            /// </summary>
+            public void SetLocationOnSuccess(Uri failedLocation, Uri successfulLocation)
+            {
+                lock (this.FailedLocations)
+                {
+                    this.FailedLocations[failedLocation] = DateTime.UtcNow;
+                    this.Current = successfulLocation;
+                }
             }
 
             public bool CanCircuitBreakerTriggerPartitionFailOver(

--- a/Microsoft.Azure.Cosmos/src/Routing/GlobalPartitionEndpointManagerNoOp.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/GlobalPartitionEndpointManagerNoOp.cs
@@ -35,6 +35,14 @@ namespace Microsoft.Azure.Cosmos.Routing
             return false;
         }
 
+        public override bool TrySetPartitionLevelLocationOverrideForSuccessfulHedge(
+            DocumentServiceRequest request,
+            Uri primaryEndpoint,
+            Uri successfulEndpoint)
+        {
+            return false;
+        }
+
         public override bool IsRequestEligibleForPartitionLevelCircuitBreaker(DocumentServiceRequest request)
         {
             return false;


### PR DESCRIPTION
## Problem

When PPAF write detection hedging is enabled, there is a **massive spike in write RUs** caused by a cascading cache-poisoning feedback loop in the `PartitionKeyRangeToLocationForWrite` cache.

### Components Involved

| Component | File | Purpose |
|-----------|------|---------|
| **CrossRegionHedgingAvailabilityStrategy** | `src/Routing/AvailabilityStrategy/CrossRegionHedgingAvailabilityStrategy.cs` | Orchestrates sending speculative hedge requests to alternate regions |
| **ClientRetryPolicy** | `src/ClientRetryPolicy.cs` | Handles retry/failover logic and updates the partition-level failover cache |
| **GlobalPartitionEndpointManagerCore** | `src/Routing/GlobalPartitionEndpointManagerCore.cs` | Maintains per-partition failover state in `PartitionKeyRangeToLocationForWrite` |
| **GlobalEndpointManager** | `src/Routing/GlobalEndpointManager.cs` | Routes requests to the correct regional endpoint |

### Cache Poisoning Cascade (Before Fix)

```mermaid
sequenceDiagram
    participant App as Application
    participant Hedge as Hedging Strategy
    participant CRP_P as ClientRetryPolicy (Primary)
    participant CRP_H as ClientRetryPolicy (Hedge)
    participant GPEM as PPAF Cache (PartitionKeyRangeToLocationForWrite)
    participant Primary as Primary Region
    participant ReadRegion as Read Region

    App->>Hedge: CreateItemAsync(item) for Partition P
    
    rect rgb(200, 255, 200)
        Note over Hedge: Request #0 (Primary)
        Hedge->>CRP_P: Send to Primary Region
        CRP_P->>Primary: Write request
    end

    Note over Hedge: Threshold exceeded...

    rect rgb(255, 200, 200)
        Note over Hedge: Request #1 (Hedge)
        Hedge->>CRP_H: Send to Read Region (with ExcludeRegions)
        CRP_H->>ReadRegion: Write request (hedged)
        ReadRegion-->>CRP_H: 403 WriteForbidden
        CRP_H->>GPEM: TryMarkEndpointUnavailableForPartitionKeyRange()
        Note over GPEM: Cache POISONED! Partition P marked as failover
    end

    Primary-->>CRP_P: 201 Created
    CRP_P-->>Hedge: Success (primary wins)
    Hedge-->>App: 201 Created

    Note over App,GPEM: BUT THE CACHE IS NOW POISONED!

    App->>Hedge: CreateItemAsync(item2) for Partition P
    Hedge->>GPEM: TryAddPartitionLevelLocationOverride()
    Note over GPEM: Override found! Route to Read Region
    Hedge->>CRP_P: Send to Read Region (re-routed)
    CRP_P->>ReadRegion: Write request
    ReadRegion-->>CRP_P: 403 WriteForbidden
    CRP_P->>GPEM: TryMarkEndpointUnavailableForPartitionKeyRange()
    Note over GPEM: Cache updated AGAIN!
    
    Note over App,GPEM: CASCADING FAILURE LOOP - Every request for Partition P hedges, updates cache, more hedging
```

### Cascade Mechanism (Before Fix)

The cascade works through three code paths in `ClientRetryPolicy.cs`:

1. **408 RequestTimeout**: `TryMarkEndpointUnavailableForPkRange()` calls `TryMarkEndpointUnavailableForPartitionKeyRange()`
2. **403 WriteForbidden**: Direct call to `TryMarkEndpointUnavailableForPartitionKeyRange()` — the most critical path since hedged writes to read regions will always get WriteForbidden
3. **OperationCanceledException**: When hedged requests are cancelled, `IncrementRequestFailureCounterAndCheckIfPartitionCanFailover()` then `TryMarkEndpointUnavailableForPartitionKeyRange()`

```mermaid
flowchart TD
    A["Write Request Arrives for Partition P"] --> B{"PPAF Cache has override for Partition P?"}
    B -- "No (first request)" --> C["Route to Primary Region"]
    B -- "Yes (poisoned!)" --> D["Route to Failover Region"]
    
    C --> E{"Primary responds before threshold?"}
    E -- "Yes" --> F["Return 201"]
    E -- "No" --> G["Spawn Hedge Request to Read Region"]
    
    G --> H["Hedge hits Read Region"]
    H --> I{"Read Region Response"}
    I -- "403 WriteForbidden" --> J["CRP calls TryMarkEndpointUnavailable"]
    I -- "408 Timeout" --> J
    I -- "Cancelled" --> K["CRP calls IncrementFailureCounter"]
    K --> J
    
    J --> L["PPAF Cache Updated: Partition P failover"]
    L --> M["Next request for P sees cache override"]
    M --> D
    
    D --> N["Request goes to non-primary region"]
    N --> O["Gets error or hedged"]
    O --> J
    
    style J fill:#ff6666,stroke:#333
    style L fill:#ff9999,stroke:#333
    style M fill:#ffcccc,stroke:#333
    style D fill:#ffcccc,stroke:#333
```

## Root Cause

Hedged (non-primary) write requests go through the same `ClientRetryPolicy` pipeline as the primary request. The PPAF partition-level failover cache (`GlobalPartitionEndpointManagerCore.PartitionKeyRangeToLocationForWrite`) was being updated indiscriminately by both primary and hedged request error paths. Since hedged writes to read regions always produce errors (403/WriteForbidden), every hedge poisons the cache, causing subsequent requests to be re-routed, triggering more hedging — an exponential RU amplification loop.

## Fix

The fix uses a **dual-behavior property flag** mechanism on hedged requests:

- **On errors** (408, 503, 403/WriteForbidden, cancellation): **SUPPRESS** cache updates to prevent poisoning
- **On success** (2xx like 201 Created): **DIRECTLY SET** the cache to the successful endpoint, so future requests route to the exact region that succeeded

### Implementation

1. **`CrossRegionHedgingAvailabilityStrategy`**: Captures the primary write endpoint before the hedge loop. For hedged (non-primary) write requests, sets two properties:
   - `SuppressPPAFCacheUpdateKey` — tells `ClientRetryPolicy` to skip error-path cache updates
   - `PPAFHedgePrimaryEndpointKey` — stores the primary write endpoint URI for success-path cache updates

2. **`ClientRetryPolicy`**:
   - `ShouldSuppressPPAFCacheUpdate()` guards three error paths (408 timeout, 403/WriteForbidden, OperationCanceledException) to prevent cache poisoning

3. **Success-path cache update** (in `CrossRegionHedgingAvailabilityStrategy.RequestSenderAndResultCheckAsync`):
   - `TryUpdatePPAFCacheOnSuccessfulHedge()` is called **after the full pipeline completes** for successful write responses
   - Calls `TrySetPartitionLevelLocationOverrideForSuccessfulHedge()` — a new API on `GlobalPartitionEndpointManagerCore` that **directly sets** the cache to point to the successful endpoint
   - Explicit write-only guard prevents read requests from triggering PPAF write cache updates
   - **Why this lives in the hedging strategy, not ClientRetryPolicy**: `AbstractRetryHandler.ExecuteHttpRequestAsync` short-circuits on success responses and never calls `ShouldRetryAsync`, making any success-path logic in CRP dead code

4. **`GlobalPartitionEndpointManagerCore.TrySetPartitionLevelLocationOverrideForSuccessfulHedge()`**:
   - A new API that directly targets the cache to a known successful endpoint
   - Calls `PartitionKeyRangeFailoverInfo.SetLocationOnSuccess()` which sets `Current` to the successful endpoint and marks the primary as failed
   - Unlike `TryMarkEndpointUnavailableForPartitionKeyRange` (which iterates endpoints sequentially via `TryMoveNextLocation`), this method goes directly to the known-good endpoint

### Why direct targeting instead of sequential iteration?

`TryMarkEndpointUnavailableForPartitionKeyRange` -> `TryMoveNextLocation` iterates through `AccountReadEndpoints` in order, picking the first non-failed endpoint. In a 3-region scenario (Primary=A, Read=B, Read=C) where the hedge to region C succeeds, the sequential approach would mark A as failed and pick **B** (the next in the list), NOT **C** (the region that actually succeeded). The new `TrySetPartitionLevelLocationOverrideForSuccessfulHedge` skips iteration entirely and points the cache directly at **C**.

### Fix Flow Diagram (3-Region Scenario: After Fix)

```mermaid
sequenceDiagram
    participant App as Application
    participant Hedge as Hedging Strategy
    participant CRP as ClientRetryPolicy
    participant GPEM as PPAF Cache
    participant A as Primary Region (A)
    participant B as Read Region (B)
    participant C as Read Region (C)

    App->>Hedge: CreateItemAsync(item) for Partition P

    rect rgb(200, 255, 200)
        Note over Hedge: Request #0 (Primary) - NO suppress flag
        Hedge->>CRP: Send to Primary (A)
        CRP->>A: Write request
    end

    Note over Hedge: Threshold exceeded...

    rect rgb(255, 230, 230)
        Note over Hedge: Request #1 (Hedge to B) - WITH suppress flag
        Hedge->>CRP: Send to Read Region (B)
        CRP->>B: Write request (hedged)
        B-->>CRP: 403 WriteForbidden
        Note over CRP: ShouldSuppressPPAFCacheUpdate() = true
        Note over CRP: Cache update SKIPPED — no poisoning
        CRP-->>Hedge: 403 (non-final, continue hedging)
    end

    Note over Hedge: Step threshold exceeded...

    rect rgb(200, 200, 255)
        Note over Hedge: Request #2 (Hedge to C) - WITH suppress flag + primary endpoint
        Hedge->>CRP: Send to Read Region (C)
        CRP->>C: Write request (hedged)
        C-->>CRP: 201 Created
        Note over CRP: IsSuccessStatusCode → return immediately (no ShouldRetryAsync call)
        CRP-->>Hedge: 201 Created
        Note over Hedge: TryUpdatePPAFCacheOnSuccessfulHedge() — write request with PPAFHedgePrimaryEndpointKey
        Hedge->>GPEM: TrySetPartitionLevelLocationOverrideForSuccessfulHedge(primary=A, successful=C)
        Note over GPEM: SetLocationOnSuccess: Current=C, FailedLocations={A}
    end

    Hedge-->>App: 201 Created (from hedge to C)

    Note over App,GPEM: PPAF Cache: Partition P → Region C (direct targeting)

    App->>Hedge: CreateItemAsync(item2) for Partition P
    Hedge->>GPEM: TryAddPartitionLevelLocationOverride()
    Note over GPEM: Override found: route to Region C
    Hedge->>CRP: Send to Region C
    CRP->>C: Write request (no hedging needed)
    C-->>CRP: 201 Created
    CRP-->>Hedge: 201 Created
    Hedge-->>App: 201 Created
```

### Error vs Success Behavior on Hedged Write Requests (After Fix)

```mermaid
flowchart TD
    A["Hedged PPAF Write Response"] --> B{"Response Status?"}
    
    B -- "Error (408, 503, 403/3, OCE)" --> C["ClientRetryPolicy.ShouldRetryAsync"]
    C --> D{"ShouldSuppressPPAFCacheUpdate?"}
    D -- "Yes (hedged request)" --> E["SKIP cache update — prevent cascade poisoning"]
    D -- "No (primary request)" --> F["Update cache normally via TryMarkEndpointUnavailableForPartitionKeyRange"]
    
    B -- "Success (2xx)" --> G["AbstractRetryHandler returns immediately — ShouldRetryAsync NOT called"]
    G --> H["CrossRegionHedgingAvailabilityStrategy.RequestSenderAndResultCheckAsync"]
    H --> I{"Write request + PPAFHedgePrimaryEndpointKey?"}
    I -- "Yes" --> J["TrySetPartitionLevelLocationOverrideForSuccessfulHedge: Set cache directly to successful endpoint"]
    I -- "No (read or primary)" --> K["No cache action"]
    
    style E fill:#90EE90
    style J fill:#87CEEB
    style F fill:#FFD700
    style G fill:#E0E0E0
```

## Changes

| File | Change |
|------|--------|
| `CrossRegionHedgingAvailabilityStrategy.cs` | Adds `SuppressPPAFCacheUpdateKey` + `PPAFHedgePrimaryEndpointKey` constants; captures primary endpoint; sets both properties on hedged write requests; adds `TryUpdatePPAFCacheOnSuccessfulHedge()` with write-only guard calling the new direct-targeting API |
| `ClientRetryPolicy.cs` | Adds `ShouldSuppressPPAFCacheUpdate()` guard on 3 error paths |
| `GlobalPartitionEndpointManager.cs` | Adds abstract `TrySetPartitionLevelLocationOverrideForSuccessfulHedge()` |
| `GlobalPartitionEndpointManagerCore.cs` | Implements `TrySetPartitionLevelLocationOverrideForSuccessfulHedge()`; adds `PartitionKeyRangeFailoverInfo.SetLocationOnSuccess()` to directly set the cache target |
| `GlobalPartitionEndpointManagerNoOp.cs` | Adds no-op override |

## Testing

- All 26 AvailabilityStrategyUnitTests pass
- All 26 GlobalPartitionEndpointManagerTests pass
- All 26 ClientRetryPolicyTests pass
