### PR TITLE
[Internal] Tests: Refactors HeadersValidationTests to use async/await instead of sync-over-async

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/HeadersValidationTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/HeadersValidationTests.cs
@@ -59,20 +59,20 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        public void ValidatePageSizeRntbd()
+        public async Task ValidatePageSizeRntbd()
         {
             using var client = TestCommon.CreateClient(false, Protocol.Tcp);
-            ValidatePageSize(client);
+            await ValidatePageSize(client);
         }
 
         [TestMethod]
-        public void ValidatePageSizeGatway()
+        public async Task ValidatePageSizeGatway()
         {
             using var client = TestCommon.CreateClient(true);
-            ValidatePageSize(client);
+            await ValidatePageSize(client);
         }
 
-        private void ValidatePageSize(DocumentClient client)
+        private async Task ValidatePageSize(DocumentClient client)
         {
             // Invalid parsing
             INameValueCollection headers = new Documents.Collections.RequestNameValueCollection
@@ -82,12 +82,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             try
             {
-                ReadDatabaseFeedRequest(client, headers);
+                await ReadDatabaseFeedRequestAsync(client, headers);
                 Assert.Fail("Should throw an exception");
             }
-            catch (Exception ex)
+            catch (DocumentClientException innerException)
             {
-                var innerException = ex.InnerException as DocumentClientException;
                 Assert.AreEqual(HttpStatusCode.BadRequest, innerException.StatusCode, $"Invalid status code: {innerException}");
             }
 
@@ -98,12 +97,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             try
             {
-                ReadFeedScript(client, headers);
+                await ReadFeedScriptAsync(client, headers);
                 Assert.Fail("Should throw an exception");
             }
-            catch (Exception ex)
+            catch (DocumentClientException innerException)
             {
-                var innerException = ex.InnerException as DocumentClientException;
                 Assert.AreEqual(HttpStatusCode.BadRequest, innerException.StatusCode, $"Invalid status code: {innerException}");
             }
 
@@ -115,12 +113,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             try
             {
-                ReadDatabaseFeedRequest(client, headers);
+                await ReadDatabaseFeedRequestAsync(client, headers);
                 Assert.Fail("Should throw an exception");
             }
-            catch (Exception ex)
+            catch (DocumentClientException innerException)
             {
-                var innerException = ex.InnerException as DocumentClientException;
                 Assert.AreEqual(HttpStatusCode.BadRequest, innerException.StatusCode, $"Invalid status code: {innerException}");
             }
 
@@ -129,35 +126,34 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             try
             {
-                ReadFeedScript(client, headers);
+                await ReadFeedScriptAsync(client, headers);
                 Assert.Fail("Should throw an exception");
             }
-            catch (Exception ex)
+            catch (DocumentClientException innerException)
             {
-                var innerException = ex.InnerException as DocumentClientException;
                 Assert.AreEqual(HttpStatusCode.BadRequest, innerException.StatusCode, $"Invalid status code: {innerException}");
             }
 
             // Valid page size
             headers = new Documents.Collections.RequestNameValueCollection();
             headers.Add(HttpConstants.HttpHeaders.PageSize, "20");
-            var response = ReadDatabaseFeedRequest(client, headers);
+            var response = await ReadDatabaseFeedRequestAsync(client, headers);
             Assert.IsTrue(response.StatusCode == HttpStatusCode.OK);
 
             headers = new Documents.Collections.RequestNameValueCollection();
             headers.Add("pageSize", "20");
-            var result = ReadFeedScript(client, headers);
+            var result = await ReadFeedScriptAsync(client, headers);
             Assert.IsTrue(result.StatusCode == HttpStatusCode.OK);
 
             // dynamic page size
             headers = new Documents.Collections.RequestNameValueCollection();
             headers.Add(HttpConstants.HttpHeaders.PageSize, "-1");
-            response = ReadDatabaseFeedRequest(client, headers);
+            response = await ReadDatabaseFeedRequestAsync(client, headers);
             Assert.IsTrue(response.StatusCode == HttpStatusCode.OK);
 
             headers = new Documents.Collections.RequestNameValueCollection();
             headers.Add("pageSize", "-1");
-            result = ReadFeedScript(client, headers);
+            result = await ReadFeedScriptAsync(client, headers);
             Assert.IsTrue(result.StatusCode == HttpStatusCode.OK);
         }
 
@@ -199,32 +195,32 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             // Supported value
             headers = new RequestNameValueCollection();
             headers.Add(HttpConstants.HttpHeaders.ConsistencyLevel, ConsistencyLevel.Eventual.ToString());
-            var response = ReadDocumentFeedRequestAsync(client, collection.ResourceId, headers).Result;
+            var response = await ReadDocumentFeedRequestAsync(client, collection.ResourceId, headers);
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode, "Invalid status code");
         }
 
         [TestMethod]
-        public void ValidateJsonSerializationFormatGateway()
+        public async Task ValidateJsonSerializationFormatGateway()
         {
             using var client = TestCommon.CreateClient(true);
-            ValidateJsonSerializationFormat(client);
+            await ValidateJsonSerializationFormat(client);
         }
 
         [TestMethod]
-        public void ValidateJsonSerializationFormatRntbd()
+        public async Task ValidateJsonSerializationFormatRntbd()
         {
             using var client = TestCommon.CreateClient(false, Protocol.Tcp);
-            ValidateJsonSerializationFormat(client);
+            await ValidateJsonSerializationFormat(client);
         }
 
-        private void ValidateJsonSerializationFormat(DocumentClient client)
+        private async Task ValidateJsonSerializationFormat(DocumentClient client)
         {
             DocumentCollection collection = TestCommon.CreateOrGetDocumentCollection(client);
-            this.ValidateJsonSerializationFormatReadFeed(client, collection);
-            this.ValidateJsonSerializationFormatQuery(client, collection);
+            await this.ValidateJsonSerializationFormatReadFeed(client, collection);
+            await this.ValidateJsonSerializationFormatQuery(client, collection);
         }
 
