### PR TITLE
[Internal] DTS: Refactors JSON property names into shared constant and changes etag constant

### DIFF
--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperationResult.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperationResult.cs
@@ -140,7 +140,7 @@ namespace Microsoft.Azure.Cosmos
         {
             DistributedTransactionOperationResult result = JsonSerializer.Deserialize<DistributedTransactionOperationResult>(json, DistributedTransactionOperationResult.CaseInsensitiveOptions);
 
-            if (json.TryGetProperty("resourceBody", out JsonElement resourceBody)
+            if (json.TryGetProperty(DistributedTransactionSerializer.ResourceBody, out JsonElement resourceBody)
                 && resourceBody.ValueKind != JsonValueKind.Undefined
                 && resourceBody.ValueKind != JsonValueKind.Null)
             {

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionSerializer.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionSerializer.cs
@@ -16,6 +16,20 @@ namespace Microsoft.Azure.Cosmos
     /// </summary>
     internal static class DistributedTransactionSerializer
     {
+        internal const string Operations = "operations";
+        internal const string DatabaseName = "databaseName";
+        internal const string CollectionName = "collectionName";
+        internal const string Id = "id";
+        internal const string CollectionResourceId = "collectionResourceId";
+        internal const string DatabaseResourceId = "databaseResourceId";
+        internal const string PartitionKey = "partitionKey";
+        internal const string Index = "index";
+        internal const string ResourceBody = "resourceBody";
+        internal const string SessionToken = "sessionToken";
+        internal const string ETag = "ifMatch";
+        internal const string OperationType = "operationType";
+        internal const string ResourceType = "resourceType";
+
         /// <summary>
         /// Serializes a distributed transaction request body to a JSON stream.
         /// The body contains only the operations array. Other metadata like idempotencyToken,
@@ -32,7 +46,7 @@ namespace Microsoft.Azure.Cosmos
                 jsonWriter.WriteStartObject();
 
                 // operations array
-                jsonWriter.WriteStartArray("operations");
+                jsonWriter.WriteStartArray(Operations);
 
                 foreach (DistributedTransactionOperation operation in operations)
                 {
@@ -58,30 +72,30 @@ namespace Microsoft.Azure.Cosmos
             jsonWriter.WriteStartObject();
 
             // databaseName 
-            jsonWriter.WriteString("databaseName", operation.Database);
+            jsonWriter.WriteString(DatabaseName, operation.Database);
 
             // collectionName
-            jsonWriter.WriteString("collectionName", operation.Container);
+            jsonWriter.WriteString(CollectionName, operation.Container);
 
             // id
-            jsonWriter.WriteString("id", operation.Id);
+            jsonWriter.WriteString(Id, operation.Id);
 
             // collectionResourceId
             if (operation.CollectionResourceId != null)
             {
-                jsonWriter.WriteString("collectionResourceId", operation.CollectionResourceId);
+                jsonWriter.WriteString(CollectionResourceId, operation.CollectionResourceId);
             }
 
             // databaseResourceId
             if (operation.DatabaseResourceId != null)
             {
-                jsonWriter.WriteString("databaseResourceId", operation.DatabaseResourceId);
+                jsonWriter.WriteString(DatabaseResourceId, operation.DatabaseResourceId);
             }
 
             // partitionKey
             if (operation.PartitionKeyJson != null)
             {
-                jsonWriter.WritePropertyName("partitionKey");
+                jsonWriter.WritePropertyName(PartitionKey);
                 jsonWriter.WriteRawValue(operation.PartitionKeyJson, skipInputValidation: true);
             }
 
@@ -90,32 +104,31 @@ namespace Microsoft.Azure.Cosmos
             {
                 throw new ArgumentOutOfRangeException(nameof(operation.OperationIndex), "Operation index must be non-negative.");
             }
-            jsonWriter.WriteNumber("index", (uint)operation.OperationIndex);
+            jsonWriter.WriteNumber(Index, (uint)operation.OperationIndex);
 
             //resourceBody - written as nested JSON object
             if (!operation.ResourceBody.IsEmpty)
             {
-                jsonWriter.WritePropertyName("resourceBody");
+                jsonWriter.WritePropertyName(ResourceBody);
                 jsonWriter.WriteRawValue(operation.ResourceBody.Span, skipInputValidation: true);
             }
 
             // sessionToken
             if (operation.SessionToken != null)
             {
-                jsonWriter.WriteString("sessionToken", operation.SessionToken);
+                jsonWriter.WriteString(SessionToken, operation.SessionToken);
             }
 
             // etag
             if (operation.ETag != null)
             {
-                jsonWriter.WriteString("etag", operation.ETag);
+                jsonWriter.WriteString(ETag, operation.ETag);
             }
 
             // operationType (string)
-            jsonWriter.WriteString("operationType", operation.OperationType.ToString());
-
+            jsonWriter.WriteString(OperationType, operation.OperationType.ToString());
             // resourceType (string)
-            jsonWriter.WriteString("resourceType", ResourceType.Document.ToString());
+            jsonWriter.WriteString(ResourceType, Documents.ResourceType.Document.ToString());
 
             jsonWriter.WriteEndObject();
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/DistributedTransaction/DistributedTransactionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/DistributedTransaction/DistributedTransactionTests.cs
@@ -101,12 +101,12 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 .CommitTransactionAsync(CancellationToken.None);
 
             using JsonDocument requestJson = JsonDocument.Parse(handler.CapturedRequestBody);
-            JsonElement ops = requestJson.RootElement.GetProperty("operations");
+            JsonElement ops = requestJson.RootElement.GetProperty(DistributedTransactionSerializer.Operations);
 
             Assert.AreEqual(3, ops.GetArrayLength());
-            Assert.AreEqual(OperationType.Create.ToString(), ops[0].GetProperty("operationType").GetString());
-            Assert.AreEqual(OperationType.Replace.ToString(), ops[1].GetProperty("operationType").GetString());
-            Assert.AreEqual(OperationType.Delete.ToString(), ops[2].GetProperty("operationType").GetString());
+            Assert.AreEqual(OperationType.Create.ToString(), ops[0].GetProperty(DistributedTransactionSerializer.OperationType).GetString());
+            Assert.AreEqual(OperationType.Replace.ToString(), ops[1].GetProperty(DistributedTransactionSerializer.OperationType).GetString());
+            Assert.AreEqual(OperationType.Delete.ToString(), ops[2].GetProperty(DistributedTransactionSerializer.OperationType).GetString());
         }
 
         [TestMethod]
@@ -127,10 +127,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 .CommitTransactionAsync(CancellationToken.None);
 
             using JsonDocument requestJson = JsonDocument.Parse(handler.CapturedRequestBody);
-            JsonElement ops = requestJson.RootElement.GetProperty("operations");
+            JsonElement ops = requestJson.RootElement.GetProperty(DistributedTransactionSerializer.Operations);
 
             Assert.AreEqual(2, ops.GetArrayLength());
-            Assert.AreEqual(OperationType.Upsert.ToString(), ops[1].GetProperty("operationType").GetString());
+            Assert.AreEqual(OperationType.Upsert.ToString(), ops[1].GetProperty(DistributedTransactionSerializer.OperationType).GetString());
             Assert.AreEqual(2, response.Count);
 
             response.Dispose();
@@ -154,10 +154,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 .CommitTransactionAsync(CancellationToken.None);
 
             using JsonDocument requestJson = JsonDocument.Parse(handler.CapturedRequestBody);
-            JsonElement ops = requestJson.RootElement.GetProperty("operations");
+            JsonElement ops = requestJson.RootElement.GetProperty(DistributedTransactionSerializer.Operations);
 
             Assert.AreEqual(2, ops.GetArrayLength());
-            Assert.AreEqual(OperationType.Patch.ToString(), ops[1].GetProperty("operationType").GetString());
+            Assert.AreEqual(OperationType.Patch.ToString(), ops[1].GetProperty(DistributedTransactionSerializer.OperationType).GetString());
         }
 
         [TestMethod]
@@ -184,12 +184,12 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 .CommitTransactionAsync(CancellationToken.None);
 
             using JsonDocument requestJson = JsonDocument.Parse(handler.CapturedRequestBody);
-            JsonElement ops = requestJson.RootElement.GetProperty("operations");
+            JsonElement ops = requestJson.RootElement.GetProperty(DistributedTransactionSerializer.Operations);
 
             Assert.AreEqual(2, ops.GetArrayLength());
             Assert.AreNotEqual(
-                ops[0].GetProperty("collectionName").GetString(),
-                ops[1].GetProperty("collectionName").GetString(),
+                ops[0].GetProperty(DistributedTransactionSerializer.CollectionName).GetString(),
+                ops[1].GetProperty(DistributedTransactionSerializer.CollectionName).GetString(),
                 "Operations should reference different containers.");
             Assert.AreEqual(2, response.Count);
 
@@ -403,7 +403,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             using JsonDocument requestJson = JsonDocument.Parse(handler.CapturedRequestBody);
 
             Assert.AreEqual(JsonValueKind.Object, requestJson.RootElement.ValueKind, "Root element should be an object");
-            Assert.IsTrue(requestJson.RootElement.TryGetProperty("operations", out JsonElement operations), "operations property should exist");
+            Assert.IsTrue(requestJson.RootElement.TryGetProperty(DistributedTransactionSerializer.Operations, out JsonElement operations), "operations property should exist");
             Assert.AreEqual(JsonValueKind.Array, operations.ValueKind, "operations should be an array");
             Assert.AreEqual(3, operations.GetArrayLength(), "operations should have 3 elements");
 
@@ -414,14 +414,14 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                 (string Property, JsonValueKind Kind)[] requiredFields =
                 {
-                    ("databaseName", JsonValueKind.String),
-                    ("collectionName", JsonValueKind.String),
-                    ("collectionResourceId", JsonValueKind.String),
-                    ("databaseResourceId", JsonValueKind.String),
-                    ("partitionKey", JsonValueKind.Array),
-                    ("index", JsonValueKind.Number),
-                    ("operationType", JsonValueKind.String),
-                    ("resourceType", JsonValueKind.String)
+                    (DistributedTransactionSerializer.DatabaseName, JsonValueKind.String),
+                    (DistributedTransactionSerializer.CollectionName, JsonValueKind.String),
+                    (DistributedTransactionSerializer.CollectionResourceId, JsonValueKind.String),
+                    (DistributedTransactionSerializer.DatabaseResourceId, JsonValueKind.String),
+                    (DistributedTransactionSerializer.PartitionKey, JsonValueKind.Array),
+                    (DistributedTransactionSerializer.Index, JsonValueKind.Number),
+                    (DistributedTransactionSerializer.OperationType, JsonValueKind.String),
+                    (DistributedTransactionSerializer.ResourceType, JsonValueKind.String)
                 };
 
                 foreach ((string property, JsonValueKind expectedKind) in requiredFields)
@@ -431,10 +431,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                 (string Property, JsonValueKind Kind)[] optionalFields =
                 {
-                    ("id", JsonValueKind.String),
-                    ("resourceBody", JsonValueKind.Object),
-                    ("sessionToken", JsonValueKind.String),
-                    ("etag", JsonValueKind.String),
+                    (DistributedTransactionSerializer.Id, JsonValueKind.String),
+                    (DistributedTransactionSerializer.ResourceBody, JsonValueKind.Object),
+                    (DistributedTransactionSerializer.SessionToken, JsonValueKind.String),
+                    (DistributedTransactionSerializer.ETag, JsonValueKind.String),
                 };
 
                 foreach ((string property, JsonValueKind expectedKind) in optionalFields)
@@ -474,10 +474,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             Assert.IsTrue(response.IsSuccessStatusCode);
             using JsonDocument requestJson = JsonDocument.Parse(handler.CapturedRequestBody);
-            JsonElement operation = requestJson.RootElement.GetProperty("operations")[0];
-            Assert.IsTrue(operation.TryGetProperty("id", out JsonElement idElement), "id field should be present for replace operation");
+            JsonElement operation = requestJson.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
+            Assert.IsTrue(operation.TryGetProperty(DistributedTransactionSerializer.Id, out JsonElement idElement), "id field should be present for replace operation");
             Assert.AreEqual(doc.id, idElement.GetString());
-            Assert.IsTrue(operation.TryGetProperty("etag", out JsonElement etagElement), "etag field should be present when IfMatchEtag is set");
+            Assert.IsTrue(operation.TryGetProperty(DistributedTransactionSerializer.ETag, out JsonElement etagElement), "etag field should be present when IfMatchEtag is set");
             Assert.AreEqual(expectedEtag, etagElement.GetString());
 
             response.Dispose();
@@ -505,10 +505,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             Assert.IsTrue(response.IsSuccessStatusCode);
             using JsonDocument requestJson = JsonDocument.Parse(handler.CapturedRequestBody);
-            JsonElement operation = requestJson.RootElement.GetProperty("operations")[0];
-            Assert.IsTrue(operation.TryGetProperty("id", out JsonElement idElement), "id field should be present for delete operation");
+            JsonElement operation = requestJson.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
+            Assert.IsTrue(operation.TryGetProperty(DistributedTransactionSerializer.Id, out JsonElement idElement), "id field should be present for delete operation");
             Assert.AreEqual("delete-id", idElement.GetString());
-            Assert.IsTrue(operation.TryGetProperty("etag", out JsonElement etagElement), "etag field should be present when IfMatchEtag is set");
+            Assert.IsTrue(operation.TryGetProperty(DistributedTransactionSerializer.ETag, out JsonElement etagElement), "etag field should be present when IfMatchEtag is set");
             Assert.AreEqual(expectedEtag, etagElement.GetString());
 
             response.Dispose();
@@ -538,10 +538,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             Assert.IsTrue(response.IsSuccessStatusCode);
             using JsonDocument requestJson = JsonDocument.Parse(handler.CapturedRequestBody);
-            JsonElement operation = requestJson.RootElement.GetProperty("operations")[0];
-            Assert.IsTrue(operation.TryGetProperty("id", out JsonElement idElement), "id field should be present for patch operation");
+            JsonElement operation = requestJson.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
+            Assert.IsTrue(operation.TryGetProperty(DistributedTransactionSerializer.Id, out JsonElement idElement), "id field should be present for patch operation");
             Assert.AreEqual("patch-id", idElement.GetString());
-            Assert.IsTrue(operation.TryGetProperty("etag", out JsonElement etagElement), "etag field should be present when IfMatchEtag is set");
+            Assert.IsTrue(operation.TryGetProperty(DistributedTransactionSerializer.ETag, out JsonElement etagElement), "etag field should be present when IfMatchEtag is set");
             Assert.AreEqual(expectedEtag, etagElement.GetString());
 
             response.Dispose();
@@ -601,10 +601,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 .CommitTransactionAsync(CancellationToken.None);
 
             using JsonDocument requestJson = JsonDocument.Parse(handler.CapturedRequestBody);
-            JsonElement ops = requestJson.RootElement.GetProperty("operations");
+            JsonElement ops = requestJson.RootElement.GetProperty(DistributedTransactionSerializer.Operations);
             foreach (JsonElement operation in ops.EnumerateArray())
             {
-                Assert.IsFalse(operation.TryGetProperty("etag", out _), "etag field should not be present when IfMatchEtag is not set");
+                Assert.IsFalse(operation.TryGetProperty(DistributedTransactionSerializer.ETag, out _), "etag field should not be present when IfMatchEtag is not set");
             }
 
             response.Dispose();
@@ -631,9 +631,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             Assert.IsTrue(response.IsSuccessStatusCode);
             using JsonDocument requestJson = JsonDocument.Parse(handler.CapturedRequestBody);
-            JsonElement operation = requestJson.RootElement.GetProperty("operations")[0];
-            Assert.AreEqual(OperationType.Create.ToString(), operation.GetProperty("operationType").GetString());
-            JsonElement resourceBody = operation.GetProperty("resourceBody");
+            JsonElement operation = requestJson.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
+            Assert.AreEqual(OperationType.Create.ToString(), operation.GetProperty(DistributedTransactionSerializer.OperationType).GetString());
+            JsonElement resourceBody = operation.GetProperty(DistributedTransactionSerializer.ResourceBody);
             Assert.AreEqual(JsonValueKind.Object, resourceBody.ValueKind);
             ToDoActivity actualDoc = JsonSerializer.Deserialize<ToDoActivity>(resourceBody.GetRawText());
             Assert.AreEqual(doc.id, actualDoc.id);
@@ -661,10 +661,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             Assert.IsTrue(response.IsSuccessStatusCode);
             using JsonDocument requestJson = JsonDocument.Parse(handler.CapturedRequestBody);
-            JsonElement operation = requestJson.RootElement.GetProperty("operations")[0];
-            Assert.AreEqual(OperationType.Replace.ToString(), operation.GetProperty("operationType").GetString());
-            Assert.AreEqual(doc.id, operation.GetProperty("id").GetString());
-            JsonElement resourceBody = operation.GetProperty("resourceBody");
+            JsonElement operation = requestJson.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
+            Assert.AreEqual(OperationType.Replace.ToString(), operation.GetProperty(DistributedTransactionSerializer.OperationType).GetString());
+            Assert.AreEqual(doc.id, operation.GetProperty(DistributedTransactionSerializer.Id).GetString());
+            JsonElement resourceBody = operation.GetProperty(DistributedTransactionSerializer.ResourceBody);
             Assert.AreEqual(JsonValueKind.Object, resourceBody.ValueKind);
             ToDoActivity actualDoc = JsonSerializer.Deserialize<ToDoActivity>(resourceBody.GetRawText());
             Assert.AreEqual(doc.id, actualDoc.id);
@@ -692,9 +692,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             Assert.IsTrue(response.IsSuccessStatusCode);
             using JsonDocument requestJson = JsonDocument.Parse(handler.CapturedRequestBody);
-            JsonElement operation = requestJson.RootElement.GetProperty("operations")[0];
-            Assert.AreEqual(OperationType.Patch.ToString(), operation.GetProperty("operationType").GetString());
-            Assert.AreEqual("patch-id", operation.GetProperty("id").GetString());
+            JsonElement operation = requestJson.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
+            Assert.AreEqual(OperationType.Patch.ToString(), operation.GetProperty(DistributedTransactionSerializer.OperationType).GetString());
+            Assert.AreEqual("patch-id", operation.GetProperty(DistributedTransactionSerializer.Id).GetString());
 
             response.Dispose();
         }
@@ -718,9 +718,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             Assert.IsTrue(response.IsSuccessStatusCode);
             using JsonDocument requestJson = JsonDocument.Parse(handler.CapturedRequestBody);
-            JsonElement operation = requestJson.RootElement.GetProperty("operations")[0];
-            Assert.AreEqual(OperationType.Upsert.ToString(), operation.GetProperty("operationType").GetString());
-            JsonElement resourceBody = operation.GetProperty("resourceBody");
+            JsonElement operation = requestJson.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
+            Assert.AreEqual(OperationType.Upsert.ToString(), operation.GetProperty(DistributedTransactionSerializer.OperationType).GetString());
+            JsonElement resourceBody = operation.GetProperty(DistributedTransactionSerializer.ResourceBody);
             Assert.AreEqual(JsonValueKind.Object, resourceBody.ValueKind);
             ToDoActivity actualDoc = JsonSerializer.Deserialize<ToDoActivity>(resourceBody.GetRawText());
             Assert.AreEqual(doc.id, actualDoc.id);
@@ -838,14 +838,14 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             // Assert – request structure
             Assert.IsNotNull(handler.CapturedRequestBody);
             using JsonDocument requestJson = JsonDocument.Parse(handler.CapturedRequestBody);
-            JsonElement operation = requestJson.RootElement.GetProperty("operations")[0];
+            JsonElement operation = requestJson.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
 
-            Assert.AreEqual(OperationType.Read.ToString(), operation.GetProperty("operationType").GetString());
-            Assert.AreEqual(doc.id, operation.GetProperty("id").GetString());
-            Assert.IsTrue(operation.TryGetProperty("databaseName", out _), "databaseName should be present");
-            Assert.IsTrue(operation.TryGetProperty("collectionName", out _), "collectionName should be present");
-            Assert.IsTrue(operation.TryGetProperty("partitionKey", out _), "partitionKey should be present");
-            Assert.IsFalse(operation.TryGetProperty("resourceBody", out _), "resourceBody must NOT be present for read operations");
+            Assert.AreEqual(OperationType.Read.ToString(), operation.GetProperty(DistributedTransactionSerializer.OperationType).GetString());
+            Assert.AreEqual(doc.id, operation.GetProperty(DistributedTransactionSerializer.Id).GetString());
+            Assert.IsTrue(operation.TryGetProperty(DistributedTransactionSerializer.DatabaseName, out _), "databaseName should be present");
+            Assert.IsTrue(operation.TryGetProperty(DistributedTransactionSerializer.CollectionName, out _), "collectionName should be present");
+            Assert.IsTrue(operation.TryGetProperty(DistributedTransactionSerializer.PartitionKey, out _), "partitionKey should be present");
+            Assert.IsFalse(operation.TryGetProperty(DistributedTransactionSerializer.ResourceBody, out _), "resourceBody must NOT be present for read operations");
 
             response.Dispose();
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionCommitterTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionCommitterTests.cs
@@ -39,7 +39,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             SessionContainer sessionContainer = new SessionContainer("testhost");
 
             string responseJson = BuildDtcResponseJson(
-                new[] { (statusCode: 201, sessionToken: sessionToken) });
+                new[] { (statusCode: 201, sessionToken) });
 
             Mock<CosmosClientContext> mockContext = this.CreateMockContext(
                 sessionContainer,
@@ -113,8 +113,10 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
 
             Mock<ISessionContainer> mockSessionContainer = new Mock<ISessionContainer>();
 
-            MockDocumentClient documentClient = new MockDocumentClient();
-            documentClient.sessionContainer = mockSessionContainer.Object;
+            MockDocumentClient documentClient = new MockDocumentClient
+            {
+                sessionContainer = mockSessionContainer.Object
+            };
 
             ContainerProperties containerProperties1 = ContainerProperties.CreateWithResourceId(collectionRid1);
             containerProperties1.PartitionKeyPath = "/pk";
@@ -135,14 +137,16 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                     It.IsAny<ITrace>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(containerProperties2);
 
-            ResponseMessage responseMessage = new ResponseMessage(HttpStatusCode.OK);
-            responseMessage.Content = new MemoryStream(
-                Encoding.UTF8.GetBytes(BuildDtcResponseJson(
-                    new[]
-                    {
-                        (statusCode: 200, sessionToken: sessionToken),
-                        (statusCode: 200, sessionToken: sessionToken),
-                    })));
+            ResponseMessage responseMessage = new ResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new MemoryStream(
+                    Encoding.UTF8.GetBytes(BuildDtcResponseJson(
+                        new[]
+                        {
+                            (statusCode: 200, sessionToken),
+                            (statusCode: 200, sessionToken),
+                        })))
+            };
             mockContext.Setup(c => c.ProcessResourceOperationStreamAsync(
                     It.IsAny<string>(),
                     ResourceType.DistributedTransactionBatch,
@@ -209,7 +213,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
 
             Mock<CosmosClientContext> mockContext = this.CreateMockContext(
                 sessionContainer,
-                responseContent: BuildDtcResponseJson(new[] { (statusCode: 404, subStatusCode: (int?)readSessionNotAvailableSubStatus, sessionToken: sessionToken) }),
+                responseContent: BuildDtcResponseJson(new[] { (statusCode: 404, subStatusCode: (int?)readSessionNotAvailableSubStatus, sessionToken) }),
                 statusCode: HttpStatusCode.NotFound);
 
             List<DistributedTransactionOperation> operations = new List<DistributedTransactionOperation>
@@ -244,7 +248,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
 
             Mock<CosmosClientContext> mockContext = this.CreateMockContext(
                 sessionContainer,
-                responseContent: BuildDtcResponseJson(new[] { (statusCode: 409, sessionToken: sessionToken) }),
+                responseContent: BuildDtcResponseJson(new[] { (statusCode: 409, sessionToken) }),
                 statusCode: HttpStatusCode.Conflict);
 
             List<DistributedTransactionOperation> operations = new List<DistributedTransactionOperation>
@@ -298,7 +302,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
 
                 if (operations[i].sessionToken != null)
                 {
-                    sb.Append($@",""sessionToken"":""{operations[i].sessionToken}""");
+                    sb.Append($@",""{DistributedTransactionSerializer.SessionToken}"":""{operations[i].sessionToken}""");
                 }
 
                 sb.Append('}');
@@ -313,8 +317,10 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             string responseContent,
             HttpStatusCode statusCode)
         {
-            MockDocumentClient documentClient = new MockDocumentClient();
-            documentClient.sessionContainer = sessionContainer;
+            MockDocumentClient documentClient = new MockDocumentClient
+            {
+                sessionContainer = sessionContainer
+            };
 
             ContainerProperties containerProperties = ContainerProperties.CreateWithResourceId(CollectionResourceId);
             containerProperties.Id = "TestContainerId";

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionSerializerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionSerializerTests.cs
@@ -44,13 +44,13 @@ namespace Microsoft.Azure.Cosmos.Tests
                 tx.CreateItem(Database, Container, new PartitionKey("pk"), itemId, new TestItem(itemId)));
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
-            JsonElement op = doc.RootElement.GetProperty("operations")[0];
+            JsonElement op = doc.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
 
-            Assert.IsTrue(op.TryGetProperty("id", out JsonElement idElement),
+            Assert.IsTrue(op.TryGetProperty(DistributedTransactionSerializer.Id, out JsonElement idElement),
                 "Create operation must include an 'id' field.");
             Assert.AreEqual(itemId, idElement.GetString(),
                 "The 'id' field must match the id passed to CreateItem.");
-            Assert.IsTrue(op.TryGetProperty("resourceBody", out _),
+            Assert.IsTrue(op.TryGetProperty(DistributedTransactionSerializer.ResourceBody, out _),
                 "Create operation must include a 'resourceBody' field.");
         }
 
@@ -64,11 +64,11 @@ namespace Microsoft.Azure.Cosmos.Tests
                 tx.ReplaceItem(Database, Container, new PartitionKey("pk"), itemId, new TestItem(itemId)));
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
-            JsonElement op = doc.RootElement.GetProperty("operations")[0];
+            JsonElement op = doc.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
 
-            Assert.IsTrue(op.TryGetProperty("id", out _),
+            Assert.IsTrue(op.TryGetProperty(DistributedTransactionSerializer.Id, out _),
                 "Replace operation must include an 'id' field.");
-            Assert.IsTrue(op.TryGetProperty("resourceBody", out _),
+            Assert.IsTrue(op.TryGetProperty(DistributedTransactionSerializer.ResourceBody, out _),
                 "Replace operation must include a 'resourceBody' field.");
         }
 
@@ -82,11 +82,11 @@ namespace Microsoft.Azure.Cosmos.Tests
                 tx.DeleteItem(Database, Container, new PartitionKey("pk"), itemId));
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
-            JsonElement op = doc.RootElement.GetProperty("operations")[0];
+            JsonElement op = doc.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
 
-            Assert.IsTrue(op.TryGetProperty("id", out _),
+            Assert.IsTrue(op.TryGetProperty(DistributedTransactionSerializer.Id, out _),
                 "Delete operation must include an 'id' field.");
-            Assert.IsFalse(op.TryGetProperty("resourceBody", out _),
+            Assert.IsFalse(op.TryGetProperty(DistributedTransactionSerializer.ResourceBody, out _),
                 "Delete operation must NOT include a 'resourceBody' field.");
         }
 
@@ -99,13 +99,13 @@ namespace Microsoft.Azure.Cosmos.Tests
                 tx.UpsertItem(Database, Container, new PartitionKey("pk"), itemId, new TestItem(itemId)));
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
-            JsonElement op = doc.RootElement.GetProperty("operations")[0];
+            JsonElement op = doc.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
 
-            Assert.IsTrue(op.TryGetProperty("id", out JsonElement idElement),
+            Assert.IsTrue(op.TryGetProperty(DistributedTransactionSerializer.Id, out JsonElement idElement),
                 "Upsert operation must include an 'id' field.");
             Assert.AreEqual(itemId, idElement.GetString(),
                 "The 'id' field must match the id passed to UpsertItem.");
-            Assert.IsTrue(op.TryGetProperty("resourceBody", out _),
+            Assert.IsTrue(op.TryGetProperty(DistributedTransactionSerializer.ResourceBody, out _),
                 "Upsert operation must include a 'resourceBody' field.");
         }
 
@@ -121,9 +121,9 @@ namespace Microsoft.Azure.Cosmos.Tests
                 tx.ReplaceItem(Database, Container, new PartitionKey("pk"), expectedId, new TestItem(expectedId)));
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
-            JsonElement op = doc.RootElement.GetProperty("operations")[0];
+            JsonElement op = doc.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
 
-            Assert.IsTrue(op.TryGetProperty("id", out JsonElement idElement));
+            Assert.IsTrue(op.TryGetProperty(DistributedTransactionSerializer.Id, out JsonElement idElement));
             Assert.AreEqual(expectedId, idElement.GetString(),
                 "The serialized 'id' field must equal the id passed to ReplaceItem().");
         }
@@ -138,9 +138,9 @@ namespace Microsoft.Azure.Cosmos.Tests
                 tx.DeleteItem(Database, Container, new PartitionKey("pk"), expectedId));
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
-            JsonElement op = doc.RootElement.GetProperty("operations")[0];
+            JsonElement op = doc.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
 
