### PR TITLE
EmbeddingGenerator: Adds ICosmosEmbeddingGenerator client-wide configuration (preview)

### DIFF
--- a/Microsoft.Azure.Cosmos/src/CosmosClient.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClient.cs
@@ -607,6 +607,15 @@ namespace Microsoft.Azure.Cosmos
         /// <remarks>This property is read-only. Modifying any options after the client has been created has no effect on the existing client instance.</remarks>
         public virtual CosmosClientOptions ClientOptions => this.ClientContext.ClientOptions;
 
+#if PREVIEW
+        /// <summary>
+        /// Gets the client-wide <see cref="ICosmosEmbeddingGenerator"/>, or <c>null</c> if none was set.
+        /// Set via <see cref="CosmosClientOptions.EmbeddingGenerator"/> or
+        /// <see cref="Fluent.CosmosClientBuilder.WithEmbeddingGenerator"/>.
+        /// </summary>
+        public virtual ICosmosEmbeddingGenerator EmbeddingGenerator => this.ClientContext.ClientOptions.EmbeddingGenerator;
+#endif
+
         /// <summary>
         /// The response factory used to create CosmosClient response types.
         /// </summary>

--- a/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
@@ -406,6 +406,18 @@ namespace Microsoft.Azure.Cosmos
         ReadConsistencyStrategy? ReadConsistencyStrategy { get; set; }
 
         /// <summary>
+        /// Gets or sets the client-wide default <see cref="ICosmosEmbeddingGenerator"/> used to generate
+        /// query-time vector embeddings for hybrid and vector-search queries.
+        /// </summary>
+        [JsonIgnore]
+#if PREVIEW
+        public
+#else
+        internal
+#endif
+        ICosmosEmbeddingGenerator EmbeddingGenerator { get; set; }
+
+        /// <summary>
         /// Sets the priority level for requests created using cosmos client.
         /// </summary>
         /// <remarks>

