### PR TITLE
[Internal] DTS: Adds required document id to all DTS operations

### DIFF
--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperation.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperation.cs
@@ -94,13 +94,15 @@ namespace Microsoft.Azure.Cosmos
 
         public T Resource { get; internal set; }
 
-        internal override async Task MaterializeResourceAsync(CosmosSerializerCore serializerCore, CancellationToken cancellationToken)
+        internal override Task MaterializeResourceAsync(CosmosSerializerCore serializerCore, CancellationToken cancellationToken)
         {
             if (this.body.IsEmpty && this.Resource != null)
             {
                 this.ResourceStream = serializerCore.ToStream(this.Resource);
-                await base.MaterializeResourceAsync(serializerCore, cancellationToken);
+                return base.MaterializeResourceAsync(serializerCore, cancellationToken);
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperation.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperation.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------
+// ------------------------------------------------------------
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // ------------------------------------------------------------
 
@@ -84,19 +84,6 @@ namespace Microsoft.Azure.Cosmos
             string database,
             string container,
             PartitionKey partitionKey,
-            T resource,
-            DistributedTransactionRequestOptions requestOptions = null)
-            : base(operationType, operationIndex, database, container, partitionKey, id: null, requestOptions)
-        {
-            this.Resource = resource;
-        }
-
-        public DistributedTransactionOperation(
-            Documents.OperationType operationType,
-            int operationIndex,
-            string database,
-            string container,
-            PartitionKey partitionKey,
             string id,
             T resource,
             DistributedTransactionRequestOptions requestOptions = null)
@@ -107,15 +94,13 @@ namespace Microsoft.Azure.Cosmos
 
         public T Resource { get; internal set; }
 
-        internal override Task MaterializeResourceAsync(CosmosSerializerCore serializerCore, CancellationToken cancellationToken)
+        internal override async Task MaterializeResourceAsync(CosmosSerializerCore serializerCore, CancellationToken cancellationToken)
         {
             if (this.body.IsEmpty && this.Resource != null)
             {
                 this.ResourceStream = serializerCore.ToStream(this.Resource);
-                return base.MaterializeResourceAsync(serializerCore, cancellationToken);
+                await base.MaterializeResourceAsync(serializerCore, cancellationToken);
             }
-
-            return Task.CompletedTask;
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionSerializer.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionSerializer.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Azure.Cosmos
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.IO;
     using System.Text.Json;
     using Microsoft.Azure.Documents;
@@ -62,6 +63,9 @@ namespace Microsoft.Azure.Cosmos
             // collectionName
             jsonWriter.WriteString("collectionName", operation.Container);
 
+            // id
+            jsonWriter.WriteString("id", operation.Id);
+
             // collectionResourceId
             if (operation.CollectionResourceId != null)
             {
@@ -72,12 +76,6 @@ namespace Microsoft.Azure.Cosmos
             if (operation.DatabaseResourceId != null)
             {
                 jsonWriter.WriteString("databaseResourceId", operation.DatabaseResourceId);
-            }
-
-            // id 
-            if (operation.Id != null)
-            {
-                jsonWriter.WriteString("id", operation.Id);
             }
 
             // partitionKey

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedWriteTransaction.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedWriteTransaction.cs
@@ -24,6 +24,7 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="database">The name of the database containing the container.</param>
         /// <param name="collection">The name of the container where the item will be created.</param>
         /// <param name="partitionKey">The partition key for the item.</param>
+        /// <param name="id">The unique identifier of the item to create.</param>
         /// <param name="resource">The resource to create.</param>
         /// <param name="requestOptions">Options for the create operation.</param>
         /// <returns>The current <see cref="DistributedWriteTransaction"/> instance for method chaining.</returns>
@@ -31,6 +32,7 @@ namespace Microsoft.Azure.Cosmos
             string database,
             string collection,
             PartitionKey partitionKey,
+            string id,
             T resource,
             DistributedTransactionRequestOptions requestOptions = null);
 
@@ -40,6 +42,7 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="database">The name of the database containing the container.</param>
         /// <param name="collection">The name of the container where the item will be created.</param>
         /// <param name="partitionKey">The partition key for the item.</param>
+        /// <param name="id">The unique identifier of the item to create.</param>
         /// <param name="streamPayload">A <see cref="Stream"/> containing the JSON serialization of the item.</param>
         /// <param name="requestOptions">Options for the create operation.</param>
         /// <returns>The current <see cref="DistributedWriteTransaction"/> instance for method chaining.</returns>
@@ -47,6 +50,7 @@ namespace Microsoft.Azure.Cosmos
             string database,
             string collection,
             PartitionKey partitionKey,
+            string id,
             Stream streamPayload,
             DistributedTransactionRequestOptions requestOptions = null);
 
@@ -147,6 +151,7 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="database">The name of the database containing the container.</param>
         /// <param name="collection">The name of the container where the item will be upserted.</param>
         /// <param name="partitionKey">The partition key for the item.</param>
+        /// <param name="id">The unique identifier of the item to upsert.</param>
         /// <param name="resource">The resource to upsert.</param>
         /// <param name="requestOptions">Options for the upsert operation.</param>
         /// <returns>The current <see cref="DistributedWriteTransaction"/> instance for method chaining.</returns>
@@ -154,6 +159,7 @@ namespace Microsoft.Azure.Cosmos
             string database,
             string collection,
             PartitionKey partitionKey,
+            string id,
             T resource,
             DistributedTransactionRequestOptions requestOptions = null);
 
@@ -164,6 +170,7 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="database">The name of the database containing the container.</param>
         /// <param name="collection">The name of the container where the item will be upserted.</param>
         /// <param name="partitionKey">The partition key for the item.</param>
+        /// <param name="id">The unique identifier of the item to upsert.</param>
         /// <param name="streamPayload">A <see cref="Stream"/> containing the JSON serialization of the item.</param>
         /// <param name="requestOptions">Options for the upsert operation.</param>
         /// <returns>The current <see cref="DistributedWriteTransaction"/> instance for method chaining.</returns>
@@ -171,6 +178,7 @@ namespace Microsoft.Azure.Cosmos
             string database,
             string collection,
             PartitionKey partitionKey,
+            string id,
             Stream streamPayload,
             DistributedTransactionRequestOptions requestOptions = null);
     }

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedWriteTransactionCore.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedWriteTransactionCore.cs
@@ -27,10 +27,12 @@ namespace Microsoft.Azure.Cosmos
             string database,
             string collection,
             PartitionKey partitionKey,
+            string id,
             T resource,
             DistributedTransactionRequestOptions requestOptions = null)
         {
             DistributedWriteTransactionCore.ValidateContainerReference(database, collection);
+            DistributedWriteTransactionCore.ValidateItemId(id);
             DistributedWriteTransactionCore.ValidateResource(resource);
 
             this.operations.Add(
@@ -40,6 +42,7 @@ namespace Microsoft.Azure.Cosmos
                     database,
                     collection,
                     partitionKey,
+                    id,
                     resource,
                     requestOptions));
             return this;
@@ -49,10 +52,12 @@ namespace Microsoft.Azure.Cosmos
             string database,
             string collection,
             PartitionKey partitionKey,
+            string id,
             Stream streamPayload,
             DistributedTransactionRequestOptions requestOptions = null)
         {
             DistributedWriteTransactionCore.ValidateContainerReference(database, collection);
+            DistributedWriteTransactionCore.ValidateItemId(id);
             if (streamPayload == null)
             {
                 throw new ArgumentNullException(nameof(streamPayload));
@@ -65,6 +70,7 @@ namespace Microsoft.Azure.Cosmos
                     database: database,
                     container: collection,
                     partitionKey: partitionKey,
+                    id: id,
                     requestOptions: requestOptions)
                 {
                     ResourceStream = streamPayload
@@ -214,10 +220,12 @@ namespace Microsoft.Azure.Cosmos
             string database,
             string collection,
             PartitionKey partitionKey,
+            string id,
             T resource,
             DistributedTransactionRequestOptions requestOptions = null)
         {
             DistributedWriteTransactionCore.ValidateContainerReference(database, collection);
+            DistributedWriteTransactionCore.ValidateItemId(id);
             DistributedWriteTransactionCore.ValidateResource(resource);
 
             this.operations.Add(
@@ -227,6 +235,7 @@ namespace Microsoft.Azure.Cosmos
                     database,
                     collection,
                     partitionKey,
+                    id,
                     resource,
                     requestOptions));
             return this;
@@ -236,10 +245,12 @@ namespace Microsoft.Azure.Cosmos
             string database,
             string collection,
             PartitionKey partitionKey,
+            string id,
             Stream streamPayload,
             DistributedTransactionRequestOptions requestOptions = null)
         {
             DistributedWriteTransactionCore.ValidateContainerReference(database, collection);
+            DistributedWriteTransactionCore.ValidateItemId(id);
             if (streamPayload == null)
             {
                 throw new ArgumentNullException(nameof(streamPayload));
@@ -252,6 +263,7 @@ namespace Microsoft.Azure.Cosmos
                     database: database,
                     container: collection,
                     partitionKey: partitionKey,
+                    id: id,
                     requestOptions: requestOptions)
                 {
                     ResourceStream = streamPayload

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/DistributedTransaction/DistributedTransactionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/DistributedTransaction/DistributedTransactionTests.cs
@@ -1,4 +1,4 @@
-// ------------------------------------------------------------
+﻿// ------------------------------------------------------------
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // ------------------------------------------------------------
 
@@ -69,8 +69,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             using CosmosClient client = this.CreateMockClient(handler);
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(doc1.pk), doc1)
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(doc2.pk), doc2)
+                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(doc1.pk), doc1.id, doc1)
+                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(doc2.pk), doc2.id, doc2)
                 .CommitTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
@@ -95,7 +95,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             using CosmosClient client = this.CreateMockClient(handler);
 
             await client.CreateDistributedWriteTransaction()
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(createDoc.pk), createDoc)
+                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(createDoc.pk), createDoc.id, createDoc)
                 .ReplaceItem(this.database.Id, this.container.Id, new PartitionKey(replaceDoc.pk), replaceDoc.id, replaceDoc)
                 .DeleteItem(this.database.Id, this.container.Id, new PartitionKey("delete-pk"), "delete-id")
                 .CommitTransactionAsync(CancellationToken.None);
@@ -122,8 +122,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             using CosmosClient client = this.CreateMockClient(handler);
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(createDoc.pk), createDoc)
-                .UpsertItem(this.database.Id, this.container.Id, new PartitionKey(upsertDoc.pk), upsertDoc)
+                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(createDoc.pk), createDoc.id, createDoc)
+                .UpsertItem(this.database.Id, this.container.Id, new PartitionKey(upsertDoc.pk), upsertDoc.id, upsertDoc)
                 .CommitTransactionAsync(CancellationToken.None);
 
             using JsonDocument requestJson = JsonDocument.Parse(handler.CapturedRequestBody);
@@ -149,7 +149,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             using CosmosClient client = this.CreateMockClient(handler);
 
             await client.CreateDistributedWriteTransaction()
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(createDoc.pk), createDoc)
+                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(createDoc.pk), createDoc.id, createDoc)
                 .PatchItem(this.database.Id, this.container.Id, new PartitionKey("patch-pk"), "item-to-patch", patchOps)
                 .CommitTransactionAsync(CancellationToken.None);
 
@@ -179,8 +179,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             using CosmosClient client = this.CreateMockClient(handler);
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(doc1.pk), doc1)
-                .CreateItem(this.database.Id, secondContainer.Id, new PartitionKey(doc2.pk), doc2)
+                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(doc1.pk), doc1.id, doc1)
+                .CreateItem(this.database.Id, secondContainer.Id, new PartitionKey(doc2.pk), doc2.id, doc2)
                 .CommitTransactionAsync(CancellationToken.None);
 
             using JsonDocument requestJson = JsonDocument.Parse(handler.CapturedRequestBody);
@@ -214,7 +214,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             ToDoActivity doc = ToDoActivity.CreateRandomToDoActivity();
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(doc.pk), doc)
+                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(doc.pk), doc.id, doc)
                 .CommitTransactionAsync(CancellationToken.None);
 
             Assert.AreNotEqual(Guid.Empty, response.IdempotencyToken, "Response must carry the idempotency token.");
@@ -236,9 +236,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             using CosmosClient client = this.CreateMockClient(handler);
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(doc1.pk), doc1)
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(doc2.pk), doc2)
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(doc3.pk), doc3)
+                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(doc1.pk), doc1.id, doc1)
+                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(doc2.pk), doc2.id, doc2)
+                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(doc3.pk), doc3.id, doc3)
                 .CommitTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(3, response.Count);
@@ -272,7 +272,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             using CosmosClient client = this.CreateMockClient(handler);
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(expectedDoc.pk), expectedDoc)
+                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(expectedDoc.pk), expectedDoc.id, expectedDoc)
                 .CommitTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(HttpStatusCode.Created, response[0].StatusCode);
@@ -309,7 +309,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             ToDoActivity doc = ToDoActivity.CreateRandomToDoActivity();
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(doc.pk), doc)
+                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(doc.pk), doc.id, doc)
                 .CommitTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(HttpStatusCode.Conflict, response.StatusCode);
@@ -369,8 +369,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             ToDoActivity doc2 = ToDoActivity.CreateRandomToDoActivity();
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(doc1.pk), doc1)
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(doc2.pk), doc2)
+                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(doc1.pk), doc1.id, doc1)
+                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(doc2.pk), doc2.id, doc2)
                 .CommitTransactionAsync(CancellationToken.None);
 
             // All results must be present regardless of partial failure
@@ -395,7 +395,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             using CosmosClient client = this.CreateMockClient(handler);
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(createDoc.pk), createDoc)
+                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(createDoc.pk), createDoc.id, createDoc)
                 .ReplaceItem(this.database.Id, this.container.Id, new PartitionKey(replaceDoc.pk), replaceDoc.id, replaceDoc)
                 .DeleteItem(this.database.Id, this.container.Id, new PartitionKey("delete-pk"), "delete-id")
                 .CommitTransactionAsync(CancellationToken.None);
