### PR TITLE
[Internal] VectorEmbeddingPolicy: Adds EmbeddingSource block to Embedding model

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/Embedding.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/Embedding.cs
@@ -43,6 +43,19 @@ namespace Microsoft.Azure.Cosmos
         public DistanceFunction DistanceFunction { get; set; }
 
         /// <summary>
+        /// Gets or sets the optional <see cref="Cosmos.EmbeddingSource"/> describing the source
+        /// document paths and embedding service that the Cosmos DB service should use to
+        /// generate the vector value for this embedding.
+        /// </summary>
+        [JsonProperty(PropertyName = "embeddingSource", NullValueHandling = NullValueHandling.Ignore)]
+#if PREVIEW
+        public
+#else
+        internal
+#endif
+        EmbeddingSource EmbeddingSource { get; set; }
+
+        /// <summary>
         /// This contains additional values for scenarios where the SDK is not aware of new fields. 
         /// This ensures that if resource is read and updated none of the fields will be lost in the process.
         /// </summary>

--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/Embedding.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/Embedding.cs
@@ -81,10 +81,16 @@ namespace Microsoft.Azure.Cosmos
         /// <inheritdoc/>
         public bool Equals(Embedding that)
         {
+            if (that is null)
+            {
+                return false;
+            }
+
             return this.Path.Equals(that.Path)
                 && this.DataType.Equals(that.DataType)
                 && this.Dimensions == that.Dimensions
-                && this.Dimensions.Equals(that.Dimensions);
+                && this.DistanceFunction.Equals(that.DistanceFunction)
+                && object.Equals(this.EmbeddingSource, that.EmbeddingSource);
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/EmbeddingAuthType.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/EmbeddingAuthType.cs
@@ -18,15 +18,21 @@ namespace Microsoft.Azure.Cosmos
     enum EmbeddingAuthType
     {
         /// <summary>
-        /// Authenticate to the embedding service using an API key.
+        /// Default sentinel — indicates no authentication type has been configured.
         /// </summary>
-        [EnumMember(Value = "ApiKey")]
-        ApiKey,
+        [EnumMember(Value = "Unknown")]
+        Unknown = 0,
 
         /// <summary>
         /// Authenticate to the embedding service using Microsoft Entra ID (managed identity / token credential).
         /// </summary>
         [EnumMember(Value = "Entra")]
         Entra,
+
+        /// <summary>
+        /// Authenticate to the embedding service using an API key.
+        /// </summary>
+        [EnumMember(Value = "ApiKey")]
+        ApiKey,
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/EmbeddingAuthType.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/EmbeddingAuthType.cs
@@ -1,0 +1,32 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos
+{
+    using System.Runtime.Serialization;
+
+    /// <summary>
+    /// Defines the authentication type used by the Azure Cosmos DB service to call the
+    /// embedding service referenced from a <see cref="EmbeddingSource"/>.
+    /// </summary>
+#if PREVIEW
+    public
+#else
+    internal
+#endif
+    enum EmbeddingAuthType
+    {
+        /// <summary>
+        /// Authenticate to the embedding service using an API key.
+        /// </summary>
+        [EnumMember(Value = "ApiKey")]
+        ApiKey,
+
+        /// <summary>
+        /// Authenticate to the embedding service using Microsoft Entra ID (managed identity / token credential).
+        /// </summary>
+        [EnumMember(Value = "Entra")]
+        Entra,
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/EmbeddingSource.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/EmbeddingSource.cs
@@ -4,7 +4,10 @@
 
 namespace Microsoft.Azure.Cosmos
 {
+    using System;
     using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using System.Linq;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Converters;
     using Newtonsoft.Json.Linq;
@@ -23,14 +26,14 @@ namespace Microsoft.Azure.Cosmos
 #else
     internal
 #endif
-    sealed class EmbeddingSource
+    sealed class EmbeddingSource : IEquatable<EmbeddingSource>
     {
         /// <summary>
         /// Gets or sets the list of document paths whose values are concatenated and sent to
         /// the embedding service to generate the vector.
         /// </summary>
         [JsonProperty(PropertyName = "sourcePaths")]
-        public IReadOnlyList<string> SourcePaths { get; set; }
+        public Collection<string> SourcePaths { get; set; }
 
         /// <summary>
         /// Gets or sets the deployment name of the embedding model on the embedding service.
@@ -64,5 +67,52 @@ namespace Microsoft.Azure.Cosmos
         /// </summary>
         [JsonExtensionData]
         internal IDictionary<string, JToken> AdditionalProperties { get; private set; }
+
+        /// <inheritdoc/>
+        public bool Equals(EmbeddingSource that)
+        {
+            if (that is null)
+            {
+                return false;
+            }
+
+            if (object.ReferenceEquals(this, that))
+            {
+                return true;
+            }
+
+            return ((this.SourcePaths == null && that.SourcePaths == null) ||
+                    (this.SourcePaths != null && that.SourcePaths != null && Enumerable.SequenceEqual(this.SourcePaths, that.SourcePaths)))
+                && this.AuthType == that.AuthType
+                && this.DeploymentName == that.DeploymentName
+                && this.Endpoint == that.Endpoint
+                && this.ModelName == that.ModelName;
+        }
+
+        /// <inheritdoc/>
+        public override bool Equals(object obj)
+        {
+            return this.Equals(obj as EmbeddingSource);
+        }
+
+        /// <inheritdoc/>
+        public override int GetHashCode()
+        {
+            int hashCode = 1265339359;
+
+            if (this.SourcePaths != null)
+            {
+                foreach (string sourcePath in this.SourcePaths)
+                {
+                    hashCode = (hashCode * -1521134295) + EqualityComparer<string>.Default.GetHashCode(sourcePath);
+                }
+            }
+
+            hashCode = (hashCode * -1521134295) + this.AuthType.GetHashCode();
+            hashCode = (hashCode * -1521134295) + EqualityComparer<string>.Default.GetHashCode(this.DeploymentName);
+            hashCode = (hashCode * -1521134295) + EqualityComparer<string>.Default.GetHashCode(this.Endpoint);
+            hashCode = (hashCode * -1521134295) + EqualityComparer<string>.Default.GetHashCode(this.ModelName);
+            return hashCode;
+        }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Resource/Settings/EmbeddingSource.cs
+++ b/Microsoft.Azure.Cosmos/src/Resource/Settings/EmbeddingSource.cs
@@ -1,0 +1,68 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos
+{
+    using System.Collections.Generic;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Converters;
+    using Newtonsoft.Json.Linq;
+
+    /// <summary>
+    /// Describes the source document paths and the embedding service that the Azure Cosmos DB
+    /// service should use to generate the vector value for an <see cref="Embedding"/>.
+    /// </summary>
+    /// <remarks>
+    /// When present on an <see cref="Embedding"/>, this block tells the SDK (and the Cosmos
+    /// DB embedding provider) where and how to call the embedding service for the vector
+    /// path in question.
+    /// </remarks>
+#if PREVIEW
+    public
+#else
+    internal
+#endif
+    sealed class EmbeddingSource
+    {
+        /// <summary>
+        /// Gets or sets the list of document paths whose values are concatenated and sent to
+        /// the embedding service to generate the vector.
+        /// </summary>
+        [JsonProperty(PropertyName = "sourcePaths")]
+        public IReadOnlyList<string> SourcePaths { get; set; }
+
+        /// <summary>
+        /// Gets or sets the deployment name of the embedding model on the embedding service.
+        /// </summary>
+        [JsonProperty(PropertyName = "deploymentName")]
+        public string DeploymentName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name of the embedding model.
+        /// </summary>
+        [JsonProperty(PropertyName = "modelName")]
+        public string ModelName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the endpoint of the embedding service.
+        /// </summary>
+        [JsonProperty(PropertyName = "endpoint")]
+        public string Endpoint { get; set; }
+
+        /// <summary>
+        /// Gets or sets the <see cref="Cosmos.EmbeddingAuthType"/> used to authenticate to the
+        /// embedding service.
+        /// </summary>
+        [JsonProperty(PropertyName = "authType")]
+        [JsonConverter(typeof(StringEnumConverter))]
+        public EmbeddingAuthType AuthType { get; set; }
+
+        /// <summary>
+        /// This contains additional values for scenarios where the SDK is not aware of new fields.
+        /// This ensures that if resource is read and updated none of the fields will be lost in the process.
+        /// </summary>
+        [JsonExtensionData]
+        internal IDictionary<string, JToken> AdditionalProperties { get; private set; }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Fluent/ContainerSettingsTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Fluent/ContainerSettingsTests.cs
@@ -630,6 +630,105 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
+        [Ignore("Requires a real Cosmos DB account with vector-embedding preview enabled. Fill in the endpoint and key before running.")]
+        public async Task TestVectorEmbeddingPolicyWithEmbeddingSource()
+        {
+            const string accountEndpoint = "";
+            const string accountKey = "";
+
+            const string databaseId = "embeddingSourceIntegrationDb";
+            const string containerId = "embeddingSourceIntegrationContainer";
+            const string partitionKeyPath = "/pk";
+            const string embeddingPath = "/embedding";
+
+            CosmosClient client = new CosmosClient(accountEndpoint, accountKey);
+            Database database = await client.CreateDatabaseIfNotExistsAsync(databaseId);
+
+            try
+            {
+                EmbeddingSource embeddingSource = new EmbeddingSource()
+                {
+                    SourcePaths = new[]
+                    {
+                        "/journal_title",
+                        "/title",
+                        "/toc_abstract",
+                        "/abstract",
+                        "/full_text",
+                    },
+                    DeploymentName = "text-embedding-3-small",
+                    ModelName = "text-embedding-3-small",
+                    Endpoint = "https://embedding-south-central.cognitiveservices.azure.com/",
+                    AuthType = EmbeddingAuthType.ApiKey,
+                };
+
+                Collection<Embedding> embeddings = new Collection<Embedding>()
+                {
+                    new Embedding()
+                    {
+                        Path = embeddingPath,
+                        DataType = VectorDataType.Float32,
+                        DistanceFunction = DistanceFunction.Cosine,
+                        Dimensions = 1536,
+                        EmbeddingSource = embeddingSource,
+                    },
+                };
+
+                try
+                {
+                    await database.GetContainer(containerId).DeleteContainerAsync();
+                }
+                catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.NotFound)
+                {
+                }
+
+                ContainerResponse containerResponse =
+                    await database.DefineContainer(containerId, partitionKeyPath)
+                        .WithVectorEmbeddingPolicy(embeddings)
+                        .Attach()
+                        .CreateAsync();
+
+                Assert.AreEqual(HttpStatusCode.Created, containerResponse.StatusCode);
+                Assert.AreEqual(containerId, containerResponse.Resource.Id);
+                Assert.AreEqual(partitionKeyPath, containerResponse.Resource.PartitionKey.Paths.First());
+
+                this.AssertEmbeddingSourceRoundTrip(containerResponse.Resource.VectorEmbeddingPolicy, embeddingPath, embeddingSource);
+
+                ContainerResponse readResponse = await containerResponse.Container.ReadContainerAsync();
+                Assert.AreEqual(HttpStatusCode.OK, readResponse.StatusCode);
+                Assert.AreEqual(containerId, readResponse.Resource.Id);
+                Assert.AreEqual(partitionKeyPath, readResponse.Resource.PartitionKey.Paths.First());
+
+                this.AssertEmbeddingSourceRoundTrip(readResponse.Resource.VectorEmbeddingPolicy, embeddingPath, embeddingSource);
+            }
+            finally
+            {
+                await database.DeleteAsync();
+                client.Dispose();
+            }
+        }
+
+        private void AssertEmbeddingSourceRoundTrip(VectorEmbeddingPolicy policy, string expectedEmbeddingPath, EmbeddingSource expected)
+        {
+            Assert.IsNotNull(policy);
+            Assert.AreEqual(1, policy.Embeddings.Count());
+
+            Embedding readEmbedding = policy.Embeddings.Single();
+            Assert.AreEqual(expectedEmbeddingPath, readEmbedding.Path);
+            Assert.AreEqual(VectorDataType.Float32, readEmbedding.DataType);
+            Assert.AreEqual(DistanceFunction.Cosine, readEmbedding.DistanceFunction);
+            Assert.AreEqual(1536, readEmbedding.Dimensions);
+
+            EmbeddingSource readSource = readEmbedding.EmbeddingSource;
+            Assert.IsNotNull(readSource, "EmbeddingSource should be returned by the server.");
+            CollectionAssert.AreEqual(expected.SourcePaths.ToArray(), readSource.SourcePaths.ToArray());
+            Assert.AreEqual(expected.DeploymentName, readSource.DeploymentName);
+            Assert.AreEqual(expected.ModelName, readSource.ModelName);
+            Assert.AreEqual(expected.Endpoint, readSource.Endpoint);
+            Assert.AreEqual(expected.AuthType, readSource.AuthType);
+        }
+
+        [TestMethod]
         public async Task WithIndexingPolicy()
         {
             string containerName = Guid.NewGuid().ToString();

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Fluent/ContainerSettingsTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Fluent/ContainerSettingsTests.cs
@@ -17,7 +17,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
     [TestClass]
     public class ContainerSettingsTests : BaseCosmosClientHelper
     {
-        private static long ToEpoch(DateTime dateTime) => (long)(dateTime - new DateTime(1970, 1, 1)).TotalSeconds;
+        private static long ToEpoch(DateTime dateTime)
+        {
+            return (long)(dateTime - new DateTime(1970, 1, 1)).TotalSeconds;
+        }
 
         [TestInitialize]
         public async Task TestInitialize()
@@ -648,7 +651,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             {
                 EmbeddingSource embeddingSource = new EmbeddingSource()
                 {
-                    SourcePaths = new[]
+                    SourcePaths = new Collection<string>
                     {
                         "/journal_title",
                         "/title",

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetPreviewSDKAPI.net6.json
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetPreviewSDKAPI.net6.json
@@ -1221,6 +1221,175 @@
       },
       "NestedTypes": {}
     },
+    "Microsoft.Azure.Cosmos.Embedding;System.Object;IsAbstract:False;IsSealed:False;IsInterface:False;IsEnum:False;IsClass:True;IsValueType:False;IsNested:False;IsGenericType:False;IsSerializable:False": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.EmbeddingSource EmbeddingSource[Newtonsoft.Json.JsonPropertyAttribute(NullValueHandling = NullValueHandling.Ignore = 1, PropertyName = \"embeddingSource\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.EmbeddingSource EmbeddingSource;CanRead:True;CanWrite:True;Microsoft.Azure.Cosmos.EmbeddingSource get_EmbeddingSource();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;Void set_EmbeddingSource(Microsoft.Azure.Cosmos.EmbeddingSource);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "Microsoft.Azure.Cosmos.EmbeddingSource get_EmbeddingSource()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.EmbeddingSource get_EmbeddingSource();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "Void set_EmbeddingSource(Microsoft.Azure.Cosmos.EmbeddingSource)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_EmbeddingSource(Microsoft.Azure.Cosmos.EmbeddingSource);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "Microsoft.Azure.Cosmos.EmbeddingAuthType;System.Enum;IsAbstract:False;IsSealed:True;IsInterface:False;IsEnum:True;IsClass:False;IsValueType:True;IsNested:False;IsGenericType:False;IsSerializable:True": {
+      "Subclasses": {},
+      "Members": {
+        "Int32 value__": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": "Int32 value__;IsInitOnly:False;IsStatic:False;"
+        },
+        "Microsoft.Azure.Cosmos.EmbeddingAuthType ApiKey[System.Runtime.Serialization.EnumMemberAttribute(Value = \"ApiKey\")]": {
+          "Type": "Field",
+          "Attributes": [
+            "EnumMemberAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.EmbeddingAuthType ApiKey;IsInitOnly:False;IsStatic:True;"
+        },
+        "Microsoft.Azure.Cosmos.EmbeddingAuthType Entra[System.Runtime.Serialization.EnumMemberAttribute(Value = \"Entra\")]": {
+          "Type": "Field",
+          "Attributes": [
+            "EnumMemberAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.EmbeddingAuthType Entra;IsInitOnly:False;IsStatic:True;"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "Microsoft.Azure.Cosmos.EmbeddingSource;System.Object;IsAbstract:False;IsSealed:True;IsInterface:False;IsEnum:False;IsClass:True;IsValueType:False;IsNested:False;IsGenericType:False;IsSerializable:False": {
+      "Subclasses": {},
+      "Members": {
+        "Microsoft.Azure.Cosmos.EmbeddingAuthType AuthType[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"authType\")]-[Newtonsoft.Json.JsonConverterAttribute(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonConverterAttribute",
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.EmbeddingAuthType AuthType;CanRead:True;CanWrite:True;Microsoft.Azure.Cosmos.EmbeddingAuthType get_AuthType();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;Void set_AuthType(Microsoft.Azure.Cosmos.EmbeddingAuthType);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "Microsoft.Azure.Cosmos.EmbeddingAuthType get_AuthType()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.EmbeddingAuthType get_AuthType();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "System.Collections.Generic.IReadOnlyList`1[System.String] get_SourcePaths()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Collections.Generic.IReadOnlyList`1[System.String] get_SourcePaths();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "System.Collections.Generic.IReadOnlyList`1[System.String] SourcePaths[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"sourcePaths\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": "System.Collections.Generic.IReadOnlyList`1[System.String] SourcePaths;CanRead:True;CanWrite:True;System.Collections.Generic.IReadOnlyList`1[System.String] get_SourcePaths();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;Void set_SourcePaths(System.Collections.Generic.IReadOnlyList`1[System.String]);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "System.String DeploymentName[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"deploymentName\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": "System.String DeploymentName;CanRead:True;CanWrite:True;System.String get_DeploymentName();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;Void set_DeploymentName(System.String);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "System.String Endpoint[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"endpoint\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": "System.String Endpoint;CanRead:True;CanWrite:True;System.String get_Endpoint();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;Void set_Endpoint(System.String);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "System.String get_DeploymentName()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_DeploymentName();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "System.String get_Endpoint()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_Endpoint();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "System.String get_ModelName()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_ModelName();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "System.String ModelName[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"modelName\")]": {
+          "Type": "Property",
+          "Attributes": [
+            "JsonPropertyAttribute"
+          ],
+          "MethodInfo": "System.String ModelName;CanRead:True;CanWrite:True;System.String get_ModelName();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;Void set_ModelName(System.String);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "Void .ctor()": {
+          "Type": "Constructor",
+          "Attributes": [],
+          "MethodInfo": "Void .ctor()"
+        },
+        "Void set_AuthType(Microsoft.Azure.Cosmos.EmbeddingAuthType)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_AuthType(Microsoft.Azure.Cosmos.EmbeddingAuthType);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "Void set_DeploymentName(System.String)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_DeploymentName(System.String);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "Void set_Endpoint(System.String)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_Endpoint(System.String);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "Void set_ModelName(System.String)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_ModelName(System.String);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "Void set_SourcePaths(System.Collections.Generic.IReadOnlyList`1[System.String])[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_SourcePaths(System.Collections.Generic.IReadOnlyList`1[System.String]);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        }
+      },
+      "NestedTypes": {}
+    },
     "Microsoft.Azure.Cosmos.Fluent.ChangeFeedPolicyDefinition;System.Object;IsAbstract:False;IsSealed:False;IsInterface:False;IsEnum:False;IsClass:True;IsValueType:False;IsNested:False;IsGenericType:False;IsSerializable:False": {
       "Subclasses": {},
       "Members": {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetPreviewSDKAPI.net6.json
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetPreviewSDKAPI.net6.json
@@ -1269,6 +1269,13 @@
             "EnumMemberAttribute"
           ],
           "MethodInfo": "Microsoft.Azure.Cosmos.EmbeddingAuthType Entra;IsInitOnly:False;IsStatic:True;"
+        },
+        "Microsoft.Azure.Cosmos.EmbeddingAuthType Unknown[System.Runtime.Serialization.EnumMemberAttribute(Value = \"Unknown\")]": {
+          "Type": "Field",
+          "Attributes": [
+            "EnumMemberAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.EmbeddingAuthType Unknown;IsInitOnly:False;IsStatic:True;"
         }
       },
       "NestedTypes": {}
@@ -1276,6 +1283,21 @@
     "Microsoft.Azure.Cosmos.EmbeddingSource;System.Object;IsAbstract:False;IsSealed:True;IsInterface:False;IsEnum:False;IsClass:True;IsValueType:False;IsNested:False;IsGenericType:False;IsSerializable:False": {
       "Subclasses": {},
       "Members": {
+        "Boolean Equals(Microsoft.Azure.Cosmos.EmbeddingSource)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean Equals(Microsoft.Azure.Cosmos.EmbeddingSource);IsAbstract:False;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:True;"
+        },
+        "Boolean Equals(System.Object)": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Boolean Equals(System.Object);IsAbstract:False;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "Int32 GetHashCode()": {
+          "Type": "Method",
+          "Attributes": [],
+          "MethodInfo": "Int32 GetHashCode();IsAbstract:False;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
         "Microsoft.Azure.Cosmos.EmbeddingAuthType AuthType[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"authType\")]-[Newtonsoft.Json.JsonConverterAttribute(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]": {
           "Type": "Property",
           "Attributes": [
@@ -1291,19 +1313,19 @@
           ],
           "MethodInfo": "Microsoft.Azure.Cosmos.EmbeddingAuthType get_AuthType();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
         },
-        "System.Collections.Generic.IReadOnlyList`1[System.String] get_SourcePaths()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+        "System.Collections.ObjectModel.Collection`1[System.String] get_SourcePaths()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
           "Type": "Method",
           "Attributes": [
             "CompilerGeneratedAttribute"
           ],
-          "MethodInfo": "System.Collections.Generic.IReadOnlyList`1[System.String] get_SourcePaths();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+          "MethodInfo": "System.Collections.ObjectModel.Collection`1[System.String] get_SourcePaths();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
         },
-        "System.Collections.Generic.IReadOnlyList`1[System.String] SourcePaths[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"sourcePaths\")]": {
+        "System.Collections.ObjectModel.Collection`1[System.String] SourcePaths[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"sourcePaths\")]": {
           "Type": "Property",
           "Attributes": [
             "JsonPropertyAttribute"
           ],
-          "MethodInfo": "System.Collections.Generic.IReadOnlyList`1[System.String] SourcePaths;CanRead:True;CanWrite:True;System.Collections.Generic.IReadOnlyList`1[System.String] get_SourcePaths();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;Void set_SourcePaths(System.Collections.Generic.IReadOnlyList`1[System.String]);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+          "MethodInfo": "System.Collections.ObjectModel.Collection`1[System.String] SourcePaths;CanRead:True;CanWrite:True;System.Collections.ObjectModel.Collection`1[System.String] get_SourcePaths();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;Void set_SourcePaths(System.Collections.ObjectModel.Collection`1[System.String]);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
         },
         "System.String DeploymentName[Newtonsoft.Json.JsonPropertyAttribute(PropertyName = \"deploymentName\")]": {
           "Type": "Property",
@@ -1380,12 +1402,12 @@
           ],
           "MethodInfo": "Void set_ModelName(System.String);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
         },
-        "Void set_SourcePaths(System.Collections.Generic.IReadOnlyList`1[System.String])[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+        "Void set_SourcePaths(System.Collections.ObjectModel.Collection`1[System.String])[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
           "Type": "Method",
           "Attributes": [
             "CompilerGeneratedAttribute"
           ],
-          "MethodInfo": "Void set_SourcePaths(System.Collections.Generic.IReadOnlyList`1[System.String]);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+          "MethodInfo": "Void set_SourcePaths(System.Collections.ObjectModel.Collection`1[System.String]);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
         }
       },
       "NestedTypes": {}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/SettingsContractTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/SettingsContractTests.cs
@@ -1155,6 +1155,28 @@ namespace Microsoft.Azure.Cosmos.Tests
         }
 
         [TestMethod]
+        public void EmbeddingSourceRoundTripSerialization()
+        {
+            const string embeddingPolicyJson = "{\"vectorEmbeddings\":[{\"path\":\"/embedding\",\"dataType\":\"float32\",\"dimensions\":1536,\"distanceFunction\":\"cosine\",\"embeddingSource\":{\"sourcePaths\":[\"/journal_title\",\"/title\",\"/toc_abstract\",\"/abstract\",\"/full_text\"],\"deploymentName\":\"text-embedding-3-small\",\"modelName\":\"text-embedding-3-small\",\"endpoint\":\"https://embedding-south-central.cognitiveservices.azure.com/\",\"authType\":\"ApiKey\"}},{\"path\":\"/embedding2\",\"dataType\":\"float32\",\"dimensions\":1536,\"distanceFunction\":\"cosine\",\"embeddingSource\":{\"sourcePaths\":[\"/title\"],\"deploymentName\":\"text-embedding-3-small\",\"modelName\":\"text-embedding-3-small\",\"endpoint\":\"https://embedding-south-central.cognitiveservices.azure.com/\",\"authType\":\"Entra\"}}]}";
+
+            Cosmos.VectorEmbeddingPolicy policy = JsonConvert.DeserializeObject<Cosmos.VectorEmbeddingPolicy>(embeddingPolicyJson);
+            Cosmos.EmbeddingSource source = policy.Embeddings[0].EmbeddingSource;
+            CollectionAssert.AreEqual(
+                new[] { "/journal_title", "/title", "/toc_abstract", "/abstract", "/full_text" },
+                source.SourcePaths.ToArray());
+            Assert.AreEqual("text-embedding-3-small", source.DeploymentName);
+            Assert.AreEqual("text-embedding-3-small", source.ModelName);
+            Assert.AreEqual("https://embedding-south-central.cognitiveservices.azure.com/", source.Endpoint);
+            Assert.AreEqual(Cosmos.EmbeddingAuthType.ApiKey, source.AuthType);
+            Assert.AreEqual(Cosmos.EmbeddingAuthType.Entra, policy.Embeddings[1].EmbeddingSource.AuthType);
+
+            string roundTripped = JsonConvert.SerializeObject(policy);
+            Assert.IsTrue(
+                JToken.DeepEquals(JObject.Parse(embeddingPolicyJson), JObject.Parse(roundTripped)),
+                $"Round-tripped JSON differs.\nExpected: {embeddingPolicyJson}\nActual:   {roundTripped}");
+        }
+
+        [TestMethod]
         public void FullTextPolicySerialization()
         {
             ContainerProperties containerSettings = new ContainerProperties("TestContainer", "/pk");

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/SettingsContractTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/SettingsContractTests.cs
@@ -1177,6 +1177,58 @@ namespace Microsoft.Azure.Cosmos.Tests
         }
 
         [TestMethod]
+        public void EmbeddingSourceValueEquality()
+        {
+            static Cosmos.EmbeddingSource Build(string deployment, Cosmos.EmbeddingAuthType auth)
+            {
+                return new()
+                {
+                    SourcePaths = new Collection<string> { "/title", "/abstract" },
+                    DeploymentName = deployment,
+                    ModelName = "text-embedding-3-small",
+                    Endpoint = "https://embedding.example.com/",
+                    AuthType = auth,
+                };
+            }
+
+            Cosmos.EmbeddingSource a = Build("text-embedding-3-small", Cosmos.EmbeddingAuthType.ApiKey);
+            Cosmos.EmbeddingSource b = Build("text-embedding-3-small", Cosmos.EmbeddingAuthType.ApiKey);
+
+            Assert.AreNotSame(a, b);
+            Assert.IsTrue(a.Equals(b));
+            Assert.IsTrue(a.Equals((object)b));
+            Assert.AreEqual(a.GetHashCode(), b.GetHashCode());
+
+            Cosmos.EmbeddingSource differentAuth = Build("text-embedding-3-small", Cosmos.EmbeddingAuthType.Entra);
+            Assert.IsFalse(a.Equals(differentAuth));
+
+            Cosmos.EmbeddingSource reorderedPaths = Build("text-embedding-3-small", Cosmos.EmbeddingAuthType.ApiKey);
+            reorderedPaths.SourcePaths = new Collection<string> { "/abstract", "/title" };
+            Assert.IsFalse(a.Equals(reorderedPaths));
+
+            Assert.IsFalse(a.Equals((Cosmos.EmbeddingSource)null));
+            Assert.IsFalse(a.Equals((object)null));
+
+            Cosmos.Embedding e1 = new Cosmos.Embedding()
+            {
+                Path = "/embedding",
+                DataType = Cosmos.VectorDataType.Float32,
+                DistanceFunction = Cosmos.DistanceFunction.Cosine,
+                Dimensions = 1536,
+                EmbeddingSource = a,
+            };
+            Cosmos.Embedding e2 = new Cosmos.Embedding()
+            {
+                Path = "/embedding",
+                DataType = Cosmos.VectorDataType.Float32,
+                DistanceFunction = Cosmos.DistanceFunction.Cosine,
+                Dimensions = 1536,
+                EmbeddingSource = b,
+            };
+            Assert.IsTrue(e1.Equals(e2));
+        }
+
+        [TestMethod]
         public void FullTextPolicySerialization()
         {
             ContainerProperties containerSettings = new ContainerProperties("TestContainer", "/pk");

--- a/changelog.md
+++ b/changelog.md
@@ -15,6 +15,14 @@ Preview features are treated as a separate branch and will not be included in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### <a name="unreleased"/> Unreleased Preview
+
+#### Fixed
+
+#### Added
+
+- [5848](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5848) VectorEmbeddingPolicy: Adds EmbeddingSource block to Embedding model
+
 ### <a name="3.60.0-preview.0"/> [3.60.0-preview.0](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.60.0-preview.0) - 2026-4-24
 
 #### Added


### PR DESCRIPTION
# Pull Request Template

## Description

Adds EmbeddingSource block to entries in VectorEmbeddingPolicy, describing where the SDK should call the embedding service for a given vector path — including the source document paths to
embed, the model and deployment name, the service endpoint, and the authentication type (ApiKey or Entra)

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## Closing issues

To automatically close an issue: closes #5840