### PR TITLE
Encryption Pipelines: Adds SDK-surface parity build to catch TypeLoad gaps

### DIFF
--- a/Microsoft.Azure.Cosmos.Encryption.Custom/src/Microsoft.Azure.Cosmos.Encryption.Custom.csproj
+++ b/Microsoft.Azure.Cosmos.Encryption.Custom/src/Microsoft.Azure.Cosmos.Encryption.Custom.csproj
@@ -68,6 +68,10 @@
   </PropertyGroup>
   
   <PropertyGroup Condition=" '$(SdkProjectRef)' == 'True' ">
+    <DefineSdkProjectRefSymbol Condition=" '$(DefineSdkProjectRefSymbol)' == '' ">true</DefineSdkProjectRefSymbol>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(DefineSdkProjectRefSymbol)' == 'true' ">
     <DefineConstants>$(DefineConstants);SDKPROJECTREF</DefineConstants>
   </PropertyGroup>
 </Project>

--- a/Microsoft.Azure.Cosmos.Encryption/src/Microsoft.Azure.Cosmos.Encryption.csproj
+++ b/Microsoft.Azure.Cosmos.Encryption/src/Microsoft.Azure.Cosmos.Encryption.csproj
@@ -74,6 +74,10 @@
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(SdkProjectRef)' == 'True' ">
+    <DefineSdkProjectRefSymbol Condition=" '$(DefineSdkProjectRefSymbol)' == '' ">true</DefineSdkProjectRefSymbol>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(DefineSdkProjectRefSymbol)' == 'true' ">
     <DefineConstants>$(DefineConstants);SDKPROJECTREF</DefineConstants>
   </PropertyGroup>
 </Project>

--- a/templates/build-preview.yml
+++ b/templates/build-preview.yml
@@ -72,6 +72,24 @@ jobs:
       arguments: -p:Optimize=true -p:IsPreview=true;SdkProjectRef=true
       versioningScheme: OFF
 
+  # Parity check: build Microsoft.Azure.Cosmos.Encryption against master SDK
+  # source WITHOUT defining SDKPROJECTREF. This matches the exact preprocessor
+  # surface the shipped NuGet package is built with (PREVIEW on, SDKPROJECTREF
+  # off) while still linking against the latest SDK abstractions. Any new
+  # abstract member on Container under #if PREVIEW that lacks an unconditional
+  # override in EncryptionContainer will produce a CS0534 compile error here
+  # instead of a runtime TypeLoadException for customers after a future SDK
+  # NuGet release. See PR #5783 (SemanticRerankAsync) for a concrete example.
+  - task: DotNetCoreCLI@2
+    displayName: Build Microsoft.Azure.Cosmos.Encryption (NuGet-surface parity vs master SDK source)
+    inputs:
+      command: build
+      configuration: $(parameters.BuildConfiguration)
+      nugetConfigPath: NuGet.config
+      projects: Microsoft.Azure.Cosmos.Encryption/src/Microsoft.Azure.Cosmos.Encryption.csproj
+      arguments: -p:Optimize=true -p:IsPreview=true -p:SdkProjectRef=true -p:DefineSdkProjectRefSymbol=false
+      versioningScheme: OFF
+
 - job:
   displayName: Preview Encryption EmulatorTests ${{ parameters.BuildConfiguration }}
   timeoutInMinutes: 60
@@ -139,6 +157,25 @@ jobs:
       nugetConfigPath: NuGet.config
       projects: Microsoft.Azure.Cosmos.sln 
       arguments: -p:Optimize=true -p:IsPreview=true;SdkProjectRef=true