-            Assert.IsTrue(op.TryGetProperty("id", out JsonElement idElement));
+            Assert.IsTrue(op.TryGetProperty(DistributedTransactionSerializer.Id, out JsonElement idElement));
             Assert.AreEqual(expectedId, idElement.GetString(),
                 "The serialized 'id' field must equal the id passed to DeleteItem().");
         }
@@ -155,9 +155,9 @@ namespace Microsoft.Azure.Cosmos.Tests
                 tx.CreateItem(Database, Container, new PartitionKey("pk"), "json-check", new TestItem("json-check")));
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
-            JsonElement op = doc.RootElement.GetProperty("operations")[0];
+            JsonElement op = doc.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
 
-            Assert.IsTrue(op.TryGetProperty("resourceBody", out JsonElement resourceBodyElement),
+            Assert.IsTrue(op.TryGetProperty(DistributedTransactionSerializer.ResourceBody, out JsonElement resourceBodyElement),
                 "resourceBody must be present.");
             Assert.AreEqual(JsonValueKind.Object, resourceBodyElement.ValueKind,
                 "resourceBody must be a valid JSON object.");
@@ -180,14 +180,14 @@ namespace Microsoft.Azure.Cosmos.Tests
                 expectedResultCount: 5);
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
-            JsonElement ops = doc.RootElement.GetProperty("operations");
+            JsonElement ops = doc.RootElement.GetProperty(DistributedTransactionSerializer.Operations);
 
             Assert.AreEqual(5, ops.GetArrayLength());
