### PR TITLE
Bump Direct package version to 3.42.4

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,7 +3,7 @@
 		<ClientOfficialVersion>3.58.0</ClientOfficialVersion>
 		<ClientPreviewVersion>3.59.0</ClientPreviewVersion>
 		<ClientPreviewSuffixVersion>preview.0</ClientPreviewSuffixVersion>
-		<DirectVersion>3.42.2</DirectVersion>
+		<DirectVersion>3.42.4</DirectVersion>
 		<FaultInjectionVersion>1.0.0</FaultInjectionVersion>
 		<FaultInjectionSuffixVersion>beta.0</FaultInjectionSuffixVersion>
 		<EncryptionOfficialVersion>2.0.5</EncryptionOfficialVersion>


### PR DESCRIPTION
Bumps `Microsoft.Azure.Cosmos.Direct` from 3.42.2 to 3.42.4.

### Changes in Direct 3.42.4

- Flow per-service `TargetReplicaSetSize` from gateway to SDK via address resolution
  - Adds account-level config flag `EnableFetchTargetReplicaSetSizeDuringAddressResolution`
  - SDK receives per-partition replica set size during address resolution, enabling better quorum decisions when partitions scale up
  - Gated behind config flag, disabled by default

### Changes in Direct 3.42.3

- Introduce new regions for CosmosDB SDK
- Cherry-pick DTS specific updates to auth resource
- Add check on DTS resourceType in GeneratePath
- Use distributedtransactionbatch as auth resource type for DTC requests