+      versioningScheme: OFF
+
+  # Parity check: build Microsoft.Azure.Cosmos.Encryption.Custom against master
+  # SDK source WITHOUT defining SDKPROJECTREF. This matches the exact
+  # preprocessor surface the shipped NuGet package is built with (PREVIEW on,
+  # SDKPROJECTREF off, so SDKPROJECTREF-gated overrides in EncryptionContainer
+  # are stripped) while still linking against the latest SDK abstractions from
+  # master. Any new abstract member on Container under #if PREVIEW that lacks
+  # an unconditional override in EncryptionContainer will produce a CS0534
+  # compile error here instead of a runtime TypeLoadException for customers
+  # after a future SDK NuGet release. See PR #5783 (SemanticRerankAsync).
+  - task: DotNetCoreCLI@2
+    displayName: Build Microsoft.Azure.Cosmos.Encryption.Custom (NuGet-surface parity vs master SDK source)
+    inputs:
+      command: build
+      configuration: $(parameters.BuildConfiguration)
+      nugetConfigPath: NuGet.config
+      projects: Microsoft.Azure.Cosmos.Encryption.Custom/src/Microsoft.Azure.Cosmos.Encryption.Custom.csproj
+      arguments: -p:Optimize=true -p:IsPreview=true -p:SdkProjectRef=true -p:DefineSdkProjectRefSymbol=false
       versioningScheme: OFF
 
 - job:

--- a/templates/static-tools-encryption-custom.yml
+++ b/templates/static-tools-encryption-custom.yml
@@ -14,13 +14,51 @@ jobs:
   - checkout: self  # self represents the repo where the initial Pipelines YAML file was found
     clean: true  # if true, execute `execute git clean -ffdx && git reset --hard HEAD` before fetching
 
+  # Build using the Microsoft.Azure.Cosmos NuGet reference declared in the .csproj.
+  # This matches what customers consume and guards against regressions on the
+  # released SDK surface (the default release pipeline build path).
   - task: DotNetCoreCLI@2
-    displayName: Build Microsoft.Azure.Cosmos.Encryption.Custom
+    displayName: Build Microsoft.Azure.Cosmos.Encryption.Custom (NuGet SDK reference)
     inputs: 
       command: build
       nugetConfigPath: NuGet.config
       projects: Microsoft.Azure.Cosmos.Encryption.Custom/src/Microsoft.Azure.Cosmos.Encryption.Custom.csproj
       arguments: '-p:Optimize=true --configuration Release'
+      versioningScheme: OFF
+
+  # Build using a ProjectReference to the Microsoft.Azure.Cosmos source in this
+  # repo (SdkProjectRef=True / SDKPROJECTREF) with IsPreview=true so the SDK
+  # source compiles with the same preview surface that the Encryption.Custom
+  # package references via NuGet. This catches mismatches between the
+  # Encryption.Custom package and the latest SDK surface in master (for
+  # example, new abstract members on Container) that would otherwise only
+  # surface at customer runtime as TypeLoadException once a newer SDK NuGet is
+  # released. See PR #5783 for a concrete example (SemanticRerankAsync).
+  - task: DotNetCoreCLI@2
+    displayName: Build Microsoft.Azure.Cosmos.Encryption.Custom (SDKREF - master SDK source)
+    inputs: 
+      command: build
+      nugetConfigPath: NuGet.config
+      projects: Microsoft.Azure.Cosmos.Encryption.Custom/src/Microsoft.Azure.Cosmos.Encryption.Custom.csproj
+      arguments: '-p:Optimize=true -p:IsPreview=true -p:SdkProjectRef=true --configuration Release'
+      versioningScheme: OFF
+
+  # Parity check: build against master SDK source WITHOUT defining SDKPROJECTREF.
+  # This matches the exact preprocessor surface the shipped NuGet package is
+  # built with (PREVIEW on, SDKPROJECTREF off, so SDKPROJECTREF-gated overrides
+  # in EncryptionContainer are stripped) while still linking against the latest
+  # SDK abstractions from master. Any new abstract member on Container under
+  # #if PREVIEW that lacks an unconditional override in EncryptionContainer
+  # will produce a CS0534 compile error here instead of a runtime
+  # TypeLoadException for customers after a future SDK NuGet release. This is
+  # the exact class of defect addressed by PR #5783 (SemanticRerankAsync).
+  - task: DotNetCoreCLI@2
+    displayName: Build Microsoft.Azure.Cosmos.Encryption.Custom (NuGet-surface parity vs master SDK source)
+    inputs: 
+      command: build
+      nugetConfigPath: NuGet.config
+      projects: Microsoft.Azure.Cosmos.Encryption.Custom/src/Microsoft.Azure.Cosmos.Encryption.Custom.csproj
+      arguments: '-p:Optimize=true -p:IsPreview=true -p:SdkProjectRef=true -p:DefineSdkProjectRefSymbol=false --configuration Release'
       versioningScheme: OFF
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-binskim.BinSkim@4