-            Assert.AreEqual(OperationType.Create.ToString(), ops[0].GetProperty("operationType").GetString());
-            Assert.AreEqual(OperationType.Replace.ToString(), ops[1].GetProperty("operationType").GetString());
-            Assert.AreEqual(OperationType.Delete.ToString(), ops[2].GetProperty("operationType").GetString());
-            Assert.AreEqual(OperationType.Upsert.ToString(), ops[3].GetProperty("operationType").GetString());
-            Assert.AreEqual(OperationType.Patch.ToString(), ops[4].GetProperty("operationType").GetString());
+            Assert.AreEqual(OperationType.Create.ToString(), ops[0].GetProperty(DistributedTransactionSerializer.OperationType).GetString());
+            Assert.AreEqual(OperationType.Replace.ToString(), ops[1].GetProperty(DistributedTransactionSerializer.OperationType).GetString());
+            Assert.AreEqual(OperationType.Delete.ToString(), ops[2].GetProperty(DistributedTransactionSerializer.OperationType).GetString());
+            Assert.AreEqual(OperationType.Upsert.ToString(), ops[3].GetProperty(DistributedTransactionSerializer.OperationType).GetString());
+            Assert.AreEqual(OperationType.Patch.ToString(), ops[4].GetProperty(DistributedTransactionSerializer.OperationType).GetString());
         }
 
         [TestMethod]
