### PR TITLE
.NET10: Fixes .NET 10 compilation warnings

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CustomSerializationTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CustomSerializationTests.cs
@@ -330,7 +330,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             client.EnsureValidClientAsync(NoOpTrace.Singleton).Wait();
 
-            // Create a simple stored procedure
+            // Create a Simple stored procedure
             string scriptId = "bulkImportScript";
             StoredProcedure sproc = new StoredProcedure
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Fluent/ContainerSettingsTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Fluent/ContainerSettingsTests.cs
@@ -949,7 +949,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.IsNotNull(throughputProperties);
             Assert.AreEqual(expectedThroughput, throughputProperties.Throughput);
 
-            // simple API
+            // Simple API
             int? throughput = await container.ReadThroughputAsync();
             Assert.IsNotNull(throughput);
             Assert.AreEqual(expectedThroughput, throughput);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Linq/LinqGeneralBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Linq/LinqGeneralBaselineTests.cs
@@ -674,7 +674,7 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests.LinqProviderTests
 
             // Customer requested scenario
             inputs.Add(new LinqTestInput(
-                "Where(simple expr && Any)", b => getQuery(b)
+                "Where(Simple expr && Any)", b => getQuery(b)
                 .Where(f => f.FamilyId.Contains("a") && f.Children.Any(c => c.Pets.Count() > 0))));
 
             inputs.Add(new LinqTestInput(

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Linq/LinqSQLTranslationBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Linq/LinqSQLTranslationBaselineTests.cs
@@ -70,30 +70,30 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests
             cosmosClient?.Dispose();
         }
 
-        struct simple
+        struct Simple
         {
             public int x;
             public int y;
             public string id;
             public string pk;
 
-            public simple(int x, int y)
+            public Simple(int x, int y)
             { this.x = x; this.y = y; this.id = Guid.NewGuid().ToString(); this.pk = "Test"; }
         }
 
-        struct nested
+        struct Nested
         {
             public int x;
-            public simple s;
+            public Simple s;
 
-            public nested(int x, simple s)
+            public Nested(int x, Simple s)
             {
                 this.x = x;
                 this.s = s;
             }
         }
 
-        struct complex
+        struct Complex
         {
             private string json;
 
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests
             public string str;
             public bool b;
             public double[] dblArray;
-            public simple inside;
+            public Simple inside;
             public string id;
             public string pk;
 
@@ -111,7 +111,7 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests
             [System.Text.Json.Serialization.JsonExtensionData()]
             public Dictionary<string, object> NetExtensionData { get; set; }
 
-            public complex(double d, string str, bool b, double[] da, simple s)
+            public Complex(double d, string str, bool b, double[] da, Simple s)
             {
                 this.dbl = d;
                 this.str = str;
@@ -127,7 +127,7 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests
 
             public override string ToString()
             {
-                // simple cached serialization
+                // Simple cached serialization
                 if (this.json == null)
                 {
                     this.json = JsonConvert.SerializeObject(this);
@@ -137,7 +137,7 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests
 
             public override bool Equals(object obj)
             {
-                if (!(obj is complex)) return false;
+                if (!(obj is Complex)) return false;
 
                 return this.ToString().Equals(obj.ToString());
             }
@@ -207,16 +207,16 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests
             float floatValue = 5.23f;
 
             const int Records = 100;
-            Func<Random, simple> createDataObj = (random) =>
+            Func<Random, Simple> createDataObj = (random) =>
             {
-                simple obj = new simple();
+                Simple obj = new Simple();
                 obj.x = random.Next();
                 obj.y = random.Next();
                 obj.id = Guid.NewGuid().ToString();
                 obj.pk = "Test";
                 return obj;
             };
-            Func<bool, IQueryable<simple>> dataQuery = LinqTestsCommon.GenerateTestCosmosData<simple>(createDataObj, Records, testContainer);
+            Func<bool, IQueryable<Simple>> dataQuery = LinqTestsCommon.GenerateTestCosmosData<Simple>(createDataObj, Records, testContainer);
 
             List<LinqTestInput> inputs = new List<LinqTestInput>();
             inputs.Add(new LinqTestInput("Select cast float", b => dataQuery(b).Select(x => (int)floatValue)));
@@ -225,7 +225,7 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests
             inputs.Add(new LinqTestInput("Select int expr w const", b => dataQuery(b).Select(x => x.x + constInt)));
             inputs.Add(new LinqTestInput("Select w new array", b => dataQuery(b).Select(d => new int[2] { d.x, d.x + 1 })));
             inputs.Add(new LinqTestInput("Select new", b => dataQuery(b).Select(d => new { first = d.x, second = d.x })));
-            inputs.Add(new LinqTestInput("Select nested new", b => dataQuery(b).Select(d => new { first = d.x, second = new { third = d.x } })));
+            inputs.Add(new LinqTestInput("Select Nested new", b => dataQuery(b).Select(d => new { first = d.x, second = new { third = d.x } })));
             inputs.Add(new LinqTestInput("Filter int >", b => dataQuery(b).Where(x => x.x > 2)));
             inputs.Add(new LinqTestInput("Filter method >", b => dataQuery(b).Where(x => x.x > id(3))));
             inputs.Add(new LinqTestInput("Filter int > -> Select int expr", b => dataQuery(b).Where(x => x.x > 2).Select(x => x.x + 2)));
@@ -236,9 +236,9 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests
             inputs.Add(new LinqTestInput("Select const array index", b => dataQuery(b)
                 .Where(x => x.x >= 0 && x.x < 3)
                 .Select(x => new int[] { 1, 2, 3 }[x.x])));
-            inputs.Add(new LinqTestInput("Select new simple", b => dataQuery(b).Select(x => new simple { x = x.x, y = x.x })));
-            inputs.Add(new LinqTestInput("Select new nested", b => dataQuery(b).Select(x => new nested { s = new simple { x = x.x, y = x.x }, x = 2 })));
-            inputs.Add(new LinqTestInput("Select new complex", b => dataQuery(b).Select(d => new complex { dbl = 1.0, str = "", b = false, dblArray = new double[] { 1.0, 2.0, }, inside = new simple { x = d.x, y = d.x } })));
+            inputs.Add(new LinqTestInput("Select new Simple", b => dataQuery(b).Select(x => new Simple { x = x.x, y = x.x })));
+            inputs.Add(new LinqTestInput("Select new Nested", b => dataQuery(b).Select(x => new Nested { s = new Simple { x = x.x, y = x.x }, x = 2 })));
+            inputs.Add(new LinqTestInput("Select new Complex", b => dataQuery(b).Select(d => new Complex { dbl = 1.0, str = "", b = false, dblArray = new double[] { 1.0, 2.0, }, inside = new Simple { x = d.x, y = d.x } })));
             inputs.Add(new LinqTestInput("Select cast double x", b => dataQuery(b).Select(x => (double)x.x)));
             inputs.Add(new LinqTestInput("Select indexer x", b => dataQuery(b)
                 .Where(x => x.x >= 0 && x.x < array.Length)
@@ -246,8 +246,8 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests
             inputs.Add(new LinqTestInput("Select new constructor", b => dataQuery(b).Select(x => new TimeSpan(x.x))));
             inputs.Add(new LinqTestInput("Select method id", b => dataQuery(b).Select(x => id(x))));
             inputs.Add(new LinqTestInput("Select identity", b => dataQuery(b).Select(x => x)));
-            inputs.Add(new LinqTestInput("Select simple property", b => dataQuery(b).Select(x => x.x)));
-            inputs.Add(new LinqTestInput("Select extension data", b => dataQuery(b).Select(x => new complex() {
+            inputs.Add(new LinqTestInput("Select Simple property", b => dataQuery(b).Select(x => x.x)));
+            inputs.Add(new LinqTestInput("Select extension data", b => dataQuery(b).Select(x => new Complex() {
                 NewtonsoftExtensionData = new() {
                     { "test", 1.5 }
                 },
@@ -268,9 +268,9 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests
             const int Records = 100;
             const int MaxArraySize = 10;
             const int MaxStringLength = 50;
-            Func<Random, complex> createDataObj = (random) =>
+            Func<Random, Complex> createDataObj = (random) =>
             {
-                complex obj = new complex();
+                Complex obj = new Complex();
                 obj.b = random.NextDouble() < 0.5;
                 obj.dbl = random.NextDouble();
                 obj.dblArray = new double[random.Next(MaxArraySize)];
@@ -278,7 +278,7 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests
                 {
                     obj.dblArray[i] = random.NextDouble() < 0.1 ? 3 : random.NextDouble();
                 }
-                obj.inside = new simple() { x = random.Next(), y = random.Next() };
+                obj.inside = new Simple() { x = random.Next(), y = random.Next() };
                 obj.str = random.NextDouble() < 0.1 ? "5" : LinqTestsCommon.RandomString(random, random.Next(MaxStringLength));
                 obj.id = Guid.NewGuid().ToString();
                 obj.pk = "Test";
@@ -288,7 +288,7 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests
                 };
                 return obj;
             };
-            Func<bool, IQueryable<complex>> getQuery = LinqTestsCommon.GenerateTestCosmosData<complex>(createDataObj, Records, testContainer);
+            Func<bool, IQueryable<Complex>> getQuery = LinqTestsCommon.GenerateTestCosmosData<Complex>(createDataObj, Records, testContainer);
 
             List<LinqTestInput> inputs = new List<LinqTestInput>();
             inputs.Add(new LinqTestInput("Select equality", b => getQuery(b).Select(s => s.str == "5")));

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Linq/LinqScalarFunctionBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Linq/LinqScalarFunctionBaselineTests.cs
@@ -156,7 +156,7 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests.LinqProviderTests
             /////////////////
 
             // ISSUE-TODO-adityasa-2024/1/26 - Support FirstOrDefault overloads.
-            // Please note, this requires potential support for user code invocation in context of rest of the client code (except maybe some simple cases).
+            // Please note, this requires potential support for user code invocation in context of rest of the client code (except maybe some Simple cases).
             // We do not currently do this for any other scenarios.
 
             // Unsupported

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Linq/LinqTestsCommon.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Linq/LinqTestsCommon.cs
@@ -636,7 +636,7 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests
 
         public override string ToString()
         {
-            // simple cached serialization
+            // Simple cached serialization
             this.json ??= this.SerializeForTestBaseline();
             return this.json;
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Linq/LinqTranslationBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Linq/LinqTranslationBaselineTests.cs
@@ -1442,7 +1442,7 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests.LinqProviderTests
                         10.123456789d,
                         new object[] {
                             "world",
-                            new object[] { "nested array", new { A = int.MaxValue, B = int.MinValue } } })).Select(doc => doc.ArrayField),
+                            new object[] { "Nested array", new { A = int.MaxValue, B = int.MinValue } } })).Select(doc => doc.ArrayField),
                     skipVerification: true,
                     serializeOutput: true),
                 new LinqTestInput("same field",
@@ -1458,7 +1458,7 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests.LinqProviderTests
                         10.123456789d,
                         new object[] {
                             "world",
-                            new object[] { "nested array", new { A = int.MaxValue, B = int.MinValue } } }
+                            new object[] { "Nested array", new { A = int.MaxValue, B = int.MinValue } } }
                         }.ArrayContainsAll(doc.ArrayField)).Select(doc => doc.ArrayField),
                     skipVerification: true,
                     serializeOutput: true),
@@ -1588,7 +1588,7 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests.LinqProviderTests
                         10.123456789d,
                         new object[] {
                             "world",
-                            new object[] { "nested array", new { A = int.MaxValue, B = int.MinValue } } })).Select(doc => doc.ArrayField),
+                            new object[] { "Nested array", new { A = int.MaxValue, B = int.MinValue } } })).Select(doc => doc.ArrayField),
                     skipVerification: true,
                     serializeOutput: true),
                 new LinqTestInput("same field",
@@ -1604,7 +1604,7 @@ namespace Microsoft.Azure.Cosmos.Services.Management.Tests.LinqProviderTests
                         10.123456789d,
                         new object[] {
                             "world",
-                            new object[] { "nested array", new { A = int.MaxValue, B = int.MinValue } } }
+                            new object[] { "Nested array", new { A = int.MaxValue, B = int.MinValue } } }
                         }.ArrayContainsAny(doc.ArrayField)).Select(doc => doc.ArrayField),
                     skipVerification: true,
                     serializeOutput: true),

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Microsoft.Azure.Cosmos.EmulatorTests.csproj
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Microsoft.Azure.Cosmos.EmulatorTests.csproj
@@ -54,12 +54,9 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.11.4" />
-    <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.2" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.7.1" />
     <PackageReference Include="OpenTelemetry" Version="1.9.0" />