--- a/Microsoft.Azure.Cosmos/src/CosmosEmbeddingResult.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosEmbeddingResult.cs
@@ -1,0 +1,69 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos
+{
+    using System;
+    using System.Collections.Generic;
+
+    /// <summary>
+    /// The result of a call to <see cref="ICosmosEmbeddingGenerator.GenerateEmbeddingsAsync"/>.
+    /// Carries the generated float32 vectors plus optional diagnostic fields (token usage,
+    /// latency) the SDK surfaces through <c>CosmosDiagnostics</c>.
+    /// </summary>
+#if PREVIEW
+    public
+#else
+    internal
+#endif
+    sealed class CosmosEmbeddingResult
+    {
+        /// <summary>
+        /// Initializes a new instance of <see cref="CosmosEmbeddingResult"/>.
+        /// </summary>
+        /// <param name="vectors">
+        /// The generated float32 embedding vectors, one per input string supplied to the
+        /// originating <see cref="ICosmosEmbeddingGenerator.GenerateEmbeddingsAsync"/> call,
+        /// in the same order as the inputs.
+        /// </param>
+        /// <param name="totalTokens">
+        /// Optional total token count consumed by the embedding service to produce these vectors.
+        /// Pass <c>null</c> when the underlying service does not report token usage.
+        /// </param>
+        /// <param name="latency">
+        /// Optional duration the implementation observed for the embedding service call (for
+        /// example, the wall-clock time around the underlying HTTP request). Surfaced through
+        /// <c>CosmosDiagnostics</c> for query-time observability. Pass <c>null</c> when the
+        /// implementation does not measure latency.
+        /// </param>
+        public CosmosEmbeddingResult(
+            IReadOnlyList<ReadOnlyMemory<float>> vectors,
+            int? totalTokens = null,
+            TimeSpan? latency = null)
+        {
+            this.Vectors = vectors ?? throw new ArgumentNullException(nameof(vectors));
+            this.TotalTokens = totalTokens;
+            this.Latency = latency;
+        }
+
+        /// <summary>
+        /// Gets the generated float32 embedding vectors, one per input string, in the same
+        /// order as the inputs supplied to <see cref="ICosmosEmbeddingGenerator.GenerateEmbeddingsAsync"/>.
+        /// </summary>
+        public IReadOnlyList<ReadOnlyMemory<float>> Vectors { get; }
+
+        /// <summary>
+        /// Gets the total number of tokens the embedding service consumed to generate
+        /// <see cref="Vectors"/>, or <c>null</c> when the underlying service does not report it.
+        /// </summary>
+        public int? TotalTokens { get; }
+
+        /// <summary>
+        /// Gets the duration the implementation observed for the underlying embedding service
+        /// call, or <c>null</c> when the implementation does not measure it. Surfaced through
+        /// <c>CosmosDiagnostics</c> for query-time observability.
+        /// </summary>
+        public TimeSpan? Latency { get; }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Fluent/CosmosClientBuilder.cs
+++ b/Microsoft.Azure.Cosmos/src/Fluent/CosmosClientBuilder.cs
@@ -869,5 +869,23 @@ namespace Microsoft.Azure.Cosmos.Fluent
             this.clientOptions.ReadConsistencyStrategy = readConsistencyStrategy;
             return this;
         }
+
+        /// <summary>
+        /// Sets the client-wide default <see cref="ICosmosEmbeddingGenerator"/> used to generate
+        /// query-time vector embeddings for hybrid and vector-search queries.
+        /// </summary>
+        /// <param name="embeddingGenerator">The embedding generator to use as the client-wide default.</param>
+        /// <returns>The current <see cref="CosmosClientBuilder"/>.</returns>
+        /// <exception cref="ArgumentNullException">Thrown if <paramref name="embeddingGenerator"/> is <c>null</c>.</exception>
+#if PREVIEW
+        public
+#else
+        internal
+#endif
+        CosmosClientBuilder WithEmbeddingGenerator(ICosmosEmbeddingGenerator embeddingGenerator)
+        {
+            this.clientOptions.EmbeddingGenerator = embeddingGenerator ?? throw new ArgumentNullException(nameof(embeddingGenerator));
+            return this;
+        }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/ICosmosEmbeddingGenerator.cs
+++ b/Microsoft.Azure.Cosmos/src/ICosmosEmbeddingGenerator.cs
@@ -1,0 +1,113 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos
+{
+    using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Defines a contract for generating float32 vector embeddings from input text strings
+    /// supplied by the Azure Cosmos DB query pipeline.
+    /// The SDK invokes this when a query plan contains <c>GenerateEmbeddings(...)</c> literals
+    /// (for example <c>VectorDistance(GenerateEmbeddings("big brown cat"), c.embedding)</c>).
+    /// Set a client-wide default via <c>CosmosClientOptions.EmbeddingGenerator</c> or
+    /// <c>CosmosClientBuilder.WithEmbeddingGenerator</c>. Implementations MUST be thread-safe and are
+    /// responsible for any caching, retries, and authentication required to call the underlying
+    /// embedding service.
+    /// </summary>
+    /// <remarks>
+    /// <para><b>Preview surface.</b> The SDK call site that invokes this method is delivered
+    /// in a follow-up release. Setting an instance via
+    /// <see cref="CosmosClientOptions.EmbeddingGenerator"/> or
+    /// <see cref="Fluent.CosmosClientBuilder.WithEmbeddingGenerator"/> has no runtime effect
+    /// today; the surface is shipped in this preview so customers can author and test
+    /// implementations against the contract ahead of the resolver landing.</para>
+    /// <para><b>Lifecycle and disposal.</b> The customer owns the generator instance. The SDK
+    /// keeps a reference for the lifetime of the configured <see cref="CosmosClient"/> (or the
+    /// <see cref="Container"/> reference it was bound to) but never disposes it. If the
+    /// implementation holds disposable resources (for example an <c>HttpClient</c> or an
+    /// <c>EmbeddingClient</c>), the customer is responsible for disposing them when their
+    /// application tears down.</para>
+    ///
+    /// <para><b>Error semantics.</b> Implementations are responsible for handling transient
+    /// failures from the underlying embedding service (network errors, rate limiting, etc.)
+    /// via their own retry policy. The SDK does not retry calls to this method. Any exception
+    /// thrown by the implementation is wrapped into a <see cref="CosmosException"/> and
+    /// surfaced to the originating SDK caller.</para>
+    ///
+    /// <para><b>Cancellation.</b> Implementations should honor the supplied
+    /// <see cref="CancellationToken"/> cooperatively wherever feasible (typically by forwarding
+    /// it to the underlying HTTP call). Best-effort cancellation is acceptable; ignoring the
+    /// token entirely is discouraged because it defeats caller-side timeouts.</para>
+    ///
+    /// <para><b>Idempotency and concurrency.</b> The SDK may invoke this method multiple times
+    /// for the same inputs (for example during internal query retry) and may invoke it
+    /// concurrently from multiple threads. Implementations must be safe to call repeatedly
+    /// and from parallel callers, and must not assume per-call state. Note that each call
+    /// typically incurs cost at the underlying embedding service; implementations may cache
+    /// responses internally if they want to avoid duplicate billing for identical inputs.</para>
+    /// </remarks>
+#if PREVIEW
+    public
+#else
+    internal
+#endif
+    interface ICosmosEmbeddingGenerator
+    {
+        /// <summary>
+        /// Generates an embedding vector for each of the supplied input strings.
+        /// </summary>
+        /// <param name="texts">
+        /// The input strings to embed, in the order the implementation MUST preserve in the
+        /// returned <see cref="CosmosEmbeddingResult.Vectors"/> (one vector per input, same
+        /// index). Typed as <see cref="IReadOnlyList{T}"/> so implementations can size their
+        /// outbound batch without re-enumeration and so the 1:1 ordered contract is encoded
+        /// in the signature.
+        /// </param>
+        /// <param name="endpoint">
+        /// The embedding service endpoint to call (for example the Azure OpenAI account endpoint).
+        /// Sourced from the container's <c>EmbeddingSource.Endpoint</c> when configured.
+        /// </param>
+        /// <param name="deploymentName">
+        /// The model deployment name to invoke at <paramref name="endpoint"/>. Sourced from the
+        /// container's <c>EmbeddingSource.DeploymentName</c> when configured.
+        /// </param>
+        /// <param name="dimensions">
+        /// The vector dimensionality the produced embeddings must match. For models that support
+        /// dimensionality reduction (for example <c>text-embedding-3-small</c> /
+        /// <c>text-embedding-3-large</c>), implementations MUST forward this value to the
+        /// underlying service so the returned vectors have the expected length; otherwise the
+        /// service returns its default size, which may not match the container's
+        /// <see cref="VectorEmbeddingPolicy"/>.
+        /// </param>
+        /// <param name="cancellationToken">
+        /// A <see cref="CancellationToken"/> propagated from the originating SDK call
+        /// (for example <c>FeedIterator.ReadNextAsync</c>). Implementations should honor cancellation.
+        /// </param>
+        /// <returns>
+        /// A task that resolves to a <see cref="CosmosEmbeddingResult"/> whose
+        /// <see cref="CosmosEmbeddingResult.Vectors"/> contains one float32 vector per input,
+        /// each of length <paramref name="dimensions"/>, in the same order as
+        /// <paramref name="texts"/>.
+        /// <para>
+        /// Query-time vectors are sent to the Azure Cosmos DB gateway as float32 regardless of
+        /// the container's stored <see cref="VectorDataType"/>. Implementations targeting
+        /// containers configured for <see cref="VectorDataType.Uint8"/>,
+        /// <see cref="VectorDataType.Int8"/>, or <see cref="VectorDataType.Float16"/> storage
+        /// should still produce float32 vectors here; the Azure Cosmos DB service applies the
+        /// configured quantization at write time. This contract
+        /// covers all four <see cref="VectorDataType"/> storage configurations supported by
+        /// the container's <see cref="VectorEmbeddingPolicy"/>.
+        /// </para>
+        /// </returns>
+        Task<CosmosEmbeddingResult> GenerateEmbeddingsAsync(
+            IReadOnlyList<string> texts,
+            string endpoint,
+            string deploymentName,
+            int dimensions,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetPreviewSDKAPI.net6.json
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetPreviewSDKAPI.net6.json
@@ -42,6 +42,22 @@
       },
       "NestedTypes": {}
     },
+    "Microsoft.Azure.Cosmos.CosmosClient;System.Object;IsAbstract:False;IsSealed:False;IsInterface:False;IsEnum:False;IsClass:True;IsValueType:False;IsNested:False;IsGenericType:False;IsSerializable:False": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.ICosmosEmbeddingGenerator EmbeddingGenerator": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.ICosmosEmbeddingGenerator EmbeddingGenerator;CanRead:True;CanWrite:False;Microsoft.Azure.Cosmos.ICosmosEmbeddingGenerator get_EmbeddingGenerator();IsAbstract:False;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "Microsoft.Azure.Cosmos.ICosmosEmbeddingGenerator get_EmbeddingGenerator()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.ICosmosEmbeddingGenerator get_EmbeddingGenerator();IsAbstract:False;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        }
+      },
+      "NestedTypes": {}
+    },
     "Microsoft.Azure.Cosmos.CosmosClientOptions;System.Object;IsAbstract:False;IsSealed:False;IsInterface:False;IsEnum:False;IsClass:True;IsValueType:False;IsNested:False;IsGenericType:False;IsSerializable:False": {
       "Subclasses": {},
       "Members": {
@@ -54,6 +70,20 @@
           "Type": "Method",
           "Attributes": [],
           "MethodInfo": "Boolean get_EnableRemoteRegionPreferredForSessionRetry();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "Microsoft.Azure.Cosmos.ICosmosEmbeddingGenerator EmbeddingGenerator[Newtonsoft.Json.JsonIgnoreAttribute()]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonIgnoreAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.ICosmosEmbeddingGenerator EmbeddingGenerator;CanRead:True;CanWrite:True;Microsoft.Azure.Cosmos.ICosmosEmbeddingGenerator get_EmbeddingGenerator();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;Void set_EmbeddingGenerator(Microsoft.Azure.Cosmos.ICosmosEmbeddingGenerator);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "Microsoft.Azure.Cosmos.ICosmosEmbeddingGenerator get_EmbeddingGenerator()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.ICosmosEmbeddingGenerator get_EmbeddingGenerator();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
         },
         "System.Nullable`1[Microsoft.Azure.Cosmos.ReadConsistencyStrategy] get_ReadConsistencyStrategy()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
           "Type": "Method",
@@ -90,6 +120,13 @@
           "Type": "Property",
           "Attributes": [],
           "MethodInfo": "System.TimeSpan InferenceRequestTimeout;CanRead:True;CanWrite:True;System.TimeSpan get_InferenceRequestTimeout();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;Void set_InferenceRequestTimeout(System.TimeSpan);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "Void set_EmbeddingGenerator(Microsoft.Azure.Cosmos.ICosmosEmbeddingGenerator)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_EmbeddingGenerator(Microsoft.Azure.Cosmos.ICosmosEmbeddingGenerator);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
         },
         "Void set_EnableRemoteRegionPreferredForSessionRetry(Boolean)": {
           "Type": "Method",
@@ -908,6 +945,53 @@
       },
       "NestedTypes": {}
     },