-        private void ValidateJsonSerializationFormatReadFeed(DocumentClient client, DocumentCollection collection)
+        private async Task ValidateJsonSerializationFormatReadFeed(DocumentClient client, DocumentCollection collection)
         {
             // Value not supported
             INameValueCollection headers = new Documents.Collections.RequestNameValueCollection();
@@ -232,12 +228,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             try
             {
-                ReadDocumentFeedRequestSinglePartition(client, collection.ResourceId, headers);
+                await ReadDocumentFeedRequestSinglePartitionAsync(client, collection.ResourceId, headers);
                 Assert.Fail("Should throw an exception");
             }
-            catch (Exception ex)
+            catch (DocumentClientException innerException)
             {
-                var innerException = ex.InnerException as DocumentClientException;
                 Assert.AreEqual(HttpStatusCode.BadRequest, innerException.StatusCode, $"invalid status code: {innerException}");
             }
 
@@ -246,25 +241,25 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             // Text
             headers = new Documents.Collections.RequestNameValueCollection();
             headers.Add(HttpConstants.HttpHeaders.ContentSerializationFormat, ContentSerializationFormat.JsonText.ToString());
-            var response = ReadDocumentFeedRequestAsync(client, collection.ResourceId, headers).Result;
+            var response = await ReadDocumentFeedRequestAsync(client, collection.ResourceId, headers);
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode, "Invalid status code");
             Assert.IsTrue(response.ResponseBody.ReadByte() < HeadersValidationTests.BinarySerializationByteMarkValue);
 
             // None
             headers = new Documents.Collections.RequestNameValueCollection();
-            response = ReadDocumentFeedRequestAsync(client, collection.ResourceId, headers).Result;
+            response = await ReadDocumentFeedRequestAsync(client, collection.ResourceId, headers);
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode, "Invalid status code");
             Assert.IsTrue(response.ResponseBody.ReadByte() < HeadersValidationTests.BinarySerializationByteMarkValue);
 
             // Binary (Read feed should ignore all options)
             headers = new Documents.Collections.RequestNameValueCollection();
             headers.Add(HttpConstants.HttpHeaders.ContentSerializationFormat, ContentSerializationFormat.CosmosBinary.ToString());
-            response = ReadDocumentFeedRequestAsync(client, collection.ResourceId, headers).Result;
+            response = await ReadDocumentFeedRequestAsync(client, collection.ResourceId, headers);
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode, "Invalid status code");
             Assert.AreEqual((int)JsonSerializationFormat.Binary, response.ResponseBody.ReadByte());
         }
 
-        private void ValidateJsonSerializationFormatQuery(DocumentClient client, DocumentCollection collection)
+        private async Task ValidateJsonSerializationFormatQuery(DocumentClient client, DocumentCollection collection)
         {
             SqlQuerySpec sqlQuerySpec = new SqlQuerySpec("SELECT * FROM c");
             // Value not supported
@@ -273,7 +268,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             try
             {
-                QueryRequest(client, collection.ResourceId, sqlQuerySpec, headers);
+                await QueryRequestAsync(client, collection.ResourceId, sqlQuerySpec, headers);
                 Assert.Fail("Should throw an exception");
             }
             catch (Exception ex)
@@ -287,42 +282,42 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             // Text
             headers = new Documents.Collections.RequestNameValueCollection();
             headers.Add(HttpConstants.HttpHeaders.ContentSerializationFormat, ContentSerializationFormat.JsonText.ToString());
-            var response = QueryRequest(client, collection.ResourceId, sqlQuerySpec, headers);
+            var response = await QueryRequestAsync(client, collection.ResourceId, sqlQuerySpec, headers);
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode, "Invalid status code");
             Assert.IsTrue(response.ResponseBody.ReadByte() < HeadersValidationTests.BinarySerializationByteMarkValue);
 
             // None
             headers = new Documents.Collections.RequestNameValueCollection();
-            response = QueryRequest(client, collection.ResourceId, sqlQuerySpec, headers);
+            response = await QueryRequestAsync(client, collection.ResourceId, sqlQuerySpec, headers);
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode, "Invalid status code");
             Assert.IsTrue(response.ResponseBody.ReadByte() < HeadersValidationTests.BinarySerializationByteMarkValue);
 
             // Binary
             headers = new Documents.Collections.RequestNameValueCollection();
             headers.Add(HttpConstants.HttpHeaders.ContentSerializationFormat, ContentSerializationFormat.CosmosBinary.ToString());
-            response = QueryRequest(client, collection.ResourceId, sqlQuerySpec, headers);
+            response = await QueryRequestAsync(client, collection.ResourceId, sqlQuerySpec, headers);
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode, "Invalid status code");
             Assert.IsTrue(response.ResponseBody.ReadByte() == HeadersValidationTests.BinarySerializationByteMarkValue);
         }
 
         [TestMethod]
-        public void ValidateSupportedSerializationFormatsGateway()
+        public async Task ValidateSupportedSerializationFormatsGateway()
         {
             using var client = TestCommon.CreateClient(true);
-            this.ValidateSupportedSerializationFormats(client, true);
+            await this.ValidateSupportedSerializationFormats(client, true);
         }
 
         [TestMethod]
-        public void ValidateSupportedSerializationFormatsRntbd()
+        public async Task ValidateSupportedSerializationFormatsRntbd()
         {
             using var client = TestCommon.CreateClient(false, Protocol.Tcp);
-            this.ValidateSupportedSerializationFormats(client, false);
+            await this.ValidateSupportedSerializationFormats(client, false);
         }
 