-    <PackageReference Include="System.Reflection.Emit" Version="4.3.0" />
-    <PackageReference Include="System.Security.SecureString" Version="4.3.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
@@ -67,7 +64,6 @@
     <PackageReference Include="MSTest.TestAdapter" Version="3.7.3" />
     <PackageReference Include="MSTest.TestFramework" Version="3.7.3" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="System.Reflection" Version="4.3.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/ConflictsE2ETest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Query/ConflictsE2ETest.cs
@@ -125,7 +125,7 @@
         /// <summary>
         /// Insert documents until exactly one conflict is generated.
         /// This is a non-deterministic operation (in terms of both duration and outcome) due to backend's behavior.
-        /// It will terminate the test based on simple heuristic if desired outcome cannot be achieved.
+        /// It will terminate the test based on Simple heuristic if desired outcome cannot be achieved.
         /// </summary>
         private async Task InsertWithConflict(IReadOnlyList<(CosmosClient Client, Container Container)> cosmosContainers)
             => await this.InsertFromMultipleClients(

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/QueryTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/QueryTests.cs
@@ -849,7 +849,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                         }
                     };
 
-                    await testDocumentSQL("doc00", "simple", null);
+                    await testDocumentSQL("doc00", "Simple", null);
                     await testDocumentSQL("doc10", "\uD83D\uDE03", @"\uD83D\uDE03");
                     await testDocumentSQL("doc20", "\uD83D\uDE03\t\u0005\uD83D\uDE03", @"\uD83D\uDE03\t\u0005\uD83D\uDE03");
                     await testDocumentSQL("doc30", "Små ord", null);
