### PR TITLE
Metadata Retry [Spike]: Adds detached-cancellation model exploration alongside grace-window fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -331,3 +331,6 @@ ASALocalRun/
 
 # Visual Studio Code files
 .vscode/
+
+.coding-harness/
+

--- a/Microsoft.Azure.Cosmos/src/MetadataDetachedExecutor.cs
+++ b/Microsoft.Azure.Cosmos/src/MetadataDetachedExecutor.cs
@@ -1,0 +1,217 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos
+{
+    using System;
+    using System.Runtime.ExceptionServices;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Core.Trace;
+    using Microsoft.Azure.Documents;
+
+    /// <summary>
+    /// Alternative metadata-read execution model under exploration: run the metadata
+    /// read on a fully detached, internally-bounded <see cref="CancellationToken"/>
+    /// and observe the caller's <see cref="CancellationToken"/> on the response path
+    /// only. This mirrors the Java SDK's <c>BackoffRetryUtility</c>, which never
+    /// threads a caller cancellation signal into the retry pipeline.
+    ///
+    /// Compared with <see cref="MetadataRetryHelper"/> (which honors the caller token
+    /// during retries and grants a single bounded grace window when cross-region
+    /// failover is preempted), this executor:
+    /// <list type="bullet">
+    ///   <item>Never preempts cross-region failover. The retry policy always runs
+    ///   to completion or to the SDK-internal deadline, regardless of caller CT.</item>
+    ///   <item>Allows the caller to surface <see cref="OperationCanceledException"/>
+    ///   immediately when their token trips, while the underlying metadata read
+    ///   continues in the background and lands in <see cref="Common.AsyncCache{TKey, TValue}"/>
+    ///   (via <c>AsyncLazy</c>) so a follow-up call observes the cached result.</item>
+    ///   <item>Bounds the detached attempt by <see cref="DefaultInternalDeadline"/>
+    ///   so a misbehaving retry policy cannot keep work in flight indefinitely.</item>
+    /// </list>
+    ///
+    /// See <c>docs/internal/metadata-retry-detached-vs-grace.md</c> in this branch for
+    /// the full comparison of the two approaches.
+    /// </summary>
+    internal static class MetadataDetachedExecutor
+    {
+        /// <summary>
+        /// Defensive upper bound on the lifetime of the detached metadata read attempt.
+        /// <see cref="ClientRetryPolicy"/> already caps cross-region attempts (one per
+        /// preferred region), but a misconfigured policy that always returns
+        /// <c>ShouldRetry=true</c> would otherwise leak background work.
+        /// </summary>
+        internal static readonly TimeSpan DefaultInternalDeadline = TimeSpan.FromMinutes(2);
+
+        /// <summary>
+        /// Defensive upper bound on the number of attempts within a single detached
+        /// invocation. Mirrors the cap in <see cref="MetadataRetryHelper"/>.
+        /// </summary>
+        private const int MaxAttemptsHardCap = 20;
+
+        internal static Task<T> ExecuteAsync<T>(
+            Func<CancellationToken, Task<T>> operation,
+            IDocumentClientRetryPolicy retryPolicy,
+            CancellationToken callerCancellationToken)
+        {
+            return ExecuteAsync(operation, retryPolicy, DefaultInternalDeadline, callerCancellationToken);
+        }
+
+        internal static async Task<T> ExecuteAsync<T>(
+            Func<CancellationToken, Task<T>> operation,
+            IDocumentClientRetryPolicy retryPolicy,
+            TimeSpan internalDeadline,
+            CancellationToken callerCancellationToken)
+        {
+            if (operation == null)
+            {
+                throw new ArgumentNullException(nameof(operation));
+            }
+
+            if (retryPolicy == null)
+            {
+                throw new ArgumentNullException(nameof(retryPolicy));
+            }
+
+            if (internalDeadline <= TimeSpan.Zero)
+            {
+                throw new ArgumentOutOfRangeException(
+                    nameof(internalDeadline),
+                    "Internal deadline must be positive.");
+            }
+
+            callerCancellationToken.ThrowIfCancellationRequested();
+
+            // Detached token: the retry-loop and underlying HTTP call are bound only by
+            // the SDK-internal deadline. The caller's token never enters this scope so
+            // ClientRetryPolicy decisions cannot be preempted by caller cancellation.
+            CancellationTokenSource detachedCts = new CancellationTokenSource(internalDeadline);
+            Task<T> detachedTask = ExecuteRetryLoopAsync(operation, retryPolicy, detachedCts.Token);
+
+            // Always observe completion so faulted detached tasks do not surface as
+            // unobserved-task exceptions if the caller cancels first.
+            Task unused = detachedTask.ContinueWith(
+                t => t.Exception,
+                TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously);
+
+            try
+            {
+                if (!callerCancellationToken.CanBeCanceled)
+                {
+                    return await detachedTask.ConfigureAwait(false);
+                }
+
+                TaskCompletionSource<bool> cancelTcs = new TaskCompletionSource<bool>(
+                    TaskCreationOptions.RunContinuationsAsynchronously);
+
+                using (callerCancellationToken.Register(() => cancelTcs.TrySetResult(true)))
+                {
+                    Task winner = await Task.WhenAny(detachedTask, cancelTcs.Task).ConfigureAwait(false);
+
+                    if (winner == detachedTask)
+                    {
+                        return await detachedTask.ConfigureAwait(false);
+                    }
+                }
+
+                // Caller cancelled before the detached attempt completed. Leave the
+                // detached task running so AsyncCache.GetAsync's compare-and-swap entry
+                // remains valid for the next caller — this is the entire point of the
+                // detached model. We do NOT cancel detachedCts here.
+                DefaultTrace.TraceInformation(
+                    "MetadataDetachedExecutor: caller token cancelled while detached metadata read in-flight; leaving background read to complete.");
+
+                callerCancellationToken.ThrowIfCancellationRequested();
+                throw new OperationCanceledException(callerCancellationToken);
+            }
+            finally
+            {
+                // Ownership note: detachedCts is intentionally NOT disposed in the
+                // caller-cancellation path. It must outlive detachedTask. Schedule
+                // disposal on completion so we do not leak the timer.
+                Task disposeWhenDone = detachedTask.ContinueWith(
+                    _ => detachedCts.Dispose(),
+                    TaskContinuationOptions.ExecuteSynchronously);
+            }
+        }
+
+        private static async Task<T> ExecuteRetryLoopAsync<T>(
+            Func<CancellationToken, Task<T>> operation,
+            IDocumentClientRetryPolicy retryPolicy,
+            CancellationToken detachedToken)
+        {
+            int attemptCount = 0;
+            while (true)
+            {
+                if (++attemptCount > MaxAttemptsHardCap)
+                {
+                    DefaultTrace.TraceError(
+                        "MetadataDetachedExecutor: exceeded hard attempt cap ({0}). Surfacing last exception.",
+                        MaxAttemptsHardCap);
+                    throw new InvalidOperationException(
+                        $"MetadataDetachedExecutor exceeded the defensive attempt cap of {MaxAttemptsHardCap}. " +
+                        "This indicates a misconfigured retry policy that returns ShouldRetry=true indefinitely.");
+                }
+
+                ExceptionDispatchInfo capturedException;
+                try
+                {
+                    return await operation(detachedToken).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    capturedException = ExceptionDispatchInfo.Capture(ex);
+                }
+
+                ShouldRetryResult shouldRetry;
+                try
+                {
+                    shouldRetry = await retryPolicy
+                        .ShouldRetryAsync(capturedException.SourceException, CancellationToken.None)
+                        .ConfigureAwait(false);
+                }
+                catch (Exception policyException)
+                {
+                    DefaultTrace.TraceWarning(
+                        "MetadataDetachedExecutor: retry policy threw while evaluating exception {0}: {1}",
+                        capturedException.SourceException.GetType().Name,
+                        policyException.Message);
+                    capturedException.Throw();
+                    throw; // unreachable
+                }
+
+                if (shouldRetry == null || !shouldRetry.ShouldRetry)
+                {
+                    if (shouldRetry?.ExceptionToThrow != null)
+                    {
+                        if (shouldRetry.ExceptionToThrow == capturedException.SourceException)
+                        {
+                            capturedException.Throw();
+                        }
+
+                        throw shouldRetry.ExceptionToThrow;
+                    }
+
+                    capturedException.Throw();
+                }
+
+                if (shouldRetry.BackoffTime > TimeSpan.Zero)
+                {
+                    try
+                    {
+                        await Task.Delay(shouldRetry.BackoffTime, detachedToken).ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException) when (detachedToken.IsCancellationRequested)
+                    {
+                        // Internal deadline reached during backoff. Surface the original
+                        // exception so callers see the underlying failure mode rather
+                        // than a deadline-induced OCE.
+                        capturedException.Throw();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Routing/ClientCollectionCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/ClientCollectionCache.cs
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.Cosmos.Routing
             IDocumentClientRetryPolicy retryPolicyInstance = new ClearingSessionContainerClientRetryPolicy(
                 this.sessionContainer, this.retryPolicy.GetRequestPolicy());
             return TaskHelper.RunInlineIfNeededAsync(
-                () => MetadataRetryHelper.ExecuteAsync(
+                () => MetadataDetachedExecutor.ExecuteAsync(
                       (ct) => this.ReadCollectionAsync(
                           PathsHelper.GeneratePath(ResourceType.Collection, collectionRid, false),
                           retryPolicyInstance,
@@ -75,7 +75,7 @@ namespace Microsoft.Azure.Cosmos.Routing
             IDocumentClientRetryPolicy retryPolicyInstance = new ClearingSessionContainerClientRetryPolicy(
                 this.sessionContainer, this.retryPolicy.GetRequestPolicy());
             return TaskHelper.RunInlineIfNeededAsync(
-                () => MetadataRetryHelper.ExecuteAsync(
+                () => MetadataDetachedExecutor.ExecuteAsync(
                     (ct) => this.ReadCollectionAsync(
                         resourceAddress, retryPolicyInstance, trace, clientSideRequestStatistics, ct),
                     retryPolicyInstance,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/MetadataDetachedExecutorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/MetadataDetachedExecutorTests.cs
@@ -1,0 +1,337 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Tests
+{
+    using System;
+    using System.Net;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Documents;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Moq;
+
+    /// <summary>
+    /// Unit tests for <see cref="MetadataDetachedExecutor"/>.
+    ///
+    /// These tests pin the behavior of the alternative "detached cancellation" model
+    /// being explored as a follow-up to PR #5806. The executor under test runs the
+    /// metadata read on a detached, internally-bounded <see cref="CancellationToken"/>
+    /// and observes the caller's <see cref="CancellationToken"/> on the response path
+    /// only — mirroring the Java SDK's <c>BackoffRetryUtility</c>.
+    /// </summary>
+    [TestClass]
+    public class MetadataDetachedExecutorTests
+    {
+        [TestMethod]
+        [Owner("ntripician")]
+        public async Task ExecuteAsync_SucceedsFirstAttempt_NoRetry()
+        {
+            Mock<IDocumentClientRetryPolicy> policy = new Mock<IDocumentClientRetryPolicy>();
+            int attempts = 0;
+
+            int result = await MetadataDetachedExecutor.ExecuteAsync<int>(
+                (_) =>
+                {
+                    attempts++;
+                    return Task.FromResult(42);
+                },
+                policy.Object,
+                CancellationToken.None);
+
+            Assert.AreEqual(42, result);
+            Assert.AreEqual(1, attempts);
+            policy.Verify(
+                p => p.ShouldRetryAsync(It.IsAny<Exception>(), It.IsAny<CancellationToken>()),
+                Times.Never);
+        }
+
+        [TestMethod]
+        [Owner("ntripician")]
+        public async Task ExecuteAsync_RetriesOnTransient_WhenPolicyAllows()
+        {
+            Mock<IDocumentClientRetryPolicy> policy = new Mock<IDocumentClientRetryPolicy>();
+            policy
+                .Setup(p => p.ShouldRetryAsync(It.IsAny<Exception>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(ShouldRetryResult.RetryAfter(TimeSpan.Zero));
+
+            int attempts = 0;
+            int result = await MetadataDetachedExecutor.ExecuteAsync<int>(
+                (_) =>
+                {
+                    attempts++;
+                    if (attempts == 1)
+                    {
+                        throw new DocumentClientException(
+                            "transient",
+                            HttpStatusCode.ServiceUnavailable,
+                            SubStatusCodes.Unknown);
+                    }
+
+                    return Task.FromResult(7);
+                },
+                policy.Object,
+                CancellationToken.None);
+
+            Assert.AreEqual(7, result);
+            Assert.AreEqual(2, attempts);
+        }
+
+        /// <summary>
+        /// Primary fix validation: when the caller's token trips MID-FLIGHT (during
+        /// the first attempt, simulating the control-plane HTTP timeout escalation),
+        /// the retry policy still drives a successful cross-region failover because
+        /// the operation runs on a detached token. The caller observes OCE; a follow-up
+        /// caller would observe the cached success via AsyncCache.
+        /// </summary>
+        [TestMethod]
+        [Owner("ntripician")]
+        public async Task ExecuteAsync_CrossRegionRetryExecutes_EvenWhenCallerTokenCancelsMidFlight()
+        {
+            Mock<IDocumentClientRetryPolicy> policy = new Mock<IDocumentClientRetryPolicy>();
+            policy
+                .Setup(p => p.ShouldRetryAsync(It.IsAny<Exception>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(ShouldRetryResult.RetryAfter(TimeSpan.Zero));
+
+            using CancellationTokenSource cts = new CancellationTokenSource();
+            int attempts = 0;
+            TaskCompletionSource<bool> firstAttemptStarted = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            TaskCompletionSource<bool> firstAttemptCanFail = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            TaskCompletionSource<int> secondAttemptResult = new TaskCompletionSource<int>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+
+            // Build the operation closure outside ExecuteAsync so we can observe the
+            // detached task by capturing it. Use a Task.Run so the call stack is not
+            // intertwined with the test thread.
+            Task<int> caller = Task.Run(() => MetadataDetachedExecutor.ExecuteAsync<int>(
+                async (ct) =>
+                {
+                    int attempt = ++attempts;
+                    if (attempt == 1)
+                    {
+                        firstAttemptStarted.TrySetResult(true);
+                        await firstAttemptCanFail.Task.ConfigureAwait(false);
+                        Assert.IsFalse(ct.IsCancellationRequested,
+                            "operation must receive the detached token, not the caller token");
+                        throw new DocumentClientException(
+                            "primary region down",
+                            HttpStatusCode.ServiceUnavailable,
+                            SubStatusCodes.Unknown);
+                    }
+
+                    Assert.IsFalse(ct.IsCancellationRequested,
+                        "second-attempt token must remain non-cancelled despite caller cancellation");
+                    int result = await secondAttemptResult.Task.ConfigureAwait(false);
+                    return result;
+                },
+                policy.Object,
+                cts.Token));
+
+            await firstAttemptStarted.Task.ConfigureAwait(false);
+
+            // Caller token trips mid-flight (analog of the HTTP timeout policy burning
+            // out against the unhealthy region).
+            cts.Cancel();
+            firstAttemptCanFail.TrySetResult(true);
+
+            // Caller surfaces OCE.
+            await Assert.ThrowsExceptionAsync<OperationCanceledException>(() => caller);
+
+            // Detached cross-region retry is now in flight. Release it and confirm a
+            // second attempt happens on the detached token.
+            secondAttemptResult.TrySetResult(99);
+            // Wait for second attempt to actually invoke the operation.
+            for (int i = 0; i < 50 && attempts < 2; i++)
+            {
+                await Task.Delay(20);
+            }
+
+            Assert.AreEqual(2, attempts,
+                "the cross-region retry attempt must execute on the detached token after caller cancellation");
+        }
+
+        /// <summary>
+        /// If the caller's token trips while the detached attempt is mid-flight, the
+        /// caller surfaces OCE immediately. The detached task is allowed to keep running
+        /// (verified via TaskCompletionSource — the operation lambda is not signalled
+        /// via its token).
+        /// </summary>
+        [TestMethod]
+        [Owner("ntripician")]
+        public async Task ExecuteAsync_CallerCancelMidFlight_SurfacesOCE_DetachedTaskKeepsRunning()
+        {
+            Mock<IDocumentClientRetryPolicy> policy = new Mock<IDocumentClientRetryPolicy>();
+            using CancellationTokenSource cts = new CancellationTokenSource();
+            TaskCompletionSource<int> operationGate = new TaskCompletionSource<int>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+            TaskCompletionSource<bool> operationStarted = new TaskCompletionSource<bool>(
+                TaskCreationOptions.RunContinuationsAsynchronously);
+
+            Task<int> caller = MetadataDetachedExecutor.ExecuteAsync<int>(
+                async (ct) =>
+                {
+                    operationStarted.TrySetResult(true);
+                    return await operationGate.Task.ConfigureAwait(false);
+                },
+                policy.Object,
+                cts.Token);
+
+            await operationStarted.Task.ConfigureAwait(false);
+            cts.Cancel();
+
+            await Assert.ThrowsExceptionAsync<OperationCanceledException>(() => caller);
+
+            // Detached task keeps running. Release it and confirm it completes.
+            operationGate.TrySetResult(123);
+
+            // Drain unobserved completion (we already cancelled, but the original
+            // detached task continues. We don't have a direct handle, but we can
+            // assert the completion source completes without timeout.)
+            await Task.WhenAny(operationGate.Task, Task.Delay(2000));
+            Assert.IsTrue(operationGate.Task.IsCompletedSuccessfully);
+        }
+
+        [TestMethod]
+        [Owner("ntripician")]
+        public async Task ExecuteAsync_PolicyDeniesRetry_SurfacesOriginalException()
+        {
+            Mock<IDocumentClientRetryPolicy> policy = new Mock<IDocumentClientRetryPolicy>();
+            policy
+                .Setup(p => p.ShouldRetryAsync(It.IsAny<Exception>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(ShouldRetryResult.NoRetry());
+
+            DocumentClientException original = new DocumentClientException(
+                "fatal",
+                HttpStatusCode.Forbidden,
+                SubStatusCodes.Unknown);
+
+            DocumentClientException thrown = await Assert.ThrowsExceptionAsync<DocumentClientException>(
+                () => MetadataDetachedExecutor.ExecuteAsync<int>(
+                    (_) => throw original,
+                    policy.Object,
+                    CancellationToken.None));
+
+            Assert.AreSame(original, thrown);
+        }
+
+        [TestMethod]
+        [Owner("ntripician")]
+        public async Task ExecuteAsync_HonorsExceptionToThrow_FromPolicy()
+        {
+            DocumentClientException wrapped = new DocumentClientException(
+                "wrapped",
+                HttpStatusCode.RequestTimeout,
+                SubStatusCodes.Unknown);
+
+            Mock<IDocumentClientRetryPolicy> policy = new Mock<IDocumentClientRetryPolicy>();
+            policy
+                .Setup(p => p.ShouldRetryAsync(It.IsAny<Exception>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(ShouldRetryResult.NoRetry(wrapped));
+
+            DocumentClientException thrown = await Assert.ThrowsExceptionAsync<DocumentClientException>(
+                () => MetadataDetachedExecutor.ExecuteAsync<int>(
+                    (_) => throw new DocumentClientException(
+                        "inner", HttpStatusCode.ServiceUnavailable, SubStatusCodes.Unknown),
+                    policy.Object,
+                    CancellationToken.None));
+
+            Assert.AreSame(wrapped, thrown);
+        }
+
+        [TestMethod]
+        [Owner("ntripician")]
+        public async Task ExecuteAsync_InternalDeadline_BoundsDetachedAttempt()
+        {
+            Mock<IDocumentClientRetryPolicy> policy = new Mock<IDocumentClientRetryPolicy>();
+            policy
+                .Setup(p => p.ShouldRetryAsync(It.IsAny<Exception>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(ShouldRetryResult.RetryAfter(TimeSpan.FromSeconds(30)));
+
+            // Operation always fails. Backoff is 30s but deadline is 200ms — we expect
+            // the original exception to surface once the internal deadline trips during
+            // the backoff delay.
+            DocumentClientException firstFailure = new DocumentClientException(
+                "transient",
+                HttpStatusCode.ServiceUnavailable,
+                SubStatusCodes.Unknown);
+
+            DocumentClientException thrown = await Assert.ThrowsExceptionAsync<DocumentClientException>(
+                () => MetadataDetachedExecutor.ExecuteAsync<int>(
+                    (_) => throw firstFailure,
+                    policy.Object,
+                    TimeSpan.FromMilliseconds(200),
+                    CancellationToken.None));
+
+            Assert.AreSame(firstFailure, thrown);
+        }
+
+        [TestMethod]
+        [Owner("ntripician")]
+        public async Task ExecuteAsync_HardAttemptCap_PreventsInfiniteSpin()
+        {
+            Mock<IDocumentClientRetryPolicy> policy = new Mock<IDocumentClientRetryPolicy>();
+            policy
+                .Setup(p => p.ShouldRetryAsync(It.IsAny<Exception>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(ShouldRetryResult.RetryAfter(TimeSpan.Zero));
+
+            int attempts = 0;
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+                () => MetadataDetachedExecutor.ExecuteAsync<int>(
+                    (_) =>
+                    {
+                        attempts++;
+                        throw new DocumentClientException(
+                            "always",
+                            HttpStatusCode.ServiceUnavailable,
+                            SubStatusCodes.Unknown);
+                    },
+                    policy.Object,
+                    CancellationToken.None));
+
+            Assert.IsTrue(attempts >= 20, $"expected >=20 attempts before cap, observed {attempts}");
+            Assert.IsTrue(attempts <= 21, $"cap should fire at ~20 attempts, observed {attempts}");
+        }
+
+        [TestMethod]
+        [Owner("ntripician")]
+        public async Task ExecuteAsync_FirstAttemptOCE_PolicyIsConsultedBeforeSurfacing()
+        {
+            // Mirrors the regression test added to MetadataRetryHelper: an OCE thrown
+            // from the operation must go through the retry policy first, not be
+            // silently re-thrown.
+            Mock<IDocumentClientRetryPolicy> policy = new Mock<IDocumentClientRetryPolicy>();
+            policy
+                .Setup(p => p.ShouldRetryAsync(It.IsAny<Exception>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(ShouldRetryResult.NoRetry());
+
+            OperationCanceledException original = new OperationCanceledException("server-side cancel");
+
+            await Assert.ThrowsExceptionAsync<OperationCanceledException>(
+                () => MetadataDetachedExecutor.ExecuteAsync<int>(
+                    (_) => throw original,
+                    policy.Object,
+                    CancellationToken.None));
+
+            policy.Verify(
+                p => p.ShouldRetryAsync(It.IsAny<Exception>(), It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        [TestMethod]
+        [Owner("ntripician")]
+        public void ExecuteAsync_NonPositiveDeadline_Throws()
+        {
+            Mock<IDocumentClientRetryPolicy> policy = new Mock<IDocumentClientRetryPolicy>();
+
+            Assert.ThrowsExceptionAsync<ArgumentOutOfRangeException>(
+                () => MetadataDetachedExecutor.ExecuteAsync<int>(
+                    (_) => Task.FromResult(0),
+                    policy.Object,
+                    TimeSpan.Zero,
+                    CancellationToken.None));
+        }
+    }
+}


### PR DESCRIPTION
# Metadata Retry [Spike]: Adds detached-cancellation model exploration alongside grace-window fix

> **This PR is a design spike, not a competing fix.**
> It targets `users/ntripician/metadata-retry-fix` (PR #5806) — not `master` — so reviewers can see the
> detached-cancellation alternative as a pure delta on top of the bounded-grace fix.
> The recommendation at the bottom is "ship #5806 as-is, treat this as the next-step direction." It is not
> "merge this instead of #5806."

## Background

PR #5806 fixes the bug where a caller `CancellationToken` timing out at the boundary of the cross-region
failover decision in `BackoffRetryUtility.ExecuteAsync` silently preempts the failover and surfaces an
`OperationCanceledException`. The fix is a `MetadataRetryHelper` that adds a bounded **10 second** grace
window — if the caller's CT trips, we still allow the in-flight metadata read up to 10s on a detached token
so cross-region failover can complete.

A senior reviewer asked the natural follow-up:

> *"why we do not choose the latter [fully detached cache refresh] instead of extending 10s for graceful retry?"*

The answer in the PR thread covered the trade-offs at a high level (caller intent, blast radius, surgical fix).
This branch turns that conversation into running code so the team can pick a direction with a concrete
implementation in front of them, including a Java-SDK-parity check.

## What's in this branch

- `Microsoft.Azure.Cosmos/src/MetadataDetachedExecutor.cs` — alternative executor that is **fully detached
  from the caller `CancellationToken` from the start**. Caller CT only short-circuits the response path
  (via `Task.WhenAny`); the underlying retry loop runs on a CTS owned by the executor with a 2-minute
  internal deadline.
- `Microsoft.Azure.Cosmos/src/Routing/ClientCollectionCache.cs` — both `GetByRidAsync` and `GetByNameAsync`
  re-pointed at the new executor. Same call sites, same arguments, no public API change.
- `Microsoft.Azure.Cosmos/tests/.../MetadataDetachedExecutorTests.cs` — 10 unit tests covering success,
  retry, mid-flight cancellation (the production bug scenario), no-retry policy, deadline, attempt cap,
  and argument validation. All pass.
- `MetadataRetryHelper.cs` is **left in place verbatim** so reviewers can compare both approaches without
  flipping branches.

## Verification

```text
dotnet build Microsoft.Azure.Cosmos\src\Microsoft.Azure.Cosmos.csproj -c Release   # clean
dotnet test  Microsoft.Azure.Cosmos\tests\...Tests.csproj
   --filter "FullyQualifiedName~MetadataDetachedExecutorTests"                      # 10 / 10 pass
   --filter "FullyQualifiedName~MetadataRetryHelperTests|...|AsyncCache|..."        # 83 / 83 pass
```

---

## Approach comparison

### A. Bounded grace window (PR #5806 — the production fix)

```text
caller CT trips → executor opens a 10s grace CTS linked to nothing →
  one more retry iteration runs on the grace token → success or grace expires →
  if grace expires: OCE bubbles to caller; in-flight HTTP eventually completes or
  gets disposed when the grace CTS disposes; AsyncLazy entry is replaced.
```

**Pros**
- Surgical: behavior identical to today on the happy path; only changes behavior in the exact bug window.
- Bounded blast radius: at most one extra retry iteration, capped at 10s wall-clock.
- Caller intent is mostly respected: a caller passing a 30s CT does not see metadata work running for
  minutes after they cancelled.
- Easy to reason about for SREs reading traces: one extra "grace retry" is visible in diagnostics.
- Backportable to other SDKs without rethinking their cancellation model.

**Cons**
- 10s is a magic number. The actual cross-region retry sequence (0.5s + 5s + 30s = ~35s) can exceed it,
  so pathological cases still fail. We're shrinking the bug window, not closing it.
- Two cancellation tokens floating around (caller + grace) — easy to introduce a future regression by
  threading the wrong one.
- Not parity with Java, which has been operating in the detached model effectively since day one.

### B. Detached executor (this branch)

```text
caller invokes ExecuteAsync(callerCT) →
  executor creates internalCTS linked to internalDeadline (2 min, hard cap) — NOT linked to callerCT →
  retry loop runs on internalCTS.Token →
  Task.WhenAny(operationTask, callerCT.WhenCanceled()) →
    if callerCT trips first: OCE to caller, operationTask continues to completion in background →
    AsyncCache.AsyncLazy still resolves, so any subsequent caller for the same key
    awaits the in-flight result for free (no duplicate HTTP).
```

**Pros**
- **Closes the bug window completely.** No magic 10s number; the in-flight read is never preempted by a
  caller.
- **Parity with Java SDK.** `BackoffRetryUtility.executeRetry` does not take a CT; cancellation is Reactor
  subscription disposal (lazy). This branch brings .NET to the same operating model. Cross-SDK behavior
  becomes consistent for the same regional-outage scenario.
- **AsyncCache deduplication becomes a feature, not a coincidence.** A caller who timed out and retries
  the operation 100ms later attaches to the *same* AsyncLazy and gets the result without firing a second
  metadata read.
- **Single cancellation source inside the executor.** The retry loop only ever observes the internal token.
  Less foot-gunning for future maintainers.
- **Internal deadline is explicit.** 2 minutes is a hard ceiling sized to "all four regions exhausted twice"
  rather than a tactical 10s. Configurable via overload.

**Cons**
- **In-flight HTTP is not aborted on caller cancel.** During a regional outage, callers who time out at
  35s leave a 30s read still pending against the gateway/backend. If the caller re-enters the cache the
  AsyncLazy dedups them, but if they don't (different CT, fire-and-forget shutdown), there is a
  resource cost.
- **Behavior change is broader than #5806.** Callers who today rely on "I cancel my CT, the metadata read
  stops" will see the read continue in the background. We believe this is correct (metadata reads are
  shared infrastructure, not user-owned work), but it is a real semantic change.
- **Trace ownership is fuzzier.** The `ITrace` flows through to a request that may outlive the caller's
  trace scope. We didn't change the trace plumbing; the activity ID is still the original caller's.
  Diagnostics for that orphan tail land on the original `ITrace` after the caller has stopped looking
  at it. Not incorrect, but unfamiliar.
- **CTS disposal is non-trivial.** The detached CTS cannot be disposed eagerly when the caller cancels
  (the operation is still using it). We schedule disposal on the operation's continuation, which works
  but is the kind of code that gets misread on a future PR. See `MetadataDetachedExecutor.cs`
  finally-block comment.
- **Harder to backport to data-plane operations.** Data-plane reads (point reads, queries) *should*
  abort on caller cancellation — the current `BackoffRetryUtility` semantic is correct for them. So this
  pattern only fits the "shared infrastructure refresh" call sites: `ClientCollectionCache`, eventually
  `PartitionKeyRangeCache`, address resolver. It's a metadata-reads-only tool.

### Side-by-side matrix

| Property                                           | A. Grace window (#5806) | B. Detached (this branch) |
|----------------------------------------------------|:-----------------------:|:-------------------------:|
| Closes the failover-preemption bug                 | Mostly (10s window)     | Yes                       |
| Adds a magic timeout number                        | Yes (10s)               | Yes (2min, but explicit)  |
| In-flight HTTP cancelled when caller cancels       | Yes (after grace)       | No                        |
| Caller sees OCE on their CT                        | Yes                     | Yes                       |
| AsyncCache dedup benefits subsequent callers       | Sometimes               | Always                    |
| Parity with Java SDK behavior                      | No                      | Yes                       |
| Pattern is generalizable beyond metadata reads     | Yes                     | No (metadata only)        |
| Diff size on top of master                         | Small                   | Small (+1 file, 1 swap)   |
| Existing test surface                              | New helper tests        | New executor tests + same |
| Risk of regressing non-metadata callers            | Low                     | None (call sites scoped)  |

## Impact on `ClientCollectionCache`

No API change. Both `GetByRidAsync` and `GetByNameAsync` continue to take `CancellationToken cancellationToken`
and to throw `OperationCanceledException` when it trips. What changes:

- **Before (with #5806):** caller CT is honored after the bounded grace; in-flight HTTP eventually
  observes cancellation when the grace CTS expires.
- **After (this branch):** caller CT short-circuits the *response path* (Task.WhenAny). The in-flight
  HTTP completes on its own schedule, populating the AsyncLazy. A caller that retries within the
  internal deadline (2 min) gets the in-flight result for free.

This composes cleanly with `AsyncCache<TKey,TValue>`'s existing AsyncLazy + CAS pattern (see
`AsyncCache.cs`): the detached factory delegate produces the value the AsyncLazy is already going to
hand out to every other awaiter. There is no new state machine.

`PartitionKeyRangeCache` is unaffected — its call sites do not flow caller cancellation through
`BackoffRetryUtility` today, so neither approach has any work to do there.

## Cross-SDK applicability

| SDK    | Today's behavior                                                                 | Applicability of detached model |
|--------|----------------------------------------------------------------------------------|---------------------------------|
| Java   | `BackoffRetryUtility.executeRetry` takes no CT. `RxClientCollectionCache` wraps reads in `ObservableHelper.inlineIfPossible(callbackMethod, retryPolicyInstance)` with no caller CT. Cancellation is Reactor subscription disposal, which is lazy and does not preempt in-flight retries. | **Already there.** No change needed. |
| Rust (`release/azure_data_cosmos-previews`) | `handler/retry_handler.rs::BackOffRetryHandler::send` runs an open-ended `loop { sender(request).await; should_retry().await; sleep(after).await; }` with **no cancellation parameter** and **no caller-CT check between iterations**. Already has a dedicated `MetadataRequestRetryPolicy` split out from `ClientRetryPolicy` in `retry_policies/mod.rs`. | **Already there *for the bug shape* — but with a caveat.** The bug we're fixing requires an explicit CT-check in the retry path; Rust has none, so the cross-region failover decision can never be silently preempted between iterations. **However**, Rust async cancellation is "drop-the-future" at the next `.await`. A caller using `tokio::time::timeout(d, op)` will, if `d` expires, drop the entire future at the next yield — which interrupts the in-flight HTTP *and* the retry loop. There is no `Task.WhenAny`-style separation of "tell the caller we cancelled while leaving the work running." So Rust matches Java on the *retry-pipeline* design but is closer to today's .NET on the *user-visible cancellation* shape: callers who compose with `timeout` will still preempt cross-region failover. The pure detached model (this branch) maps to wrapping `BackOffRetryHandler::send` in a `tokio::spawn`-detached task fed by a `oneshot` channel back to the caller — feasible but more invasive in Rust because spawning forces `'static + Send` bounds on captured state. |
| Python (`azure-cosmos` async) | `_retry_utility_async.ExecuteAsync` accepts a token and does check it between retries. Same class of bug as .NET. | Yes — same fix shape. asyncio.CancelledError propagation has the same trade-offs. |
| Go     | Uses `context.Context` deadlines; metadata-cache refresh path observes the caller context directly. | Yes — would require introducing an internal context for the retry loop and observing the caller context only on the response. Same trade-off (orphan request body). |
| JS/TS  | `AbortSignal`-based; metadata cache wires `abortSignal` through to fetch. | Yes — same shape; `AbortController` swap analogous to the .NET CTS swap. |

The detached model is the right answer for the metadata refresh path on every SDK we ship, and the .NET
implementation here is the most complex one to land (because we have the strictest "operation honors its
CT" idiom). Java and Rust are already half-way there at the retry-pipeline layer (no CT threaded into
the loop); Python / Go / JS / Rust would all benefit from a follow-up that adds the explicit
"caller-cancel ≠ in-flight-cancel" separation that this PR introduces for .NET.

## Side effects (Skeptic Lens)

- **Resource:** during a regional brownout, callers timing out leaves orphan requests in flight. With
  AsyncCache dedup, the orphan still serves any subsequent caller, so this is bounded by "one in-flight
  read per cold cache key per gateway." Acceptable.
- **Observability:** as noted, the orphan tail logs against the original caller's trace. If we want to
  cut that, we'd need to introduce a "background trace" concept — out of scope for this spike.
- **Memory:** one extra `CancellationTokenSource` and one `TaskCompletionSource` per call. Same order
  of magnitude as the existing `MetadataRetryHelper`.
- **Concurrency:** the AsyncLazy contract was already designed for this pattern; we're just leaning into
  it more deliberately. No new locks.
- **Cancellation propagation:** verified by tests — the caller sees OCE promptly, the detached task
  continues, the next caller for the same key awaits the same AsyncLazy.

## Recommendation

**Ship PR #5806 as the production fix for the immediate cross-region-failover bug.** It is small,
bounded, and reversible.

**Treat this branch as the agreed direction for the next iteration.** Once #5806 is in master, follow up
with this detached executor (or an evolution of it) and delete `MetadataRetryHelper.cs`. That follow-up
should be paired with the Python/Go/JS analogous changes so all SDKs land in the same operating model
that Java already enjoys.

If reviewers prefer to skip the intermediate step and merge the detached model directly, this branch is
test-clean and ready — but the recommendation above is the conservative path.

---

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