-        private void ValidateSupportedSerializationFormats(DocumentClient client, bool isHttps)
+        private async Task ValidateSupportedSerializationFormats(DocumentClient client, bool isHttps)
         {
             DocumentCollection collection = TestCommon.CreateOrGetDocumentCollection(client);
-            this.ValidateSupportedSerializationFormatsReadFeed(client, collection, isHttps);
+            await this.ValidateSupportedSerializationFormatsReadFeed(client, collection, isHttps);
 
             List<SqlQuerySpec> sqlQueryList = new List<SqlQuerySpec>()
             {
@@ -333,11 +328,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             foreach(SqlQuerySpec sqlQuery in sqlQueryList)
             {
-                this.ValidateSupportedSerializationFormatsQuery(client, collection, sqlQuery, isHttps);
+                await this.ValidateSupportedSerializationFormatsQuery(client, collection, sqlQuery, isHttps);
             }
         }
 
-        private void SupportedSerializationFormatsNegativeCases(
+        private async Task SupportedSerializationFormatsNegativeCases(
             DocumentClient client, 
             DocumentCollection collection, 
             string invalidValue,
@@ -352,12 +347,12 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 DocumentServiceResponse response;
                 if (sqlQuerySpec != null)
                 {
-                    response = this.QueryRequest(client, collection.ResourceId, sqlQuerySpec, headers);
+                    response = await this.QueryRequestAsync(client, collection.ResourceId, sqlQuerySpec, headers);
                 }
                 else
                 {
                     headers.Set(HttpConstants.HttpHeaders.PartitionKey, "[\"test\"]");
-                    response = this.ReadDocumentFeedRequestSinglePartition(client, collection.ResourceId, headers);
+                    response = await this.ReadDocumentFeedRequestSinglePartitionAsync(client, collection.ResourceId, headers);
                 }
 
                 if (isHttps)
@@ -371,14 +366,13 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     Assert.Fail("Should throw an exception");
                 }
             }
-            catch (Exception ex)
+            catch (DocumentClientException innerException)
             {
-                DocumentClientException innerException = ex.InnerException as DocumentClientException;
                 Assert.AreEqual(HttpStatusCode.BadRequest, innerException.StatusCode, $"invalid status code {innerException}");
             }
         }
 
-        private void SupportedSerializationFormatsPositiveCases(
+        private async Task SupportedSerializationFormatsPositiveCases(
             DocumentClient client,
             DocumentCollection collection,
             SupportedSerializationFormats expectedFormat,
@@ -391,12 +385,12 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             DocumentServiceResponse response;
             if(sqlQuerySpec!=null)
             {
-                response = this.QueryRequest(client, collection.ResourceId, sqlQuerySpec, headers);
+                response = await this.QueryRequestAsync(client, collection.ResourceId, sqlQuerySpec, headers);
             }
             else
             {
                 Assert.IsTrue(expectedFormat == SupportedSerializationFormats.JsonText, "ReadFeed response should be in Text");
-                response = this.ReadDocumentFeedRequestAsync(client, collection.ResourceId, headers).Result;
+                response = await this.ReadDocumentFeedRequestAsync(client, collection.ResourceId, headers);
             }
 
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode, "Invalid status code");
@@ -411,55 +405,55 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
         }
 
-        private void ValidateSupportedSerializationFormatsReadFeed(DocumentClient client, DocumentCollection collection, bool isHttps)
+        private async Task ValidateSupportedSerializationFormatsReadFeed(DocumentClient client, DocumentCollection collection, bool isHttps)
         {
             // Value not supported
-            this.SupportedSerializationFormatsNegativeCases(client, collection, "Invalid value", isHttps);
+            await this.SupportedSerializationFormatsNegativeCases(client, collection, "Invalid value", isHttps);
 
             // Supported values
-            this.SupportedSerializationFormatsPositiveCases(client, collection, expectedFormat: SupportedSerializationFormats.JsonText, supportedSerializationFormats: "JSONText");
-            this.SupportedSerializationFormatsPositiveCases(client, collection, expectedFormat: SupportedSerializationFormats.JsonText, supportedSerializationFormats: "COSMOSbinary");
-            this.SupportedSerializationFormatsPositiveCases(client, collection, expectedFormat: SupportedSerializationFormats.JsonText, supportedSerializationFormats: "JsonText, CosmosBinary");
+            await this.SupportedSerializationFormatsPositiveCases(client, collection, expectedFormat: SupportedSerializationFormats.JsonText, supportedSerializationFormats: "JSONText");
+            await this.SupportedSerializationFormatsPositiveCases(client, collection, expectedFormat: SupportedSerializationFormats.JsonText, supportedSerializationFormats: "COSMOSbinary");
+            await this.SupportedSerializationFormatsPositiveCases(client, collection, expectedFormat: SupportedSerializationFormats.JsonText, supportedSerializationFormats: "JsonText, CosmosBinary");
         }
 
