### PR TITLE
FaultInjection: Adds 1.0.0-beta.1 release

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
 		<ClientPreviewSuffixVersion>preview.0</ClientPreviewSuffixVersion>
 		<DirectVersion>3.42.4</DirectVersion>
 		<FaultInjectionVersion>1.0.0</FaultInjectionVersion>
-		<FaultInjectionSuffixVersion>beta.0</FaultInjectionSuffixVersion>
+		<FaultInjectionSuffixVersion>beta.1</FaultInjectionSuffixVersion>
 		<EncryptionOfficialVersion>2.0.5</EncryptionOfficialVersion>
 		<EncryptionPreviewVersion>2.1.0</EncryptionPreviewVersion>
 		<EncryptionPreviewSuffixVersion>preview5</EncryptionPreviewSuffixVersion>

--- a/Microsoft.Azure.Cosmos/FaultInjection/changelog.md
+++ b/Microsoft.Azure.Cosmos/FaultInjection/changelog.md
@@ -5,6 +5,21 @@ This project is in beta. The API and functionality may change when the project i
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### <a name="1.0.0-beta.1"/> [1.0.0-beta.1](https://www.nuget.org/packages/Microsoft.Azure.Cosmos.FaultInjection/1.0.0-beta.1) - 2026-04-30
+
+#### Added
+- [#4867](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/4867) FaultInjection: Adds method to add FaultInjection using CosmosClientBuilder
+- [#4989](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/4989) Metadata Requests: Adds Metadata request support for FaultInjection
+- [#5264](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5264) ThinClient Compatibility: Adds compatibility with Thin Client Proxy
+- [#5510](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5510) Unauthorized Errors: Adds Unauthorized status codes
+- [#5677](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5677) FaultInjection: Adds XML documentation, stylecop.json, and updates test packages
+- [#5679](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5679) FaultInjection: Adds comprehensive unit test coverage
+
+#### Fixed
+- [#5676](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5676) FaultInjection: Fixes naming typos and XML documentation
+- [#5675](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5675) FaultInjection: Fixes critical bugs for release 2
+- [#5678](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5678) FaultInjection: Refactors code quality improvements
+
 ### <a name="1.0.0-beta.0"/> [1.0.0-beta.0](https://www.nuget.org/packages/Microsoft.Azure.Cosmos.FaultInjection/1.0.0-beta.0) - 2024-11-15
 
 #### Added


### PR DESCRIPTION
## FaultInjection 1.0.0-beta.1 release

This PR releases the Microsoft.Azure.Cosmos.FaultInjection package at version **1.0.0-beta.1**. The previous release was 1.0.0-beta.0 on 2024-11-15.

### Version
- `FaultInjectionVersion` = 1.0.0
- `FaultInjectionSuffixVersion` = beta.1 (was beta.0)

### Scope
- Only the FaultInjection package is being released. No version bumps for Microsoft.Azure.Cosmos, Microsoft.Azure.Cosmos.Encryption, or Microsoft.Azure.Cosmos.Encryption.Custom.

### Included PRs (since 1.0.0-beta.0)

#### Added
- #4867 FaultInjection: Adds method to add FaultInjection using CosmosClientBuilder
- #4989 Metadata Requests: Adds Metadata request support for FaultInjection
- #5264 ThinClient Compatibility: Adds compatibility with Thin Client Proxy
- #5510 Unauthorized Errors: Adds Unauthorized status codes
- #5677 FaultInjection: Adds XML documentation, stylecop.json, and updates test packages
- #5679 FaultInjection: Adds comprehensive unit test coverage

#### Fixed
- #5676 FaultInjection: Fixes naming typos and XML documentation
- #5675 FaultInjection: Fixes critical bugs for release 2
- #5678 FaultInjection: Refactors code quality improvements

### Checklist
- [x] Changelog updated (`Microsoft.Azure.Cosmos/FaultInjection/changelog.md`)
- [x] Version bumped in `Directory.Build.props`
- [ ] Release pipeline (`azure-pipelines-faultinjection.yml`) run after merge

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>