### PR TITLE
ChangeFeedProcessor: Fixes lease de-duplication for /partitionKey-partitioned lease containers

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseManagerCosmos.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseManagerCosmos.cs
@@ -130,10 +130,9 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
                 Mode = this.GetChangeFeedMode()
             };
 
-            string partitionKeyValue = this.useDeterministicPartitionKey
-                ? documentServiceLease.LeaseId
-                : Guid.NewGuid().ToString();
-            this.requestOptionsFactory.AddPartitionKeyIfNeeded((string pk) => documentServiceLease.LeasePartitionKey = pk, partitionKeyValue);
+            this.requestOptionsFactory.AddPartitionKeyIfNeeded(
+                (string pk) => documentServiceLease.LeasePartitionKey = pk,
+                this.GetLeasePartitionKeyValue(documentServiceLease.LeaseId));
 
             return this.TryCreateDocumentServiceLeaseAsync(documentServiceLease);
         }
@@ -158,12 +157,18 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
                 Mode = this.GetChangeFeedMode()
             };
 
-            string partitionKeyValue = this.useDeterministicPartitionKey
-                ? documentServiceLease.LeaseId
-                : Guid.NewGuid().ToString();
-            this.requestOptionsFactory.AddPartitionKeyIfNeeded((string pk) => documentServiceLease.LeasePartitionKey = pk, partitionKeyValue);
+            this.requestOptionsFactory.AddPartitionKeyIfNeeded(
+                (string pk) => documentServiceLease.LeasePartitionKey = pk,
+                this.GetLeasePartitionKeyValue(documentServiceLease.LeaseId));
 
             return this.TryCreateDocumentServiceLeaseAsync(documentServiceLease);
+        }
+
+        private string GetLeasePartitionKeyValue(string leaseId)
+        {
+            return this.useDeterministicPartitionKey
+                ? leaseId
+                : Guid.NewGuid().ToString();
         }
 
         private string GetChangeFeedMode()

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseManagerCosmos.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseManagerCosmos.cs
@@ -132,7 +132,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
 
             this.requestOptionsFactory.AddPartitionKeyIfNeeded(
                 (string pk) => documentServiceLease.LeasePartitionKey = pk,
-                GetLeasePartitionKeyValue(IsChangeFeedLeaseIdAsPartitionKeyEnabled, documentServiceLease.LeaseId));
+                DocumentServiceLeaseManagerCosmos.GetLeasePartitionKeyValue(documentServiceLease.LeaseId));
 
             return this.TryCreateDocumentServiceLeaseAsync(documentServiceLease);
         }
@@ -159,14 +159,14 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
 
             this.requestOptionsFactory.AddPartitionKeyIfNeeded(
                 (string pk) => documentServiceLease.LeasePartitionKey = pk,
-                GetLeasePartitionKeyValue(IsChangeFeedLeaseIdAsPartitionKeyEnabled, documentServiceLease.LeaseId));
+                DocumentServiceLeaseManagerCosmos.GetLeasePartitionKeyValue(documentServiceLease.LeaseId));
 
             return this.TryCreateDocumentServiceLeaseAsync(documentServiceLease);
         }
 
-        private static string GetLeasePartitionKeyValue(bool isLeaseIdAsPartitionKeyEnabled, string leaseId)
+        private static string GetLeasePartitionKeyValue(string leaseId)
         {
-            return isLeaseIdAsPartitionKeyEnabled
+            return DocumentServiceLeaseManagerCosmos.IsChangeFeedLeaseIdAsPartitionKeyEnabled
                 ? leaseId
                 : Guid.NewGuid().ToString();
         }

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseManagerCosmos.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseManagerCosmos.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
         private readonly DocumentServiceLeaseStoreManagerOptions options;
         private readonly RequestOptionsFactory requestOptionsFactory;
         private readonly AsyncLazy<TryCatch<string>> lazyContainerRid;
+        private readonly bool useDeterministicPartitionKey;
         private PartitionKeyRangeCache partitionKeyRangeCache;
 
         public DocumentServiceLeaseManagerCosmos(
@@ -44,6 +45,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
             this.options = options;
             this.requestOptionsFactory = requestOptionsFactory;
             this.lazyContainerRid = new AsyncLazy<TryCatch<string>>(valueFactory: (trace, innerCancellationToken) => this.TryInitializeContainerRIdAsync(innerCancellationToken));
+            this.useDeterministicPartitionKey = ConfigurationManager.IsChangeFeedLeaseIdAsPartitionKeyEnabled();
         }
 
         public override async Task<DocumentServiceLease> AcquireAsync(DocumentServiceLease lease)
@@ -128,7 +130,10 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
                 Mode = this.GetChangeFeedMode()
             };
 
-            this.requestOptionsFactory.AddPartitionKeyIfNeeded((string pk) => documentServiceLease.LeasePartitionKey = pk, Guid.NewGuid().ToString());
+            string partitionKeyValue = this.useDeterministicPartitionKey
+                ? documentServiceLease.LeaseId
+                : Guid.NewGuid().ToString();
+            this.requestOptionsFactory.AddPartitionKeyIfNeeded((string pk) => documentServiceLease.LeasePartitionKey = pk, partitionKeyValue);
 
             return this.TryCreateDocumentServiceLeaseAsync(documentServiceLease);
         }
@@ -153,7 +158,10 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
                 Mode = this.GetChangeFeedMode()
             };
 
-            this.requestOptionsFactory.AddPartitionKeyIfNeeded((string pk) => documentServiceLease.LeasePartitionKey = pk, Guid.NewGuid().ToString());
+            string partitionKeyValue = this.useDeterministicPartitionKey
+                ? documentServiceLease.LeaseId
+                : Guid.NewGuid().ToString();
+            this.requestOptionsFactory.AddPartitionKeyIfNeeded((string pk) => documentServiceLease.LeasePartitionKey = pk, partitionKeyValue);
 
             return this.TryCreateDocumentServiceLeaseAsync(documentServiceLease);
         }

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseManagerCosmos.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseManagerCosmos.cs
@@ -29,8 +29,9 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
         private readonly DocumentServiceLeaseStoreManagerOptions options;
         private readonly RequestOptionsFactory requestOptionsFactory;
         private readonly AsyncLazy<TryCatch<string>> lazyContainerRid;
-        private readonly bool isChangeFeedLeaseIdAsPartitionKeyEnabled;
         private PartitionKeyRangeCache partitionKeyRangeCache;
+
+        internal static bool IsChangeFeedLeaseIdAsPartitionKeyEnabled = ConfigurationManager.IsChangeFeedLeaseIdAsPartitionKeyEnabled();
 
         public DocumentServiceLeaseManagerCosmos(
             ContainerInternal monitoredContainer,
@@ -45,7 +46,6 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
             this.options = options;
             this.requestOptionsFactory = requestOptionsFactory;
             this.lazyContainerRid = new AsyncLazy<TryCatch<string>>(valueFactory: (trace, innerCancellationToken) => this.TryInitializeContainerRIdAsync(innerCancellationToken));
-            this.isChangeFeedLeaseIdAsPartitionKeyEnabled = ConfigurationManager.IsChangeFeedLeaseIdAsPartitionKeyEnabled();
         }
 
         public override async Task<DocumentServiceLease> AcquireAsync(DocumentServiceLease lease)
@@ -132,7 +132,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
 
             this.requestOptionsFactory.AddPartitionKeyIfNeeded(
                 (string pk) => documentServiceLease.LeasePartitionKey = pk,
-                GetLeasePartitionKeyValue(this.isChangeFeedLeaseIdAsPartitionKeyEnabled, documentServiceLease.LeaseId));
+                GetLeasePartitionKeyValue(IsChangeFeedLeaseIdAsPartitionKeyEnabled, documentServiceLease.LeaseId));
 
             return this.TryCreateDocumentServiceLeaseAsync(documentServiceLease);
         }
@@ -159,7 +159,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
 
             this.requestOptionsFactory.AddPartitionKeyIfNeeded(
                 (string pk) => documentServiceLease.LeasePartitionKey = pk,
-                GetLeasePartitionKeyValue(this.isChangeFeedLeaseIdAsPartitionKeyEnabled, documentServiceLease.LeaseId));
+                GetLeasePartitionKeyValue(IsChangeFeedLeaseIdAsPartitionKeyEnabled, documentServiceLease.LeaseId));
 
             return this.TryCreateDocumentServiceLeaseAsync(documentServiceLease);
         }

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseManagerCosmos.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseManagerCosmos.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
         private readonly DocumentServiceLeaseStoreManagerOptions options;
         private readonly RequestOptionsFactory requestOptionsFactory;
         private readonly AsyncLazy<TryCatch<string>> lazyContainerRid;
-        private readonly bool useDeterministicPartitionKey;
+        private readonly bool isChangeFeedLeaseIdAsPartitionKeyEnabled;
         private PartitionKeyRangeCache partitionKeyRangeCache;
 
         public DocumentServiceLeaseManagerCosmos(
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
             this.options = options;
             this.requestOptionsFactory = requestOptionsFactory;
             this.lazyContainerRid = new AsyncLazy<TryCatch<string>>(valueFactory: (trace, innerCancellationToken) => this.TryInitializeContainerRIdAsync(innerCancellationToken));
-            this.useDeterministicPartitionKey = ConfigurationManager.IsChangeFeedLeaseIdAsPartitionKeyEnabled();
+            this.isChangeFeedLeaseIdAsPartitionKeyEnabled = ConfigurationManager.IsChangeFeedLeaseIdAsPartitionKeyEnabled();
         }
 
         public override async Task<DocumentServiceLease> AcquireAsync(DocumentServiceLease lease)
@@ -132,7 +132,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
 
             this.requestOptionsFactory.AddPartitionKeyIfNeeded(
                 (string pk) => documentServiceLease.LeasePartitionKey = pk,
-                this.GetLeasePartitionKeyValue(documentServiceLease.LeaseId));
+                GetLeasePartitionKeyValue(this.isChangeFeedLeaseIdAsPartitionKeyEnabled, documentServiceLease.LeaseId));
 
             return this.TryCreateDocumentServiceLeaseAsync(documentServiceLease);
         }
@@ -159,14 +159,14 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
 
             this.requestOptionsFactory.AddPartitionKeyIfNeeded(
                 (string pk) => documentServiceLease.LeasePartitionKey = pk,
-                this.GetLeasePartitionKeyValue(documentServiceLease.LeaseId));
+                GetLeasePartitionKeyValue(this.isChangeFeedLeaseIdAsPartitionKeyEnabled, documentServiceLease.LeaseId));
 
             return this.TryCreateDocumentServiceLeaseAsync(documentServiceLease);
         }
 
-        private string GetLeasePartitionKeyValue(string leaseId)
+        private static string GetLeasePartitionKeyValue(bool isLeaseIdAsPartitionKeyEnabled, string leaseId)
         {
-            return this.useDeterministicPartitionKey
+            return isLeaseIdAsPartitionKeyEnabled
                 ? leaseId
                 : Guid.NewGuid().ToString();
         }

--- a/Microsoft.Azure.Cosmos/src/Util/ConfigurationManager.cs
+++ b/Microsoft.Azure.Cosmos/src/Util/ConfigurationManager.cs
@@ -133,6 +133,11 @@ namespace Microsoft.Azure.Cosmos
         /// </summary>
         internal static readonly string TcpDnsDotSuffixEnabled = "AZURE_COSMOS_TCP_DNS_DOT_SUFFIX_ENABLED";
 