@@ -205,13 +205,13 @@ namespace Microsoft.Azure.Cosmos.Tests
                 expectedResultCount: 5);
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
-            JsonElement ops = doc.RootElement.GetProperty("operations");
+            JsonElement ops = doc.RootElement.GetProperty(DistributedTransactionSerializer.Operations);
 
             for (int i = 0; i < ops.GetArrayLength(); i++)
             {
                 Assert.AreEqual(
                     ResourceType.Document.ToString(),
-                    ops[i].GetProperty("resourceType").GetString(),
+                    ops[i].GetProperty(DistributedTransactionSerializer.ResourceType).GetString(),
                     $"Operation[{i}] must have resourceType = 'Document'.");
             }
         }
@@ -228,18 +228,18 @@ namespace Microsoft.Azure.Cosmos.Tests
                 tx.ReplaceItem(Database, Container, new PartitionKey("pk"), itemId, new TestItem(itemId)));
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
-            JsonElement op = doc.RootElement.GetProperty("operations")[0];
+            JsonElement op = doc.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
 
-            Assert.AreEqual(JsonValueKind.String, op.GetProperty("databaseName").ValueKind, "'databaseName' must be a JSON string.");
-            Assert.AreEqual(JsonValueKind.String, op.GetProperty("collectionName").ValueKind, "'collectionName' must be a JSON string.");
-            Assert.AreEqual(JsonValueKind.String, op.GetProperty("collectionResourceId").ValueKind, "'collectionResourceId' must be a JSON string.");
-            Assert.AreEqual(JsonValueKind.String, op.GetProperty("databaseResourceId").ValueKind, "'databaseResourceId' must be a JSON string.");
-            Assert.AreEqual(JsonValueKind.String, op.GetProperty("id").ValueKind, "'id' must be a JSON string.");
-            Assert.AreEqual(JsonValueKind.Array,  op.GetProperty("partitionKey").ValueKind, "'partitionKey' must be a JSON array, not a quoted string.");
-            Assert.AreEqual(JsonValueKind.Number, op.GetProperty("index").ValueKind, "'index' must be a JSON number, not a quoted string.");
-            Assert.AreEqual(JsonValueKind.Object, op.GetProperty("resourceBody").ValueKind, "'resourceBody' must be a JSON object.");
-            Assert.AreEqual(JsonValueKind.String, op.GetProperty("operationType").ValueKind, "'operationType' must be a JSON string.");
-            Assert.AreEqual(JsonValueKind.String, op.GetProperty("resourceType").ValueKind, "'resourceType' must be a JSON string.");
+            Assert.AreEqual(JsonValueKind.String, op.GetProperty(DistributedTransactionSerializer.DatabaseName).ValueKind, "'databaseName' must be a JSON string.");
+            Assert.AreEqual(JsonValueKind.String, op.GetProperty(DistributedTransactionSerializer.CollectionName).ValueKind, "'collectionName' must be a JSON string.");
+            Assert.AreEqual(JsonValueKind.String, op.GetProperty(DistributedTransactionSerializer.CollectionResourceId).ValueKind, "'collectionResourceId' must be a JSON string.");
+            Assert.AreEqual(JsonValueKind.String, op.GetProperty(DistributedTransactionSerializer.DatabaseResourceId).ValueKind, "'databaseResourceId' must be a JSON string.");
+            Assert.AreEqual(JsonValueKind.String, op.GetProperty(DistributedTransactionSerializer.Id).ValueKind, "'id' must be a JSON string.");
+            Assert.AreEqual(JsonValueKind.Array,  op.GetProperty(DistributedTransactionSerializer.PartitionKey).ValueKind, "'partitionKey' must be a JSON array, not a quoted string.");
+            Assert.AreEqual(JsonValueKind.Number, op.GetProperty(DistributedTransactionSerializer.Index).ValueKind, "'index' must be a JSON number, not a quoted string.");
+            Assert.AreEqual(JsonValueKind.Object, op.GetProperty(DistributedTransactionSerializer.ResourceBody).ValueKind, "'resourceBody' must be a JSON object.");
+            Assert.AreEqual(JsonValueKind.String, op.GetProperty(DistributedTransactionSerializer.OperationType).ValueKind, "'operationType' must be a JSON string.");
+            Assert.AreEqual(JsonValueKind.String, op.GetProperty(DistributedTransactionSerializer.ResourceType).ValueKind, "'resourceType' must be a JSON string.");
         }
 
         // Stream operations