+    "Microsoft.Azure.Cosmos.CosmosEmbeddingResult;System.Object;IsAbstract:False;IsSealed:True;IsInterface:False;IsEnum:False;IsClass:True;IsValueType:False;IsNested:False;IsGenericType:False;IsSerializable:False": {
+      "Subclasses": {},
+      "Members": {
+        "System.Collections.Generic.IReadOnlyList`1[System.ReadOnlyMemory`1[System.Single]] get_Vectors()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Collections.Generic.IReadOnlyList`1[System.ReadOnlyMemory`1[System.Single]] get_Vectors();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "System.Collections.Generic.IReadOnlyList`1[System.ReadOnlyMemory`1[System.Single]] Vectors": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": "System.Collections.Generic.IReadOnlyList`1[System.ReadOnlyMemory`1[System.Single]] Vectors;CanRead:True;CanWrite:False;System.Collections.Generic.IReadOnlyList`1[System.ReadOnlyMemory`1[System.Single]] get_Vectors();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "System.Nullable`1[System.Int32] get_TotalTokens()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Nullable`1[System.Int32] get_TotalTokens();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "System.Nullable`1[System.Int32] TotalTokens": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": "System.Nullable`1[System.Int32] TotalTokens;CanRead:True;CanWrite:False;System.Nullable`1[System.Int32] get_TotalTokens();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "System.Nullable`1[System.TimeSpan] get_Latency()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Nullable`1[System.TimeSpan] get_Latency();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "System.Nullable`1[System.TimeSpan] Latency": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": "System.Nullable`1[System.TimeSpan] Latency;CanRead:True;CanWrite:False;System.Nullable`1[System.TimeSpan] get_Latency();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "Void .ctor(System.Collections.Generic.IReadOnlyList`1[System.ReadOnlyMemory`1[System.Single]], System.Nullable`1[System.Int32], System.Nullable`1[System.TimeSpan])": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor(System.Collections.Generic.IReadOnlyList`1[System.ReadOnlyMemory`1[System.Single]], System.Nullable`1[System.Int32], System.Nullable`1[System.TimeSpan])"
+        }
+      },
+      "NestedTypes": {}
+    },
     "Microsoft.Azure.Cosmos.Embedding;System.Object;IsAbstract:False;IsSealed:False;IsInterface:False;IsEnum:False;IsClass:True;IsValueType:False;IsNested:False;IsGenericType:False;IsSerializable:False": {
       "Subclasses": {},
       "Members": {
@@ -1102,6 +1186,11 @@
     "Microsoft.Azure.Cosmos.Fluent.CosmosClientBuilder;System.Object;IsAbstract:False;IsSealed:False;IsInterface:False;IsEnum:False;IsClass:True;IsValueType:False;IsNested:False;IsGenericType:False;IsSerializable:False": {
       "Subclasses": {},
       "Members": {
+        "Microsoft.Azure.Cosmos.Fluent.CosmosClientBuilder WithEmbeddingGenerator(Microsoft.Azure.Cosmos.ICosmosEmbeddingGenerator)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Fluent.CosmosClientBuilder WithEmbeddingGenerator(Microsoft.Azure.Cosmos.ICosmosEmbeddingGenerator);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
         "Microsoft.Azure.Cosmos.Fluent.CosmosClientBuilder WithEnableRemoteRegionPreferredForSessionRetry(Boolean)": {
           "Type": "Method",
           "Attributes": [],
@@ -1147,6 +1236,17 @@
           "Type": "Method",
           "Attributes": [],
           "MethodInfo": "Microsoft.Azure.Cosmos.Fluent.VectorIndexDefinition`1[T] WithVectorIndexShardKey(System.String[]);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "Microsoft.Azure.Cosmos.ICosmosEmbeddingGenerator;;IsAbstract:True;IsSealed:False;IsInterface:True;IsEnum:False;IsClass:False;IsValueType:False;IsNested:False;IsGenericType:False;IsSerializable:False": {
+      "Subclasses": {},
+      "Members": {
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.CosmosEmbeddingResult] GenerateEmbeddingsAsync(System.Collections.Generic.IReadOnlyList`1[System.String], System.String, System.String, Int32, System.Threading.CancellationToken)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.CosmosEmbeddingResult] GenerateEmbeddingsAsync(System.Collections.Generic.IReadOnlyList`1[System.String], System.String, System.String, Int32, System.Threading.CancellationToken);IsAbstract:True;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
         }
       },
       "NestedTypes": {}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
@@ -278,6 +278,100 @@ namespace Microsoft.Azure.Cosmos.Tests
             }
         }
 
+        [TestMethod]
+        public void VerifyEmbeddingGeneratorBuilderProperties()
+        {
+            string endpoint = AccountEndpoint;
+            string key = MockCosmosUtil.RandomInvalidCorrectlyFormatedAuthKey;
+
+            // Verify default is null
+            CosmosClientBuilder cosmosClientBuilder = new CosmosClientBuilder(
+                accountEndpoint: endpoint,
+                authKeyOrResourceToken: key);
+
+            CosmosClient cosmosClient = cosmosClientBuilder.Build(new MockDocumentClient());
+            CosmosClientOptions clientOptions = cosmosClient.ClientOptions;
+
+            Assert.IsNull(clientOptions.EmbeddingGenerator);
+
+            // Verify WithEmbeddingGenerator sets the property
+            ICosmosEmbeddingGenerator generator = new MockEmbeddingGenerator();
+            cosmosClientBuilder = new CosmosClientBuilder(
+                accountEndpoint: endpoint,
+                authKeyOrResourceToken: key);
+
+            cosmosClientBuilder.WithEmbeddingGenerator(generator);
+
+            cosmosClient = cosmosClientBuilder.Build(new MockDocumentClient());
+            clientOptions = cosmosClient.ClientOptions;
+
+            Assert.AreSame(generator, clientOptions.EmbeddingGenerator,
+                "EmbeddingGenerator instance did not round-trip through the builder");
+
+            // Verify null throws ArgumentNullException
+            Assert.ThrowsException<ArgumentNullException>(
+                () => new CosmosClientBuilder(accountEndpoint: endpoint, authKeyOrResourceToken: key)
+                          .WithEmbeddingGenerator(null),
+                "WithEmbeddingGenerator should throw ArgumentNullException for null input");
+        }
+
+#if PREVIEW
+        [TestMethod]
+        public void CosmosClient_EmbeddingGenerator_ReturnsConfiguredInstance()
+        {
+            string endpoint = AccountEndpoint;
+            string key = MockCosmosUtil.RandomInvalidCorrectlyFormatedAuthKey;
+
+            // Default: CosmosClient.EmbeddingGenerator is null when nothing was configured.
+            CosmosClient defaultClient = new CosmosClientBuilder(endpoint, key)
+                .Build(new MockDocumentClient());
+            Assert.IsNull(defaultClient.EmbeddingGenerator,
+                "CosmosClient.EmbeddingGenerator must be null when no generator was configured");
+
+            // Configured via builder: CosmosClient.EmbeddingGenerator returns the same instance.
+            ICosmosEmbeddingGenerator builderGenerator = new MockEmbeddingGenerator();
+            CosmosClient builderClient = new CosmosClientBuilder(endpoint, key)
+                .WithEmbeddingGenerator(builderGenerator)
+                .Build(new MockDocumentClient());
+            Assert.AreSame(builderGenerator, builderClient.EmbeddingGenerator,
+                "CosmosClient.EmbeddingGenerator must return the instance set via CosmosClientBuilder.WithEmbeddingGenerator");
+
+            // Configured via CosmosClientOptions directly: same accessor surfaces it.
+            ICosmosEmbeddingGenerator optionsGenerator = new MockEmbeddingGenerator();
+            CosmosClient optionsClient = new CosmosClientBuilder(endpoint, key)
+                .WithCustomSerializer(new CosmosJsonDotNetSerializer())  // ensures non-default options path
+                .Build(new MockDocumentClient());
+            optionsClient.ClientOptions.EmbeddingGenerator = optionsGenerator;
+            Assert.AreSame(optionsGenerator, optionsClient.EmbeddingGenerator,
+                "CosmosClient.EmbeddingGenerator must return the instance set on CosmosClientOptions.EmbeddingGenerator");
+        }
+
+        [TestMethod]
+        public void CosmosClientOptions_Clone_PreservesEmbeddingGenerator()
+        {
+            ICosmosEmbeddingGenerator generator = new MockEmbeddingGenerator();
+
+            CosmosClientOptions options = new CosmosClientOptions
+            {
+                EmbeddingGenerator = generator,
+            };
+
+            CosmosClientOptions clone = options.Clone();
+
+            Assert.AreSame(generator, clone.EmbeddingGenerator,
+                "CosmosClientOptions.Clone() must preserve the EmbeddingGenerator reference on the clone");
+
+            // The clone must be a distinct instance so subsequent mutations are isolated.
+            Assert.AreNotSame(options, clone, "Clone() must return a distinct instance");
+
+            // Mutating the clone must not affect the source.
+            ICosmosEmbeddingGenerator otherGenerator = new MockEmbeddingGenerator();
+            clone.EmbeddingGenerator = otherGenerator;
+            Assert.AreSame(generator, options.EmbeddingGenerator,
+                "Mutating EmbeddingGenerator on a clone must not affect the original options instance");
+        }
+#endif
+
         /// <summary>
         /// Test to validate that when the partition level failover is enabled with the preferred regions list is missing, then the client
         /// initialization should succeed. This should hold true for both environment variable and CosmosClientOptions.
@@ -1333,6 +1427,19 @@ namespace Microsoft.Azure.Cosmos.Tests
                 }
 
                 return 1;
+            }
+        }
+
+        private sealed class MockEmbeddingGenerator : ICosmosEmbeddingGenerator
+        {
+            public System.Threading.Tasks.Task<CosmosEmbeddingResult> GenerateEmbeddingsAsync(
+                System.Collections.Generic.IReadOnlyList<string> texts,
+                string endpoint,
+                string deploymentName,
+                int dimensions,
+                System.Threading.CancellationToken cancellationToken = default)
+            {
+                throw new NotImplementedException();
             }
         }
     }

--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Features Added
 
+- [5838](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5838) EmbeddingGenerator: Adds ICosmosEmbeddingGenerator client-wide configuration (preview)
+
 #### Breaking Changes
 
 #### Bugs Fixed


### PR DESCRIPTION
Adds the **public surface only** for V0 query-time embedding generation in the .NET SDK (preview). No runtime behavior is wired up yet — pipeline resolver and binding land in a follow-up PR.

## Customer-facing API (preview)

### Interface and result type

```csharp
public interface ICosmosEmbeddingGenerator
{
    Task<CosmosEmbeddingResult> GenerateEmbeddingsAsync(
        IReadOnlyList<string> texts,
        string endpoint,
        string deploymentName,
        int dimensions,
        CancellationToken cancellationToken = default);
}

public sealed class CosmosEmbeddingResult
{
    public IReadOnlyList<ReadOnlyMemory<float>> Vectors { get; }
    public int? TotalTokens { get; }
    public TimeSpan? Latency { get; }
}
```

Signature mirrors [Python SDK PR #46902](https://github.com/Azure/azure-sdk-for-python/pull/46902).

### Client-wide configuration

```csharp
var client = new CosmosClientBuilder(endpoint, cred)
    .WithEmbeddingGenerator(myGenerator)
    .Build();

ICosmosEmbeddingGenerator current = client.EmbeddingGenerator;
```

Or via options:

```csharp
var client = new CosmosClient(endpoint, key, new CosmosClientOptions
{
    EmbeddingGenerator = myGenerator,
});
```

## Files

### Source (new)
- `Microsoft.Azure.Cosmos/src/ICosmosEmbeddingGenerator.cs`
- `Microsoft.Azure.Cosmos/src/CosmosEmbeddingResult.cs`

### Source (modified)
- `CosmosClientOptions.cs` — adds `EmbeddingGenerator` (`[JsonIgnore]`)
- `Fluent/CosmosClientBuilder.cs` — adds `WithEmbeddingGenerator(...)`
- `CosmosClient.cs` — adds `EmbeddingGenerator` read-only accessor

### Tests
- `CosmosClientOptionsUnitTests.cs`:
  - `VerifyEmbeddingGeneratorBuilderProperties` — builder round-trip + null-arg guard
  - `CosmosClient_EmbeddingGenerator_ReturnsConfiguredInstance` — read-only accessor surfaces builder- and options-set instances
  - `CosmosClientOptions_Clone_PreservesEmbeddingGenerator` — locks down `Clone()` preservation
- `Contracts/DotNetPreviewSDKAPI.net6.json` — regenerated for the new surface

## Validation

- ✅ PREVIEW build (`/p:IsPreview=true`): 0 errors
- ✅ Non-PREVIEW build: 0 errors
- ✅ `ContractEnforcement` + `SettingsContractTests` + `CosmosClientOptionsUnitTests`: PREVIEW 220/220 ; non-PREVIEW 221/221
- ✅ Baseline regenerated with LF line endings preserved