-        private void ValidateSupportedSerializationFormatsQuery(DocumentClient client, DocumentCollection collection, SqlQuerySpec sqlQuerySpec, bool isHttps)
+        private async Task ValidateSupportedSerializationFormatsQuery(DocumentClient client, DocumentCollection collection, SqlQuerySpec sqlQuerySpec, bool isHttps)
         {
             // Values not supported
-            this.SupportedSerializationFormatsNegativeCases(client, collection, "Invalid value", isHttps, sqlQuerySpec: sqlQuerySpec);
-            this.SupportedSerializationFormatsNegativeCases(client, collection, ", ,", isHttps, sqlQuerySpec: sqlQuerySpec);
-            this.SupportedSerializationFormatsNegativeCases(client, collection, ",,", isHttps, sqlQuerySpec: sqlQuerySpec);
-            this.SupportedSerializationFormatsNegativeCases(client, collection, "JsonText CosmosBinary", isHttps, sqlQuerySpec: sqlQuerySpec);
-            this.SupportedSerializationFormatsNegativeCases(client, collection, ",JsonText|CosmosBinary", isHttps, sqlQuerySpec: sqlQuerySpec);
-            this.SupportedSerializationFormatsNegativeCases(client, collection, "Json Text", isHttps, sqlQuerySpec: sqlQuerySpec);
-            this.SupportedSerializationFormatsNegativeCases(client, collection, "Json,Text", isHttps, sqlQuerySpec: sqlQuerySpec);
-            this.SupportedSerializationFormatsNegativeCases(client, collection, "JsonText, ", isHttps, sqlQuerySpec: sqlQuerySpec);
+            await this.SupportedSerializationFormatsNegativeCases(client, collection, "Invalid value", isHttps, sqlQuerySpec: sqlQuerySpec);
+            await this.SupportedSerializationFormatsNegativeCases(client, collection, ", ,", isHttps, sqlQuerySpec: sqlQuerySpec);
+            await this.SupportedSerializationFormatsNegativeCases(client, collection, ",,", isHttps, sqlQuerySpec: sqlQuerySpec);
+            await this.SupportedSerializationFormatsNegativeCases(client, collection, "JsonText CosmosBinary", isHttps, sqlQuerySpec: sqlQuerySpec);
+            await this.SupportedSerializationFormatsNegativeCases(client, collection, ",JsonText|CosmosBinary", isHttps, sqlQuerySpec: sqlQuerySpec);
+            await this.SupportedSerializationFormatsNegativeCases(client, collection, "Json Text", isHttps, sqlQuerySpec: sqlQuerySpec);
+            await this.SupportedSerializationFormatsNegativeCases(client, collection, "Json,Text", isHttps, sqlQuerySpec: sqlQuerySpec);
+            await this.SupportedSerializationFormatsNegativeCases(client, collection, "JsonText, ", isHttps, sqlQuerySpec: sqlQuerySpec);
 
             // Supported values
-            this.SupportedSerializationFormatsPositiveCases(client, collection,
+            await this.SupportedSerializationFormatsPositiveCases(client, collection,
                 expectedFormat: SupportedSerializationFormats.JsonText,
                 supportedSerializationFormats: "jsontext",
                 sqlQuerySpec: sqlQuerySpec);
-            this.SupportedSerializationFormatsPositiveCases(client, collection,
+            await this.SupportedSerializationFormatsPositiveCases(client, collection,
                 expectedFormat: SupportedSerializationFormats.CosmosBinary,
                 supportedSerializationFormats: "COSMOSBINARY",
                 sqlQuerySpec: sqlQuerySpec);
-            this.SupportedSerializationFormatsPositiveCases(client, collection,
+            await this.SupportedSerializationFormatsPositiveCases(client, collection,
                 expectedFormat: SupportedSerializationFormats.CosmosBinary,
                 supportedSerializationFormats: "JsonText, CosmosBinary",
                 sqlQuerySpec: sqlQuerySpec);
-            this.SupportedSerializationFormatsPositiveCases(client, collection,
+            await this.SupportedSerializationFormatsPositiveCases(client, collection,
                 expectedFormat: SupportedSerializationFormats.CosmosBinary,
                 supportedSerializationFormats: "CosmosBinary, HybridRow",
                 sqlQuerySpec: sqlQuerySpec);
-            this.SupportedSerializationFormatsPositiveCases(client, collection,
+            await this.SupportedSerializationFormatsPositiveCases(client, collection,
                 expectedFormat: SupportedSerializationFormats.CosmosBinary,
                 supportedSerializationFormats: "JsonText, CosmosBinary, HybridRow",
                 sqlQuerySpec: sqlQuerySpec);
-            this.SupportedSerializationFormatsPositiveCases(client, collection,
+            await this.SupportedSerializationFormatsPositiveCases(client, collection,
                 expectedFormat: SupportedSerializationFormats.CosmosBinary,
                 supportedSerializationFormats: "JsonText, CosmosBinary, HybridRow",
                 sqlQuerySpec: sqlQuerySpec);
-            this.SupportedSerializationFormatsPositiveCases(client, collection,
+            await this.SupportedSerializationFormatsPositiveCases(client, collection,
                 expectedFormat: SupportedSerializationFormats.CosmosBinary,
                 supportedSerializationFormats: "JsonText, CosmosBinary, HybridRow",
                 sqlQuerySpec: sqlQuerySpec);
@@ -478,20 +472,20 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        public void ValidateIndexingDirectiveGateway()
+        public async Task ValidateIndexingDirectiveGateway()
         {
             var client = TestCommon.CreateClient(true);
-            ValidateIndexingDirective(client);
+            await ValidateIndexingDirective(client);
         }
         [TestMethod]
-        public void ValidateIndexingDirectiveRntbd()
+        public async Task ValidateIndexingDirectiveRntbd()
         {
             //var client = TestCommon.CreateClient(false, Protocol.Tcp);
             var client = TestCommon.CreateClient(true, Protocol.Tcp);
-            ValidateIndexingDirective(client);
+            await ValidateIndexingDirective(client);
         }
 
-        private void ValidateIndexingDirective(DocumentClient client)
+        private async Task ValidateIndexingDirective(DocumentClient client)
         {
             // Number out of range.
             INameValueCollection headers = new Documents.Collections.RequestNameValueCollection();
@@ -499,12 +493,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             try
             {
-                CreateDocumentRequest(client, headers);
+                await CreateDocumentRequestAsync(client, headers);
                 Assert.Fail("Should throw an exception");
             }
-            catch (Exception ex)
+            catch (DocumentClientException innerException)
             {
-                var innerException = ex.InnerException as DocumentClientException;
                 Assert.AreEqual(HttpStatusCode.BadRequest, innerException.StatusCode, $"invalid status code {innerException}");
             }
 
@@ -513,42 +506,41 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             try
             {
-                CreateDocumentScript(client, headers);
+                await CreateDocumentScriptAsync(client, headers);
                 Assert.Fail("Should throw an exception");
             }
-            catch (Exception ex)
+            catch (DocumentClientException innerException)
             {
-                var innerException = ex.InnerException as DocumentClientException;
                 Assert.AreEqual(HttpStatusCode.BadRequest, innerException.StatusCode, $"invalid status code {innerException}");
             }
 
             // Valid Indexing Directive
             headers = new Documents.Collections.RequestNameValueCollection();
             headers.Add(HttpConstants.HttpHeaders.IndexingDirective, IndexingDirective.Exclude.ToString());
-            var response = CreateDocumentRequest(client, headers);
+            var response = await CreateDocumentRequestAsync(client, headers);
             Assert.IsTrue(response.StatusCode == HttpStatusCode.Created);
 
             headers = new Documents.Collections.RequestNameValueCollection();
             headers.Add("indexAction", "\"exclude\"");
-            var result = CreateDocumentScript(client, headers);
+            var result = await CreateDocumentScriptAsync(client, headers);
             Assert.AreEqual(HttpStatusCode.OK, result.StatusCode, "Invalid status code");
         }
 
         [TestMethod]
-        public void ValidateEnableScanInQueryGateway()
+        public async Task ValidateEnableScanInQueryGateway()
         {
             var client = TestCommon.CreateClient(true);
-            ValidateEnableScanInQuery(client);
+            await ValidateEnableScanInQuery(client);
         }
 
         [TestMethod]
-        public void ValidateEnableScanInQueryRntbd()
+        public async Task ValidateEnableScanInQueryRntbd()
         {
             var client = TestCommon.CreateClient(false, Protocol.Tcp);
-            ValidateEnableScanInQuery(client);
+            await ValidateEnableScanInQuery(client);
         }
 
-        private void ValidateEnableScanInQuery(DocumentClient client, bool isHttps = false)
+        private async Task ValidateEnableScanInQuery(DocumentClient client, bool isHttps = false)
         {
             // Value not boolean
             INameValueCollection headers = new Documents.Collections.RequestNameValueCollection();
@@ -556,7 +548,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             try
             {
-                var response = ReadDatabaseFeedRequest(client, headers);
+                var response = await ReadDatabaseFeedRequestAsync(client, headers);
                 if (isHttps)
                 {
                     Assert.Fail("Should throw an exception");
@@ -567,43 +559,42 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     Assert.AreEqual(HttpStatusCode.OK, response.StatusCode, "Invalid status code");
                 }
             }
-            catch (Exception ex)
+            catch (DocumentClientException innerException)
             {
-                var innerException = ex.InnerException as DocumentClientException;
                 Assert.AreEqual(HttpStatusCode.BadRequest, innerException.StatusCode, $"invalid status code {innerException}");
             }
 
             // Valid boolean
             headers = new Documents.Collections.RequestNameValueCollection();
             headers.Add(HttpConstants.HttpHeaders.EnableScanInQuery, "true");
-            var response2 = ReadDatabaseFeedRequest(client, headers);
+            var response2 = await ReadDatabaseFeedRequestAsync(client, headers);
             Assert.AreEqual(HttpStatusCode.OK, response2.StatusCode, "Invalid status code");
         }
 
         [TestMethod]
-        public void ValidateEnableLowPrecisionOrderByGateway()
+        public async Task ValidateEnableLowPrecisionOrderByGateway()
         {
             var client = TestCommon.CreateClient(true);
-            ValidateEnableLowPrecisionOrderBy(client);
+            await ValidateEnableLowPrecisionOrderBy(client);
         }
 
         [TestMethod]
-        public void ValidateEnableLowPrecisionOrderByRntbd()
+        public async Task ValidateEnableLowPrecisionOrderByRntbd()
         {
             var client = TestCommon.CreateClient(false, Protocol.Tcp);
-            ValidateEnableLowPrecisionOrderBy(client);
+            await ValidateEnableLowPrecisionOrderBy(client);
         }
 
-        private void ValidateEnableLowPrecisionOrderBy(DocumentClient client, bool isHttps = false)
+        private async Task ValidateEnableLowPrecisionOrderBy(DocumentClient client, bool isHttps = false)
         {
             // Value not boolean
             INameValueCollection headers = new Documents.Collections.RequestNameValueCollection();
             headers.Add(HttpConstants.HttpHeaders.EnableLowPrecisionOrderBy, "Not a boolean");
 
-            var document = CreateDocumentRequest(client, new Documents.Collections.RequestNameValueCollection()).GetResource<Document>();
+            var document = (await CreateDocumentRequestAsync(client, new Documents.Collections.RequestNameValueCollection())).GetResource<Document>();
             try
             {
-                var response = ReadDocumentRequest(client, document, headers);
+                var response = await ReadDocumentRequestAsync(client, document, headers);
                 if (isHttps)
                 {
                     Assert.Fail("Should throw an exception");
@@ -614,35 +605,34 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     Assert.AreEqual(HttpStatusCode.OK, response.StatusCode, "Invalid status code");
                 }
             }
-            catch (Exception ex)
+            catch (DocumentClientException innerException)
             {
-                var innerException = ex.InnerException as DocumentClientException;
                 Assert.AreEqual(HttpStatusCode.BadRequest, innerException.StatusCode, "Invalid status code");
             }
 
             // Valid boolean
-            document = CreateDocumentRequest(client, new Documents.Collections.RequestNameValueCollection()).GetResource<Document>();
+            document = (await CreateDocumentRequestAsync(client, new Documents.Collections.RequestNameValueCollection())).GetResource<Document>();
             headers = new Documents.Collections.RequestNameValueCollection();
             headers.Add(HttpConstants.HttpHeaders.EnableLowPrecisionOrderBy, "true");
-            var response2 = ReadDocumentRequest(client, document, headers);
+            var response2 = await ReadDocumentRequestAsync(client, document, headers);
             Assert.AreEqual(HttpStatusCode.OK, response2.StatusCode, "Invalid status code");
         }
 
         [TestMethod]
-        public void ValidateEmitVerboseTracesInQueryGateway()
+        public async Task ValidateEmitVerboseTracesInQueryGateway()
         {
             var client = TestCommon.CreateClient(true);
-            ValidateEmitVerboseTracesInQuery(client);
+            await ValidateEmitVerboseTracesInQuery(client);
         }
 
         [TestMethod]
-        public void ValidateEmitVerboseTracesInQueryRntbd()
+        public async Task ValidateEmitVerboseTracesInQueryRntbd()
         {
             var client = TestCommon.CreateClient(false, Protocol.Tcp);
-            ValidateEmitVerboseTracesInQuery(client);
+            await ValidateEmitVerboseTracesInQuery(client);
         }
 
-        private void ValidateEmitVerboseTracesInQuery(DocumentClient client, bool isHttps = false)
+        private async Task ValidateEmitVerboseTracesInQuery(DocumentClient client, bool isHttps = false)
         {
             // Value not boolean
             INameValueCollection headers = new Documents.Collections.RequestNameValueCollection();
@@ -650,7 +640,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             try
             {
-                var response = ReadDatabaseFeedRequest(client, headers);
+                var response = await ReadDatabaseFeedRequestAsync(client, headers);
                 if (isHttps)
                 {
                     Assert.Fail("Should throw an exception");
@@ -661,32 +651,31 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     Assert.AreEqual(HttpStatusCode.OK, response.StatusCode, "Invalid status code");
                 }
             }
-            catch (Exception ex)
+            catch (DocumentClientException innerException)
             {
-                var innerException = ex.InnerException as DocumentClientException;
                 Assert.AreEqual(HttpStatusCode.BadRequest, innerException.StatusCode, $"invalid status code {innerException}");
             }
 
             // Valid boolean
             headers = new Documents.Collections.RequestNameValueCollection();
             headers.Add(HttpConstants.HttpHeaders.EmitVerboseTracesInQuery, "true");
-            var response2 = ReadDatabaseFeedRequest(client, headers);
+            var response2 = await ReadDatabaseFeedRequestAsync(client, headers);
             Assert.AreEqual(HttpStatusCode.OK, response2.StatusCode, "Invalid status code");
         }
 
         [TestMethod]
-        public void ValidateIfNonMatchGateway()
+        public async Task ValidateIfNonMatchGateway()
         {
             using var client = TestCommon.CreateClient(true);
-            ValidateIfNonMatch(client);
+            await ValidateIfNonMatch(client);
 
         }
 
         [TestMethod]
-        public void ValidateIfNonMatchRntbd()
+        public async Task ValidateIfNonMatchRntbd()
         {
             using var client = TestCommon.CreateClient(false, Protocol.Tcp);
-            ValidateIfNonMatch(client);
+            await ValidateIfNonMatch(client);
         }
 
         [TestMethod]
@@ -791,22 +780,22 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         [TestMethod]
         [Ignore]
         [TestCategory("Ignore") /* Used to filter out ignored tests in lab runs */]
-        public void ValidateGlobalCompltedLSNAndNumberOfReadRegionsHeader()
+        public async Task ValidateGlobalCompltedLSNAndNumberOfReadRegionsHeader()
         {
             using DocumentClient client = TestCommon.CreateClient(false);
             Database db = null;
             try
             {
-                var dbResource = client.CreateDatabaseAsync(new Database() { Id = Guid.NewGuid().ToString() }).Result;
+                var dbResource = await client.CreateDatabaseAsync(new Database() { Id = Guid.NewGuid().ToString() });
                 db = dbResource.Resource;
-                var coll = client.CreateDocumentCollectionAsync(db, new DocumentCollection() { Id = Guid.NewGuid().ToString() }).Result.Resource;
-                var docResult = client.CreateDocumentAsync(coll, new Document() { Id = Guid.NewGuid().ToString() }).Result;
+                var coll = (await client.CreateDocumentCollectionAsync(db, new DocumentCollection() { Id = Guid.NewGuid().ToString() })).Resource;
+                var docResult = await client.CreateDocumentAsync(coll, new Document() { Id = Guid.NewGuid().ToString() });
                 long nCurrentGlobalCommittedLSN = -1;
                 long nNumberOfReadRegions = 0;
                 for (uint i = 0; i < 3; i++)
                 {
                     client.LockClient(i);
-                    var readResult = client.ReadDocumentAsync(docResult.Resource).Result;
+                    var readResult = await client.ReadDocumentAsync(docResult.Resource);
                     nCurrentGlobalCommittedLSN = long.Parse(readResult.ResponseHeaders[WFConstants.BackendHeaders.GlobalCommittedLSN], CultureInfo.InvariantCulture);
                     nNumberOfReadRegions = long.Parse(readResult.ResponseHeaders[WFConstants.BackendHeaders.NumberOfReadRegions], CultureInfo.InvariantCulture);
 
@@ -816,7 +805,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
             finally
             {
-                client.DeleteDatabaseAsync(db).Wait();
+                await client.DeleteDatabaseAsync(db);
             }
         }
 
@@ -843,7 +832,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
         private async Task ValidateExcludeSystemProperties(DocumentClient client)
         {
-            var db = client.CreateDatabaseAsync(new Database() { Id = Guid.NewGuid().ToString() }).Result.Resource;
+            var db = (await client.CreateDatabaseAsync(new Database() { Id = Guid.NewGuid().ToString() })).Resource;
             PartitionKeyDefinition partitionKeyDefinition = new PartitionKeyDefinition { Paths = new System.Collections.ObjectModel.Collection<string>(new[] { "/id" }), Kind = PartitionKind.Hash };
             var coll = (await client.CreateDocumentCollectionAsync(db.SelfLink, new DocumentCollection() { Id = Guid.NewGuid().ToString(), PartitionKey = partitionKeyDefinition })).Resource;
 
@@ -1052,30 +1041,29 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
         }
 
-        private void ValidateIfNonMatch(DocumentClient client)
+        private async Task ValidateIfNonMatch(DocumentClient client)
         {
             // Valid if-match
-            var document = CreateDocumentRequest(client, new Documents.Collections.RequestNameValueCollection()).GetResource<Document>();
+            var document = (await CreateDocumentRequestAsync(client, new Documents.Collections.RequestNameValueCollection())).GetResource<Document>();
             var headers = new Documents.Collections.RequestNameValueCollection();
             headers.Add(HttpConstants.HttpHeaders.IfNoneMatch, document.ETag);
-            var response = ReadDocumentRequest(client, document, headers);
+            var response = await ReadDocumentRequestAsync(client, document, headers);
             Assert.AreEqual(HttpStatusCode.NotModified, response.StatusCode, "Invalid status code");
 
             // validateInvalidIfMatch
             AccessCondition condition = new AccessCondition() { Type = AccessConditionType.IfMatch, Condition = "invalid etag" };
             try
             {
-                var replacedDoc = client.ReplaceDocumentAsync(document.SelfLink, document, new RequestOptions() { AccessCondition = condition }).Result.Resource;
+                var replacedDoc = (await client.ReplaceDocumentAsync(document.SelfLink, document, new RequestOptions() { AccessCondition = condition })).Resource;
                 Assert.Fail("should not reach here");
             }
-            catch (Exception ex)
+            catch (DocumentClientException innerException)
             {
-                var innerException = ex.InnerException as DocumentClientException;
                 Assert.AreEqual(HttpStatusCode.PreconditionFailed, innerException.StatusCode, $"invalid status code {innerException}");
             }
         }
 
-        private DocumentServiceResponse QueryRequest(DocumentClient client, string collectionId, SqlQuerySpec sqlQuerySpec, INameValueCollection headers)
+        private async Task<DocumentServiceResponse> QueryRequestAsync(DocumentClient client, string collectionId, SqlQuerySpec sqlQuerySpec, INameValueCollection headers)
         {
             headers.Add(HttpConstants.HttpHeaders.IsQuery, bool.TrueString);
             headers.Add(HttpConstants.HttpHeaders.ContentType, RuntimeConstants.MediaTypes.QueryJson);
@@ -1086,18 +1074,18 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 PartitionKeyInternal.MaximumExclusiveEffectivePartitionKey,
                 true,
                 false);
-            IRoutingMapProvider routingMapProvider = client.GetPartitionKeyRangeCacheAsync(NoOpTrace.Singleton).Result;
-            IReadOnlyList<PartitionKeyRange> ranges = routingMapProvider.TryGetOverlappingRangesAsync(collectionId, fullRange, NoOpTrace.Singleton).Result;
+            IRoutingMapProvider routingMapProvider = await client.GetPartitionKeyRangeCacheAsync(NoOpTrace.Singleton);
+            IReadOnlyList<PartitionKeyRange> ranges = await routingMapProvider.TryGetOverlappingRangesAsync(collectionId, fullRange, NoOpTrace.Singleton);
             request.RouteTo(new PartitionKeyRangeIdentity(collectionId, ranges.First().Id));
 
             string queryText = JsonConvert.SerializeObject(sqlQuerySpec);
             request.Body = new MemoryStream(Encoding.UTF8.GetBytes(queryText));
 
-            var response = client.ExecuteQueryAsync(request, null).Result;
+            var response = await client.ExecuteQueryAsync(request, null);
             return response;
         }
 
-        private Task<DocumentServiceResponse> ReadDocumentFeedRequestAsync(DocumentClient client, string collectionId, INameValueCollection headers)
+        private async Task<DocumentServiceResponse> ReadDocumentFeedRequestAsync(DocumentClient client, string collectionId, INameValueCollection headers)
         {
             DocumentServiceRequest request = DocumentServiceRequest.Create(OperationType.ReadFeed, collectionId, ResourceType.Document, AuthorizationTokenType.PrimaryMasterKey, headers);
 
@@ -1106,11 +1094,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 PartitionKeyInternal.MaximumExclusiveEffectivePartitionKey,
                 true,
                 false);
-            IRoutingMapProvider routingMapProvider = client.GetPartitionKeyRangeCacheAsync(NoOpTrace.Singleton).Result;
-            IReadOnlyList<PartitionKeyRange> ranges = routingMapProvider.TryGetOverlappingRangesAsync(collectionId, fullRange, NoOpTrace.Singleton).Result;
+            IRoutingMapProvider routingMapProvider = await client.GetPartitionKeyRangeCacheAsync(NoOpTrace.Singleton);
+            IReadOnlyList<PartitionKeyRange> ranges = await routingMapProvider.TryGetOverlappingRangesAsync(collectionId, fullRange, NoOpTrace.Singleton);
             request.RouteTo(new PartitionKeyRangeIdentity(collectionId, ranges.First().Id));
 
-            Task<DocumentServiceResponse> response = client.ReadFeedAsync(request, retryPolicy: null);
+            DocumentServiceResponse response = await client.ReadFeedAsync(request, retryPolicy: null);
             return response;
         }
 
@@ -1138,21 +1126,21 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             return ReadDocumentFeedRequestAsync(client, collectionId, headers);
         }
 
-        private DocumentServiceResponse ReadDocumentFeedRequestSinglePartition(DocumentClient client, string collectionId, INameValueCollection headers)
+        private async Task<DocumentServiceResponse> ReadDocumentFeedRequestSinglePartitionAsync(DocumentClient client, string collectionId, INameValueCollection headers)
         {
             DocumentServiceRequest request = DocumentServiceRequest.Create(OperationType.ReadFeed, collectionId, ResourceType.Document, AuthorizationTokenType.PrimaryMasterKey, headers);
-            var response = client.ReadFeedAsync(request, null).Result;
+            var response = await client.ReadFeedAsync(request, null);
             return response;
         }
 
-        private DocumentServiceResponse ReadDatabaseFeedRequest(DocumentClient client, INameValueCollection headers)
+        private async Task<DocumentServiceResponse> ReadDatabaseFeedRequestAsync(DocumentClient client, INameValueCollection headers)
         {
             DocumentServiceRequest request = DocumentServiceRequest.Create(OperationType.ReadFeed, null, ResourceType.Database, AuthorizationTokenType.PrimaryMasterKey, headers);
-            var response = client.ReadFeedAsync(request, null).Result;
+            var response = await client.ReadFeedAsync(request, null);
             return response;
         }
 
-        private StoredProcedureResponse<string> ReadFeedScript(DocumentClient client, INameValueCollection headers)
+        private async Task<StoredProcedureResponse<string>> ReadFeedScriptAsync(DocumentClient client, INameValueCollection headers)
         {
             var headersIterator = headers.AllKeys().SelectMany(headers.GetValues, (k, v) => new { key = k, value = v });
             var scriptOptions = "{";
@@ -1178,41 +1166,41 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 };
                 client.readDocuments(client.getSelfLink()," + scriptOptions + @", callback);}";
 
-            Database database = client.CreateDatabaseAsync(new Database { Id = Guid.NewGuid().ToString() }).Result;
+            Database database = await client.CreateDatabaseAsync(new Database { Id = Guid.NewGuid().ToString() });
             PartitionKeyDefinition partitionKeyDefinition = new PartitionKeyDefinition { Paths = new System.Collections.ObjectModel.Collection<string>(new[] { "/id" }), Kind = PartitionKind.Hash };
-            DocumentCollection collection = client.CreateDocumentCollectionAsync(database.SelfLink,
+            DocumentCollection collection = await client.CreateDocumentCollectionAsync(database.SelfLink,
                 new DocumentCollection
                 {
                     Id = Guid.NewGuid().ToString(),
                     PartitionKey = partitionKeyDefinition
-                }).Result;
+                });
             var sproc = new StoredProcedure() { Id = Guid.NewGuid().ToString(), Body = script };
-            var createdSproc = client.CreateStoredProcedureAsync(collection, sproc).Result.Resource;
+            var createdSproc = (await client.CreateStoredProcedureAsync(collection, sproc)).Resource;
             RequestOptions requestOptions = new RequestOptions();
             requestOptions.PartitionKey = new PartitionKey("test");
-            var result = client.ExecuteStoredProcedureAsync<string>(createdSproc, requestOptions).Result;
+            var result = await client.ExecuteStoredProcedureAsync<string>(createdSproc, requestOptions);
             return result;
         }
 
-        private DocumentServiceResponse CreateDocumentRequest(DocumentClient client, INameValueCollection headers)
+        private async Task<DocumentServiceResponse> CreateDocumentRequestAsync(DocumentClient client, INameValueCollection headers)
         {
-            Database database = client.CreateDatabaseAsync(new Database { Id = Guid.NewGuid().ToString() }).Result;
+            Database database = await client.CreateDatabaseAsync(new Database { Id = Guid.NewGuid().ToString() });
             PartitionKeyDefinition partitionKeyDefinition = new PartitionKeyDefinition { Paths = new System.Collections.ObjectModel.Collection<string>(new[] { "/id" }), Kind = PartitionKind.Hash };
-            DocumentCollection collection = client.CreateDocumentCollectionAsync(database.SelfLink,
+            DocumentCollection collection = await client.CreateDocumentCollectionAsync(database.SelfLink,
                 new DocumentCollection
                 {
                     Id = Guid.NewGuid().ToString(),
                     PartitionKey = partitionKeyDefinition
-                }).Result;
+                });
             var document = new Document() { Id = Guid.NewGuid().ToString() };
             DocumentServiceRequest request = DocumentServiceRequest.Create(OperationType.Create, collection.SelfLink, document, ResourceType.Document, AuthorizationTokenType.Invalid, headers, SerializationFormattingPolicy.None);
             PartitionKey partitionKey = new PartitionKey(document.Id);
             request.Headers.Set(HttpConstants.HttpHeaders.PartitionKey, partitionKey.InternalKey.ToJsonString());
-            var response = client.CreateAsync(request, null).Result;
+            var response = await client.CreateAsync(request, null);
             return response;
         }
 
-        private StoredProcedureResponse<string> CreateDocumentScript(DocumentClient client, INameValueCollection headers)
+        private async Task<StoredProcedureResponse<string>> CreateDocumentScriptAsync(DocumentClient client, INameValueCollection headers)
         {
             var headersIterator = headers.AllKeys().SelectMany(headers.GetValues, (k, v) => new { key = k, value = v });
             var scriptOptions = "{";
@@ -1240,27 +1228,27 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                    }
                 });}";
 