@@ -255,13 +255,13 @@ namespace Microsoft.Azure.Cosmos.Tests
                 tx => tx.CreateItemStream(Database, Container, new PartitionKey("pk"), itemId, stream));
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
-            JsonElement op = doc.RootElement.GetProperty("operations")[0];
+            JsonElement op = doc.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
 
-            Assert.IsTrue(op.TryGetProperty("id", out JsonElement idElement),
+            Assert.IsTrue(op.TryGetProperty(DistributedTransactionSerializer.Id, out JsonElement idElement),
                 "CreateItemStream operation must include an 'id' field.");
             Assert.AreEqual(itemId, idElement.GetString(),
                 "The 'id' field must match the id passed to CreateItemStream.");
-            Assert.IsTrue(op.TryGetProperty("resourceBody", out _),
+            Assert.IsTrue(op.TryGetProperty(DistributedTransactionSerializer.ResourceBody, out _),
                 "CreateItemStream operation must include a 'resourceBody' field.");
         }
 
@@ -276,11 +276,11 @@ namespace Microsoft.Azure.Cosmos.Tests
                 tx => tx.ReplaceItemStream(Database, Container, new PartitionKey("pk"), itemId, stream));
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
-            JsonElement op = doc.RootElement.GetProperty("operations")[0];
+            JsonElement op = doc.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
 