+        /// <summary>
+        /// Environment variable name to enable deterministic lease-id partition key values for Change Feed lease creation.
+        /// </summary>
+        internal static readonly string ChangeFeedLeaseIdAsPartitionKeyEnabled = "AZURE_COSMOS_CHANGE_FEED_LEASE_ID_AS_PARTITION_KEY_ENABLED";
+
         public static T GetEnvironmentVariable<T>(string variable, T defaultValue)
         {
             string value = Environment.GetEnvironmentVariable(variable);
@@ -199,6 +204,18 @@ namespace Microsoft.Azure.Cosmos
                     .GetEnvironmentVariable(
                         variable: ConfigurationManager.ThinClientModeEnabled,
                         defaultValue: defaultValue);
+        }
+
+        /// <summary>
+        /// Gets the boolean value indicating whether Change Feed lease creation should use lease id as the partition key value.
+        /// </summary>
+        /// <returns>A boolean flag indicating if deterministic lease-id partition key behavior is enabled.</returns>
+        public static bool IsChangeFeedLeaseIdAsPartitionKeyEnabled()
+        {
+            return ConfigurationManager
+                    .GetEnvironmentVariable(
+                        variable: ConfigurationManager.ChangeFeedLeaseIdAsPartitionKeyEnabled,
+                        defaultValue: true);
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/GremlinSmokeTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/GremlinSmokeTests.cs
@@ -75,41 +75,67 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
 
         }
 
-        [TestMethod]
-        public async Task Schema_DefaultsToHavingPartitionKey()
+        [DataTestMethod]
+        [DataRow(null, true, DisplayName = "Default (deterministic PK): partition key equals lease id")]
+        [DataRow("false", false, DisplayName = "Opt-out (legacy GUID PK): partition key differs from lease id")]
+        public async Task Schema_DefaultsToHavingPartitionKey(string envVarValue, bool expectDeterministicPk)
         {
-            ChangeFeedProcessor processor = this.Container
-                .GetChangeFeedProcessorBuilder("test", (IReadOnlyCollection<TestClass> docs, CancellationToken token) => Task.CompletedTask)
-                .WithInstanceName("random")
-                .WithLeaseContainer(this.LeaseContainer).Build();
+            System.Environment.SetEnvironmentVariable(
+                ConfigurationManager.ChangeFeedLeaseIdAsPartitionKeyEnabled,
+                envVarValue);
 
-            await processor.StartAsync();
-            // Letting processor initialize
-            await Task.Delay(BaseChangeFeedClientHelper.ChangeFeedSetupTime);
-
-            // Verify that leases have the partitionKey attribute
-            using FeedIterator<dynamic> iterator = this.LeaseContainer.GetItemQueryIterator<dynamic>();
-            while (iterator.HasMoreResults)
+            try
             {
-                FeedResponse<dynamic> page = await iterator.ReadNextAsync();
-                foreach (dynamic lease in page)
+                ChangeFeedProcessor processor = this.Container
+                    .GetChangeFeedProcessorBuilder("test", (IReadOnlyCollection<TestClass> docs, CancellationToken token) => Task.CompletedTask)
+                    .WithInstanceName("random")
+                    .WithLeaseContainer(this.LeaseContainer).Build();
+
+                await processor.StartAsync();
+                // Letting processor initialize
+                await Task.Delay(BaseChangeFeedClientHelper.ChangeFeedSetupTime);
+
+                // Verify that leases have the partitionKey attribute
+                using FeedIterator<dynamic> iterator = this.LeaseContainer.GetItemQueryIterator<dynamic>();
+                while (iterator.HasMoreResults)
                 {
-                    string leaseId = lease.id;
-                    Assert.IsNotNull(lease.partitionKey);
-                    if (leaseId.Contains(".info") || leaseId.Contains(".lock"))
+                    FeedResponse<dynamic> page = await iterator.ReadNextAsync();
+                    foreach (dynamic lease in page)
                     {
-                        // These are the store initialization marks
-                        continue;
+                        string leaseId = lease.id;
+                        Assert.IsNotNull(lease.partitionKey);
+                        if (leaseId.Contains(".info") || leaseId.Contains(".lock"))
+                        {
+                            // These are the store initialization marks
+                            continue;
+                        }
+
+                        if (expectDeterministicPk)
+                        {
+                            Assert.AreEqual((string)lease.id, (string)lease.partitionKey,
+                                "Deterministic mode: lease partition key must equal lease id for dedup invariant.");
+                        }
+                        else
+                        {
+                            Assert.AreNotEqual((string)lease.id, (string)lease.partitionKey,
+                                "Legacy mode: lease partition key should be a random GUID, not the lease id.");
+                            Assert.IsTrue(System.Guid.TryParse((string)lease.partitionKey, out _),
+                                "Legacy mode: partition key should be a valid GUID.");
+                        }
+
+                        Assert.IsNotNull(lease.LeaseToken);
+                        Assert.IsNull(lease.PartitionId);
                     }
-
-                    Assert.AreEqual((string)lease.id, (string)lease.partitionKey, "Lease partition key must equal lease id for dedup invariant.");
-
-                    Assert.IsNotNull(lease.LeaseToken);
-                    Assert.IsNull(lease.PartitionId);
                 }
-            }
 
-            await processor.StopAsync();
+                await processor.StopAsync();
+            }
+            finally
+            {
+                System.Environment.SetEnvironmentVariable(
+                    ConfigurationManager.ChangeFeedLeaseIdAsPartitionKeyEnabled,
+                    null);
+            }
         }
 
         public class TestClass

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/GremlinSmokeTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/GremlinSmokeTests.cs
@@ -102,6 +102,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
                         continue;
                     }
 
+                    Assert.AreEqual((string)lease.id, (string)lease.partitionKey, "Lease partition key must equal lease id for dedup invariant.");
+
                     Assert.IsNotNull(lease.LeaseToken);
                     Assert.IsNull(lease.PartitionId);
                 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/GremlinSmokeTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/GremlinSmokeTests.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
 
     [TestClass]
     [TestCategory("ChangeFeed")]
+    [DoNotParallelize]
     public class GremlinSmokeTests : BaseChangeFeedClientHelper
     {
         private Container Container;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/GremlinSmokeTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/GremlinSmokeTests.cs
@@ -8,6 +8,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     [TestClass]
@@ -77,13 +78,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
         }
 
         [DataTestMethod]
-        [DataRow(null, true, DisplayName = "Default (deterministic PK): partition key equals lease id")]
-        [DataRow("false", false, DisplayName = "Opt-out (legacy GUID PK): partition key differs from lease id")]
-        public async Task Schema_DefaultsToHavingPartitionKey(string envVarValue, bool expectDeterministicPk)
+        [DataRow(true, DisplayName = "Default (deterministic PK): partition key equals lease id")]
+        [DataRow(false, DisplayName = "Opt-out (legacy GUID PK): partition key differs from lease id")]
+        public async Task Schema_DefaultsToHavingPartitionKey(bool isChangeFeedLeaseIdAsPartitionKeyEnabled)
         {
-            System.Environment.SetEnvironmentVariable(
-                ConfigurationManager.ChangeFeedLeaseIdAsPartitionKeyEnabled,
-                envVarValue);
+            DocumentServiceLeaseManagerCosmos.IsChangeFeedLeaseIdAsPartitionKeyEnabled = isChangeFeedLeaseIdAsPartitionKeyEnabled;
 
             try
             {
@@ -111,7 +110,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
                             continue;
                         }
 
-                        if (expectDeterministicPk)
+                        if (isChangeFeedLeaseIdAsPartitionKeyEnabled)
                         {
                             Assert.AreEqual((string)lease.id, (string)lease.partitionKey,
                                 "Deterministic mode: lease partition key must equal lease id for dedup invariant.");
@@ -133,9 +132,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
             }
             finally
             {
-                System.Environment.SetEnvironmentVariable(
-                    ConfigurationManager.ChangeFeedLeaseIdAsPartitionKeyEnabled,
-                    null);
+                DocumentServiceLeaseManagerCosmos.IsChangeFeedLeaseIdAsPartitionKeyEnabled =
+                    ConfigurationManager.IsChangeFeedLeaseIdAsPartitionKeyEnabled();
             }
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseManagerCosmosTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseManagerCosmosTests.cs
@@ -25,13 +25,13 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         [TestInitialize]
         public void TestInitialize()
         {
-            DocumentServiceLeaseManagerCosmos.IsChangeFeedLeaseIdAsPartitionKeyEnabled = true;
+            DocumentServiceLeaseManagerCosmos.IsChangeFeedLeaseIdAsPartitionKeyEnabled = ConfigurationManager.IsChangeFeedLeaseIdAsPartitionKeyEnabled();
         }
 
         [TestCleanup]
         public void TestCleanup()
         {
-            DocumentServiceLeaseManagerCosmos.IsChangeFeedLeaseIdAsPartitionKeyEnabled = true;
+            DocumentServiceLeaseManagerCosmos.IsChangeFeedLeaseIdAsPartitionKeyEnabled = ConfigurationManager.IsChangeFeedLeaseIdAsPartitionKeyEnabled();
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseManagerCosmosTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseManagerCosmosTests.cs
@@ -175,158 +175,36 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
             }
         }
 