-            Database database = client.CreateDatabaseAsync(new Database { Id = Guid.NewGuid().ToString() }).Result;
+            Database database = await client.CreateDatabaseAsync(new Database { Id = Guid.NewGuid().ToString() });
             PartitionKeyDefinition partitionKeyDefinition = new PartitionKeyDefinition { Paths = new System.Collections.ObjectModel.Collection<string>(new[] { "/id" }), Kind = PartitionKind.Hash };
-            DocumentCollection collection = client.CreateDocumentCollectionAsync(database.SelfLink,
+            DocumentCollection collection = await client.CreateDocumentCollectionAsync(database.SelfLink,
                 new DocumentCollection
                 {
                     Id = Guid.NewGuid().ToString(),
                     PartitionKey = partitionKeyDefinition
-                }).Result;
+                });
             var sproc = new StoredProcedure() { Id = Guid.NewGuid().ToString(), Body = script };
-            var createdSproc = client.CreateStoredProcedureAsync(collection, sproc).Result.Resource;
+            var createdSproc = (await client.CreateStoredProcedureAsync(collection, sproc)).Resource;
             RequestOptions requestOptions = new RequestOptions();
             requestOptions.PartitionKey = new PartitionKey("TestDoc");
-            var result = client.ExecuteStoredProcedureAsync<string>(createdSproc, requestOptions).Result;
+            var result = await client.ExecuteStoredProcedureAsync<string>(createdSproc, requestOptions);
             return result;
         }
 
-        private DocumentServiceResponse ReadDocumentRequest(DocumentClient client, Document doc, INameValueCollection headers)
+        private async Task<DocumentServiceResponse> ReadDocumentRequestAsync(DocumentClient client, Document doc, INameValueCollection headers)
         {
             DocumentServiceRequest request = DocumentServiceRequest.Create(OperationType.Read, ResourceType.Document, doc.SelfLink, AuthorizationTokenType.PrimaryMasterKey, headers);
             request.Headers.Set(HttpConstants.HttpHeaders.PartitionKey, new PartitionKey(doc.Id).InternalKey.ToJsonString());
-            var retrievedDocResponse = client.ReadAsync(request, null).Result;
+            var retrievedDocResponse = await client.ReadAsync(request, null);
             return retrievedDocResponse;
         }
 


### PR DESCRIPTION
Eliminates sync-over-async anti-patterns (.Result, .Wait()) in HeadersValidationTests.cs by converting test and helper methods to async and using await.