### PR TITLE
Region Availability: Adds missing regions from Direct 3.42.4

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Regions.cs
+++ b/Microsoft.Azure.Cosmos/src/Regions.cs
@@ -76,6 +76,11 @@ namespace Microsoft.Azure.Cosmos
         public const string SoutheastAsia = "Southeast Asia";
 
         /// <summary>
+        /// Name of the Azure Southeast Asia 3 region in the Azure Cosmos DB service.
+        /// </summary>
+        public const string SoutheastAsia3 = "Southeast Asia 3";
+
+        /// <summary>
         /// Name of the Azure Japan East region in the Azure Cosmos DB service.
         /// </summary>
         public const string JapanEast = "Japan East";
@@ -489,5 +494,15 @@ namespace Microsoft.Azure.Cosmos
         /// Name of the Azure Singapore North region in the Azure Cosmos DB service.
         /// </summary>
         public const string SingaporeNorth = "Singapore North";
+
+        /// <summary>
+        /// Name of the Azure Saudi Arabia East region in the Azure Cosmos DB service.
+        /// </summary>
+        public const string SaudiArabiaEast = "Saudi Arabia East";
+
+        /// <summary>
+        /// Name of the Azure West Central US FRE region in the Azure Cosmos DB service.
+        /// </summary>
+        public const string WestCentralUSFRE = "West Central US FRE";
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetSDKAPI.net6.json
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetSDKAPI.net6.json
@@ -8193,6 +8193,11 @@
           "Attributes": [],
           "MethodInfo": "System.String QatarCentral;IsInitOnly:False;IsStatic:True;"
         },
+        "System.String SaudiArabiaEast": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": "System.String SaudiArabiaEast;IsInitOnly:False;IsStatic:True;"
+        },
         "System.String SingaporeCentral": {
           "Type": "Field",
           "Attributes": [],
@@ -8227,6 +8232,11 @@
           "Type": "Field",
           "Attributes": [],
           "MethodInfo": "System.String SoutheastAsia;IsInitOnly:False;IsStatic:True;"
+        },
+        "System.String SoutheastAsia3": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": "System.String SoutheastAsia3;IsInitOnly:False;IsStatic:True;"
         },
         "System.String SoutheastUS": {
           "Type": "Field",
@@ -8362,6 +8372,11 @@
           "Type": "Field",
           "Attributes": [],
           "MethodInfo": "System.String WestCentralUS;IsInitOnly:False;IsStatic:True;"
+        },
+        "System.String WestCentralUSFRE": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": "System.String WestCentralUSFRE;IsInitOnly:False;IsStatic:True;"
         },
         "System.String WestEurope": {
           "Type": "Field",


### PR DESCRIPTION
## Description

Adds 3 regions introduced in Direct SDK 3.42.3/3.42.4 that were missing from `Cosmos.Regions` and the API contract baseline:

- `SoutheastAsia3` → `Southeast Asia 3`
- `SaudiArabiaEast` → `Saudi Arabia East`
- `WestCentralUSFRE` → `West Central US FRE`

These were added to `LocationNames` in the Direct package bump (#5779) but the corresponding `Regions.cs` entries and contract baseline were not updated, causing `MappedRegionsTest` to fail.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Does this introduce a breaking change?

No. Additive-only: 3 new public `const string` fields.