-        [TestMethod]
-        public async Task CreatesPartitionKeyBasedLeaseWithDeterministicPartitionKeyByDefault()
+        /// <summary>
+        /// Verifies partition key behavior for both overloads and both env-var states:
+        /// default (deterministic PK = lease id) and opt-out (legacy GUID PK).
+        /// </summary>
+        [DataTestMethod]
+        [DataRow("PKRange", null, true, DisplayName = "PKRange: deterministic PK by default")]
+        [DataRow("PKRange", "false", false, DisplayName = "PKRange: legacy GUID PK when opted out")]
+        [DataRow("EPK", null, true, DisplayName = "EPK: deterministic PK by default")]
+        [DataRow("EPK", "false", false, DisplayName = "EPK: legacy GUID PK when opted out")]
+        public async Task CreateLeaseIfNotExistAsync_PartitionKeyBehavior(string overloadType, string envVarValue, bool expectDeterministic)
         {
-            PartitionKey? capturedPartitionKey = null;
-            RequestOptionsFactory requestOptionsFactory = new PartitionedByPartitionKeyCollectionRequestOptionsFactory();
-            string continuation = Guid.NewGuid().ToString();
-            DocumentServiceLeaseStoreManagerOptions options = new DocumentServiceLeaseStoreManagerOptions
-            {
-                HostName = Guid.NewGuid().ToString()
-            };
-
-            Documents.PartitionKeyRange partitionKeyRange = new Documents.PartitionKeyRange()
-            {
-                Id = "0",
-                MinInclusive = "",
-                MaxExclusive = "FF"
-            };
-
-            Mock<ContainerInternal> mockedContainer = new Mock<ContainerInternal>();
-            mockedContainer.Setup(c => c.CreateItemStreamAsync(
-                It.IsAny<Stream>(),
-                It.IsAny<PartitionKey>(),
-                It.IsAny<ItemRequestOptions>(),
-                It.IsAny<CancellationToken>())).Callback((Stream stream, PartitionKey partitionKey, ItemRequestOptions itemRequestOptions, CancellationToken token) => capturedPartitionKey = partitionKey)
-                .ReturnsAsync((Stream stream, PartitionKey partitionKey, ItemRequestOptions itemRequestOptions, CancellationToken token) => new ResponseMessage(System.Net.HttpStatusCode.OK) { Content = stream });
-
-            DocumentServiceLeaseManagerCosmos documentServiceLeaseManagerCosmos = new DocumentServiceLeaseManagerCosmos(
-                Mock.Of<ContainerInternal>(),
-                mockedContainer.Object,
-                Mock.Of<DocumentServiceLeaseUpdater>(),
-                options,
-                requestOptionsFactory);
-
-            DocumentServiceLease lease = await documentServiceLeaseManagerCosmos.CreateLeaseIfNotExistAsync(partitionKeyRange, continuation);
-
-            Assert.IsTrue(capturedPartitionKey.HasValue);
-            Assert.AreEqual(new PartitionKey(lease.Id), capturedPartitionKey.Value);
-            Assert.AreEqual(lease.Id, lease.PartitionKey);
-        }
-
-        [TestMethod]
-        public async Task CreatesEPKBasedLeaseWithLegacyGuidPartitionKeyWhenOptedOut()
-        {
-            Environment.SetEnvironmentVariable(ConfigurationManager.ChangeFeedLeaseIdAsPartitionKeyEnabled, "false");
+            Environment.SetEnvironmentVariable(ConfigurationManager.ChangeFeedLeaseIdAsPartitionKeyEnabled, envVarValue);
 
             PartitionKey? capturedPartitionKey = null;
-            RequestOptionsFactory requestOptionsFactory = new PartitionedByPartitionKeyCollectionRequestOptionsFactory();
-            string continuation = Guid.NewGuid().ToString();
-            DocumentServiceLeaseStoreManagerOptions options = new DocumentServiceLeaseStoreManagerOptions
-            {
-                HostName = Guid.NewGuid().ToString()
-            };
+            Mock<ContainerInternal> mockedContainer = CreatePkCapturingMockContainer(pk => capturedPartitionKey = pk);
+            DocumentServiceLeaseManagerCosmos manager = CreateLeaseManager(mockedContainer.Object, new PartitionedByPartitionKeyCollectionRequestOptionsFactory());
 
-            FeedRangeEpk feedRangeEpk = new FeedRangeEpk(new Documents.Routing.Range<string>("AA", "BB", true, false));
-
-            Mock<ContainerInternal> mockedContainer = new Mock<ContainerInternal>();
-            mockedContainer.Setup(c => c.CreateItemStreamAsync(
-                It.IsAny<Stream>(),
-                It.IsAny<PartitionKey>(),
-                It.IsAny<ItemRequestOptions>(),
-                It.IsAny<CancellationToken>())).Callback((Stream stream, PartitionKey partitionKey, ItemRequestOptions itemRequestOptions, CancellationToken token) => capturedPartitionKey = partitionKey)
-                .ReturnsAsync((Stream stream, PartitionKey partitionKey, ItemRequestOptions itemRequestOptions, CancellationToken token) => new ResponseMessage(System.Net.HttpStatusCode.OK) { Content = stream });
-
-            DocumentServiceLeaseManagerCosmos documentServiceLeaseManagerCosmos = new DocumentServiceLeaseManagerCosmos(
-                Mock.Of<ContainerInternal>(),
-                mockedContainer.Object,
-                Mock.Of<DocumentServiceLeaseUpdater>(),
-                options,
-                requestOptionsFactory);
-
-            DocumentServiceLease lease = await documentServiceLeaseManagerCosmos.CreateLeaseIfNotExistAsync(feedRangeEpk, continuation);
+            DocumentServiceLease lease = await CreateLeaseAsync(manager, overloadType, Guid.NewGuid().ToString());
 
             Assert.IsTrue(capturedPartitionKey.HasValue);
-            Assert.AreNotEqual(new PartitionKey(lease.Id), capturedPartitionKey.Value);
-            Assert.IsTrue(Guid.TryParse(lease.PartitionKey, out _));
-        }
-
-        [TestMethod]
-        public async Task CreatesEPKBasedLeaseWithDeterministicPartitionKeyByDefault()
-        {
-            PartitionKey? capturedPartitionKey = null;
-            RequestOptionsFactory requestOptionsFactory = new PartitionedByPartitionKeyCollectionRequestOptionsFactory();
-            string continuation = Guid.NewGuid().ToString();
-            DocumentServiceLeaseStoreManagerOptions options = new DocumentServiceLeaseStoreManagerOptions
+            if (expectDeterministic)
             {
-                HostName = Guid.NewGuid().ToString()
-            };
-
-            FeedRangeEpk feedRangeEpk = new FeedRangeEpk(new Documents.Routing.Range<string>("AA", "BB", true, false));
-
-            Mock<ContainerInternal> mockedContainer = new Mock<ContainerInternal>();
-            mockedContainer.Setup(c => c.CreateItemStreamAsync(
-                It.IsAny<Stream>(),
-                It.IsAny<PartitionKey>(),
-                It.IsAny<ItemRequestOptions>(),
-                It.IsAny<CancellationToken>())).Callback((Stream stream, PartitionKey partitionKey, ItemRequestOptions itemRequestOptions, CancellationToken token) => capturedPartitionKey = partitionKey)
-                .ReturnsAsync((Stream stream, PartitionKey partitionKey, ItemRequestOptions itemRequestOptions, CancellationToken token) => new ResponseMessage(System.Net.HttpStatusCode.OK) { Content = stream });
-
-            DocumentServiceLeaseManagerCosmos documentServiceLeaseManagerCosmos = new DocumentServiceLeaseManagerCosmos(
-                Mock.Of<ContainerInternal>(),
-                mockedContainer.Object,
-                Mock.Of<DocumentServiceLeaseUpdater>(),
-                options,
-                requestOptionsFactory);
-
-            DocumentServiceLease lease = await documentServiceLeaseManagerCosmos.CreateLeaseIfNotExistAsync(feedRangeEpk, continuation);
-
-            Assert.IsTrue(capturedPartitionKey.HasValue);
-            Assert.AreEqual(new PartitionKey(lease.Id), capturedPartitionKey.Value);
-            Assert.AreEqual(lease.Id, lease.PartitionKey);
-        }
-
-        [TestMethod]
-        public async Task CreatesPartitionKeyBasedLeaseWithLegacyGuidPartitionKeyWhenOptedOut()
-        {
-            Environment.SetEnvironmentVariable(ConfigurationManager.ChangeFeedLeaseIdAsPartitionKeyEnabled, "false");
-
-            PartitionKey? capturedPartitionKey = null;
-            RequestOptionsFactory requestOptionsFactory = new PartitionedByPartitionKeyCollectionRequestOptionsFactory();
-            string continuation = Guid.NewGuid().ToString();
-            DocumentServiceLeaseStoreManagerOptions options = new DocumentServiceLeaseStoreManagerOptions
+                Assert.AreEqual(new PartitionKey(lease.Id), capturedPartitionKey.Value);
+                Assert.AreEqual(lease.Id, lease.PartitionKey);
+            }
+            else
             {
-                HostName = Guid.NewGuid().ToString()
-            };
-
-            Documents.PartitionKeyRange partitionKeyRange = new Documents.PartitionKeyRange()
-            {
-                Id = "0",
-                MinInclusive = "",
-                MaxExclusive = "FF"
-            };
-
-            Mock<ContainerInternal> mockedContainer = new Mock<ContainerInternal>();
-            mockedContainer.Setup(c => c.CreateItemStreamAsync(
-                It.IsAny<Stream>(),
-                It.IsAny<PartitionKey>(),
-                It.IsAny<ItemRequestOptions>(),
-                It.IsAny<CancellationToken>())).Callback((Stream stream, PartitionKey partitionKey, ItemRequestOptions itemRequestOptions, CancellationToken token) => capturedPartitionKey = partitionKey)
-                .ReturnsAsync((Stream stream, PartitionKey partitionKey, ItemRequestOptions itemRequestOptions, CancellationToken token) => new ResponseMessage(System.Net.HttpStatusCode.OK) { Content = stream });
-
-            DocumentServiceLeaseManagerCosmos documentServiceLeaseManagerCosmos = new DocumentServiceLeaseManagerCosmos(
-                Mock.Of<ContainerInternal>(),
-                mockedContainer.Object,
-                Mock.Of<DocumentServiceLeaseUpdater>(),
-                options,
-                requestOptionsFactory);
-
-            DocumentServiceLease lease = await documentServiceLeaseManagerCosmos.CreateLeaseIfNotExistAsync(partitionKeyRange, continuation);
-
-            Assert.IsTrue(capturedPartitionKey.HasValue);
-            Assert.AreNotEqual(new PartitionKey(lease.Id), capturedPartitionKey.Value);
-            Assert.IsTrue(Guid.TryParse(lease.PartitionKey, out _));
+                Assert.AreNotEqual(new PartitionKey(lease.Id), capturedPartitionKey.Value);
+                Assert.IsTrue(Guid.TryParse(lease.PartitionKey, out _));
+            }
         }
 
         /// <summary>
@@ -335,143 +213,33 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         /// This proves the deterministic PK value ensures both creates land in the same logical
         /// partition and trigger the id-uniqueness conflict.
         /// </summary>
