### PR TITLE
Update CODEOWNERS: add Abhijeet/Deb/Annie across all rules, remove kirillg

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,19 +6,19 @@
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
 *       @kirankumarkolli @FabianMeiswinkel @sboshra @Pilchie @kushagraThapar @jeet1995 @kundadebdatta @xinlian12
-Microsoft.Azure.Cosmos/src/Json @adityasa @neildsh @kirankumarkolli @sboshra @kushagraThapar
-Microsoft.Azure.Cosmos/src/Query @adityasa @neildsh @kirankumarkolli @sboshra @kushagraThapar
-Microsoft.Azure.Cosmos/src/CosmosElements @adityasa @neildsh @kirankumarkolli @sboshra @kushagraThapar
-Microsoft.Azure.Cosmos/src/SqlObjects @leminh98 @adityasa @kirankumarkolli @sboshra @kushagraThapar
-Microsoft.Azure.Cosmos/src/Linq @khdang @adityasa @sboshra @kirankumarkolli @kushagraThapar
-Microsoft.Azure.Cosmos/src/Spatial @neildsh @adityasa @sboshra @kirankumarkolli @kushagraThapar
-Microsoft.Azure.Cosmos/tests @khdang @sboshra @adityasa @neildsh @kirankumarkolli @FabianMeiswinkel @kirillg @kushagraThapar
-Microsoft.Azure.Cosmos.Samples @khdang @sboshra @adityasa @neildsh @kirankumarkolli @FabianMeiswinkel @kirillg @kushagraThapar
+Microsoft.Azure.Cosmos/src/Json @adityasa @neildsh @kirankumarkolli @sboshra @kushagraThapar @jeet1995 @kundadebdatta @xinlian12
+Microsoft.Azure.Cosmos/src/Query @adityasa @neildsh @kirankumarkolli @sboshra @kushagraThapar @jeet1995 @kundadebdatta @xinlian12
+Microsoft.Azure.Cosmos/src/CosmosElements @adityasa @neildsh @kirankumarkolli @sboshra @kushagraThapar @jeet1995 @kundadebdatta @xinlian12
+Microsoft.Azure.Cosmos/src/SqlObjects @leminh98 @adityasa @kirankumarkolli @sboshra @kushagraThapar @jeet1995 @kundadebdatta @xinlian12
+Microsoft.Azure.Cosmos/src/Linq @khdang @adityasa @sboshra @kirankumarkolli @kushagraThapar @jeet1995 @kundadebdatta @xinlian12
+Microsoft.Azure.Cosmos/src/Spatial @neildsh @adityasa @sboshra @kirankumarkolli @kushagraThapar @jeet1995 @kundadebdatta @xinlian12
+Microsoft.Azure.Cosmos/tests @khdang @sboshra @adityasa @neildsh @kirankumarkolli @FabianMeiswinkel @kushagraThapar @jeet1995 @kundadebdatta @xinlian12
+Microsoft.Azure.Cosmos.Samples @khdang @sboshra @adityasa @neildsh @kirankumarkolli @FabianMeiswinkel @kushagraThapar @jeet1995 @kundadebdatta @xinlian12
 
 # Order is important; the last matching pattern takes the most precedence
-Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts @kirillg @kirankumarkolli @FabianMeiswinkel @kushagraThapar
-Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Contracts @kirillg @kirankumarkolli @FabianMeiswinkel @kushagraThapar
+Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts @kirankumarkolli @FabianMeiswinkel @kushagraThapar @jeet1995 @kundadebdatta @xinlian12
+Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Contracts @kirankumarkolli @FabianMeiswinkel @kushagraThapar @jeet1995 @kundadebdatta @xinlian12
 Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetSDKAPI.json @Azure/azure-cosmosdb-lt
 Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetPreviewSDKAPI.json @Azure/azure-cosmosdb-lt
 Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetSDKTelemetryAPI.json @Azure/azure-cosmosdb-lt
-CODEOWNERS @Pilchie @kirankumarkolli
+CODEOWNERS @Pilchie @kirankumarkolli @kushagraThapar @jeet1995 @kundadebdatta @xinlian12

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,7 +5,7 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-*       @kirankumarkolli @FabianMeiswinkel @sboshra @Pilchie @kushagraThapar
+*       @kirankumarkolli @FabianMeiswinkel @sboshra @Pilchie @kushagraThapar @jeet1995 @kundadebdatta @xinlian12
 Microsoft.Azure.Cosmos/src/Json @adityasa @neildsh @kirankumarkolli @sboshra @kushagraThapar
 Microsoft.Azure.Cosmos/src/Query @adityasa @neildsh @kirankumarkolli @sboshra @kushagraThapar
 Microsoft.Azure.Cosmos/src/CosmosElements @adityasa @neildsh @kirankumarkolli @sboshra @kushagraThapar


### PR DESCRIPTION
## Description

Updates `CODEOWNERS` for the .NET SDK:

### Added
Adds the following owners to every individual-owner rule (global `*` line, all `Microsoft.Azure.Cosmos/src/*` paths, `tests`, `Samples`, both `Contracts` directories, and the `CODEOWNERS` file rule itself):

- @jeet1995 (Abhijeet Mohanty)
- @kundadebdatta (Debdatta Kunda)
- @xinlian12 (Annie Liang)

Also adds @kushagraThapar to the `CODEOWNERS` file ownership rule (last line).

### Removed
Removes @kirillg from all rules where they were listed:
- `Microsoft.Azure.Cosmos/tests`
- `Microsoft.Azure.Cosmos.Samples`
- `Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts`
- `Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Contracts`

### Unchanged
The three contract JSON files (`DotNetSDKAPI.json`, `DotNetPreviewSDKAPI.json`, `DotNetSDKTelemetryAPI.json`) are owned by the team `@Azure/azure-cosmosdb-lt` and are intentionally left untouched — those follow SDK-LT governance review.

## Type of change

- [x] Repo configuration / process change

## Closing issues

N/A