--- a/templates/static-tools-encryption.yml
+++ b/templates/static-tools-encryption.yml
@@ -14,13 +14,46 @@ jobs:
   - checkout: self  # self represents the repo where the initial Pipelines YAML file was found
     clean: true  # if true, execute `execute git clean -ffdx && git reset --hard HEAD` before fetching
 
+  # Build using the Microsoft.Azure.Cosmos NuGet reference declared in the .csproj.
+  # This matches what customers consume and guards against regressions on the
+  # released SDK surface (the default release pipeline build path).
   - task: DotNetCoreCLI@2
-    displayName: Build Microsoft.Azure.Cosmos.Encryption
+    displayName: Build Microsoft.Azure.Cosmos.Encryption (NuGet SDK reference)
     inputs: 
       command: build
       nugetConfigPath: NuGet.config
       projects: Microsoft.Azure.Cosmos.Encryption/src/Microsoft.Azure.Cosmos.Encryption.csproj
       arguments: '-p:Optimize=true --configuration Release'
+      versioningScheme: OFF
+
+  # Build using a ProjectReference to the Microsoft.Azure.Cosmos source in this
+  # repo (SdkProjectRef=True / SDKPROJECTREF). This catches mismatches between
+  # the Encryption package and the latest SDK surface in master (for example,
+  # new abstract members on Container) that would otherwise only surface at
+  # customer runtime as TypeLoadException once a newer SDK NuGet is released.
+  - task: DotNetCoreCLI@2
+    displayName: Build Microsoft.Azure.Cosmos.Encryption (SDKREF - master SDK source)
+    inputs: 
+      command: build
+      nugetConfigPath: NuGet.config
+      projects: Microsoft.Azure.Cosmos.Encryption/src/Microsoft.Azure.Cosmos.Encryption.csproj
+      arguments: '-p:Optimize=true -p:IsPreview=true -p:SdkProjectRef=true --configuration Release'
+      versioningScheme: OFF
+
+  # Parity check: build against master SDK source WITHOUT defining SDKPROJECTREF.
+  # This matches the exact preprocessor surface the shipped NuGet package is
+  # built with (PREVIEW on, SDKPROJECTREF off) while still linking against the
+  # latest SDK abstractions. Any new abstract member on Container that is not
+  # backed by an unconditional override in EncryptionContainer will produce a
+  # CS0534 compile error here instead of a runtime TypeLoadException for
+  # customers after a future SDK NuGet release.
+  - task: DotNetCoreCLI@2
+    displayName: Build Microsoft.Azure.Cosmos.Encryption (NuGet-surface parity vs master SDK source)
+    inputs: 
+      command: build
+      nugetConfigPath: NuGet.config
+      projects: Microsoft.Azure.Cosmos.Encryption/src/Microsoft.Azure.Cosmos.Encryption.csproj
+      arguments: '-p:Optimize=true -p:IsPreview=true -p:SdkProjectRef=true -p:DefineSdkProjectRefSymbol=false --configuration Release'
       versioningScheme: OFF
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-binskim.BinSkim@4


### PR DESCRIPTION
## Problem