@@ -2224,7 +2224,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 });
             }
 
-            // simple validations - existence - yes & no
+            // Simple validations - existence - yes & no
             DocumentFeedResponse<dynamic> result = await this.client.CreateDocumentQuery<Document>(collection, "SELECT r.id FROM root r", new FeedOptions() { EnableCrossPartitionQuery = true }).AsDocumentQuery().ExecuteNextAsync();
             Assert.IsNull(result.ResponseHeaders[WFConstants.BackendHeaders.QueryMetrics], "Expected no metrics headers for query");
             Assert.IsNull(result.ResponseHeaders[WFConstants.BackendHeaders.IndexUtilization], "Expected no index utilization headers for query");


### PR DESCRIPTION
    C:\src\v32\Microsoft.Azure.Cosmos\tests\Microsoft.Azure.Cosmos.EmulatorTests\Linq\LinqSQLTranslationBaselineTests.cs(73,16): error CS8981: The type name 'simple' only contains lower-cased ascii characters. Such names may become reserved for the language.
    C:\src\v32\Microsoft.Azure.Cosmos\tests\Microsoft.Azure.Cosmos.EmulatorTests\Linq\LinqSQLTranslationBaselineTests.cs(84,16): error CS8981: The type name 'nested' only contains lower-cased ascii characters. Such names may become reserved for the language.
    C:\src\v32\Microsoft.Azure.Cosmos\tests\Microsoft.Azure.Cosmos.EmulatorTests\Linq\LinqSQLTranslationBaselineTests.cs(96,16): error CS8981: The type name 'complex' only contains lower-cased ascii characters. Such names may become reserved for the language.

# Pull Request Template

## Description

Please include a summary of the change and which issue is fixed. Include samples if adding new API, and include relevant motivation and context. List any dependencies that are required for this change.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber