### PR TITLE
[Internal] Tests: Refactors QueryTests to use async/await instead of sync-over-async

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/QueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/QueryTests.cs
@@ -48,7 +48,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestInitialize]
-        public void TestInitialize()
+        public async Task TestInitialize()
         {
             this.client = TestCommon.CreateClient(true, defaultConsistencyLevel: ConsistencyLevel.Session);
 
@@ -65,13 +65,13 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                          (HttpMessageHandler)null,
                          connectionPolicy: null);
 
-            this.CleanUp();
+            await this.CleanUp();
         }
 
         [TestCleanup]
-        public void TestCleanup()
+        public async Task TestCleanup()
         {
-            this.CleanUp();
+            await this.CleanUp();
 
             this.client.Dispose();
             this.primaryReadonlyClient.Dispose();
@@ -85,7 +85,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        public void TestQueryWithPageSize()
+        public async Task TestQueryWithPageSize()
         {
             // Create collection and insert 200 small documents
             Database database = TestCommon.RetryRateLimiting<Database>(() =>
@@ -107,15 +107,15 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
 
             // Arbitrary count of elements up to int.MaxValue.
-            DocumentFeedResponse<dynamic> result = this.client.CreateDocumentQuery<Document>(collection, "SELECT r.id FROM root r", new FeedOptions() { EnableCrossPartitionQuery = true }).AsDocumentQuery().ExecuteNextAsync().Result;
+            DocumentFeedResponse<dynamic> result = await this.client.CreateDocumentQuery<Document>(collection, "SELECT r.id FROM root r", new FeedOptions() { EnableCrossPartitionQuery = true }).AsDocumentQuery().ExecuteNextAsync();
             Assert.IsTrue(result.Count <= 200, $"{result.Count} elements returned. It is more than available on collection");
 
             // dynamic page size (-1), expect arbitrary count of elements up to int.MaxValue.
-            result = this.client.CreateDocumentQuery<Document>(collection, "SELECT r.id FROM root r", new FeedOptions() { MaxItemCount = -1, EnableCrossPartitionQuery = true }).AsDocumentQuery().ExecuteNextAsync().Result;
+            result = await this.client.CreateDocumentQuery<Document>(collection, "SELECT r.id FROM root r", new FeedOptions() { MaxItemCount = -1, EnableCrossPartitionQuery = true }).AsDocumentQuery().ExecuteNextAsync();
             Assert.IsTrue(result.Count <= 200, $"{result.Count} elements returned. It is more than available on collection");
 
             // page size 10
-            result = this.client.CreateDocumentQuery<Document>(collection, "SELECT r.id FROM root r", new FeedOptions() { MaxItemCount = 10, EnableCrossPartitionQuery = true }).AsDocumentQuery().ExecuteNextAsync().Result;
+            result = await this.client.CreateDocumentQuery<Document>(collection, "SELECT r.id FROM root r", new FeedOptions() { MaxItemCount = 10, EnableCrossPartitionQuery = true }).AsDocumentQuery().ExecuteNextAsync();
             Assert.IsTrue(result.Count <= 10, $"{result.Count} elements returned. It is more than MaxItemCount = 10");
 
             TestCommon.RetryRateLimiting<ResourceResponse<Database>>(() =>
@@ -554,7 +554,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         */
 
         [TestMethod]
-        public void TestQueryDocumentsSecondaryIndex()
+        public async Task TestQueryDocumentsSecondaryIndex()
         {
             try
             {
@@ -563,7 +563,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 collectionDefinition.IndexingPolicy.Automatic = true;
                 collectionDefinition.IndexingPolicy.IndexingMode = IndexingMode.Consistent;
 
-                DocumentCollection collection = TestCommon.CreateCollectionAsync(this.client, database, collectionDefinition).Result;
+                DocumentCollection collection = await TestCommon.CreateCollectionAsync(this.client, database, collectionDefinition);
 
                 this.TestQueryDocuments(collection);
             }
@@ -574,14 +574,14 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        public void TestQueryDocumentsIndex()
+        public async Task TestQueryDocumentsIndex()
         {
             try
             {
                 Database database = this.client.Create<Database>(null, new Database { Id = "TestQueryDocumentsDatabase" + Guid.NewGuid().ToString() });
                 DocumentCollection documentCollection = new DocumentCollection { Id = "TestQueryDocumentsCollection" + Guid.NewGuid().ToString(), PartitionKey = defaultPartitionKeyDefinition };
                 documentCollection.IndexingPolicy.IndexingMode = IndexingMode.Consistent;
-                DocumentCollection collection = TestCommon.CreateCollectionAsync(this.client, database, documentCollection).Result;
+                DocumentCollection collection = await TestCommon.CreateCollectionAsync(this.client, database, documentCollection);
 
                 this.TestQueryDocuments(collection);
             }
@@ -592,7 +592,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        public void TestQueryDocumentManualRemoveIndex()
+        public async Task TestQueryDocumentManualRemoveIndex()
         {
             try
             {
@@ -604,7 +604,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     PartitionKey = defaultPartitionKeyDefinition
                 };
                 sourceCollection.IndexingPolicy.IndexingMode = IndexingMode.Consistent;
-                DocumentCollection collection = TestCommon.CreateCollectionAsync(this.client, database, sourceCollection).Result;
+                DocumentCollection collection = await TestCommon.CreateCollectionAsync(this.client, database, sourceCollection);
                 JObject property = new JObject
                 {
                     ["pk"] = JToken.FromObject("test")
@@ -634,7 +634,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
 
         [TestMethod]
-        public void TestQueryDocumentManualAddRemoveIndex()
+        public async Task TestQueryDocumentManualAddRemoveIndex()
         {
             try
             {
@@ -646,7 +646,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     PartitionKey = defaultPartitionKeyDefinition
                 };
                 sourceCollection.IndexingPolicy.IndexingMode = IndexingMode.Consistent;
-                DocumentCollection collection = TestCommon.CreateCollectionAsync(this.client, database, sourceCollection).Result;
+                DocumentCollection collection = await TestCommon.CreateCollectionAsync(this.client, database, sourceCollection);
 
                 QueryDocument doc = new QueryDocument()
                 {
@@ -693,7 +693,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        public void TestQueryDocumentsManualIndex()
+        public async Task TestQueryDocumentsManualIndex()
         {
             try
             {
@@ -707,7 +707,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 sourceCollection.IndexingPolicy.Automatic = false;
                 sourceCollection.IndexingPolicy.IndexingMode = IndexingMode.Consistent;
 
-                DocumentCollection collection = TestCommon.CreateCollectionAsync(this.client, database, sourceCollection).Result;
+                DocumentCollection collection = await TestCommon.CreateCollectionAsync(this.client, database, sourceCollection);
 
                 this.TestQueryDocuments(collection, true);
             }
@@ -718,7 +718,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        public void TestSessionTokenControlThroughFeedOptions()
+        public async Task TestSessionTokenControlThroughFeedOptions()
         {
             Database database = this.client.Create<Database>(null, new Database { Id = "TestSessionTokenControlThroughFeedOptions" + Guid.NewGuid().ToString() });
 
@@ -728,7 +728,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 PartitionKey = defaultPartitionKeyDefinition
             };
             collection.IndexingPolicy.IndexingMode = IndexingMode.Consistent;
-            collection = TestCommon.CreateCollectionAsync(this.client, database, collection).Result;
+            collection = await TestCommon.CreateCollectionAsync(this.client, database, collection);
 
             try
             {
@@ -736,7 +736,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 dynamic myDocument = new Document();
                 myDocument.Id = "doc0";
                 myDocument.Title = "TestSessionTokenControlThroughFeedOptions";
-                ResourceResponse<Document> response = this.client.CreateDocumentAsync(collection.GetLink(), myDocument).Result;
+                ResourceResponse<Document> response = await this.client.CreateDocumentAsync(collection.GetLink(), myDocument);
                 sessionTokenBeforeReplication = response.SessionToken;
 
                 Assert.IsNotNull(sessionTokenBeforeReplication);
@@ -755,7 +755,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     myDocument = new Document();
                     myDocument.Id = "doc" + retryCounter;
                     myDocument.Title = "TestSessionTokenControlThroughFeedOptions";
-                    response = this.client.CreateDocumentAsync(collection.SelfLink, myDocument).Result;
+                    response = await this.client.CreateDocumentAsync(collection.SelfLink, myDocument);
 
                     sessionTokenAfterReplication = response.SessionToken;
                     Assert.IsNotNull(sessionTokenAfterReplication);
@@ -777,17 +777,17 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
             finally
             {
-                this.client.DeleteDocumentCollectionAsync(collection).Wait();
+                await this.client.DeleteDocumentCollectionAsync(collection);
             }
         }
 
         [TestMethod]
-        public void TestQueryUnicodeDocumentHttpsGateway()
+        public async Task TestQueryUnicodeDocumentHttpsGateway()
         {
-            this.TestQueryUnicodeDocument(useGateway: true, protocol: Protocol.Https);
+            await this.TestQueryUnicodeDocument(useGateway: true, protocol: Protocol.Https);
         }
 
-        private void TestQueryUnicodeDocument(bool useGateway, Protocol protocol)
+        private async Task TestQueryUnicodeDocument(bool useGateway, Protocol protocol)
         {
             try
             {
@@ -809,7 +809,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                         { "x-ms-indexing-directive", "include" }
                     };
 
-                    Action<string, string, string> testDocumentSQL = (name, rawValue, escapedValue) =>
+                    Func<string, string, string, Task> testDocumentSQL = async (name, rawValue, escapedValue) =>
                     {
                         escapedValue = escapedValue ?? rawValue;
 
@@ -822,43 +822,43 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                         QueryDocument docCreated = testClient.Create<QueryDocument>(collection.GetIdOrFullName(), document, requestHeaders);
 
                         {
-                            IEnumerable<JObject> result = testClient
+                            IEnumerable<JObject> result = await testClient
                                 .CreateDocumentQuery(collection,
                                 string.Format(CultureInfo.InvariantCulture, "SELECT r.StringField FROM ROOT r WHERE r.StringField=\"{0}\"", rawValue),
-                                new FeedOptions { EnableCrossPartitionQuery = true }).AsDocumentQuery().ExecuteNextAsync<JObject>().Result;
+                                new FeedOptions { EnableCrossPartitionQuery = true }).AsDocumentQuery().ExecuteNextAsync<JObject>();
 
                             Assert.AreEqual(document.StringField, result.Single()["StringField"].Value<string>());
                         }
 
                         {
-                            IEnumerable<JObject> result = testClient
+                            IEnumerable<JObject> result = await testClient
                                 .CreateDocumentQuery(collection,
                                 string.Format(CultureInfo.InvariantCulture, "SELECT r.StringField FROM ROOT r WHERE r.StringField=\"{0}\"", escapedValue),
-                                new FeedOptions { EnableCrossPartitionQuery = true }).AsDocumentQuery().ExecuteNextAsync<JObject>().Result;
+                                new FeedOptions { EnableCrossPartitionQuery = true }).AsDocumentQuery().ExecuteNextAsync<JObject>();
 
                             Assert.AreEqual(document.StringField, result.Single()["StringField"].Value<string>());
                         }
 
                         {
-                            IEnumerable<JObject> result = testClient
+                            IEnumerable<JObject> result = await testClient
                                 .CreateDocumentQuery(collection,
                                 string.Format(CultureInfo.InvariantCulture, "SELECT * FROM ROOT r WHERE r.StringField=\"{0}\"", rawValue),
-                                new FeedOptions { EnableCrossPartitionQuery = true }).AsDocumentQuery().ExecuteNextAsync<JObject>().Result;
+                                new FeedOptions { EnableCrossPartitionQuery = true }).AsDocumentQuery().ExecuteNextAsync<JObject>();
 
                             Assert.AreEqual(document.Id, result.Single()["id"].Value<string>());
                         }
                     };
 
-                    testDocumentSQL("doc00", "simple", null);
-                    testDocumentSQL("doc10", "\uD83D\uDE03", @"\uD83D\uDE03");
-                    testDocumentSQL("doc20", "\uD83D\uDE03\t\u0005\uD83D\uDE03", @"\uD83D\uDE03\t\u0005\uD83D\uDE03");
-                    testDocumentSQL("doc30", "Små ord", null);
-                    testDocumentSQL("doc40", "contains space and other white characters like \t\r\n", null);
-                    testDocumentSQL("CJK Ext A0", "㐀㐁㨀㨁䶴䶵", null);
-                    testDocumentSQL("doc5CJK Ext B0", "������������", null);
-                    testDocumentSQL("Tibetan0", "དབྱངས་ཅན་སྒྲོལ་དཀར། བཀྲ་ཤིས་རྒྱལ།", null);
-                    testDocumentSQL("Uighur0", "ۋېڭكقق ھس قك كدسدق د كوكو الضعيف بقي قوي", null);
-                    testDocumentSQL("Yi0", "ꉬꄒꐵꄓꐨꐵꄓꐨ", null);
+                    await testDocumentSQL("doc00", "simple", null);
+                    await testDocumentSQL("doc10", "\uD83D\uDE03", @"\uD83D\uDE03");
+                    await testDocumentSQL("doc20", "\uD83D\uDE03\t\u0005\uD83D\uDE03", @"\uD83D\uDE03\t\u0005\uD83D\uDE03");
+                    await testDocumentSQL("doc30", "Små ord", null);
+                    await testDocumentSQL("doc40", "contains space and other white characters like \t\r\n", null);
+                    await testDocumentSQL("CJK Ext A0", "㐀㐁㨀㨁䶴䶵", null);
+                    await testDocumentSQL("doc5CJK Ext B0", "������������", null);
+                    await testDocumentSQL("Tibetan0", "དབྱངས་ཅན་སྒྲོལ་དཀར། བཀྲ་ཤིས་རྒྱལ།", null);
+                    await testDocumentSQL("Uighur0", "ۋېڭكقق ھس قك كدسدق د كوكو الضعيف بقي قوي", null);
+                    await testDocumentSQL("Yi0", "ꉬꄒꐵꄓꐨꐵꄓꐨ", null);
                 }
             }
             catch (DocumentClientException e)
@@ -869,38 +869,38 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
         [Ignore] // Flaky
         [TestMethod]
-        public void TestLazyIndexAllTerms()
+        public async Task TestLazyIndexAllTerms()
         {
             try
             {
                 // Let the lazy indexer do force checkpointing frequently as possible.
                 TestCommon.SetFederationWideConfigurationProperty("lazyIndexForceCheckpointIntervalInSeconds", 1);
 
-                Database db = this.client.CreateDatabaseAsync(new Database
+                Database db = (await this.client.CreateDatabaseAsync(new Database
                 {
                     Id = System.Reflection.MethodBase.GetCurrentMethod().Name + Guid.NewGuid().ToString("N")
-                }).Result.Resource;
+                })).Resource;
 
                 DocumentCollection coll = new DocumentCollection { Id = db.Id, PartitionKey = defaultPartitionKeyDefinition };
                 coll.IndexingPolicy.Automatic = true;
                 coll.IndexingPolicy.IndexingMode = IndexingMode.Lazy;
 
-                coll = TestCommon.CreateCollectionAsync(this.client, db, coll).Result;
+                coll = await TestCommon.CreateCollectionAsync(this.client, db, coll);
 
                 DateTime startTime = DateTime.Now;
-                this.LoadDocuments(coll).Wait();
+                await this.LoadDocuments(coll);
                 System.Diagnostics.Trace.TraceInformation("Load documents took {0} ms", (DateTime.Now - startTime).TotalMilliseconds);
 
                 startTime = DateTime.Now;
 
-                Util.WaitForLazyIndexingToCompleteAsync(coll).Wait();
+                await Util.WaitForLazyIndexingToCompleteAsync(coll);
                 System.Diagnostics.Trace.TraceInformation("Indexing took {0} ms", (DateTime.Now - startTime).TotalMilliseconds);
 
                 QueryOracle.QueryOracle qo =
                     new QueryOracle.QueryOracle(this.client, coll.SelfLink, true,
                                                 targetNumberOfQueriesToValidate: 20000);
                 Assert.AreEqual(0, qo.IndexAndValidate(100), "Query oracle validation failed");
-                this.client.DeleteDatabaseAsync(db).Wait();
+                await this.client.DeleteDatabaseAsync(db);
             }
             finally
             {
@@ -1142,7 +1142,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             //3. Delete Database
             if (isDeleteDB)
             {
-                client.DeleteDatabaseAsync(database).Wait();
+                await client.DeleteDatabaseAsync(database);
             }
         }
 
@@ -1357,7 +1357,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             if (isDeleteDB)
             {
-                client.DeleteDatabaseAsync(database).Wait();
+                await client.DeleteDatabaseAsync(database);
             }
         }
 
@@ -1464,7 +1464,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             if (isDeleteDB)
             {
-                client.DeleteDatabaseAsync(database).Wait();
+                await client.DeleteDatabaseAsync(database);
             }
         }
 
@@ -1812,7 +1812,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         //Query metrics are not on by default anymore, but turned on hin Feed options. This to be quarantined until a recent FI from master to direct and sdk is completed
         [Ignore] // Need to use v3 pipeline
         [TestMethod]
-        public void TestQueryMetricsHeaders()
+        public async Task TestQueryMetricsHeaders()
         {
 
             Database database = TestCommon.RetryRateLimiting<Database>(() =>
@@ -1820,7 +1820,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 return this.client.CreateDatabaseAsync(new Database() { Id = Guid.NewGuid().ToString() }).Result.Resource;
             });
 
-            this.TestQueryMetricsHeaders(database, true);
+            await this.TestQueryMetricsHeaders(database, true);
 
             TestCommon.RetryRateLimiting<ResourceResponse<Database>>(() =>
             {
@@ -1881,14 +1881,14 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
         [TestMethod]
         [Ignore] //Ignore until v3 support query metrics
-        public void TestForceQueryScanHeaders()
+        public async Task TestForceQueryScanHeaders()
         {
             Database database = TestCommon.RetryRateLimiting<Database>(() =>
             {
                 return this.client.CreateDatabaseAsync(new Database() { Id = Guid.NewGuid().ToString() }).Result.Resource;
             });
 
-            this.TestForceQueryScanHeaders(database, true);
+            await this.TestForceQueryScanHeaders(database, true);
 
             TestCommon.RetryRateLimiting<ResourceResponse<Database>>(() =>
             {
@@ -1896,7 +1896,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             });
         }
 
-        private void TestForceQueryScanHeaders(Database database, bool partitionedCollection)
+        private async Task TestForceQueryScanHeaders(Database database, bool partitionedCollection)
         {
             DocumentCollection collection;
             RequestOptions options = new RequestOptions();
@@ -1955,10 +1955,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 PopulateQueryMetrics = true,
                 MaxDegreeOfParallelism = 10,
             };
-            result = this.client.CreateDocumentQuery<Document>(
+            result = await this.client.CreateDocumentQuery<Document>(
                     collection,
                     query,
-                    feedOptions).AsDocumentQuery().ExecuteNextAsync().Result;
+                    feedOptions).AsDocumentQuery().ExecuteNextAsync();
             queryMetrics = result.QueryMetrics.Values.Aggregate((curr, acc) => curr + acc);
             Assert.AreEqual(TimeSpan.Zero, queryMetrics.ServerSideMetrics.IndexLookupTime);
 
@@ -1971,15 +1971,15 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 PopulateQueryMetrics = true,
                 MaxDegreeOfParallelism = 10,
             };
-            result = this.client.CreateDocumentQuery<Document>(
+            result = await this.client.CreateDocumentQuery<Document>(
                     collection,
                     query,
-                    feedOptions).AsDocumentQuery().ExecuteNextAsync().Result;
+                    feedOptions).AsDocumentQuery().ExecuteNextAsync();
             queryMetrics = result.QueryMetrics.Values.Aggregate((curr, acc) => curr + acc);
             Assert.AreNotEqual(TimeSpan.Zero, queryMetrics.ServerSideMetrics.IndexLookupTime);
         }
 
-        private void TestFeedOptionInput(
+        private async Task TestFeedOptionInput(
             string feedOptionPropertyName,
             string componentPropertyName,
             List<Tuple<int?, int>> inputOutputs)
@@ -1993,7 +1993,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     }).Result.Resource;
             });
 
-            DocumentCollection documentCollection = this.client.CreateDocumentCollectionAsync(
+            DocumentCollection documentCollection = (await this.client.CreateDocumentCollectionAsync(
                 database.SelfLink,
                 new DocumentCollection()
                 {
@@ -2006,7 +2006,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                             "/id",
                         }
                     }
-                }).Result.Resource;
+                })).Resource;
 
             foreach (Tuple<int?, int> inputOutput in inputOutputs)
             {
@@ -2029,7 +2029,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     .AsDocumentQuery();
 
                 // Execute Once to force the execution context to initialize
-                DocumentFeedResponse<dynamic> garbage = documentQuery.ExecuteNextAsync().Result;
+                DocumentFeedResponse<dynamic> garbage = await documentQuery.ExecuteNextAsync();
 
                 // Get the value using reflection.
                 Type documentQueryType = documentQuery.GetType();
@@ -2062,7 +2062,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        public void TestContinuationLimitHeaders()
+        public async Task TestContinuationLimitHeaders()
         {
 
             Database database = TestCommon.RetryRateLimiting<Database>(() =>
@@ -2070,7 +2070,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 return this.client.CreateDatabaseAsync(new Database() { Id = Guid.NewGuid().ToString() }).Result.Resource;
             });
 
-            this.TestContinuationLimitHeaders(database, true);
+            await this.TestContinuationLimitHeaders(database, true);
 
             TestCommon.RetryRateLimiting<ResourceResponse<Database>>(() =>
             {
@@ -2078,7 +2078,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             });
         }
 
-        private void TestContinuationLimitHeaders(Database database, bool partitionedCollection)
+        private async Task TestContinuationLimitHeaders(Database database, bool partitionedCollection)
         {
             DocumentCollection collection;
             RequestOptions options = new RequestOptions();
@@ -2125,19 +2125,14 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             try
             {
-                result = this.client.CreateDocumentQuery<Document>(
+                result = await this.client.CreateDocumentQuery<Document>(
                     collection,
                     "SELECT r.id FROM root r WHERE r._ts > 0",
-                    feedOptions).AsDocumentQuery().ExecuteNextAsync().Result;
+                    feedOptions).AsDocumentQuery().ExecuteNextAsync();
                 Assert.Fail("Expected query to fail");
             }
-            catch (AggregateException e)
+            catch (DocumentClientException exception)
             {
-                if (!(e.InnerException is DocumentClientException exception))
-                {
-                    throw;
-                }
-
                 if (exception.StatusCode != HttpStatusCode.BadRequest)
                 {
                     throw;
@@ -2149,19 +2144,14 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             feedOptions.ResponseContinuationTokenLimitInKb = -1;
             try
             {
-                result = this.client.CreateDocumentQuery<Document>(
+                result = await this.client.CreateDocumentQuery<Document>(
                     collection,
                     "SELECT r.id FROM root r WHERE r._ts > 0",
-                    feedOptions).AsDocumentQuery().ExecuteNextAsync().Result;
+                    feedOptions).AsDocumentQuery().ExecuteNextAsync();
                 Assert.Fail("Expected query to fail");
             }
-            catch (AggregateException e)
+            catch (DocumentClientException exception)
             {
-                if (!(e.InnerException is DocumentClientException exception))
-                {
-                    throw;
-                }
-
                 if (exception.StatusCode != HttpStatusCode.BadRequest)
                 {
                     throw;
@@ -2171,21 +2161,21 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
 
             feedOptions.ResponseContinuationTokenLimitInKb = 1;
-            result = this.client.CreateDocumentQuery<Document>(collection, "SELECT r.id FROM root r WHERE r._ts > 0", feedOptions).AsDocumentQuery().ExecuteNextAsync().Result;
+            result = await this.client.CreateDocumentQuery<Document>(collection, "SELECT r.id FROM root r WHERE r._ts > 0", feedOptions).AsDocumentQuery().ExecuteNextAsync();
             string continuation = result.ResponseContinuation;
             Assert.IsTrue(
                 continuation.StartsWith("CGW") || (!continuation.Contains("#FPC") && !continuation.Contains("#FPP")),
                 $"{continuation} neither constructed by Compute nor proper BE token");
 
             feedOptions.ResponseContinuationTokenLimitInKb = 2;
-            result = this.client.CreateDocumentQuery<Document>(collection, "SELECT r.id FROM root r WHERE r._ts > 0", feedOptions).AsDocumentQuery().ExecuteNextAsync().Result;
+            result = await this.client.CreateDocumentQuery<Document>(collection, "SELECT r.id FROM root r WHERE r._ts > 0", feedOptions).AsDocumentQuery().ExecuteNextAsync();
             continuation = result.ResponseContinuation;
             Assert.IsTrue(
                 continuation.StartsWith("CGW") || (continuation.Contains("#FPC") || continuation.Contains("#FPP")),
                 $"{continuation} neither constructed by Compute nor proper BE token");
         }
 
-        private void TestQueryMetricsHeaders(Database database, bool partitionedCollection)
+        private async Task TestQueryMetricsHeaders(Database database, bool partitionedCollection)
         {
             DocumentCollection collection;
             RequestOptions options = new RequestOptions();
@@ -2235,15 +2225,15 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
 
             // simple validations - existence - yes & no
-            DocumentFeedResponse<dynamic> result = this.client.CreateDocumentQuery<Document>(collection, "SELECT r.id FROM root r", new FeedOptions() { EnableCrossPartitionQuery = true }).AsDocumentQuery().ExecuteNextAsync().Result;
+            DocumentFeedResponse<dynamic> result = await this.client.CreateDocumentQuery<Document>(collection, "SELECT r.id FROM root r", new FeedOptions() { EnableCrossPartitionQuery = true }).AsDocumentQuery().ExecuteNextAsync();
             Assert.IsNull(result.ResponseHeaders[WFConstants.BackendHeaders.QueryMetrics], "Expected no metrics headers for query");
             Assert.IsNull(result.ResponseHeaders[WFConstants.BackendHeaders.IndexUtilization], "Expected no index utilization headers for query");
 
-            result = this.client.CreateDocumentQuery<Document>(collection, "SELECT r.id FROM root r", new FeedOptions() { PopulateQueryMetrics = true, EnableCrossPartitionQuery = true }).AsDocumentQuery().ExecuteNextAsync().Result;
+            result = await this.client.CreateDocumentQuery<Document>(collection, "SELECT r.id FROM root r", new FeedOptions() { PopulateQueryMetrics = true, EnableCrossPartitionQuery = true }).AsDocumentQuery().ExecuteNextAsync();
             Assert.IsNotNull(result.ResponseHeaders[WFConstants.BackendHeaders.QueryMetrics], "Expected metrics headers for query");
             Assert.IsNull(result.ResponseHeaders[WFConstants.BackendHeaders.IndexUtilization], "Expected index utilization headers for query"); // False for now
 
-            this.ValidateQueryMetricsHeadersOverContinuations(collection, maxDocumentCount).Wait();
+            await this.ValidateQueryMetricsHeadersOverContinuations(collection, maxDocumentCount);
         }
 
         private async Task ValidateQueryMetricsHeadersOverContinuations(
@@ -2597,14 +2587,14 @@ function sproc(feed) {
             queryAction(this.secondaryReadonlyClient);
         }
 
-        private void CleanUp()
+        private async Task CleanUp()
         {
             IEnumerable<Database> allDatabases = from database in this.client.CreateDatabaseQuery()
                                                  select database;
 
             foreach (Database database in allDatabases)
             {
-                this.client.DeleteDatabaseAsync(database.SelfLink).Wait();
+                await this.client.DeleteDatabaseAsync(database.SelfLink);
             }
         }
 


### PR DESCRIPTION
Eliminates sync-over-async anti-patterns (.Result, .Wait()) in QueryTests.cs by converting test and helper methods to async and using await.