### PR TITLE
Client Encryption: Fixes MemoryTextReader.ReadToEnd returning empty string

### DIFF
--- a/Microsoft.Azure.Cosmos.Encryption.Custom/src/Transformation/MemoryTextReader.cs
+++ b/Microsoft.Azure.Cosmos.Encryption.Custom/src/Transformation/MemoryTextReader.cs
@@ -103,9 +103,15 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom.Transformation
                 throw new InvalidOperationException("Reader is closed");
             }
 
+            int start = this.pos;
+            int count = this.length - start;
             this.pos = this.length;
-            Memory<char> remaining = this.chars.Slice(this.pos, this.length - this.pos);
-            return new string(remaining.ToArray());
+            if (count == 0)
+            {
+                return string.Empty;
+            }
+
+            return this.chars.Span.Slice(start, count).ToString();
         }
 
         public override string ReadLine()

--- a/Microsoft.Azure.Cosmos.Encryption.Custom/tests/Microsoft.Azure.Cosmos.Encryption.Custom.Tests/Transformation/MemoryTextReaderTests.cs
+++ b/Microsoft.Azure.Cosmos.Encryption.Custom/tests/Microsoft.Azure.Cosmos.Encryption.Custom.Tests/Transformation/MemoryTextReaderTests.cs
@@ -1,0 +1,246 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+namespace Microsoft.Azure.Cosmos.Encryption.Tests.Transformation
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using Microsoft.Azure.Cosmos.Encryption.Custom.Transformation;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class MemoryTextReaderTests
+    {
+        private static MemoryTextReader Create(string value)
+        {
+            return new MemoryTextReader(value.ToCharArray().AsMemory());
+        }
+
+        [TestMethod]
+        public void ReadToEnd_WhenFreshReader_ReturnsFullContent()
+        {
+            using MemoryTextReader reader = Create("hello world");
+
+            string result = reader.ReadToEnd();
+
+            Assert.AreEqual("hello world", result);
+        }
+
+        [TestMethod]
+        public void ReadToEnd_AfterPartialRead_ReturnsRemainderOnly()
+        {
+            using MemoryTextReader reader = Create("abcdef");
+            _ = reader.Read();
+            _ = reader.Read();
+
+            string result = reader.ReadToEnd();
+
+            Assert.AreEqual("cdef", result);
+        }
+
+        [TestMethod]
+        public void ReadToEnd_WhenEmptyInput_ReturnsEmptyString()
+        {
+            using MemoryTextReader reader = Create(string.Empty);
+
+            Assert.AreEqual(string.Empty, reader.ReadToEnd());
+        }
+
+        [TestMethod]
+        public void ReadToEnd_AfterFullyConsumed_ReturnsEmptyString()
+        {
+            using MemoryTextReader reader = Create("xyz");
+            char[] buffer = new char[16];
+            int n = reader.Read(buffer, 0, buffer.Length);
+            Assert.AreEqual(3, n);
+
+            Assert.AreEqual(string.Empty, reader.ReadToEnd());
+        }
+
+        [TestMethod]
+        public void ReadToEnd_CalledTwice_SecondCallReturnsEmptyString()
+        {
+            using MemoryTextReader reader = Create("payload");
+
+            Assert.AreEqual("payload", reader.ReadToEnd());
+            Assert.AreEqual(string.Empty, reader.ReadToEnd());
+        }
+
+        [TestMethod]
+        public void ReadToEnd_AfterClose_Throws()
+        {
+            MemoryTextReader reader = Create("data");
+            reader.Close();
+
+            Assert.ThrowsException<InvalidOperationException>(() => reader.ReadToEnd());
+        }
+
+        [TestMethod]
+        public void ReadToEnd_OnUnicodeContent_PreservesCharacters()
+        {
+            string input = "héllo → 🙂 αβγ";
+            using MemoryTextReader reader = Create(input);
+
+            Assert.AreEqual(input, reader.ReadToEnd());
+        }
+
+        [TestMethod]
+        public void ReadToEnd_MatchesStringReaderBehaviour()
+        {
+            string input = "line1\r\nline2\nline3";
+            using MemoryTextReader memoryReader = Create(input);
+            using StringReader stringReader = new (input);
+
+            Assert.AreEqual(stringReader.ReadToEnd(), memoryReader.ReadToEnd());
+        }
+
+        [TestMethod]
+        public void ReadToEnd_AfterPartialRead_MatchesStringReaderBehaviour()
+        {
+            string input = "abcdefghij";
+            using MemoryTextReader memoryReader = Create(input);
+            using StringReader stringReader = new (input);
+
+            char[] buffer = new char[4];
+            int n1 = memoryReader.Read(buffer, 0, buffer.Length);
+            int n2 = stringReader.Read(buffer, 0, buffer.Length);
+            Assert.AreEqual(n2, n1);
+
+            Assert.AreEqual(stringReader.ReadToEnd(), memoryReader.ReadToEnd());
+        }
+
+        [TestMethod]
+        public void Peek_WhenFreshReader_ReturnsFirstChar_WithoutAdvancingPosition()
+        {
+            using MemoryTextReader reader = Create("abc");
+
+            Assert.AreEqual((int)'a', reader.Peek());
+            Assert.AreEqual((int)'a', reader.Peek());
+            Assert.AreEqual((int)'a', reader.Read());
+            Assert.AreEqual((int)'b', reader.Peek());
+        }
+
+        [TestMethod]
+        public void Peek_AtEnd_ReturnsMinusOne()
+        {
+            using MemoryTextReader reader = Create("x");
+            _ = reader.Read();
+
+            Assert.AreEqual(-1, reader.Peek());
+        }
+
+        [TestMethod]
+        public void Peek_WhenEmpty_ReturnsMinusOne()
+        {
+            using MemoryTextReader reader = Create(string.Empty);
+
+            Assert.AreEqual(-1, reader.Peek());
+        }
+
+        [TestMethod]
+        public void Peek_AfterClose_Throws()
+        {
+            MemoryTextReader reader = Create("x");
+            reader.Close();
+
+            Assert.ThrowsException<InvalidOperationException>(() => reader.Peek());
+        }
+
+        [TestMethod]
+        public void Read_AfterClose_Throws()
+        {
+            MemoryTextReader reader = Create("x");
+            reader.Close();
+
+            Assert.ThrowsException<InvalidOperationException>(() => reader.Read());
+        }
+
+        [TestMethod]
+        public void ReadBuffer_AfterClose_Throws()
+        {
+            MemoryTextReader reader = Create("x");
+            reader.Close();
+
+            Assert.ThrowsException<InvalidOperationException>(
+                () => reader.Read(new char[1], 0, 1));
+        }
+
+        [TestMethod]
+        public void ReadBuffer_NullBuffer_Throws()
+        {
+            using MemoryTextReader reader = Create("x");
+
+            Assert.ThrowsException<ArgumentNullException>(() => reader.Read(null, 0, 1));
+        }
+
+        [TestMethod]
+        public void ReadBuffer_NegativeIndex_Throws()
+        {
+            using MemoryTextReader reader = Create("x");
+
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => reader.Read(new char[4], -1, 1));
+        }
+
+        [TestMethod]
+        public void ReadBuffer_NegativeCount_Throws()
+        {
+            using MemoryTextReader reader = Create("x");
+
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => reader.Read(new char[4], 0, -1));
+        }
+
+        [TestMethod]
+        public void ReadBuffer_CountExceedsBuffer_Throws()
+        {
+            using MemoryTextReader reader = Create("x");
+
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => reader.Read(new char[4], 2, 10));
+        }
+
+        [TestMethod]
+        public void ReadBuffer_WhenCountLargerThanRemaining_ReturnsOnlyRemaining()
+        {
+            using MemoryTextReader reader = Create("abc");
+            char[] dest = new char[16];
+
+            int n = reader.Read(dest, 2, 10);
+            Assert.AreEqual(3, n);
+            Assert.AreEqual('a', dest[2]);
+            Assert.AreEqual('b', dest[3]);
+            Assert.AreEqual('c', dest[4]);
+        }
+
+        [TestMethod]
+        public void ReadBuffer_WhenAtEnd_ReturnsZero()
+        {
+            using MemoryTextReader reader = Create("ab");
+            _ = reader.ReadToEnd();
+
+            Assert.AreEqual(0, reader.Read(new char[4], 0, 4));
+        }
+
+        [TestMethod]
+        public void ReadLine_IteratesExpectedLines()
+        {
+            using MemoryTextReader reader = Create("a\r\nbc\nd");
+            List<string> lines = new ();
+            string line;
+            while ((line = reader.ReadLine()) != null)
+            {
+                lines.Add(line);
+            }
+
+            CollectionAssert.AreEqual(new[] { "a", "bc", "d" }, lines);
+        }
+
+        [TestMethod]
+        public void ReadLine_AfterClose_Throws()
+        {
+            MemoryTextReader reader = Create("x");
+            reader.Close();
+
+            Assert.ThrowsException<InvalidOperationException>(() => reader.ReadLine());
+        }
+    }
+}


### PR DESCRIPTION
# Fixes `MemoryTextReader.ReadToEnd` returning an empty string

## The bug

`Microsoft.Azure.Cosmos.Encryption.Custom.Transformation.MemoryTextReader.ReadToEnd()` set `this.pos = this.length` **before** computing the remaining slice as `(this.pos, this.length - this.pos)`. `this.length - this.pos` was therefore always zero, and the method returned an empty string regardless of the reader's contents or position.

```csharp
// before
this.pos = this.length;
Memory<char> remaining = this.chars.Slice(this.pos, this.length - this.pos); // always empty slice
return new string(remaining.ToArray());
```

## The fix

Swap the ordering so the slice is computed from the current position first, then advance `pos`. Also replaces `Memory<char>.ToArray() + new string(char[])` with `ReadOnlySpan<char>.ToString()` to avoid an intermediate `char[]` allocation on every call.

```csharp
// after
int start = this.pos;
int count = this.length - start;
this.pos = this.length;
if (count == 0)
{
    return string.Empty;
}

return this.chars.Span.Slice(start, count).ToString();
```

## Impact on production code: none today

The only in-tree caller of `MemoryTextReader` is `JObjectSqlSerializer.Deserialize` (line 114), which hands the reader to `Newtonsoft.Json.JsonTextReader`. `JsonTextReader` reads via `Read(buffer, index, count)` — not `ReadToEnd` — so this bug has no observable effect on the encrypt/decrypt paths today.