-            Assert.IsTrue(op.TryGetProperty("id", out _),
+            Assert.IsTrue(op.TryGetProperty(DistributedTransactionSerializer.Id, out _),
                 "ReplaceItemStream operation must include an 'id' field.");
-            Assert.IsTrue(op.TryGetProperty("resourceBody", out _),
+            Assert.IsTrue(op.TryGetProperty(DistributedTransactionSerializer.ResourceBody, out _),
                 "ReplaceItemStream operation must include a 'resourceBody' field.");
         }
 
@@ -295,11 +295,11 @@ namespace Microsoft.Azure.Cosmos.Tests
                 tx => tx.PatchItemStream(Database, Container, new PartitionKey("pk"), itemId, stream));
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
-            JsonElement op = doc.RootElement.GetProperty("operations")[0];
+            JsonElement op = doc.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
 
-            Assert.IsTrue(op.TryGetProperty("id", out _),
+            Assert.IsTrue(op.TryGetProperty(DistributedTransactionSerializer.Id, out _),
                 "PatchItemStream operation must include an 'id' field.");
-            Assert.IsTrue(op.TryGetProperty("resourceBody", out _),
+            Assert.IsTrue(op.TryGetProperty(DistributedTransactionSerializer.ResourceBody, out _),
                 "PatchItemStream operation must include a 'resourceBody' field.");
         }
 
@@ -314,13 +314,13 @@ namespace Microsoft.Azure.Cosmos.Tests
                 tx => tx.UpsertItemStream(Database, Container, new PartitionKey("pk"), itemId, stream));
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
-            JsonElement op = doc.RootElement.GetProperty("operations")[0];
+            JsonElement op = doc.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
 