-        [TestMethod]
-        public async Task CreateLeaseIfNotExistAsync_FirstSucceeds_SecondReturns409_PKRange()
+        [DataTestMethod]
+        [DataRow("PKRange", DisplayName = "PKRange: dedup via (PK, id) uniqueness")]
+        [DataRow("EPK", DisplayName = "EPK: dedup via (PK, id) uniqueness")]
+        public async Task CreateLeaseIfNotExistAsync_DuplicatePkId_Returns409(string overloadType)
         {
-            RequestOptionsFactory requestOptionsFactory = new PartitionedByPartitionKeyCollectionRequestOptionsFactory();
+            Mock<ContainerInternal> mockedContainer = CreateDedupSimulatingMockContainer();
+            DocumentServiceLeaseManagerCosmos manager = CreateLeaseManager(mockedContainer.Object, new PartitionedByPartitionKeyCollectionRequestOptionsFactory());
             string continuation = Guid.NewGuid().ToString();
-            DocumentServiceLeaseStoreManagerOptions options = new DocumentServiceLeaseStoreManagerOptions
-            {
-                HostName = Guid.NewGuid().ToString()
-            };
 
-            Documents.PartitionKeyRange partitionKeyRange = new Documents.PartitionKeyRange()
-            {
-                Id = "0",
-                MinInclusive = "",
-                MaxExclusive = "FF"
-            };
-
-            // Track created (PartitionKey, id) pairs to simulate Cosmos DB's per-logical-partition id uniqueness.
-            ConcurrentDictionary<string, byte> createdPkIdPairs = new ConcurrentDictionary<string, byte>();
-            Mock<ContainerInternal> mockedContainer = new Mock<ContainerInternal>();
-            mockedContainer.Setup(c => c.CreateItemStreamAsync(
-                It.IsAny<Stream>(),
-                It.IsAny<PartitionKey>(),
-                It.IsAny<ItemRequestOptions>(),
-                It.IsAny<CancellationToken>()))
-                .ReturnsAsync((Stream stream, PartitionKey partitionKey, ItemRequestOptions opts, CancellationToken token) =>
-                {
-                    // Read the lease id from the stream to form the composite key
-                    stream.Position = 0;
-                    using StreamReader reader = new StreamReader(stream, leaveOpen: true);
-                    string json = reader.ReadToEnd();
-                    stream.Position = 0;
-                    string leaseId = Newtonsoft.Json.Linq.JObject.Parse(json)["id"].ToString();
-
-                    string compositeKey = $"{partitionKey}:{leaseId}";
-                    if (createdPkIdPairs.TryAdd(compositeKey, 0))
-                    {
-                        return new ResponseMessage(HttpStatusCode.OK) { Content = stream };
-                    }
-
-                    return new ResponseMessage(HttpStatusCode.Conflict);
-                });
-
-            DocumentServiceLeaseManagerCosmos leaseManager = new DocumentServiceLeaseManagerCosmos(
-                Mock.Of<ContainerInternal>(),
-                mockedContainer.Object,
-                Mock.Of<DocumentServiceLeaseUpdater>(),
-                options,
-                requestOptionsFactory);
-
-            // First call: host A creates the lease successfully
-            DocumentServiceLease firstResult = await leaseManager.CreateLeaseIfNotExistAsync(partitionKeyRange, continuation);
+            DocumentServiceLease firstResult = await CreateLeaseAsync(manager, overloadType, continuation);
             Assert.IsNotNull(firstResult, "First create should succeed with 200.");
 
-            // Second call: host B races for the same lease token — same (PK, id) triggers 409
-            DocumentServiceLease secondResult = await leaseManager.CreateLeaseIfNotExistAsync(partitionKeyRange, continuation);
-            Assert.IsNull(secondResult, "Second create should return null due to 409 Conflict (same PK + id dedup).");
-        }
-
-        [TestMethod]
-        public async Task CreateLeaseIfNotExistAsync_FirstSucceeds_SecondReturns409_EPK()
-        {
-            RequestOptionsFactory requestOptionsFactory = new PartitionedByPartitionKeyCollectionRequestOptionsFactory();
-            string continuation = Guid.NewGuid().ToString();
-            DocumentServiceLeaseStoreManagerOptions options = new DocumentServiceLeaseStoreManagerOptions
-            {
-                HostName = Guid.NewGuid().ToString()
-            };
-
-            FeedRangeEpk feedRangeEpk = new FeedRangeEpk(new Documents.Routing.Range<string>("AA", "BB", true, false));
-
-            // Track created (PartitionKey, id) pairs to simulate Cosmos DB's per-logical-partition id uniqueness.
-            ConcurrentDictionary<string, byte> createdPkIdPairs = new ConcurrentDictionary<string, byte>();
-            Mock<ContainerInternal> mockedContainer = new Mock<ContainerInternal>();
-            mockedContainer.Setup(c => c.CreateItemStreamAsync(
-                It.IsAny<Stream>(),
-                It.IsAny<PartitionKey>(),
-                It.IsAny<ItemRequestOptions>(),
-                It.IsAny<CancellationToken>()))
-                .ReturnsAsync((Stream stream, PartitionKey partitionKey, ItemRequestOptions opts, CancellationToken token) =>
-                {
-                    stream.Position = 0;
-                    using StreamReader reader = new StreamReader(stream, leaveOpen: true);
-                    string json = reader.ReadToEnd();
-                    stream.Position = 0;
-                    string leaseId = Newtonsoft.Json.Linq.JObject.Parse(json)["id"].ToString();
-
-                    string compositeKey = $"{partitionKey}:{leaseId}";
-                    if (createdPkIdPairs.TryAdd(compositeKey, 0))
-                    {
-                        return new ResponseMessage(HttpStatusCode.OK) { Content = stream };
-                    }
-
-                    return new ResponseMessage(HttpStatusCode.Conflict);
-                });
-
-            DocumentServiceLeaseManagerCosmos leaseManager = new DocumentServiceLeaseManagerCosmos(
-                Mock.Of<ContainerInternal>(),
-                mockedContainer.Object,
-                Mock.Of<DocumentServiceLeaseUpdater>(),
-                options,
-                requestOptionsFactory);
-
-            // First call: host A creates the lease successfully
-            DocumentServiceLease firstResult = await leaseManager.CreateLeaseIfNotExistAsync(feedRangeEpk, continuation);
-            Assert.IsNotNull(firstResult, "First create should succeed with 200.");
-
-            // Second call: host B races for the same lease token — same (PK, id) triggers 409
-            DocumentServiceLease secondResult = await leaseManager.CreateLeaseIfNotExistAsync(feedRangeEpk, continuation);
+            DocumentServiceLease secondResult = await CreateLeaseAsync(manager, overloadType, continuation);
             Assert.IsNull(secondResult, "Second create should return null due to 409 Conflict (same PK + id dedup).");
         }
 
         /// <summary>
         /// Verifies back-compatibility: a pre-existing lease with a random GUID partition key
