### PR TITLE
﻿DocumentClient: Fixes missing Dispose of GlobalPartitionEndpointManagerCore causing timer leak

### DIFF
--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -1405,6 +1405,12 @@ namespace Microsoft.Azure.Cosmos
                 this.cosmosAuthorization.Dispose();
             }
 
+            if (this.PartitionKeyRangeLocation is IDisposable partitionKeyRangeLocationDisposable)
+            {
+                partitionKeyRangeLocationDisposable.Dispose();
+                this.PartitionKeyRangeLocation = null;
+            }
+
             if (this.GlobalEndpointManager != null)
             {
                 this.GlobalEndpointManager.OnEnablePartitionLevelFailoverConfigChanged -= this.UpdatePartitionLevelFailoverConfigWithAccountRefresh;


### PR DESCRIPTION
## Description

DocumentClient.Dispose() disposes GlobalEndpointManager, HttpClient, StoreModel, AddressResolver, and other owned resources, but never disposes PartitionKeyRangeLocation (GlobalPartitionEndpointManagerCore). This leaves the circuit breaker failback loop running indefinitely, leaking Task.Delay timers.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