-            Assert.IsTrue(op.TryGetProperty("id", out JsonElement idElement),
+            Assert.IsTrue(op.TryGetProperty(DistributedTransactionSerializer.Id, out JsonElement idElement),
                 "UpsertItemStream operation must include an 'id' field.");
             Assert.AreEqual(itemId, idElement.GetString(),
                 "The 'id' field must match the id passed to UpsertItemStream.");
-            Assert.IsTrue(op.TryGetProperty("resourceBody", out _),
+            Assert.IsTrue(op.TryGetProperty(DistributedTransactionSerializer.ResourceBody, out _),
                 "UpsertItemStream operation must include a 'resourceBody' field.");
         }
 
@@ -338,9 +338,9 @@ namespace Microsoft.Azure.Cosmos.Tests
                     new DistributedTransactionRequestOptions { IfNoneMatchEtag = etag }));
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
-            JsonElement op = doc.RootElement.GetProperty("operations")[0];
+            JsonElement op = doc.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
 
-            Assert.IsTrue(op.TryGetProperty("etag", out JsonElement etagElement),
+            Assert.IsTrue(op.TryGetProperty(DistributedTransactionSerializer.ETag, out JsonElement etagElement),
                 "Read operation with IfNoneMatchEtag must include an 'etag' field.");
             Assert.AreEqual(etag, etagElement.GetString());
         }