The Encryption and Encryption.Custom official release pipelines previously built each project only against the pinned `Microsoft.Azure.Cosmos` NuGet declared in the project file. That does not detect abstract members added to `Container` on master that lack an unconditional override in `EncryptionContainer` — the exact class of defect fixed by #5783 (`SemanticRerankAsync` `TypeLoadException`).

The customer-facing symptom from #5783:

> `System.TypeLoadException`: Method `SemanticRerankAsync` in type `Microsoft.Azure.Cosmos.Encryption.Custom.EncryptionContainer` does not have an implementation.

## Why a naive SDKREF build is not enough

The override was gated `#if PREVIEW && SDKPROJECTREF`. Any build that defines **both** symbols — which is what the existing PR-validation build (`build-preview.yml`) does, and what an obvious "build with `SdkProjectRef=true`" addition would also do — compiles the override back in and the missing-implementation condition never manifests:

| Build mode | `PREVIEW` | `SDKPROJECTREF` | Override present? | Catches the bug? |
|---|---|---|---|---|
| Current default (NuGet ref, pinned `3.41.0-preview.0`) | ❌ | ❌ | — (no abstract either) | ❌ |
| `-p:IsPreview=true -p:SdkProjectRef=true` | ✅ | ✅ | ✅ | ❌ (masks the defect) |
| **New parity build** (`DefineSdkProjectRefSymbol=false`) | ✅ | ❌ | ❌ | ✅ |

The bug only manifests when `PREVIEW` is on and `SDKPROJECTREF` is off, linked against an SDK that contains the new abstract member. That is the exact surface of the shipped Encryption.Custom NuGet.

## Change

1. **Decouple the `SDKPROJECTREF` preprocessor define from the `SdkProjectRef` MSBuild property** via a new `DefineSdkProjectRefSymbol` knob in both:
   - `Microsoft.Azure.Cosmos.Encryption.Custom/src/Microsoft.Azure.Cosmos.Encryption.Custom.csproj`
   - `Microsoft.Azure.Cosmos.Encryption/src/Microsoft.Azure.Cosmos.Encryption.csproj`

   Default behaviour is unchanged: `SdkProjectRef=true` still sets `SDKPROJECTREF`. Pipelines can now opt out with `-p:DefineSdkProjectRefSymbol=false`.

2. **Add two build steps** to each encryption official release-gate template (`templates/static-tools-encryption.yml`, `templates/static-tools-encryption-custom.yml`):

   - **SDKREF build** — `-p:IsPreview=true -p:SdkProjectRef=true`. Verifies the full project-reference path still compiles against master SDK source.
   - **NuGet-surface parity build** — `-p:IsPreview=true -p:SdkProjectRef=true -p:DefineSdkProjectRefSymbol=false`. Links against master SDK source with the exact preprocessor surface of the shipped NuGet. Any newly-added abstract member on `Container` under `#if PREVIEW` without an unconditional override in `EncryptionContainer` now fails this step with `CS0534`.

## Proof the pipeline catches #5783

I reverted #5783 in a worktree (`virtual` → `abstract` on `Container.SemanticRerankAsync`) and ran the new parity build for Encryption.Custom:

```
error CS0534: 'EncryptionContainer' does not implement inherited abstract
member 'Container.SemanticRerankAsync(string, IEnumerable<string>,
IDictionary<string, object>, CancellationToken)'
Build FAILED.
```

That is exactly the runtime `TypeLoadException` surface from the customer report, caught at compile time.

All six build permutations (default / SDKREF / parity × Encryption / Encryption.Custom) pass at the fixed state:

| Project | Default (NuGet) | SDKREF | NuGet-surface parity |
|---|---|---|---|
| `Microsoft.Azure.Cosmos.Encryption` | ✅ | ✅ | ✅ |
| `Microsoft.Azure.Cosmos.Encryption.Custom` | ✅ | ✅ | ✅ |

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Closing issues

Related to #5783.