-        /// (created before the deterministic PK fix) can still be read, acquired, renewed, and released
-        /// because all downstream operations use the stored lease.PartitionKey value.
+        /// (created before the deterministic PK fix) can still be acquired because
+        /// downstream operations use the stored lease.PartitionKey value.
         /// </summary>
         [TestMethod]
         public async Task AcquireCompletes_WithPreExistingGuidPartitionKey()
         {
-            string guidPartitionKey = Guid.NewGuid().ToString();
-            DocumentServiceLeaseStoreManagerOptions options = new DocumentServiceLeaseStoreManagerOptions
-            {
-                HostName = Guid.NewGuid().ToString()
-            };
-
-            DocumentServiceLeaseCore lease = new DocumentServiceLeaseCore()
-            {
-                LeaseId = "some-prefix..0",
-                LeaseToken = "0",
-                Owner = Guid.NewGuid().ToString(),
-                LeasePartitionKey = guidPartitionKey,
-                FeedRange = new FeedRangePartitionKeyRange("0")
-            };
+            DocumentServiceLeaseCore lease = CreatePreExistingGuidPkLease(out string guidPartitionKey, out DocumentServiceLeaseStoreManagerOptions options);
 
             Mock<DocumentServiceLeaseUpdater> mockUpdater = new Mock<DocumentServiceLeaseUpdater>();
-
             mockUpdater.Setup(c => c.UpdateLeaseAsync(
                 It.IsAny<DocumentServiceLease>(),
                 It.Is<string>(id => id == lease.LeaseId),
@@ -492,24 +260,15 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
             Assert.AreEqual(guidPartitionKey, afterAcquire.PartitionKey, "Old GUID partition key must be preserved through acquire.");
         }
 
+        /// <summary>
+        /// Verifies back-compatibility: a pre-existing lease with a random GUID partition key
+        /// (created before the deterministic PK fix) can still be renewed because
+        /// downstream operations use the stored lease.PartitionKey value.
+        /// </summary>
         [TestMethod]
         public async Task RenewCompletes_WithPreExistingGuidPartitionKey()
         {
-            string guidPartitionKey = Guid.NewGuid().ToString();
-            string hostName = Guid.NewGuid().ToString();
-            DocumentServiceLeaseStoreManagerOptions options = new DocumentServiceLeaseStoreManagerOptions
-            {
-                HostName = hostName
-            };
-
-            DocumentServiceLeaseCore lease = new DocumentServiceLeaseCore()
-            {
-                LeaseId = "some-prefix..0",
-                LeaseToken = "0",
-                Owner = hostName,
-                LeasePartitionKey = guidPartitionKey,
-                FeedRange = new FeedRangePartitionKeyRange("0")
-            };
+            DocumentServiceLeaseCore lease = CreatePreExistingGuidPkLease(out string guidPartitionKey, out DocumentServiceLeaseStoreManagerOptions options);
 
             ResponseMessage leaseResponse = new ResponseMessage(HttpStatusCode.OK)
             {
@@ -1003,6 +762,89 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
                 1 => new PartitionedByIdCollectionRequestOptionsFactory(),
                 2 => new PartitionedByPartitionKeyCollectionRequestOptionsFactory(),
                 _ => throw new Exception($"Unkown value for FactoryType: {factoryType}."),
+            };
+        }
+
+        private static Mock<ContainerInternal> CreatePkCapturingMockContainer(Action<PartitionKey> onCapture)
+        {
+            Mock<ContainerInternal> mockedContainer = new Mock<ContainerInternal>();
+            mockedContainer.Setup(c => c.CreateItemStreamAsync(
+                It.IsAny<Stream>(),
+                It.IsAny<PartitionKey>(),
+                It.IsAny<ItemRequestOptions>(),
+                It.IsAny<CancellationToken>()))
+                .Callback((Stream stream, PartitionKey partitionKey, ItemRequestOptions opts, CancellationToken token) => onCapture(partitionKey))
+                .ReturnsAsync((Stream stream, PartitionKey partitionKey, ItemRequestOptions opts, CancellationToken token)
+                    => new ResponseMessage(HttpStatusCode.OK) { Content = stream });
+            return mockedContainer;
+        }
+
+        private static Mock<ContainerInternal> CreateDedupSimulatingMockContainer()
+        {
+            ConcurrentDictionary<string, byte> createdPkIdPairs = new ConcurrentDictionary<string, byte>();
+            Mock<ContainerInternal> mockedContainer = new Mock<ContainerInternal>();
+            mockedContainer.Setup(c => c.CreateItemStreamAsync(
+                It.IsAny<Stream>(),
+                It.IsAny<PartitionKey>(),
+                It.IsAny<ItemRequestOptions>(),
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync((Stream stream, PartitionKey partitionKey, ItemRequestOptions opts, CancellationToken token) =>
+                {
+                    stream.Position = 0;
+                    using StreamReader reader = new StreamReader(stream, leaveOpen: true);
+                    string json = reader.ReadToEnd();
+                    stream.Position = 0;
+                    string leaseId = Newtonsoft.Json.Linq.JObject.Parse(json)["id"].ToString();
+
+                    string compositeKey = $"{partitionKey}:{leaseId}";
+                    return createdPkIdPairs.TryAdd(compositeKey, 0)
+                        ? new ResponseMessage(HttpStatusCode.OK) { Content = stream }
+                        : new ResponseMessage(HttpStatusCode.Conflict);
+                });
+            return mockedContainer;
+        }
+
+        private static DocumentServiceLeaseManagerCosmos CreateLeaseManager(
+            ContainerInternal leaseContainer,
+            RequestOptionsFactory requestOptionsFactory,
+            DocumentServiceLeaseUpdater updater = null)
+        {
+            return new DocumentServiceLeaseManagerCosmos(
+                Mock.Of<ContainerInternal>(),
+                leaseContainer,
+                updater ?? Mock.Of<DocumentServiceLeaseUpdater>(),
+                new DocumentServiceLeaseStoreManagerOptions { HostName = Guid.NewGuid().ToString() },
+                requestOptionsFactory);
+        }
+
+        private static Task<DocumentServiceLease> CreateLeaseAsync(
+            DocumentServiceLeaseManagerCosmos manager,
+            string overloadType,
+            string continuation)
+        {
+            return overloadType == "PKRange"
+                ? manager.CreateLeaseIfNotExistAsync(
+                    new Documents.PartitionKeyRange { Id = "0", MinInclusive = "", MaxExclusive = "FF" },
+                    continuation)
+                : manager.CreateLeaseIfNotExistAsync(
+                    new FeedRangeEpk(new Documents.Routing.Range<string>("AA", "BB", true, false)),
+                    continuation);
+        }
+
+        private static DocumentServiceLeaseCore CreatePreExistingGuidPkLease(
+            out string guidPartitionKey,
+            out DocumentServiceLeaseStoreManagerOptions options)
+        {
+            guidPartitionKey = Guid.NewGuid().ToString();
+            string hostName = Guid.NewGuid().ToString();
+            options = new DocumentServiceLeaseStoreManagerOptions { HostName = hostName };
+            return new DocumentServiceLeaseCore
+            {
+                LeaseId = "some-prefix..0",
+                LeaseToken = "0",
+                Owner = hostName,
+                LeasePartitionKey = guidPartitionKey,
+                FeedRange = new FeedRangePartitionKeyRange("0")
             };
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseManagerCosmosTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseManagerCosmosTests.cs
@@ -119,10 +119,6 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
             Assert.AreEqual(feedRangeEpk.Range.Min, ((FeedRangeEpk)epkBasedLease.FeedRange).Range.Min);
             Assert.AreEqual(feedRangeEpk.Range.Max, ((FeedRangeEpk)epkBasedLease.FeedRange).Range.Max);
             ValidateRequestOptionsFactory(requestOptionsFactory, epkBasedLease);
-            if (requestOptionsFactory is PartitionedByPartitionKeyCollectionRequestOptionsFactory)
-            {
-                Assert.AreEqual(epkBasedLease.Id, epkBasedLease.PartitionKey);
-            }
         }
 
         [DataTestMethod]
@@ -169,10 +165,6 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
             Assert.AreEqual(continuation, afterAcquire.ContinuationToken);
             Assert.AreEqual(partitionKeyRange.Id, pkRangeBasedLease.CurrentLeaseToken);
             ValidateRequestOptionsFactory(requestOptionsFactory, pkRangeBasedLease);
-            if (requestOptionsFactory is PartitionedByPartitionKeyCollectionRequestOptionsFactory)
-            {
-                Assert.AreEqual(pkRangeBasedLease.Id, pkRangeBasedLease.PartitionKey);
-            }
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseManagerCosmosTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseManagerCosmosTests.cs
@@ -77,6 +77,8 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         [DataRow(2, DisplayName = "Container with partitionKey PK")]
         public async Task CreatesEPKBasedLease(int factoryType)
         {
+            Environment.SetEnvironmentVariable(ConfigurationManager.ChangeFeedLeaseIdAsPartitionKeyEnabled, "true");
+
             RequestOptionsFactory requestOptionsFactory = GetRequestOptionsFactory(factoryType);
             string continuation = Guid.NewGuid().ToString();
             DocumentServiceLeaseStoreManagerOptions options = new DocumentServiceLeaseStoreManagerOptions
@@ -119,6 +121,8 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         [DataRow(2, DisplayName = "Container with partitionKey PK")]
         public async Task CreatesPartitionKeyBasedLease(int factoryType)
         {
+            Environment.SetEnvironmentVariable(ConfigurationManager.ChangeFeedLeaseIdAsPartitionKeyEnabled, "true");
+
             RequestOptionsFactory requestOptionsFactory = GetRequestOptionsFactory(factoryType);
             string continuation = Guid.NewGuid().ToString();
             DocumentServiceLeaseStoreManagerOptions options = new DocumentServiceLeaseStoreManagerOptions

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseManagerCosmosTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseManagerCosmosTests.cs
@@ -5,6 +5,7 @@
 namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
 {
     using System;
+    using System.Collections.Concurrent;
     using System.IO;
     using System.Net;
     using System.Threading;
@@ -329,9 +330,10 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         }
 
         /// <summary>
-        /// Verifies the full 409 dedup chain: first call succeeds (200), second concurrent call for the
-        /// same lease token gets 409 Conflict and returns null. This proves the deterministic PK value
-        /// ensures both creates land in the same logical partition, triggering the id-uniqueness conflict.
+        /// Verifies the 409 dedup chain by simulating Cosmos DB's uniqueness constraint:
+        /// a duplicate (PartitionKey, id) combination returns 409 Conflict regardless of call order.
+        /// This proves the deterministic PK value ensures both creates land in the same logical
+        /// partition and trigger the id-uniqueness conflict.
         /// </summary>
         [TestMethod]
         public async Task CreateLeaseIfNotExistAsync_FirstSucceeds_SecondReturns409_PKRange()
@@ -350,7 +352,8 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
                 MaxExclusive = "FF"
             };
 
-            int callCount = 0;
+            // Track created (PartitionKey, id) pairs to simulate Cosmos DB's per-logical-partition id uniqueness.
+            ConcurrentDictionary<string, byte> createdPkIdPairs = new ConcurrentDictionary<string, byte>();
             Mock<ContainerInternal> mockedContainer = new Mock<ContainerInternal>();
             mockedContainer.Setup(c => c.CreateItemStreamAsync(
                 It.IsAny<Stream>(),
@@ -359,9 +362,20 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
                 It.IsAny<CancellationToken>()))
                 .ReturnsAsync((Stream stream, PartitionKey partitionKey, ItemRequestOptions opts, CancellationToken token) =>
                 {
-                    return Interlocked.Increment(ref callCount) == 1
-                        ? new ResponseMessage(HttpStatusCode.OK) { Content = stream }
-                        : new ResponseMessage(HttpStatusCode.Conflict);
+                    // Read the lease id from the stream to form the composite key
+                    stream.Position = 0;
+                    using StreamReader reader = new StreamReader(stream, leaveOpen: true);
+                    string json = reader.ReadToEnd();
+                    stream.Position = 0;
+                    string leaseId = Newtonsoft.Json.Linq.JObject.Parse(json)["id"].ToString();
+
+                    string compositeKey = $"{partitionKey}:{leaseId}";
+                    if (createdPkIdPairs.TryAdd(compositeKey, 0))
+                    {
+                        return new ResponseMessage(HttpStatusCode.OK) { Content = stream };
+                    }
+
+                    return new ResponseMessage(HttpStatusCode.Conflict);
                 });
 
             DocumentServiceLeaseManagerCosmos leaseManager = new DocumentServiceLeaseManagerCosmos(
@@ -375,9 +389,9 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
             DocumentServiceLease firstResult = await leaseManager.CreateLeaseIfNotExistAsync(partitionKeyRange, continuation);
             Assert.IsNotNull(firstResult, "First create should succeed with 200.");
 
-            // Second call: host B races for the same lease token, gets 409 (dedup)
+            // Second call: host B races for the same lease token — same (PK, id) triggers 409
             DocumentServiceLease secondResult = await leaseManager.CreateLeaseIfNotExistAsync(partitionKeyRange, continuation);
-            Assert.IsNull(secondResult, "Second create should return null due to 409 Conflict (dedup).");
+            Assert.IsNull(secondResult, "Second create should return null due to 409 Conflict (same PK + id dedup).");
         }
 
         [TestMethod]
@@ -392,7 +406,8 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
 
             FeedRangeEpk feedRangeEpk = new FeedRangeEpk(new Documents.Routing.Range<string>("AA", "BB", true, false));
 
-            int callCount = 0;
+            // Track created (PartitionKey, id) pairs to simulate Cosmos DB's per-logical-partition id uniqueness.
+            ConcurrentDictionary<string, byte> createdPkIdPairs = new ConcurrentDictionary<string, byte>();
             Mock<ContainerInternal> mockedContainer = new Mock<ContainerInternal>();
             mockedContainer.Setup(c => c.CreateItemStreamAsync(
                 It.IsAny<Stream>(),
@@ -401,9 +416,19 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
                 It.IsAny<CancellationToken>()))
                 .ReturnsAsync((Stream stream, PartitionKey partitionKey, ItemRequestOptions opts, CancellationToken token) =>
                 {
-                    return Interlocked.Increment(ref callCount) == 1
-                        ? new ResponseMessage(HttpStatusCode.OK) { Content = stream }
-                        : new ResponseMessage(HttpStatusCode.Conflict);
+                    stream.Position = 0;
+                    using StreamReader reader = new StreamReader(stream, leaveOpen: true);
+                    string json = reader.ReadToEnd();
+                    stream.Position = 0;
+                    string leaseId = Newtonsoft.Json.Linq.JObject.Parse(json)["id"].ToString();
+
+                    string compositeKey = $"{partitionKey}:{leaseId}";
+                    if (createdPkIdPairs.TryAdd(compositeKey, 0))
+                    {
+                        return new ResponseMessage(HttpStatusCode.OK) { Content = stream };
+                    }
+
+                    return new ResponseMessage(HttpStatusCode.Conflict);
                 });
 
             DocumentServiceLeaseManagerCosmos leaseManager = new DocumentServiceLeaseManagerCosmos(
@@ -417,9 +442,9 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
             DocumentServiceLease firstResult = await leaseManager.CreateLeaseIfNotExistAsync(feedRangeEpk, continuation);
             Assert.IsNotNull(firstResult, "First create should succeed with 200.");
 
-            // Second call: host B races for the same lease token, gets 409 (dedup)
+            // Second call: host B races for the same lease token — same (PK, id) triggers 409
             DocumentServiceLease secondResult = await leaseManager.CreateLeaseIfNotExistAsync(feedRangeEpk, continuation);
-            Assert.IsNull(secondResult, "Second create should return null due to 409 Conflict (dedup).");
+            Assert.IsNull(secondResult, "Second create should return null due to 409 Conflict (same PK + id dedup).");
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseManagerCosmosTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseManagerCosmosTests.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
 
     [TestClass]
     [TestCategory("ChangeFeed")]
+    [DoNotParallelize]
     public class DocumentServiceLeaseManagerCosmosTests
     {
         [TestInitialize]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseManagerCosmosTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseManagerCosmosTests.cs
@@ -328,12 +328,12 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         }
 
         /// <summary>
-        /// Verifies that when CreateItemStreamAsync returns 409 Conflict (another host created the lease first),
-        /// the dedup chain returns null, proving the deterministic PK ensures conflict detection works.
-        /// Tests both PKRange and EPK overloads.
+        /// Verifies the full 409 dedup chain: first call succeeds (200), second concurrent call for the
+        /// same lease token gets 409 Conflict and returns null. This proves the deterministic PK value
+        /// ensures both creates land in the same logical partition, triggering the id-uniqueness conflict.
         /// </summary>
         [TestMethod]
-        public async Task CreateLeaseIfNotExistAsync_Returns409Conflict_ReturnsNull_PKRange()
+        public async Task CreateLeaseIfNotExistAsync_FirstSucceeds_SecondReturns409_PKRange()
         {
             RequestOptionsFactory requestOptionsFactory = new PartitionedByPartitionKeyCollectionRequestOptionsFactory();
             string continuation = Guid.NewGuid().ToString();
@@ -349,28 +349,38 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
                 MaxExclusive = "FF"
             };
 
+            int callCount = 0;
             Mock<ContainerInternal> mockedContainer = new Mock<ContainerInternal>();
             mockedContainer.Setup(c => c.CreateItemStreamAsync(
                 It.IsAny<Stream>(),
                 It.IsAny<PartitionKey>(),
                 It.IsAny<ItemRequestOptions>(),
                 It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new ResponseMessage(HttpStatusCode.Conflict));
+                .ReturnsAsync((Stream stream, PartitionKey partitionKey, ItemRequestOptions opts, CancellationToken token) =>
+                {
+                    return Interlocked.Increment(ref callCount) == 1
+                        ? new ResponseMessage(HttpStatusCode.OK) { Content = stream }
+                        : new ResponseMessage(HttpStatusCode.Conflict);
+                });
 
-            DocumentServiceLeaseManagerCosmos documentServiceLeaseManagerCosmos = new DocumentServiceLeaseManagerCosmos(
+            DocumentServiceLeaseManagerCosmos leaseManager = new DocumentServiceLeaseManagerCosmos(
                 Mock.Of<ContainerInternal>(),
                 mockedContainer.Object,
                 Mock.Of<DocumentServiceLeaseUpdater>(),
                 options,
                 requestOptionsFactory);
 
-            DocumentServiceLease result = await documentServiceLeaseManagerCosmos.CreateLeaseIfNotExistAsync(partitionKeyRange, continuation);
+            // First call: host A creates the lease successfully
+            DocumentServiceLease firstResult = await leaseManager.CreateLeaseIfNotExistAsync(partitionKeyRange, continuation);
+            Assert.IsNotNull(firstResult, "First create should succeed with 200.");
 
-            Assert.IsNull(result, "When 409 Conflict is returned, CreateLeaseIfNotExistAsync should return null (dedup).");
+            // Second call: host B races for the same lease token, gets 409 (dedup)
+            DocumentServiceLease secondResult = await leaseManager.CreateLeaseIfNotExistAsync(partitionKeyRange, continuation);
+            Assert.IsNull(secondResult, "Second create should return null due to 409 Conflict (dedup).");
         }
 
         [TestMethod]
-        public async Task CreateLeaseIfNotExistAsync_Returns409Conflict_ReturnsNull_EPK()
+        public async Task CreateLeaseIfNotExistAsync_FirstSucceeds_SecondReturns409_EPK()
         {
             RequestOptionsFactory requestOptionsFactory = new PartitionedByPartitionKeyCollectionRequestOptionsFactory();
             string continuation = Guid.NewGuid().ToString();
@@ -381,24 +391,34 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
 
             FeedRangeEpk feedRangeEpk = new FeedRangeEpk(new Documents.Routing.Range<string>("AA", "BB", true, false));
 
+            int callCount = 0;
             Mock<ContainerInternal> mockedContainer = new Mock<ContainerInternal>();
             mockedContainer.Setup(c => c.CreateItemStreamAsync(
                 It.IsAny<Stream>(),
                 It.IsAny<PartitionKey>(),
                 It.IsAny<ItemRequestOptions>(),
                 It.IsAny<CancellationToken>()))
-                .ReturnsAsync(new ResponseMessage(HttpStatusCode.Conflict));
+                .ReturnsAsync((Stream stream, PartitionKey partitionKey, ItemRequestOptions opts, CancellationToken token) =>
+                {
+                    return Interlocked.Increment(ref callCount) == 1
+                        ? new ResponseMessage(HttpStatusCode.OK) { Content = stream }
+                        : new ResponseMessage(HttpStatusCode.Conflict);
+                });
 
-            DocumentServiceLeaseManagerCosmos documentServiceLeaseManagerCosmos = new DocumentServiceLeaseManagerCosmos(
+            DocumentServiceLeaseManagerCosmos leaseManager = new DocumentServiceLeaseManagerCosmos(
                 Mock.Of<ContainerInternal>(),
                 mockedContainer.Object,
                 Mock.Of<DocumentServiceLeaseUpdater>(),
                 options,
                 requestOptionsFactory);
 
-            DocumentServiceLease result = await documentServiceLeaseManagerCosmos.CreateLeaseIfNotExistAsync(feedRangeEpk, continuation);
+            // First call: host A creates the lease successfully
+            DocumentServiceLease firstResult = await leaseManager.CreateLeaseIfNotExistAsync(feedRangeEpk, continuation);
+            Assert.IsNotNull(firstResult, "First create should succeed with 200.");
 
-            Assert.IsNull(result, "When 409 Conflict is returned, CreateLeaseIfNotExistAsync should return null (dedup).");
+            // Second call: host B races for the same lease token, gets 409 (dedup)
+            DocumentServiceLease secondResult = await leaseManager.CreateLeaseIfNotExistAsync(feedRangeEpk, continuation);
+            Assert.IsNull(secondResult, "Second create should return null due to 409 Conflict (dedup).");
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseManagerCosmosTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseManagerCosmosTests.cs
@@ -117,6 +117,10 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
             Assert.AreEqual(feedRangeEpk.Range.Min, ((FeedRangeEpk)epkBasedLease.FeedRange).Range.Min);
             Assert.AreEqual(feedRangeEpk.Range.Max, ((FeedRangeEpk)epkBasedLease.FeedRange).Range.Max);
             ValidateRequestOptionsFactory(requestOptionsFactory, epkBasedLease);
+            if (requestOptionsFactory is PartitionedByPartitionKeyCollectionRequestOptionsFactory)
+            {
+                Assert.AreEqual(epkBasedLease.Id, epkBasedLease.PartitionKey);
+            }
         }
 
         [DataTestMethod]
@@ -163,6 +167,10 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
             Assert.AreEqual(continuation, afterAcquire.ContinuationToken);
             Assert.AreEqual(partitionKeyRange.Id, pkRangeBasedLease.CurrentLeaseToken);
             ValidateRequestOptionsFactory(requestOptionsFactory, pkRangeBasedLease);
+            if (requestOptionsFactory is PartitionedByPartitionKeyCollectionRequestOptionsFactory)
+            {
+                Assert.AreEqual(pkRangeBasedLease.Id, pkRangeBasedLease.PartitionKey);
+            }
         }
 
         [TestMethod]
@@ -794,7 +802,6 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
             else if (requestOptionsFactory is PartitionedByPartitionKeyCollectionRequestOptionsFactory)
             {
                 Assert.IsNotNull(lease.PartitionKey);
-                Assert.AreEqual(lease.Id, lease.PartitionKey);
             }
             else
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseManagerCosmosTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseManagerCosmosTests.cs
@@ -328,6 +328,177 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         }
 
         /// <summary>
+        /// Verifies that when CreateItemStreamAsync returns 409 Conflict (another host created the lease first),
+        /// the dedup chain returns null, proving the deterministic PK ensures conflict detection works.
+        /// Tests both PKRange and EPK overloads.
+        /// </summary>
+        [TestMethod]
+        public async Task CreateLeaseIfNotExistAsync_Returns409Conflict_ReturnsNull_PKRange()
+        {
+            RequestOptionsFactory requestOptionsFactory = new PartitionedByPartitionKeyCollectionRequestOptionsFactory();
+            string continuation = Guid.NewGuid().ToString();
+            DocumentServiceLeaseStoreManagerOptions options = new DocumentServiceLeaseStoreManagerOptions
+            {
+                HostName = Guid.NewGuid().ToString()
+            };
+
+            Documents.PartitionKeyRange partitionKeyRange = new Documents.PartitionKeyRange()
+            {
+                Id = "0",
+                MinInclusive = "",
+                MaxExclusive = "FF"
+            };
+
+            Mock<ContainerInternal> mockedContainer = new Mock<ContainerInternal>();
+            mockedContainer.Setup(c => c.CreateItemStreamAsync(
+                It.IsAny<Stream>(),
+                It.IsAny<PartitionKey>(),
+                It.IsAny<ItemRequestOptions>(),
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ResponseMessage(HttpStatusCode.Conflict));
+
+            DocumentServiceLeaseManagerCosmos documentServiceLeaseManagerCosmos = new DocumentServiceLeaseManagerCosmos(
+                Mock.Of<ContainerInternal>(),
+                mockedContainer.Object,
+                Mock.Of<DocumentServiceLeaseUpdater>(),
+                options,
+                requestOptionsFactory);
+
+            DocumentServiceLease result = await documentServiceLeaseManagerCosmos.CreateLeaseIfNotExistAsync(partitionKeyRange, continuation);
+
+            Assert.IsNull(result, "When 409 Conflict is returned, CreateLeaseIfNotExistAsync should return null (dedup).");
+        }
+
+        [TestMethod]
+        public async Task CreateLeaseIfNotExistAsync_Returns409Conflict_ReturnsNull_EPK()
+        {
+            RequestOptionsFactory requestOptionsFactory = new PartitionedByPartitionKeyCollectionRequestOptionsFactory();
+            string continuation = Guid.NewGuid().ToString();
+            DocumentServiceLeaseStoreManagerOptions options = new DocumentServiceLeaseStoreManagerOptions
+            {
+                HostName = Guid.NewGuid().ToString()
+            };
+
+            FeedRangeEpk feedRangeEpk = new FeedRangeEpk(new Documents.Routing.Range<string>("AA", "BB", true, false));
+
+            Mock<ContainerInternal> mockedContainer = new Mock<ContainerInternal>();
+            mockedContainer.Setup(c => c.CreateItemStreamAsync(
+                It.IsAny<Stream>(),
+                It.IsAny<PartitionKey>(),
+                It.IsAny<ItemRequestOptions>(),
+                It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ResponseMessage(HttpStatusCode.Conflict));
+
+            DocumentServiceLeaseManagerCosmos documentServiceLeaseManagerCosmos = new DocumentServiceLeaseManagerCosmos(
+                Mock.Of<ContainerInternal>(),
+                mockedContainer.Object,
+                Mock.Of<DocumentServiceLeaseUpdater>(),
+                options,
+                requestOptionsFactory);
+
+            DocumentServiceLease result = await documentServiceLeaseManagerCosmos.CreateLeaseIfNotExistAsync(feedRangeEpk, continuation);
+
+            Assert.IsNull(result, "When 409 Conflict is returned, CreateLeaseIfNotExistAsync should return null (dedup).");
+        }
+
+        /// <summary>
+        /// Verifies back-compatibility: a pre-existing lease with a random GUID partition key
+        /// (created before the deterministic PK fix) can still be read, acquired, renewed, and released
+        /// because all downstream operations use the stored lease.PartitionKey value.
+        /// </summary>
+        [TestMethod]
+        public async Task AcquireCompletes_WithPreExistingGuidPartitionKey()
+        {
+            string guidPartitionKey = Guid.NewGuid().ToString();
+            DocumentServiceLeaseStoreManagerOptions options = new DocumentServiceLeaseStoreManagerOptions
+            {
+                HostName = Guid.NewGuid().ToString()
+            };
+
+            DocumentServiceLeaseCore lease = new DocumentServiceLeaseCore()
+            {
+                LeaseId = "some-prefix..0",
+                LeaseToken = "0",
+                Owner = Guid.NewGuid().ToString(),
+                LeasePartitionKey = guidPartitionKey,
+                FeedRange = new FeedRangePartitionKeyRange("0")
+            };
+
+            Mock<DocumentServiceLeaseUpdater> mockUpdater = new Mock<DocumentServiceLeaseUpdater>();
+
+            mockUpdater.Setup(c => c.UpdateLeaseAsync(
+                It.IsAny<DocumentServiceLease>(),
+                It.Is<string>(id => id == lease.LeaseId),
+                It.Is<PartitionKey>(pk => pk == new PartitionKey(guidPartitionKey)),
+                It.IsAny<Func<DocumentServiceLease, DocumentServiceLease>>()))
+                .ReturnsAsync(lease);
+
+            DocumentServiceLeaseManagerCosmos documentServiceLeaseManagerCosmos = new DocumentServiceLeaseManagerCosmos(
+                Mock.Of<ContainerInternal>(),
+                Mock.Of<ContainerInternal>(),
+                mockUpdater.Object,
+                options,
+                new PartitionedByPartitionKeyCollectionRequestOptionsFactory());
+
+            DocumentServiceLease afterAcquire = await documentServiceLeaseManagerCosmos.AcquireAsync(lease);
+
+            Assert.IsNotNull(afterAcquire);
+            Assert.AreEqual(guidPartitionKey, afterAcquire.PartitionKey, "Old GUID partition key must be preserved through acquire.");
+        }
+
+        [TestMethod]
+        public async Task RenewCompletes_WithPreExistingGuidPartitionKey()
+        {
+            string guidPartitionKey = Guid.NewGuid().ToString();
+            string hostName = Guid.NewGuid().ToString();
+            DocumentServiceLeaseStoreManagerOptions options = new DocumentServiceLeaseStoreManagerOptions
+            {
+                HostName = hostName
+            };
+
+            DocumentServiceLeaseCore lease = new DocumentServiceLeaseCore()
+            {
+                LeaseId = "some-prefix..0",
+                LeaseToken = "0",
+                Owner = hostName,
+                LeasePartitionKey = guidPartitionKey,
+                FeedRange = new FeedRangePartitionKeyRange("0")
+            };
+
+            ResponseMessage leaseResponse = new ResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new CosmosJsonDotNetSerializer().ToStream(lease)
+            };
+
+            Mock<ContainerInternal> mockedContainer = new Mock<ContainerInternal>();
+            mockedContainer.Setup(c => c.ReadItemStreamAsync(
+                It.Is<string>(id => id == lease.LeaseId),
+                It.Is<PartitionKey>(pk => pk == new PartitionKey(guidPartitionKey)),
+                It.IsAny<ItemRequestOptions>(),
+                It.IsAny<CancellationToken>())).ReturnsAsync(leaseResponse);
+
+            Mock<DocumentServiceLeaseUpdater> mockUpdater = new Mock<DocumentServiceLeaseUpdater>();
+            mockUpdater.Setup(c => c.UpdateLeaseAsync(
+                It.IsAny<DocumentServiceLease>(),
+                It.Is<string>(id => id == lease.LeaseId),
+                It.Is<PartitionKey>(pk => pk == new PartitionKey(guidPartitionKey)),
+                It.IsAny<Func<DocumentServiceLease, DocumentServiceLease>>()))
+                .ReturnsAsync(lease);
+
+            DocumentServiceLeaseManagerCosmos documentServiceLeaseManagerCosmos = new DocumentServiceLeaseManagerCosmos(
+                Mock.Of<ContainerInternal>(),
+                mockedContainer.Object,
+                mockUpdater.Object,
+                options,
+                new PartitionedByPartitionKeyCollectionRequestOptionsFactory());
+
+            DocumentServiceLease afterRenew = await documentServiceLeaseManagerCosmos.RenewAsync(lease);
+
+            Assert.IsNotNull(afterRenew);
+            Assert.AreEqual(guidPartitionKey, afterRenew.PartitionKey, "Old GUID partition key must be preserved through renew.");
+        }
+
+        /// <summary>
         /// Verifies a Release sets the owner on null
         /// </summary>
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseManagerCosmosTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseManagerCosmosTests.cs
@@ -20,6 +20,12 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
     [TestCategory("ChangeFeed")]
     public class DocumentServiceLeaseManagerCosmosTests
     {
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            Environment.SetEnvironmentVariable(ConfigurationManager.ChangeFeedLeaseIdAsPartitionKeyEnabled, null);
+        }
+
         /// <summary>
         /// Verifies that the update lambda updates the owner.
         /// </summary>
@@ -151,6 +157,83 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
             Assert.AreEqual(continuation, afterAcquire.ContinuationToken);
             Assert.AreEqual(partitionKeyRange.Id, pkRangeBasedLease.CurrentLeaseToken);
             ValidateRequestOptionsFactory(requestOptionsFactory, pkRangeBasedLease);
+        }
+
+        [TestMethod]
+        public async Task CreatesPartitionKeyBasedLeaseWithDeterministicPartitionKeyByDefault()
+        {
+            PartitionKey? capturedPartitionKey = null;
+            RequestOptionsFactory requestOptionsFactory = new PartitionedByPartitionKeyCollectionRequestOptionsFactory();
+            string continuation = Guid.NewGuid().ToString();
+            DocumentServiceLeaseStoreManagerOptions options = new DocumentServiceLeaseStoreManagerOptions
+            {
+                HostName = Guid.NewGuid().ToString()
+            };
+
+            Documents.PartitionKeyRange partitionKeyRange = new Documents.PartitionKeyRange()
+            {
+                Id = "0",
+                MinInclusive = "",
+                MaxExclusive = "FF"
+            };
+
+            Mock<ContainerInternal> mockedContainer = new Mock<ContainerInternal>();
+            mockedContainer.Setup(c => c.CreateItemStreamAsync(
+                It.IsAny<Stream>(),
+                It.IsAny<PartitionKey>(),
+                It.IsAny<ItemRequestOptions>(),
+                It.IsAny<CancellationToken>())).Callback((Stream stream, PartitionKey partitionKey, ItemRequestOptions itemRequestOptions, CancellationToken token) => capturedPartitionKey = partitionKey)
+                .ReturnsAsync((Stream stream, PartitionKey partitionKey, ItemRequestOptions itemRequestOptions, CancellationToken token) => new ResponseMessage(System.Net.HttpStatusCode.OK) { Content = stream });
+
+            DocumentServiceLeaseManagerCosmos documentServiceLeaseManagerCosmos = new DocumentServiceLeaseManagerCosmos(
+                Mock.Of<ContainerInternal>(),
+                mockedContainer.Object,
+                Mock.Of<DocumentServiceLeaseUpdater>(),
+                options,
+                requestOptionsFactory);
+
+            DocumentServiceLease lease = await documentServiceLeaseManagerCosmos.CreateLeaseIfNotExistAsync(partitionKeyRange, continuation);
+
+            Assert.IsTrue(capturedPartitionKey.HasValue);
+            Assert.AreEqual(new PartitionKey(lease.Id), capturedPartitionKey.Value);
+            Assert.AreEqual(lease.Id, lease.PartitionKey);
+        }
+
+        [TestMethod]
+        public async Task CreatesEPKBasedLeaseWithLegacyGuidPartitionKeyWhenOptedOut()
+        {
+            Environment.SetEnvironmentVariable(ConfigurationManager.ChangeFeedLeaseIdAsPartitionKeyEnabled, "false");
+
+            PartitionKey? capturedPartitionKey = null;
+            RequestOptionsFactory requestOptionsFactory = new PartitionedByPartitionKeyCollectionRequestOptionsFactory();
+            string continuation = Guid.NewGuid().ToString();
+            DocumentServiceLeaseStoreManagerOptions options = new DocumentServiceLeaseStoreManagerOptions
+            {
+                HostName = Guid.NewGuid().ToString()
+            };
+
+            FeedRangeEpk feedRangeEpk = new FeedRangeEpk(new Documents.Routing.Range<string>("AA", "BB", true, false));
+
+            Mock<ContainerInternal> mockedContainer = new Mock<ContainerInternal>();
+            mockedContainer.Setup(c => c.CreateItemStreamAsync(
+                It.IsAny<Stream>(),
+                It.IsAny<PartitionKey>(),
+                It.IsAny<ItemRequestOptions>(),
+                It.IsAny<CancellationToken>())).Callback((Stream stream, PartitionKey partitionKey, ItemRequestOptions itemRequestOptions, CancellationToken token) => capturedPartitionKey = partitionKey)
+                .ReturnsAsync((Stream stream, PartitionKey partitionKey, ItemRequestOptions itemRequestOptions, CancellationToken token) => new ResponseMessage(System.Net.HttpStatusCode.OK) { Content = stream });
+
+            DocumentServiceLeaseManagerCosmos documentServiceLeaseManagerCosmos = new DocumentServiceLeaseManagerCosmos(
+                Mock.Of<ContainerInternal>(),
+                mockedContainer.Object,
+                Mock.Of<DocumentServiceLeaseUpdater>(),
+                options,
+                requestOptionsFactory);
+
+            DocumentServiceLease lease = await documentServiceLeaseManagerCosmos.CreateLeaseIfNotExistAsync(feedRangeEpk, continuation);
+
+            Assert.IsTrue(capturedPartitionKey.HasValue);
+            Assert.AreNotEqual(new PartitionKey(lease.Id), capturedPartitionKey.Value);
+            Assert.IsTrue(Guid.TryParse(lease.PartitionKey, out _));
         }
 
         /// <summary>
@@ -628,6 +711,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
             else if (requestOptionsFactory is PartitionedByPartitionKeyCollectionRequestOptionsFactory)
             {
                 Assert.IsNotNull(lease.PartitionKey);
+                Assert.AreEqual(lease.Id, lease.PartitionKey);
             }
             else
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseManagerCosmosTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseManagerCosmosTests.cs
@@ -20,6 +20,12 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
     [TestCategory("ChangeFeed")]
     public class DocumentServiceLeaseManagerCosmosTests
     {
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            Environment.SetEnvironmentVariable(ConfigurationManager.ChangeFeedLeaseIdAsPartitionKeyEnabled, null);
+        }
+
         [TestCleanup]
         public void TestCleanup()
         {
@@ -77,8 +83,6 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         [DataRow(2, DisplayName = "Container with partitionKey PK")]
         public async Task CreatesEPKBasedLease(int factoryType)
         {
-            Environment.SetEnvironmentVariable(ConfigurationManager.ChangeFeedLeaseIdAsPartitionKeyEnabled, "true");
-
             RequestOptionsFactory requestOptionsFactory = GetRequestOptionsFactory(factoryType);
             string continuation = Guid.NewGuid().ToString();
             DocumentServiceLeaseStoreManagerOptions options = new DocumentServiceLeaseStoreManagerOptions
@@ -121,8 +125,6 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         [DataRow(2, DisplayName = "Container with partitionKey PK")]
         public async Task CreatesPartitionKeyBasedLease(int factoryType)
         {
-            Environment.SetEnvironmentVariable(ConfigurationManager.ChangeFeedLeaseIdAsPartitionKeyEnabled, "true");
-
             RequestOptionsFactory requestOptionsFactory = GetRequestOptionsFactory(factoryType);
             string continuation = Guid.NewGuid().ToString();
             DocumentServiceLeaseStoreManagerOptions options = new DocumentServiceLeaseStoreManagerOptions

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseManagerCosmosTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseManagerCosmosTests.cs
@@ -236,6 +236,83 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
             Assert.IsTrue(Guid.TryParse(lease.PartitionKey, out _));
         }
 
+        [TestMethod]
+        public async Task CreatesEPKBasedLeaseWithDeterministicPartitionKeyByDefault()
+        {
+            PartitionKey? capturedPartitionKey = null;
+            RequestOptionsFactory requestOptionsFactory = new PartitionedByPartitionKeyCollectionRequestOptionsFactory();
+            string continuation = Guid.NewGuid().ToString();
+            DocumentServiceLeaseStoreManagerOptions options = new DocumentServiceLeaseStoreManagerOptions
+            {
+                HostName = Guid.NewGuid().ToString()
+            };
+
+            FeedRangeEpk feedRangeEpk = new FeedRangeEpk(new Documents.Routing.Range<string>("AA", "BB", true, false));
+
+            Mock<ContainerInternal> mockedContainer = new Mock<ContainerInternal>();
+            mockedContainer.Setup(c => c.CreateItemStreamAsync(
+                It.IsAny<Stream>(),
+                It.IsAny<PartitionKey>(),
+                It.IsAny<ItemRequestOptions>(),
+                It.IsAny<CancellationToken>())).Callback((Stream stream, PartitionKey partitionKey, ItemRequestOptions itemRequestOptions, CancellationToken token) => capturedPartitionKey = partitionKey)
+                .ReturnsAsync((Stream stream, PartitionKey partitionKey, ItemRequestOptions itemRequestOptions, CancellationToken token) => new ResponseMessage(System.Net.HttpStatusCode.OK) { Content = stream });
+
+            DocumentServiceLeaseManagerCosmos documentServiceLeaseManagerCosmos = new DocumentServiceLeaseManagerCosmos(
+                Mock.Of<ContainerInternal>(),
+                mockedContainer.Object,
+                Mock.Of<DocumentServiceLeaseUpdater>(),
+                options,
+                requestOptionsFactory);
+
+            DocumentServiceLease lease = await documentServiceLeaseManagerCosmos.CreateLeaseIfNotExistAsync(feedRangeEpk, continuation);
+
+            Assert.IsTrue(capturedPartitionKey.HasValue);
+            Assert.AreEqual(new PartitionKey(lease.Id), capturedPartitionKey.Value);
+            Assert.AreEqual(lease.Id, lease.PartitionKey);
+        }
+
+        [TestMethod]
+        public async Task CreatesPartitionKeyBasedLeaseWithLegacyGuidPartitionKeyWhenOptedOut()
+        {
+            Environment.SetEnvironmentVariable(ConfigurationManager.ChangeFeedLeaseIdAsPartitionKeyEnabled, "false");
+
+            PartitionKey? capturedPartitionKey = null;
+            RequestOptionsFactory requestOptionsFactory = new PartitionedByPartitionKeyCollectionRequestOptionsFactory();
+            string continuation = Guid.NewGuid().ToString();
+            DocumentServiceLeaseStoreManagerOptions options = new DocumentServiceLeaseStoreManagerOptions
+            {
+                HostName = Guid.NewGuid().ToString()
+            };
+
+            Documents.PartitionKeyRange partitionKeyRange = new Documents.PartitionKeyRange()
+            {
+                Id = "0",
+                MinInclusive = "",
+                MaxExclusive = "FF"
+            };
+
+            Mock<ContainerInternal> mockedContainer = new Mock<ContainerInternal>();
+            mockedContainer.Setup(c => c.CreateItemStreamAsync(
+                It.IsAny<Stream>(),
+                It.IsAny<PartitionKey>(),
+                It.IsAny<ItemRequestOptions>(),
+                It.IsAny<CancellationToken>())).Callback((Stream stream, PartitionKey partitionKey, ItemRequestOptions itemRequestOptions, CancellationToken token) => capturedPartitionKey = partitionKey)
+                .ReturnsAsync((Stream stream, PartitionKey partitionKey, ItemRequestOptions itemRequestOptions, CancellationToken token) => new ResponseMessage(System.Net.HttpStatusCode.OK) { Content = stream });
+
+            DocumentServiceLeaseManagerCosmos documentServiceLeaseManagerCosmos = new DocumentServiceLeaseManagerCosmos(
+                Mock.Of<ContainerInternal>(),
+                mockedContainer.Object,
+                Mock.Of<DocumentServiceLeaseUpdater>(),
+                options,
+                requestOptionsFactory);
+
+            DocumentServiceLease lease = await documentServiceLeaseManagerCosmos.CreateLeaseIfNotExistAsync(partitionKeyRange, continuation);
+
+            Assert.IsTrue(capturedPartitionKey.HasValue);
+            Assert.AreNotEqual(new PartitionKey(lease.Id), capturedPartitionKey.Value);
+            Assert.IsTrue(Guid.TryParse(lease.PartitionKey, out _));
+        }
+
         /// <summary>
         /// Verifies a Release sets the owner on null
         /// </summary>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseManagerCosmosTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseManagerCosmosTests.cs
@@ -25,13 +25,13 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         [TestInitialize]
         public void TestInitialize()
         {
-            Environment.SetEnvironmentVariable(ConfigurationManager.ChangeFeedLeaseIdAsPartitionKeyEnabled, null);
+            DocumentServiceLeaseManagerCosmos.IsChangeFeedLeaseIdAsPartitionKeyEnabled = true;
         }
 
         [TestCleanup]
         public void TestCleanup()
         {
-            Environment.SetEnvironmentVariable(ConfigurationManager.ChangeFeedLeaseIdAsPartitionKeyEnabled, null);
+            DocumentServiceLeaseManagerCosmos.IsChangeFeedLeaseIdAsPartitionKeyEnabled = true;
         }
 
         /// <summary>
@@ -176,17 +176,17 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         }
 
         /// <summary>
-        /// Verifies partition key behavior for both overloads and both env-var states:
+        /// Verifies partition key behavior for both overloads and both flag states:
         /// default (deterministic PK = lease id) and opt-out (legacy GUID PK).
         /// </summary>
         [DataTestMethod]
-        [DataRow("PKRange", null, true, DisplayName = "PKRange: deterministic PK by default")]
-        [DataRow("PKRange", "false", false, DisplayName = "PKRange: legacy GUID PK when opted out")]
-        [DataRow("EPK", null, true, DisplayName = "EPK: deterministic PK by default")]
-        [DataRow("EPK", "false", false, DisplayName = "EPK: legacy GUID PK when opted out")]
-        public async Task CreateLeaseIfNotExistAsync_PartitionKeyBehavior(string overloadType, string envVarValue, bool expectDeterministic)
+        [DataRow("PKRange", true, true, DisplayName = "PKRange: deterministic PK by default")]
+        [DataRow("PKRange", false, false, DisplayName = "PKRange: legacy GUID PK when opted out")]
+        [DataRow("EPK", true, true, DisplayName = "EPK: deterministic PK by default")]
+        [DataRow("EPK", false, false, DisplayName = "EPK: legacy GUID PK when opted out")]
+        public async Task CreateLeaseIfNotExistAsync_PartitionKeyBehavior(string overloadType, bool flagValue, bool expectDeterministic)
         {
-            Environment.SetEnvironmentVariable(ConfigurationManager.ChangeFeedLeaseIdAsPartitionKeyEnabled, envVarValue);
+            DocumentServiceLeaseManagerCosmos.IsChangeFeedLeaseIdAsPartitionKeyEnabled = flagValue;
 
             PartitionKey? capturedPartitionKey = null;
             Mock<ContainerInternal> mockedContainer = CreatePkCapturingMockContainer(pk => capturedPartitionKey = pk);


### PR DESCRIPTION
**Research report (gist):** https://gist.github.com/kirankumarkolli/8bf1cbb9c3ee45dfa64511c4a0cb35ad

## Problem statement

In V3 SDK 3.20.0+, when the lease container is partitioned on `/partitionKey` (used for Gremlin/Graph API accounts and any customer-chosen layout), `DocumentServiceLeaseManagerCosmos.CreateLeaseIfNotExistAsync` sets the new lease's partition-key **value** to `Guid.NewGuid().ToString()`. Because Cosmos DB's `id` uniqueness is scoped per logical partition, two racing hosts that compute the same deterministic lease `id` land in different logical partitions and both succeed with `201 Created` instead of the `409 Conflict` the dedup logic relies on.

**Root cause:** V3 PR #2491 (2021-05-27) and its V2 predecessor PR #158 silently violated the original V2 PR #105 (2018) invariant that *"lease collection PK must be a function of monitored collection PK Range. We already have that function as lease id."*

## Fix (minimal, env-gated with safe default)

### New env var

| Variable | Default | Purpose |
|---|---|---|
| `AZURE_COSMOS_CHANGE_FEED_LEASE_ID_AS_PARTITION_KEY_ENABLED` | `true` | When `true`, lease docs in a `/partitionKey`-partitioned lease container use the deterministic lease `id` as the partition-key value (restores the 409-based dedup invariant). When `false`, falls back to legacy `Guid.NewGuid()` behavior. |

### Code changes

**`ConfigurationManager.cs`** — New env-var constant and accessor `IsChangeFeedLeaseIdAsPartitionKeyEnabled()`, mirroring the established `AZURE_COSMOS_*_ENABLED` pattern.

**`DocumentServiceLeaseManagerCosmos.cs`** — New `useDeterministicPartitionKey` field snapshotted in the constructor (ensures consistency for the manager's lifetime). New `GetLeasePartitionKeyValue(leaseId)` helper used at both `CreateLeaseIfNotExistAsync` call sites, replacing the `Guid.NewGuid().ToString()` calls.

### Why this is the right fix

| Property | Status after fix |
|---|---|
| PK path | Unchanged (`/partitionKey`) — Gremlin still works |
| Public API surface | Unchanged |
| Default behavior | **New deterministic PK** (fix is on by default) |
| Operational escape hatch | `AZURE_COSMOS_CHANGE_FEED_LEASE_ID_AS_PARTITION_KEY_ENABLED=false` reverts per-process |
| Dedup invariant (PR #105) | **Restored** for all three lease-container layouts |
| Back-compat read path | Unchanged — `TryGetLeaseAsync` uses stored PK value |

### Not required (explicitly)

- No schema migration — old GUID-PK leases coexist with new `id`-PK leases; both read/update paths route through the stored `PartitionKey` field.
- No change to `PartitionedByPartitionKeyCollectionRequestOptionsFactory` (already routes by stored PK value).

## Risks and mitigations

| # | Risk | Likelihood | Mitigation |
|---|---|---|---|
| 1 | Existing customers carry a mix of GUID-PK (old) and `id`-PK (new) leases | Certain | Safe by design — `TryGetLeaseAsync` reads stored `lease.PartitionKey`; old leases remain readable/updatable |
| 2 | Duplicate leases already written under old code persist | Certain | Out of scope — not self-clearing; manual cleanup needed |
| 3 | Mixed-fleet window during rolling upgrade | Certain during rollout | Dedup fully restored only after all hosts upgraded. Not a new failure mode. |
| 4 | Hot-partition risk | Very low | Each lease has a different PK value (per-leaseToken), so distribution is similar to `/id` layout |

### Upgrade semantics — mixed-fleet behavior

During rolling upgrade (old + new SDK hosts coexist):
- Read/update/delete/checkpoint of **existing** leases: works on both sides (routes through stored `lease.PartitionKey`).
- Concurrent **create** of the same missing lease: still produces duplicates if one host is old SDK (GUID PK) and another is new (id PK). **Dedup is fully restored only after rollout completes.**

### Known limitation — pre-existing duplicates not auto-cleaned

Duplicate leases written by older SDK versions persist until the corresponding PKRange undergoes a split/merge. Manual cleanup (`SELECT * FROM c WHERE c.id = @id` + `DELETE` extras) is needed for existing duplicates.

## Test coverage

### Unit tests — `DocumentServiceLeaseManagerCosmosTests.cs`

| Test | What it proves |
|---|---|
| `CreateLeaseIfNotExistAsync_PartitionKeyBehavior` (4 DataRows) | Parameterized across PKRange/EPK × default/opt-out: captures the `PartitionKey` sent in the create request and asserts deterministic (PK = lease.Id) or legacy (PK = GUID ≠ lease.Id) behavior |
| `CreateLeaseIfNotExistAsync_DuplicatePkId_Returns409` (2 DataRows) | Simulates Cosmos DB's (PK, id) uniqueness constraint via `ConcurrentDictionary` — first create succeeds, second with same (PK, id) gets 409 |
| `AcquireCompletes_WithPreExistingGuidPartitionKey` | Back-compat: lease with old random-GUID PK can still be acquired (stored PK preserved) |
| `RenewCompletes_WithPreExistingGuidPartitionKey` | Back-compat: lease with old random-GUID PK can still be renewed (stored PK preserved) |
| Existing `CreatesEPKBasedLease` / `CreatesPartitionKeyBasedLease` | **Strengthened:** added `Assert.AreEqual(lease.Id, lease.PartitionKey)` for `/partitionKey` factory |

Infrastructure: `[DoNotParallelize]` + `[TestInitialize]`/`[TestCleanup]` for env var safety. Shared helpers eliminate duplication across overload types.

### Emulator integration test — `GremlinSmokeTests.cs`

| Test | What changed |
|---|---|
| `Schema_DefaultsToHavingPartitionKey` | Converted to `[DataTestMethod]` with two rows: **(a)** default env → asserts `partitionKey == lease.id` (dedup invariant), **(b)** env var `false` → asserts `partitionKey` is a GUID ≠ `lease.id` (legacy behavior) |

Infrastructure: `[DoNotParallelize]` added (env var mutation is process-global).