@@ -353,9 +353,9 @@ namespace Microsoft.Azure.Cosmos.Tests
                 tx.ReadItem(Database, Container, new PartitionKey("pk"), "read-no-etag"));
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
-            JsonElement op = doc.RootElement.GetProperty("operations")[0];
+            JsonElement op = doc.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
 
-            Assert.IsFalse(op.TryGetProperty("etag", out _),
+            Assert.IsFalse(op.TryGetProperty(DistributedTransactionSerializer.ETag, out _),
                 "Read operation without etag options must NOT include an 'etag' field.");
         }
 
@@ -371,9 +371,9 @@ namespace Microsoft.Azure.Cosmos.Tests
                     new DistributedTransactionRequestOptions { IfMatchEtag = etag }));
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
-            JsonElement op = doc.RootElement.GetProperty("operations")[0];
+            JsonElement op = doc.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
 
-            Assert.IsFalse(op.TryGetProperty("etag", out _),
+            Assert.IsFalse(op.TryGetProperty(DistributedTransactionSerializer.ETag, out _),
                 "Read operation must not use IfMatchEtag; only IfNoneMatchEtag is serialized for reads.");
         }
 
@@ -391,9 +391,9 @@ namespace Microsoft.Azure.Cosmos.Tests
                     new DistributedTransactionRequestOptions { IfMatchEtag = etag }));
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
-            JsonElement op = doc.RootElement.GetProperty("operations")[0];
+            JsonElement op = doc.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
 
-            Assert.IsTrue(op.TryGetProperty("etag", out JsonElement etagElement),
+            Assert.IsTrue(op.TryGetProperty(DistributedTransactionSerializer.ETag, out JsonElement etagElement),
                 "Replace operation with IfMatchEtag must include an 'etag' field.");
             Assert.AreEqual(etag, etagElement.GetString());
         }
@@ -410,9 +410,9 @@ namespace Microsoft.Azure.Cosmos.Tests
                     new DistributedTransactionRequestOptions { IfMatchEtag = etag }));
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
-            JsonElement op = doc.RootElement.GetProperty("operations")[0];
+            JsonElement op = doc.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
 
-            Assert.IsTrue(op.TryGetProperty("etag", out JsonElement etagElement),
+            Assert.IsTrue(op.TryGetProperty(DistributedTransactionSerializer.ETag, out JsonElement etagElement),
                 "Delete operation with IfMatchEtag must include an 'etag' field.");
             Assert.AreEqual(etag, etagElement.GetString());
         }
@@ -430,9 +430,9 @@ namespace Microsoft.Azure.Cosmos.Tests
                     new DistributedTransactionRequestOptions { IfMatchEtag = etag }));
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
-            JsonElement op = doc.RootElement.GetProperty("operations")[0];
+            JsonElement op = doc.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
 
-            Assert.IsTrue(op.TryGetProperty("etag", out JsonElement etagElement),
+            Assert.IsTrue(op.TryGetProperty(DistributedTransactionSerializer.ETag, out JsonElement etagElement),
                 "Patch operation with IfMatchEtag must include an 'etag' field.");
             Assert.AreEqual(etag, etagElement.GetString());
         }
@@ -447,11 +447,11 @@ namespace Microsoft.Azure.Cosmos.Tests
                 expectedResultCount: 2);
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
-            JsonElement ops = doc.RootElement.GetProperty("operations");
+            JsonElement ops = doc.RootElement.GetProperty(DistributedTransactionSerializer.Operations);
 
             for (int i = 0; i < ops.GetArrayLength(); i++)
             {
-                Assert.IsFalse(ops[i].TryGetProperty("etag", out _),
+                Assert.IsFalse(ops[i].TryGetProperty(DistributedTransactionSerializer.ETag, out _),
                     $"Operation[{i}] without IfMatchEtag must NOT include an 'etag' field.");
             }
         }
@@ -578,8 +578,10 @@ namespace Microsoft.Azure.Cosmos.Tests
             ContainerProperties containerProps = ContainerProperties.CreateWithResourceId("ccZ1ANCszwk=");
             containerProps.PartitionKeyPath = "/pk";
 
-            MockDocumentClient documentClient = new MockDocumentClient();
-            documentClient.sessionContainer = new SessionContainer("testhost");
+            MockDocumentClient documentClient = new MockDocumentClient
+            {
+                sessionContainer = new SessionContainer("testhost")
+            };
 
             Mock<CosmosClientContext> contextMock = new Mock<CosmosClientContext>();
 


### PR DESCRIPTION
# Pull Request Template

## Description

Extract all JSON field name string literals from DistributedTransactionSerializer into `internal const string` constants at the top of the class

Replace the literals in the serializer body with the new constants.

Update all test files that previously hardcoded these same strings in `GetProperty`/`TryGetProperty` calls to reference `DistributedTransactionSerializer.<Constant>`
 instead — ensuring any future rename of a property automatically propagates to tests without a separate search-and-replace:
 - `DistributedTransactionOperationResult.cs`
 - `DistributedTransactionSerializerTests.cs`
 - `DistributedTransactionCommitterTests.cs`
 - `DistributedTransactionTests.cs` (emulator)

 No behavioral changes. All 58 unit tests pass.

Additionally, updates the constant `etag` to `ifMatch` in the request body to align with the wire contract update.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [✓] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber