### PR TITLE
[Internal] CODEOWNERS: Adds @kushagraThapar as a codeowner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,19 +5,19 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-*       @kirankumarkolli @FabianMeiswinkel @sboshra @Pilchie
-Microsoft.Azure.Cosmos/src/Json @adityasa @neildsh @kirankumarkolli @sboshra
-Microsoft.Azure.Cosmos/src/Query @adityasa @neildsh @kirankumarkolli @sboshra
-Microsoft.Azure.Cosmos/src/CosmosElements @adityasa @neildsh @kirankumarkolli @sboshra
-Microsoft.Azure.Cosmos/src/SqlObjects @leminh98 @adityasa @kirankumarkolli @sboshra
-Microsoft.Azure.Cosmos/src/Linq @khdang @adityasa @sboshra @kirankumarkolli
-Microsoft.Azure.Cosmos/src/Spatial @neildsh @adityasa @sboshra @kirankumarkolli
-Microsoft.Azure.Cosmos/tests @khdang @sboshra @adityasa @neildsh @kirankumarkolli @FabianMeiswinkel @kirillg
-Microsoft.Azure.Cosmos.Samples @khdang @sboshra @adityasa @neildsh @kirankumarkolli @FabianMeiswinkel @kirillg
+*       @kirankumarkolli @FabianMeiswinkel @sboshra @Pilchie @kushagraThapar
+Microsoft.Azure.Cosmos/src/Json @adityasa @neildsh @kirankumarkolli @sboshra @kushagraThapar
+Microsoft.Azure.Cosmos/src/Query @adityasa @neildsh @kirankumarkolli @sboshra @kushagraThapar
+Microsoft.Azure.Cosmos/src/CosmosElements @adityasa @neildsh @kirankumarkolli @sboshra @kushagraThapar
+Microsoft.Azure.Cosmos/src/SqlObjects @leminh98 @adityasa @kirankumarkolli @sboshra @kushagraThapar
+Microsoft.Azure.Cosmos/src/Linq @khdang @adityasa @sboshra @kirankumarkolli @kushagraThapar
+Microsoft.Azure.Cosmos/src/Spatial @neildsh @adityasa @sboshra @kirankumarkolli @kushagraThapar
+Microsoft.Azure.Cosmos/tests @khdang @sboshra @adityasa @neildsh @kirankumarkolli @FabianMeiswinkel @kirillg @kushagraThapar
+Microsoft.Azure.Cosmos.Samples @khdang @sboshra @adityasa @neildsh @kirankumarkolli @FabianMeiswinkel @kirillg @kushagraThapar
 
 # Order is important; the last matching pattern takes the most precedence
-Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts @kirillg @kirankumarkolli @FabianMeiswinkel
-Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Contracts @kirillg @kirankumarkolli @FabianMeiswinkel
+Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts @kirillg @kirankumarkolli @FabianMeiswinkel @kushagraThapar
+Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Contracts @kirillg @kirankumarkolli @FabianMeiswinkel @kushagraThapar
 Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetSDKAPI.json @Azure/azure-cosmosdb-lt
 Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetPreviewSDKAPI.json @Azure/azure-cosmosdb-lt
 Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetSDKTelemetryAPI.json @Azure/azure-cosmosdb-lt


### PR DESCRIPTION
Adds @kushagraThapar as a codeowner for the default scope and per-folder ownership rules so I am auto-requested for review on relevant changes.

Skipped:
- `*.json` API contract files (owned by @Azure/azure-cosmosdb-lt team)
- `CODEOWNERS` line (admin-only)