### PR TITLE
Exceptionless: Adds enabling exception less 404/1002 status code

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Handler/RequestMessage.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/RequestMessage.cs
@@ -298,7 +298,6 @@ namespace Microsoft.Azure.Cosmos
                 serviceRequest.UseStatusCodeFor429 = true;
                 serviceRequest.UseStatusCodeFor403 = true;
                 serviceRequest.UseStatusCodeForBadRequest = true;
-                serviceRequest.UseStatusCodeFor4041002 = true;
                 serviceRequest.Properties = this.Properties;
                 this.DocumentServiceRequest = serviceRequest;
             }

--- a/Microsoft.Azure.Cosmos/src/Handler/RequestMessage.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/RequestMessage.cs
@@ -298,6 +298,7 @@ namespace Microsoft.Azure.Cosmos
                 serviceRequest.UseStatusCodeFor429 = true;
                 serviceRequest.UseStatusCodeFor403 = true;
                 serviceRequest.UseStatusCodeForBadRequest = true;
+                serviceRequest.UseStatusCodeFor4041002 = true;
                 serviceRequest.Properties = this.Properties;
                 this.DocumentServiceRequest = serviceRequest;
             }

--- a/Microsoft.Azure.Cosmos/src/Handler/RequestMessage.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/RequestMessage.cs
@@ -296,6 +296,7 @@ namespace Microsoft.Azure.Cosmos
 
                 serviceRequest.UseStatusCodeForFailures = true;
                 serviceRequest.UseStatusCodeFor429 = true;
+                serviceRequest.UseStatusCodeFor4041002 = true;
                 serviceRequest.Properties = this.Properties;
                 this.DocumentServiceRequest = serviceRequest;
             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -3402,8 +3402,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 catch (CosmosException cosmosException)
                 {
                     Assert.IsTrue(cosmosException.Message.Contains("The read/write session is not available"), cosmosException.Message);
-                    string exception = cosmosException.ToString();
-                    Assert.IsTrue(exception.Contains("Point Operation Statistics"), exception);
                 }
             }
             finally

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -3401,7 +3401,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 }
                 catch (CosmosException cosmosException)
                 {
-                    Assert.IsTrue(cosmosException.Message.Contains("The read session is not available for the input session token."), cosmosException.Message);
+                    Assert.IsTrue(cosmosException.Message.Contains("The read/write session is not available"), cosmosException.Message);
                     string exception = cosmosException.ToString();
                     Assert.IsTrue(exception.Contains("Point Operation Statistics"), exception);
                 }


### PR DESCRIPTION
Excptionless: Adds enabling exception less 404/1002 status code

Breaking aspect: 
- Error message changes now (GatewayMode already had this breaking change)

<img width="917" height="47" alt="image" src="https://github.com/user-attachments/assets/f333dbe2-2414-4954-949a-bf94f1560314" />

- "Point Operation Statistics" in Diagnostics: Only populated in exception flow and irrelevant