However, `MemoryTextReader` derives from `TextReader` and any future consumer reaching for `ReadToEnd` would silently see an empty result. This fix makes the method behave as its public `TextReader` contract requires.

## Tests

Adds `MemoryTextReaderTests.cs` with 23 cases covering:

- The bug directly (`ReadToEnd_WhenFreshReader_ReturnsFullContent`, cross-validated against `StringReader`).
- Edge cases: empty input, fully-consumed reader, double-`ReadToEnd`, partial read then `ReadToEnd`, Unicode input.
- Argument validation: null buffer, negative index/count, count exceeding buffer.
- Disposal guards: `Peek`/`Read`/`ReadLine`/`ReadToEnd` after `Close()` all throw.
- Other previously-uncovered overrides: `Peek`, `Read()`, `Read(buffer,index,count)`, `ReadLine`.

**Regression guard**: 6 of the new `ReadToEnd` tests fail against the buggy implementation and pass against the fixed one:

```
Failed ReadToEnd_WhenFreshReader_ReturnsFullContent
Failed ReadToEnd_AfterPartialRead_ReturnsRemainderOnly
Failed ReadToEnd_CalledTwice_SecondCallReturnsEmptyString
Failed ReadToEnd_OnUnicodeContent_PreservesCharacters
Failed ReadToEnd_MatchesStringReaderBehaviour
Failed ReadToEnd_AfterPartialRead_MatchesStringReaderBehaviour
Failed!  - Failed:     6, Passed:    17, Skipped:     0, Total:    23
```

After the fix: 23/23 pass; all 214 other encryption-custom tests pass (`net8.0`, `--filter "TestCategory!=Integration"`).

## Risks

Minimal. The method had no observed callers relying on the broken behaviour (it was always returning `""` which no consumer is plausibly relying on). The fix is a 2-line swap plus a cheap allocation optimisation. No public API surface changes.

## Checklist

- [x] Branch: `users/adamnova/memorytextreader-readtoend`
- [x] PR title matches the required regex (`Client Encryption: Fixes MemoryTextReader.ReadToEnd returning empty string`)
- [x] `Co-authored-by: Copilot` trailer on the commit
- [x] No changes to `Directory.Build.props` / versioning / packaging
- [x] Both `net8.0` and `netstandard2.0` targets build
- [x] Unit tests added with regression coverage; full suite passes
- [x] Integration tests (require Cosmos emulator) — not run