@@ -596,7 +596,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             using CosmosClient client = this.CreateMockClient(handler);
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(createDoc.pk), createDoc)
+                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(createDoc.pk), createDoc.id, createDoc)
                 .ReplaceItem(this.database.Id, this.container.Id, new PartitionKey(replaceDoc.pk), replaceDoc.id, replaceDoc)
                 .CommitTransactionAsync(CancellationToken.None);
 
@@ -626,7 +626,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             using MemoryStream stream = new MemoryStream(docBytes);
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .CreateItemStream(this.database.Id, this.container.Id, new PartitionKey(doc.pk), stream)
+                .CreateItemStream(this.database.Id, this.container.Id, new PartitionKey(doc.pk), doc.id, stream)
                 .CommitTransactionAsync(CancellationToken.None);
 
             Assert.IsTrue(response.IsSuccessStatusCode);
@@ -713,7 +713,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             using MemoryStream stream = new MemoryStream(docBytes);
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .UpsertItemStream(this.database.Id, this.container.Id, new PartitionKey(doc.pk), stream)
+                .UpsertItemStream(this.database.Id, this.container.Id, new PartitionKey(doc.pk), doc.id, stream)
                 .CommitTransactionAsync(CancellationToken.None);
 
             Assert.IsTrue(response.IsSuccessStatusCode);
@@ -757,7 +757,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             ToDoActivity newDoc = ToDoActivity.CreateRandomToDoActivity();
             DistributedTransactionResponse dtcResponse = await dtcClient
                 .CreateDistributedWriteTransaction()
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(newDoc.pk), newDoc)
+                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(newDoc.pk), newDoc.id, newDoc)
                 .CommitTransactionAsync(this.cancellationToken);
 
             Assert.IsTrue(dtcResponse.IsSuccessStatusCode, "The simulated DTC commit should appear successful to the client.");

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionCommitterTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionCommitterTests.cs
@@ -53,7 +53,8 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                     operationIndex: 0,
                     DatabaseName,
                     ContainerName,
-                    new PartitionKey("pk1"))
+                    new PartitionKey("pk1"),
+                    id: "doc1")
             };
 
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
@@ -86,7 +87,8 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                     operationIndex: 0,
                     DatabaseName,
                     ContainerName,
-                    new PartitionKey("pk1"))
+                    new PartitionKey("pk1"),
+                    id: "doc1")
             };
 
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
@@ -162,13 +164,15 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                     operationIndex: 0,
                     DatabaseName,
                     ContainerName,
-                    new PartitionKey("pk1")),
+                    new PartitionKey("pk1"),
+                    id: "doc1"),
                 new DistributedTransactionOperation(
                     OperationType.Create,
                     operationIndex: 1,
                     DatabaseName,
                     container2,
-                    new PartitionKey("pk2")),
+                    new PartitionKey("pk2"),
+                    id: "doc2"),
             };
 
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
@@ -215,7 +219,8 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                     operationIndex: 0,
                     DatabaseName,
                     ContainerName,
-                    new PartitionKey("pk1"))
+                    new PartitionKey("pk1"),
+                    id: "doc1")
             };
 
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
@@ -249,7 +254,8 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                     operationIndex: 0,
                     DatabaseName,
                     ContainerName,
-                    new PartitionKey("pk1"))
+                    new PartitionKey("pk1"),
+                    id: "doc1")
             };
 
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionResponseTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionResponseTests.cs
@@ -639,7 +639,8 @@ namespace Microsoft.Azure.Cosmos.Tests
                     operationIndex: i,
                     database: "testDb",
                     container: "testContainer",
-                    partitionKey: new PartitionKey($"pk{i}")));
+                    partitionKey: new PartitionKey($"pk{i}"),
+                    id: $"doc{i}"));
             }
 
             return await DistributedTransactionServerRequest.CreateAsync(

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionSerializerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionSerializerTests.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Azure.Cosmos.Tests
     using System;
     using System.Collections.Generic;
     using System.IO;
+    using System.Linq;
     using System.Text;
     using System.Text.Json;
     using System.Threading;
@@ -35,17 +36,20 @@ namespace Microsoft.Azure.Cosmos.Tests
         // id field presence per operation type
 
         [TestMethod]
-        [Description("CreateItem does not set an explicit id field on the operation, so 'id' must be absent from the serialized JSON.")]
-        public async Task CreateItem_SerializedBody_HasResourceBody_NoIdField()
+        [Description("CreateItem sets id explicitly; 'id' must be present in the serialized JSON with the correct value.")]
+        public async Task CreateItem_SerializedBody_HasResourceBody_AndIdField()
         {
+            const string itemId = "create-item";
             string capturedJson = await this.CaptureCommitBodyAsync(tx =>
-                tx.CreateItem(Database, Container, new PartitionKey("pk"), new TestItem("create-item")));
+                tx.CreateItem(Database, Container, new PartitionKey("pk"), itemId, new TestItem(itemId)));
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
             JsonElement op = doc.RootElement.GetProperty("operations")[0];
 
-            Assert.IsFalse(op.TryGetProperty("id", out _),
-                "Create operation must NOT include an 'id' field in the serialized body.");
+            Assert.IsTrue(op.TryGetProperty("id", out JsonElement idElement),
+                "Create operation must include an 'id' field.");
+            Assert.AreEqual(itemId, idElement.GetString(),
+                "The 'id' field must match the id passed to CreateItem.");
             Assert.IsTrue(op.TryGetProperty("resourceBody", out _),
                 "Create operation must include a 'resourceBody' field.");
         }
@@ -87,17 +91,20 @@ namespace Microsoft.Azure.Cosmos.Tests
         }
 
         [TestMethod]
-        [Description("UpsertItem provides a resource but no explicit id, so 'resourceBody' must be present and 'id' must be absent.")]
-        public async Task UpsertItem_SerializedBody_HasResourceBody_NoIdField()
+        [Description("UpsertItem sets id explicitly; 'id' must be present in the serialized JSON with the correct value.")]
+        public async Task UpsertItem_SerializedBody_HasResourceBody_AndIdField()
         {
+            const string itemId = "upsert-item";
             string capturedJson = await this.CaptureCommitBodyAsync(tx =>
-                tx.UpsertItem(Database, Container, new PartitionKey("pk"), new TestItem("upsert-item")));
+                tx.UpsertItem(Database, Container, new PartitionKey("pk"), itemId, new TestItem(itemId)));
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
             JsonElement op = doc.RootElement.GetProperty("operations")[0];
 
-            Assert.IsFalse(op.TryGetProperty("id", out _),
-                "Upsert operation must NOT include an 'id' field.");
+            Assert.IsTrue(op.TryGetProperty("id", out JsonElement idElement),
+                "Upsert operation must include an 'id' field.");
+            Assert.AreEqual(itemId, idElement.GetString(),
+                "The 'id' field must match the id passed to UpsertItem.");
             Assert.IsTrue(op.TryGetProperty("resourceBody", out _),
                 "Upsert operation must include a 'resourceBody' field.");
         }
@@ -145,7 +152,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         public async Task CreateItem_SerializedBody_ResourceBodyIsValidJson()
         {
             string capturedJson = await this.CaptureCommitBodyAsync(tx =>
-                tx.CreateItem(Database, Container, new PartitionKey("pk"), new TestItem("json-check")));
+                tx.CreateItem(Database, Container, new PartitionKey("pk"), "json-check", new TestItem("json-check")));
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
             JsonElement op = doc.RootElement.GetProperty("operations")[0];
@@ -165,10 +172,10 @@ namespace Microsoft.Azure.Cosmos.Tests
             IReadOnlyList<PatchOperation> patchOps = new[] { PatchOperation.Add("/value", "v") };
 
             string capturedJson = await this.CaptureCommitBodyAsync(tx =>
-                tx.CreateItem(Database, Container, new PartitionKey("pk"), new TestItem("c"))
+                tx.CreateItem(Database, Container, new PartitionKey("pk"), "c", new TestItem("c"))
                   .ReplaceItem(Database, Container, new PartitionKey("pk"), "r", new TestItem("r"))
                   .DeleteItem(Database, Container, new PartitionKey("pk"), "d")
-                  .UpsertItem(Database, Container, new PartitionKey("pk"), new TestItem("u"))
+                  .UpsertItem(Database, Container, new PartitionKey("pk"), "u", new TestItem("u"))
                   .PatchItem(Database, Container, new PartitionKey("pk"), "p", patchOps),
                 expectedResultCount: 5);
 
@@ -190,10 +197,10 @@ namespace Microsoft.Azure.Cosmos.Tests
             IReadOnlyList<PatchOperation> patchOps = new[] { PatchOperation.Add("/value", "v") };
 
             string capturedJson = await this.CaptureCommitBodyAsync(tx =>
-                tx.CreateItem(Database, Container, new PartitionKey("pk"), new TestItem("c"))
+                tx.CreateItem(Database, Container, new PartitionKey("pk"), "c", new TestItem("c"))
                   .ReplaceItem(Database, Container, new PartitionKey("pk"), "r", new TestItem("r"))
                   .DeleteItem(Database, Container, new PartitionKey("pk"), "d")
-                  .UpsertItem(Database, Container, new PartitionKey("pk"), new TestItem("u"))
+                  .UpsertItem(Database, Container, new PartitionKey("pk"), "u", new TestItem("u"))
                   .PatchItem(Database, Container, new PartitionKey("pk"), "p", patchOps),
                 expectedResultCount: 5);
 
@@ -238,19 +245,22 @@ namespace Microsoft.Azure.Cosmos.Tests
         // Stream operations
 
         [TestMethod]
-        [Description("CreateItemStream with a JSON stream sets resourceBody on the operation; no explicit 'id' field should appear.")]
-        public async Task CreateItemStream_SerializedBody_HasResourceBody_NoIdField()
+        [Description("CreateItemStream sets id explicitly; 'id' must be present in the serialized JSON with the correct value.")]
+        public async Task CreateItemStream_SerializedBody_HasResourceBody_AndIdField()
         {
-            byte[] docBytes = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(new TestItem("test-id")));
+            const string itemId = "test-id";
+            byte[] docBytes = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(new TestItem(itemId)));
             using MemoryStream stream = new MemoryStream(docBytes);
             string capturedJson = await this.CaptureCommitBodyAsync(
-                tx => tx.CreateItemStream(Database, Container, new PartitionKey("pk"), stream));
+                tx => tx.CreateItemStream(Database, Container, new PartitionKey("pk"), itemId, stream));
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
             JsonElement op = doc.RootElement.GetProperty("operations")[0];
 
-            Assert.IsFalse(op.TryGetProperty("id", out _),
-                "CreateItemStream operation must NOT include an 'id' field in the serialized body.");
+            Assert.IsTrue(op.TryGetProperty("id", out JsonElement idElement),
+                "CreateItemStream operation must include an 'id' field.");
+            Assert.AreEqual(itemId, idElement.GetString(),
+                "The 'id' field must match the id passed to CreateItemStream.");
             Assert.IsTrue(op.TryGetProperty("resourceBody", out _),
                 "CreateItemStream operation must include a 'resourceBody' field.");
         }
@@ -294,19 +304,22 @@ namespace Microsoft.Azure.Cosmos.Tests
         }
 
         [TestMethod]
-        [Description("UpsertItemStream sets resource but no explicit id; 'resourceBody' must be present and 'id' must be absent.")]
-        public async Task UpsertItemStream_SerializedBody_HasResourceBody_NoIdField()
+        [Description("UpsertItemStream sets id explicitly; 'id' must be present in the serialized JSON with the correct value.")]
+        public async Task UpsertItemStream_SerializedBody_HasResourceBody_AndIdField()
         {
-            byte[] docBytes = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(new TestItem("upsert-stream-id")));
+            const string itemId = "upsert-stream-id";
+            byte[] docBytes = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(new TestItem(itemId)));
             using MemoryStream stream = new MemoryStream(docBytes);
             string capturedJson = await this.CaptureCommitBodyAsync(
-                tx => tx.UpsertItemStream(Database, Container, new PartitionKey("pk"), stream));
+                tx => tx.UpsertItemStream(Database, Container, new PartitionKey("pk"), itemId, stream));
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
             JsonElement op = doc.RootElement.GetProperty("operations")[0];
 
-            Assert.IsFalse(op.TryGetProperty("id", out _),
-                "UpsertItemStream operation must NOT include an 'id' field in the serialized body.");
+            Assert.IsTrue(op.TryGetProperty("id", out JsonElement idElement),
+                "UpsertItemStream operation must include an 'id' field.");
+            Assert.AreEqual(itemId, idElement.GetString(),
+                "The 'id' field must match the id passed to UpsertItemStream.");
             Assert.IsTrue(op.TryGetProperty("resourceBody", out _),
                 "UpsertItemStream operation must include a 'resourceBody' field.");
         }
@@ -376,7 +389,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         public async Task Operations_WithoutIfMatchEtag_DoNotIncludeEtagField()
         {
             string capturedJson = await this.CaptureCommitBodyAsync(tx =>
-                tx.CreateItem(Database, Container, new PartitionKey("pk"), new TestItem("create-no-etag"))
+                tx.CreateItem(Database, Container, new PartitionKey("pk"), "create-no-etag", new TestItem("create-no-etag"))
                   .ReplaceItem(Database, Container, new PartitionKey("pk"), "replace-no-etag", new TestItem("replace-no-etag")),
                 expectedResultCount: 2);
 
@@ -388,6 +401,44 @@ namespace Microsoft.Azure.Cosmos.Tests
                 Assert.IsFalse(ops[i].TryGetProperty("etag", out _),
                     $"Operation[{i}] without IfMatchEtag must NOT include an 'etag' field.");
             }
+        }
+
+        [TestMethod]
+        [Description("CreateItem with a null id must throw ArgumentNullException at the call site.")]
+        public void CreateItem_NullId_ThrowsArgumentNullException()
+        {
+            DistributedWriteTransaction tx = new DistributedWriteTransactionCore(this.BuildContextSetup().Object);
+            Assert.ThrowsException<ArgumentNullException>(() =>
+                tx.CreateItem(Database, Container, new PartitionKey("pk"), id: null, new TestItem("body-id")));
+        }
+
+        [TestMethod]
+        [Description("UpsertItem with an empty id must throw ArgumentNullException at the call site.")]
+        public void UpsertItem_EmptyId_ThrowsArgumentNullException()
+        {
+            DistributedWriteTransaction tx = new DistributedWriteTransactionCore(this.BuildContextSetup().Object);
+            Assert.ThrowsException<ArgumentNullException>(() =>
+                tx.UpsertItem(Database, Container, new PartitionKey("pk"), id: string.Empty, new TestItem("body-id")));
+        }
+
+        [TestMethod]
+        [Description("CreateItemStream with a null id must throw ArgumentNullException at the call site.")]
+        public void CreateItemStream_NullId_ThrowsArgumentNullException()
+        {
+            DistributedWriteTransaction tx = new DistributedWriteTransactionCore(this.BuildContextSetup().Object);
+            using MemoryStream stream = new MemoryStream(Encoding.UTF8.GetBytes(@"{""value"":1}"));
+            Assert.ThrowsException<ArgumentNullException>(() =>
+                tx.CreateItemStream(Database, Container, new PartitionKey("pk"), id: null, stream));
+        }
+
+        [TestMethod]
+        [Description("UpsertItemStream with a whitespace id must throw ArgumentNullException at the call site.")]
+        public void UpsertItemStream_WhitespaceId_ThrowsArgumentNullException()
+        {
+            DistributedWriteTransaction tx = new DistributedWriteTransactionCore(this.BuildContextSetup().Object);
+            using MemoryStream stream = new MemoryStream(Encoding.UTF8.GetBytes(@"{""value"":1}"));
+            Assert.ThrowsException<ArgumentNullException>(() =>
+                tx.UpsertItemStream(Database, Container, new PartitionKey("pk"), id: "   ", stream));
         }
 
         // Helpers

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedWriteTransactionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedWriteTransactionTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             DistributedWriteTransaction tx = this.NewTransaction();
             Assert.ThrowsException<ArgumentNullException>(
-                () => tx.CreateItem(null, Container, new PartitionKey("pk"), new TestItem()));
+                () => tx.CreateItem(null, Container, new PartitionKey("pk"), "item-id", new TestItem()));
         }
 
         [TestMethod]
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             DistributedWriteTransaction tx = this.NewTransaction();
             Assert.ThrowsException<ArgumentNullException>(
-                () => tx.CreateItem(Database, null, new PartitionKey("pk"), new TestItem()));
+                () => tx.CreateItem(Database, null, new PartitionKey("pk"), "item-id", new TestItem()));
         }
 
         [TestMethod]
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             DistributedWriteTransaction tx = this.NewTransaction();
             Assert.ThrowsException<ArgumentNullException>(
-                () => tx.CreateItem<TestItem>(Database, Container, new PartitionKey("pk"), null));
+                () => tx.CreateItem<TestItem>(Database, Container, new PartitionKey("pk"), "item-id", null));
         }
 
         [TestMethod]
@@ -93,7 +93,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             DistributedWriteTransaction tx = this.NewTransaction();
             Assert.ThrowsException<ArgumentNullException>(
-                () => tx.CreateItemStream(Database, Container, new PartitionKey("pk"), null));
+                () => tx.CreateItemStream(Database, Container, new PartitionKey("pk"), "item-id", null));
         }
 
         [TestMethod]
@@ -117,7 +117,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             DistributedWriteTransaction tx = this.NewTransaction();
             Assert.ThrowsException<ArgumentNullException>(
-                () => tx.UpsertItemStream(Database, Container, new PartitionKey("pk"), null));
+                () => tx.UpsertItemStream(Database, Container, new PartitionKey("pk"), "item-id", null));
         }
 
         // Request structure
@@ -151,7 +151,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                     });
 
             await new DistributedWriteTransactionCore(contextMock.Object)
-                .CreateItem(Database, Container, new PartitionKey("pk"), new TestItem())
+                .CreateItem(Database, Container, new PartitionKey("pk"), "item-id", new TestItem())
                 .CommitTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(ResourceType.DistributedTransactionBatch, capturedResourceType);
@@ -187,7 +187,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                     });
 
             await new DistributedWriteTransactionCore(contextMock.Object)
-                .CreateItem(Database, Container, new PartitionKey("pk"), new TestItem())
+                .CreateItem(Database, Container, new PartitionKey("pk"), "item-id", new TestItem())
                 .CommitTransactionAsync(CancellationToken.None);
 
             Assert.IsNotNull(capturedToken, "Idempotency token header must be set.");
@@ -227,7 +227,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                     });
 
             DistributedTransactionResponse response = await new DistributedWriteTransactionCore(contextMock.Object)
-                .CreateItem(Database, Container, new PartitionKey("pk"), new TestItem())
+                .CreateItem(Database, Container, new PartitionKey("pk"), "item-id", new TestItem())
                 .CommitTransactionAsync(CancellationToken.None);
 
             Assert.AreNotEqual(Guid.Empty, response.IdempotencyToken, "Response must carry the idempotency token.");
@@ -262,7 +262,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                     });
 
             await new DistributedWriteTransactionCore(contextMock.Object)
-                .CreateItem(Database, Container, new PartitionKey("pk1"), new TestItem("id1"))
+                .CreateItem(Database, Container, new PartitionKey("pk1"), "id1", new TestItem("id1"))
                 .ReplaceItem(Database, Container, new PartitionKey("pk2"), "id2", new TestItem("id2"))
                 .DeleteItem(Database, Container, new PartitionKey("pk3"), "id3")
                 .CommitTransactionAsync(CancellationToken.None);
@@ -306,11 +306,11 @@ namespace Microsoft.Azure.Cosmos.Tests
                     });
 
             await new DistributedWriteTransactionCore(contextMock.Object)
-                .CreateItem(Database, Container, new PartitionKey("pk"), new TestItem("create"))
+                .CreateItem(Database, Container, new PartitionKey("pk"), "create", new TestItem("create"))
                 .ReplaceItem(Database, Container, new PartitionKey("pk"), "replace", new TestItem("replace"))
                 .DeleteItem(Database, Container, new PartitionKey("pk"), "delete")
                 .PatchItem(Database, Container, new PartitionKey("pk"), "patch", new[] { PatchOperation.Add("/value", "v") })
-                .UpsertItem(Database, Container, new PartitionKey("pk"), new TestItem("upsert"))
+                .UpsertItem(Database, Container, new PartitionKey("pk"), "upsert", new TestItem("upsert"))
                 .CommitTransactionAsync(CancellationToken.None);
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
@@ -351,8 +351,8 @@ namespace Microsoft.Azure.Cosmos.Tests
                 .ReturnsAsync(BuildSuccessResponse(2));
 
             DistributedTransactionResponse response = await new DistributedWriteTransactionCore(contextMock.Object)
-                .CreateItem(Database, Container, new PartitionKey("pk1"), new TestItem("id1"))
-                .CreateItem(Database, Container, new PartitionKey("pk2"), new TestItem("id2"))
+                .CreateItem(Database, Container, new PartitionKey("pk1"), "id1", new TestItem("id1"))
+                .CreateItem(Database, Container, new PartitionKey("pk2"), "id2", new TestItem("id2"))
                 .CommitTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
@@ -380,7 +380,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 .ReturnsAsync(BuildErrorResponse(HttpStatusCode.Conflict));
 
             DistributedTransactionResponse response = await new DistributedWriteTransactionCore(contextMock.Object)
-                .CreateItem(Database, Container, new PartitionKey("pk"), new TestItem())
+                .CreateItem(Database, Container, new PartitionKey("pk"), "item-id", new TestItem())
                 .CommitTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(HttpStatusCode.Conflict, response.StatusCode);


### PR DESCRIPTION
## Description

- The coordinator needs `documentId` to reliably commit or abort stuck transactions—the transaction log doesn’t store document content.
- Always sending it enables deterministic replay without request bodies and avoids special cases (especially for create).
- Making it mandatory keeps the SDK–backend contract future‑proof and correct.

All distributed transaction operations now require an explicit 'id' parameter, consistent with Delete, Replace, and Patch. Previously, Create and Upsert omitted id from the metadata sent to the DTC coordinator (the id was only in the resource body).

- Add string id parameter to CreateItem, CreateItemStream, UpsertItem, UpsertItemStream in both the abstract class and the core implementation
- Validate id at call site via existing ValidateItemId (fails fast with ArgumentNullException before serialization)
- Simplify DistributedTransactionOperation<T>: one constructor (with id), MaterializeResourceAsync just serializes and calls base
- Update all tests

> Note: To ensure consistency with Create/Upsert operations in other SDK flows, we will implement a long-term solution by extracting the id from the resource body instead of having users provide it explicitly.
 
## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber