### PR TITLE
[Internal] DTS: Refactors Create/Upsert item ops in DTx to extract id from resource body

### DIFF
--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperation.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperation.cs
@@ -6,6 +6,8 @@ namespace Microsoft.Azure.Cosmos
 {
     using System;
     using System.IO;
+    using System.Text;
+    using System.Text.Json;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Documents;
@@ -15,6 +17,8 @@ namespace Microsoft.Azure.Cosmos
     /// </summary>
     internal class DistributedTransactionOperation
     {
+        private static readonly byte[] IdPropertyNameUtf8 = Encoding.UTF8.GetBytes("id");
+
         protected Memory<byte> body;
 
         public DistributedTransactionOperation(
@@ -75,11 +79,88 @@ namespace Microsoft.Azure.Cosmos
             {
                 this.body = await BatchExecUtils.StreamToMemoryAsync(this.ResourceStream, cancellationToken);
             }
+
+            this.ReconcileIdWithBody();
+        }
+
+        /// <summary>
+        /// For Create/Upsert operations the item id is always derived from the resource body.
+        /// Extracts the top-level <c>id</c> string property and assigns it to <see cref="Id"/>.
+        /// Throws <see cref="ArgumentException"/> if the body has no non-empty <c>id</c> string.
+        /// </summary>
+        private void ReconcileIdWithBody()
+        {
+            if (this.OperationType != Documents.OperationType.Create
+                && this.OperationType != Documents.OperationType.Upsert)
+            {
+                return;
+            }
+
+            if (this.body.IsEmpty)
+            {
+                return;
+            }
+
+            string bodyId = TryReadIdFromJsonObject(this.body.Span);
+
+            if (string.IsNullOrWhiteSpace(bodyId))
+            {
+                throw new ArgumentException(
+                    $"The resource body for the {this.OperationType} operation at index {this.OperationIndex} does not contain a non-empty 'id' string property. Provide 'id' in the resource body.");
+            }
+
+            this.Id = bodyId;
+        }
+
+        /// <summary>
+        /// Scans the top level of a JSON object for an "id" string property and returns its value.
+        /// Returns null if the body is not a JSON object, has no "id" property, or the value is not a string.
+        /// Allocation is limited to the returned id string itself.
+        /// </summary>
+        private static string TryReadIdFromJsonObject(ReadOnlySpan<byte> body)
+        {
+            try
+            {
+                Utf8JsonReader reader = new Utf8JsonReader(body);
+                if (!reader.Read() || reader.TokenType != JsonTokenType.StartObject)
+                {
+                    return null;
+                }
+
+                while (reader.Read() && reader.TokenType == JsonTokenType.PropertyName)
+                {
+                    if (reader.ValueTextEquals(IdPropertyNameUtf8))
+                    {
+                        return reader.Read() && reader.TokenType == JsonTokenType.String ? reader.GetString() : null;
+                    }
+
+                    reader.Skip();
+                }
+
+                return null;
+            }
+            catch (JsonException)
+            {
+                return null;
+            }
         }
     }
 
     internal class DistributedTransactionOperation<T> : DistributedTransactionOperation
     {
+        public DistributedTransactionOperation(
+            Documents.OperationType operationType,
+            int operationIndex,
+            string database,
+            string container,
+            PartitionKey partitionKey,
+            T resource,
+            DistributedTransactionRequestOptions requestOptions = null)
+            : base(operationType, operationIndex, database, container, partitionKey, id: null, requestOptions)
+        {
+            this.Resource = resource;
+        }
+
         public DistributedTransactionOperation(
             Documents.OperationType operationType,
             int operationIndex,

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedWriteTransaction.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedWriteTransaction.cs
@@ -24,15 +24,13 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="database">The name of the database containing the container.</param>
         /// <param name="collection">The name of the container where the item will be created.</param>
         /// <param name="partitionKey">The partition key for the item.</param>
-        /// <param name="id">The unique identifier of the item to create.</param>
-        /// <param name="resource">The resource to create.</param>
+        /// <param name="resource">The resource to create. The item's <c>id</c> is read from the serialized resource body.</param>
         /// <param name="requestOptions">Options for the create operation.</param>
         /// <returns>The current <see cref="DistributedWriteTransaction"/> instance for method chaining.</returns>
         public abstract DistributedWriteTransaction CreateItem<T>(
             string database,
             string collection,
             PartitionKey partitionKey,
-            string id,
             T resource,
             DistributedTransactionRequestOptions requestOptions = null);
 
@@ -42,15 +40,13 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="database">The name of the database containing the container.</param>
         /// <param name="collection">The name of the container where the item will be created.</param>
         /// <param name="partitionKey">The partition key for the item.</param>
-        /// <param name="id">The unique identifier of the item to create.</param>
-        /// <param name="streamPayload">A <see cref="Stream"/> containing the JSON serialization of the item.</param>
+        /// <param name="streamPayload">A <see cref="Stream"/> containing the JSON serialization of the item. The item's <c>id</c> is read from the stream payload.</param>
         /// <param name="requestOptions">Options for the create operation.</param>
         /// <returns>The current <see cref="DistributedWriteTransaction"/> instance for method chaining.</returns>
         public abstract DistributedWriteTransaction CreateItemStream(
             string database,
             string collection,
             PartitionKey partitionKey,
-            string id,
             Stream streamPayload,
             DistributedTransactionRequestOptions requestOptions = null);
 
@@ -151,15 +147,13 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="database">The name of the database containing the container.</param>
         /// <param name="collection">The name of the container where the item will be upserted.</param>
         /// <param name="partitionKey">The partition key for the item.</param>
-        /// <param name="id">The unique identifier of the item to upsert.</param>
-        /// <param name="resource">The resource to upsert.</param>
+        /// <param name="resource">The resource to upsert. The item's <c>id</c> is read from the serialized resource body.</param>
         /// <param name="requestOptions">Options for the upsert operation.</param>
         /// <returns>The current <see cref="DistributedWriteTransaction"/> instance for method chaining.</returns>
         public abstract DistributedWriteTransaction UpsertItem<T>(
             string database,
             string collection,
             PartitionKey partitionKey,
-            string id,
             T resource,
             DistributedTransactionRequestOptions requestOptions = null);
 
@@ -170,15 +164,13 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="database">The name of the database containing the container.</param>
         /// <param name="collection">The name of the container where the item will be upserted.</param>
         /// <param name="partitionKey">The partition key for the item.</param>
-        /// <param name="id">The unique identifier of the item to upsert.</param>
-        /// <param name="streamPayload">A <see cref="Stream"/> containing the JSON serialization of the item.</param>
+        /// <param name="streamPayload">A <see cref="Stream"/> containing the JSON serialization of the item. The item's <c>id</c> is read from the stream payload.</param>
         /// <param name="requestOptions">Options for the upsert operation.</param>
         /// <returns>The current <see cref="DistributedWriteTransaction"/> instance for method chaining.</returns>
         public abstract DistributedWriteTransaction UpsertItemStream(
             string database,
             string collection,
             PartitionKey partitionKey,
-            string id,
             Stream streamPayload,
             DistributedTransactionRequestOptions requestOptions = null);
     }

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedWriteTransactionCore.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedWriteTransactionCore.cs
@@ -27,12 +27,10 @@ namespace Microsoft.Azure.Cosmos
             string database,
             string collection,
             PartitionKey partitionKey,
-            string id,
             T resource,
             DistributedTransactionRequestOptions requestOptions = null)
         {
             DistributedWriteTransactionCore.ValidateContainerReference(database, collection);
-            DistributedWriteTransactionCore.ValidateItemId(id);
             DistributedWriteTransactionCore.ValidateResource(resource);
 
             this.operations.Add(
@@ -42,7 +40,6 @@ namespace Microsoft.Azure.Cosmos
                     database,
                     collection,
                     partitionKey,
-                    id,
                     resource,
                     requestOptions));
             return this;
@@ -52,12 +49,10 @@ namespace Microsoft.Azure.Cosmos
             string database,
             string collection,
             PartitionKey partitionKey,
-            string id,
             Stream streamPayload,
             DistributedTransactionRequestOptions requestOptions = null)
         {
             DistributedWriteTransactionCore.ValidateContainerReference(database, collection);
-            DistributedWriteTransactionCore.ValidateItemId(id);
             if (streamPayload == null)
             {
                 throw new ArgumentNullException(nameof(streamPayload));
@@ -70,7 +65,6 @@ namespace Microsoft.Azure.Cosmos
                     database: database,
                     container: collection,
                     partitionKey: partitionKey,
-                    id: id,
                     requestOptions: requestOptions)
                 {
                     ResourceStream = streamPayload
@@ -220,12 +214,10 @@ namespace Microsoft.Azure.Cosmos
             string database,
             string collection,
             PartitionKey partitionKey,
-            string id,
             T resource,
             DistributedTransactionRequestOptions requestOptions = null)
         {
             DistributedWriteTransactionCore.ValidateContainerReference(database, collection);
-            DistributedWriteTransactionCore.ValidateItemId(id);
             DistributedWriteTransactionCore.ValidateResource(resource);
 
             this.operations.Add(
@@ -235,7 +227,6 @@ namespace Microsoft.Azure.Cosmos
                     database,
                     collection,
                     partitionKey,
-                    id,
                     resource,
                     requestOptions));
             return this;
@@ -245,12 +236,10 @@ namespace Microsoft.Azure.Cosmos
             string database,
             string collection,
             PartitionKey partitionKey,
-            string id,
             Stream streamPayload,
             DistributedTransactionRequestOptions requestOptions = null)
         {
             DistributedWriteTransactionCore.ValidateContainerReference(database, collection);
-            DistributedWriteTransactionCore.ValidateItemId(id);
             if (streamPayload == null)
             {
                 throw new ArgumentNullException(nameof(streamPayload));
@@ -263,7 +252,6 @@ namespace Microsoft.Azure.Cosmos
                     database: database,
                     container: collection,
                     partitionKey: partitionKey,
-                    id: id,
                     requestOptions: requestOptions)
                 {
                     ResourceStream = streamPayload

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/DistributedTransaction/DistributedTransactionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/DistributedTransaction/DistributedTransactionTests.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------
+// ------------------------------------------------------------
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // ------------------------------------------------------------
 
@@ -54,6 +54,37 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             await base.TestCleanup();
         }
 
+        [TestMethod]
+        [Description("CreateItem/UpsertItem extract the item id from the resource body and serialize it correctly.")]
+        public async Task CreateAndUpsert_IdlessOverloads_IdExtractedFromBody()
+        {
+            ToDoActivity createDoc = ToDoActivity.CreateRandomToDoActivity();
+            ToDoActivity upsertDoc = ToDoActivity.CreateRandomToDoActivity();
+
+            DistributedTransactionMockHandler handler = new DistributedTransactionMockHandler(
+                request => Task.FromResult(this.BuildMockResponse(HttpStatusCode.OK, BuildSuccessResponseJson(2))));
+
+            using CosmosClient client = this.CreateMockClient(handler);
+
+            DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
+                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(createDoc.pk), createDoc)
+                .UpsertItem(this.database.Id, this.container.Id, new PartitionKey(upsertDoc.pk), upsertDoc)
+                .CommitTransactionAsync(CancellationToken.None);
+
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            Assert.AreEqual(2, response.Count);
+
+            using JsonDocument requestJson = JsonDocument.Parse(handler.CapturedRequestBody);
+            JsonElement ops = requestJson.RootElement.GetProperty(DistributedTransactionSerializer.Operations);
+
+            Assert.AreEqual(createDoc.id, ops[0].GetProperty(DistributedTransactionSerializer.Id).GetString(),
+                "Create operation id must be extracted from the resource body.");
+            Assert.AreEqual(upsertDoc.id, ops[1].GetProperty(DistributedTransactionSerializer.Id).GetString(),
+                "Upsert operation id must be extracted from the resource body.");
+
+            response.Dispose();
+        }
+
         // Happy path scenarios
 
         [TestMethod]
@@ -69,8 +100,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             using CosmosClient client = this.CreateMockClient(handler);
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(doc1.pk), doc1.id, doc1)
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(doc2.pk), doc2.id, doc2)
+                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(doc1.pk), doc1)
+                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(doc2.pk), doc2)
                 .CommitTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
@@ -95,7 +126,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             using CosmosClient client = this.CreateMockClient(handler);
 
             await client.CreateDistributedWriteTransaction()
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(createDoc.pk), createDoc.id, createDoc)
+                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(createDoc.pk), createDoc)
                 .ReplaceItem(this.database.Id, this.container.Id, new PartitionKey(replaceDoc.pk), replaceDoc.id, replaceDoc)
                 .DeleteItem(this.database.Id, this.container.Id, new PartitionKey("delete-pk"), "delete-id")
                 .CommitTransactionAsync(CancellationToken.None);
@@ -122,8 +153,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             using CosmosClient client = this.CreateMockClient(handler);
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(createDoc.pk), createDoc.id, createDoc)
-                .UpsertItem(this.database.Id, this.container.Id, new PartitionKey(upsertDoc.pk), upsertDoc.id, upsertDoc)
+                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(createDoc.pk), createDoc)
+                .UpsertItem(this.database.Id, this.container.Id, new PartitionKey(upsertDoc.pk), upsertDoc)
                 .CommitTransactionAsync(CancellationToken.None);
 
             using JsonDocument requestJson = JsonDocument.Parse(handler.CapturedRequestBody);
@@ -149,7 +180,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             using CosmosClient client = this.CreateMockClient(handler);
 
             await client.CreateDistributedWriteTransaction()
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(createDoc.pk), createDoc.id, createDoc)
+                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(createDoc.pk), createDoc)
                 .PatchItem(this.database.Id, this.container.Id, new PartitionKey("patch-pk"), "item-to-patch", patchOps)
                 .CommitTransactionAsync(CancellationToken.None);
 
@@ -179,8 +210,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             using CosmosClient client = this.CreateMockClient(handler);
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(doc1.pk), doc1.id, doc1)
-                .CreateItem(this.database.Id, secondContainer.Id, new PartitionKey(doc2.pk), doc2.id, doc2)
+                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(doc1.pk), doc1)
+                .CreateItem(this.database.Id, secondContainer.Id, new PartitionKey(doc2.pk), doc2)
                 .CommitTransactionAsync(CancellationToken.None);
 
             using JsonDocument requestJson = JsonDocument.Parse(handler.CapturedRequestBody);
@@ -214,7 +245,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             ToDoActivity doc = ToDoActivity.CreateRandomToDoActivity();
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(doc.pk), doc.id, doc)
+                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(doc.pk), doc)
                 .CommitTransactionAsync(CancellationToken.None);
 
             Assert.AreNotEqual(Guid.Empty, response.IdempotencyToken, "Response must carry the idempotency token.");
@@ -236,9 +267,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             using CosmosClient client = this.CreateMockClient(handler);
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(doc1.pk), doc1.id, doc1)
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(doc2.pk), doc2.id, doc2)
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(doc3.pk), doc3.id, doc3)
+                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(doc1.pk), doc1)
+                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(doc2.pk), doc2)
+                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(doc3.pk), doc3)
                 .CommitTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(3, response.Count);
@@ -272,7 +303,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             using CosmosClient client = this.CreateMockClient(handler);
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(expectedDoc.pk), expectedDoc.id, expectedDoc)
+                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(expectedDoc.pk), expectedDoc)
                 .CommitTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(HttpStatusCode.Created, response[0].StatusCode);
@@ -309,7 +340,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             ToDoActivity doc = ToDoActivity.CreateRandomToDoActivity();
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(doc.pk), doc.id, doc)
+                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(doc.pk), doc)
                 .CommitTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(HttpStatusCode.Conflict, response.StatusCode);
@@ -369,8 +400,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             ToDoActivity doc2 = ToDoActivity.CreateRandomToDoActivity();
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(doc1.pk), doc1.id, doc1)
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(doc2.pk), doc2.id, doc2)
+                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(doc1.pk), doc1)
+                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(doc2.pk), doc2)
                 .CommitTransactionAsync(CancellationToken.None);
 
             // All results must be present regardless of partial failure
@@ -395,7 +426,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             using CosmosClient client = this.CreateMockClient(handler);
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(createDoc.pk), createDoc.id, createDoc)
+                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(createDoc.pk), createDoc)
                 .ReplaceItem(this.database.Id, this.container.Id, new PartitionKey(replaceDoc.pk), replaceDoc.id, replaceDoc)
                 .DeleteItem(this.database.Id, this.container.Id, new PartitionKey("delete-pk"), "delete-id")
                 .CommitTransactionAsync(CancellationToken.None);
@@ -596,7 +627,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             using CosmosClient client = this.CreateMockClient(handler);
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(createDoc.pk), createDoc.id, createDoc)
+                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(createDoc.pk), createDoc)
                 .ReplaceItem(this.database.Id, this.container.Id, new PartitionKey(replaceDoc.pk), replaceDoc.id, replaceDoc)
                 .CommitTransactionAsync(CancellationToken.None);
 
@@ -626,7 +657,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             using MemoryStream stream = new MemoryStream(docBytes);
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .CreateItemStream(this.database.Id, this.container.Id, new PartitionKey(doc.pk), doc.id, stream)
+                .CreateItemStream(this.database.Id, this.container.Id, new PartitionKey(doc.pk), stream)
                 .CommitTransactionAsync(CancellationToken.None);
 
             Assert.IsTrue(response.IsSuccessStatusCode);
@@ -713,7 +744,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             using MemoryStream stream = new MemoryStream(docBytes);
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .UpsertItemStream(this.database.Id, this.container.Id, new PartitionKey(doc.pk), doc.id, stream)
+                .UpsertItemStream(this.database.Id, this.container.Id, new PartitionKey(doc.pk), stream)
                 .CommitTransactionAsync(CancellationToken.None);
 
             Assert.IsTrue(response.IsSuccessStatusCode);
@@ -757,7 +788,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             ToDoActivity newDoc = ToDoActivity.CreateRandomToDoActivity();
             DistributedTransactionResponse dtcResponse = await dtcClient
                 .CreateDistributedWriteTransaction()
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(newDoc.pk), newDoc.id, newDoc)
+                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(newDoc.pk), newDoc)
                 .CommitTransactionAsync(this.cancellationToken);
 
             Assert.IsTrue(dtcResponse.IsSuccessStatusCode, "The simulated DTC commit should appear successful to the client.");
@@ -1026,3 +1057,4 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
     }
 }
+

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionSerializerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionSerializerTests.cs
@@ -36,12 +36,12 @@ namespace Microsoft.Azure.Cosmos.Tests
         // id field presence per operation type
 
         [TestMethod]
-        [Description("CreateItem sets id explicitly; 'id' must be present in the serialized JSON with the correct value.")]
+        [Description("CreateItem derives 'id' from the resource body; 'id' must be present in the serialized JSON with the correct value.")]
         public async Task CreateItem_SerializedBody_HasResourceBody_AndIdField()
         {
             const string itemId = "create-item";
             string capturedJson = await this.CaptureCommitBodyAsync(tx =>
-                tx.CreateItem(Database, Container, new PartitionKey("pk"), itemId, new TestItem(itemId)));
+                tx.CreateItem(Database, Container, new PartitionKey("pk"), new { id = itemId, value = "v" }));
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
             JsonElement op = doc.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
@@ -91,12 +91,12 @@ namespace Microsoft.Azure.Cosmos.Tests
         }
 
         [TestMethod]
-        [Description("UpsertItem sets id explicitly; 'id' must be present in the serialized JSON with the correct value.")]
+        [Description("UpsertItem derives 'id' from the resource body; 'id' must be present in the serialized JSON with the correct value.")]
         public async Task UpsertItem_SerializedBody_HasResourceBody_AndIdField()
         {
             const string itemId = "upsert-item";
             string capturedJson = await this.CaptureCommitBodyAsync(tx =>
-                tx.UpsertItem(Database, Container, new PartitionKey("pk"), itemId, new TestItem(itemId)));
+                tx.UpsertItem(Database, Container, new PartitionKey("pk"), new { id = itemId, value = "v" }));
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
             JsonElement op = doc.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
@@ -152,7 +152,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         public async Task CreateItem_SerializedBody_ResourceBodyIsValidJson()
         {
             string capturedJson = await this.CaptureCommitBodyAsync(tx =>
-                tx.CreateItem(Database, Container, new PartitionKey("pk"), "json-check", new TestItem("json-check")));
+                tx.CreateItem(Database, Container, new PartitionKey("pk"), new { id = "json-check", value = "v" }));
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
             JsonElement op = doc.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
@@ -172,10 +172,10 @@ namespace Microsoft.Azure.Cosmos.Tests
             IReadOnlyList<PatchOperation> patchOps = new[] { PatchOperation.Add("/value", "v") };
 
             string capturedJson = await this.CaptureCommitBodyAsync(tx =>
-                tx.CreateItem(Database, Container, new PartitionKey("pk"), "c", new TestItem("c"))
+                tx.CreateItem(Database, Container, new PartitionKey("pk"), new { id = "c", value = "v" })
                   .ReplaceItem(Database, Container, new PartitionKey("pk"), "r", new TestItem("r"))
                   .DeleteItem(Database, Container, new PartitionKey("pk"), "d")
-                  .UpsertItem(Database, Container, new PartitionKey("pk"), "u", new TestItem("u"))
+                  .UpsertItem(Database, Container, new PartitionKey("pk"), new { id = "u", value = "v" })
                   .PatchItem(Database, Container, new PartitionKey("pk"), "p", patchOps),
                 expectedResultCount: 5);
 
@@ -197,10 +197,10 @@ namespace Microsoft.Azure.Cosmos.Tests
             IReadOnlyList<PatchOperation> patchOps = new[] { PatchOperation.Add("/value", "v") };
 
             string capturedJson = await this.CaptureCommitBodyAsync(tx =>
-                tx.CreateItem(Database, Container, new PartitionKey("pk"), "c", new TestItem("c"))
+                tx.CreateItem(Database, Container, new PartitionKey("pk"), new { id = "c", value = "v" })
                   .ReplaceItem(Database, Container, new PartitionKey("pk"), "r", new TestItem("r"))
                   .DeleteItem(Database, Container, new PartitionKey("pk"), "d")
-                  .UpsertItem(Database, Container, new PartitionKey("pk"), "u", new TestItem("u"))
+                  .UpsertItem(Database, Container, new PartitionKey("pk"), new { id = "u", value = "v" })
                   .PatchItem(Database, Container, new PartitionKey("pk"), "p", patchOps),
                 expectedResultCount: 5);
 
@@ -245,14 +245,14 @@ namespace Microsoft.Azure.Cosmos.Tests
         // Stream operations
 
         [TestMethod]
-        [Description("CreateItemStream sets id explicitly; 'id' must be present in the serialized JSON with the correct value.")]
+        [Description("CreateItemStream derives 'id' from the JSON in the stream; 'id' must be present in the serialized JSON with the correct value.")]
         public async Task CreateItemStream_SerializedBody_HasResourceBody_AndIdField()
         {
             const string itemId = "test-id";
             byte[] docBytes = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(new TestItem(itemId)));
             using MemoryStream stream = new MemoryStream(docBytes);
             string capturedJson = await this.CaptureCommitBodyAsync(
-                tx => tx.CreateItemStream(Database, Container, new PartitionKey("pk"), itemId, stream));
+                tx => tx.CreateItemStream(Database, Container, new PartitionKey("pk"), stream));
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
             JsonElement op = doc.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
@@ -304,14 +304,14 @@ namespace Microsoft.Azure.Cosmos.Tests
         }
 
         [TestMethod]
-        [Description("UpsertItemStream sets id explicitly; 'id' must be present in the serialized JSON with the correct value.")]
+        [Description("UpsertItemStream derives 'id' from the JSON in the stream; 'id' must be present in the serialized JSON with the correct value.")]
         public async Task UpsertItemStream_SerializedBody_HasResourceBody_AndIdField()
         {
             const string itemId = "upsert-stream-id";
             byte[] docBytes = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(new TestItem(itemId)));
             using MemoryStream stream = new MemoryStream(docBytes);
             string capturedJson = await this.CaptureCommitBodyAsync(
-                tx => tx.UpsertItemStream(Database, Container, new PartitionKey("pk"), itemId, stream));
+                tx => tx.UpsertItemStream(Database, Container, new PartitionKey("pk"), stream));
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
             JsonElement op = doc.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
@@ -442,7 +442,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         public async Task Operations_WithoutIfMatchEtag_DoNotIncludeEtagField()
         {
             string capturedJson = await this.CaptureCommitBodyAsync(tx =>
-                tx.CreateItem(Database, Container, new PartitionKey("pk"), "create-no-etag", new TestItem("create-no-etag"))
+                tx.CreateItem(Database, Container, new PartitionKey("pk"), new { id = "create-no-etag", value = "v" })
                   .ReplaceItem(Database, Container, new PartitionKey("pk"), "replace-no-etag", new TestItem("replace-no-etag")),
                 expectedResultCount: 2);
 
@@ -456,42 +456,51 @@ namespace Microsoft.Azure.Cosmos.Tests
             }
         }
 
+        // id extraction from resource body
+
         [TestMethod]
-        [Description("CreateItem with a null id must throw ArgumentNullException at the call site.")]
-        public void CreateItem_NullId_ThrowsArgumentNullException()
+        [Description("UpsertItemStream extracts only the top-level 'id'; a nested object with its own 'id' must be ignored.")]
+        public async Task UpsertItemStream_NestedIdIgnored()
         {
-            DistributedWriteTransaction tx = new DistributedWriteTransactionCore(this.BuildContextSetup().Object);
-            Assert.ThrowsException<ArgumentNullException>(() =>
-                tx.CreateItem(Database, Container, new PartitionKey("pk"), id: null, new TestItem("body-id")));
+            const string itemId = "stream-upsert";
+            byte[] docBytes = Encoding.UTF8.GetBytes($@"{{""id"":""{itemId}"",""nested"":{{""id"":""nope""}}}}");
+
+            string capturedJson = await this.CaptureCommitBodyAsync(tx =>
+                tx.UpsertItemStream(Database, Container, new PartitionKey("pk"), new MemoryStream(docBytes)));
+
+            using JsonDocument doc = JsonDocument.Parse(capturedJson);
+            JsonElement op = doc.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
+
+            Assert.AreEqual(itemId, op.GetProperty(DistributedTransactionSerializer.Id).GetString(),
+                "Only the top-level 'id' should be extracted; nested 'id' must be ignored.");
         }
 
         [TestMethod]
-        [Description("UpsertItem with an empty id must throw ArgumentNullException at the call site.")]
-        public void UpsertItem_EmptyId_ThrowsArgumentNullException()
+        [DataRow(@"{""value"":1}")]
+        [DataRow(@"{""id"":""""}")]
+        [DataRow(@"{""id"":""   ""}")]
+        [Description("CreateItemStream throws ArgumentException at commit time when the body has a missing, empty, or whitespace-only 'id'.")]
+        public async Task CreateItemStream_InvalidBodyId_ThrowsAtCommit(string bodyJson)
         {
-            DistributedWriteTransaction tx = new DistributedWriteTransactionCore(this.BuildContextSetup().Object);
-            Assert.ThrowsException<ArgumentNullException>(() =>
-                tx.UpsertItem(Database, Container, new PartitionKey("pk"), id: string.Empty, new TestItem("body-id")));
+            using MemoryStream stream = new MemoryStream(Encoding.UTF8.GetBytes(bodyJson));
+            DistributedWriteTransaction tx = new DistributedWriteTransactionCore(this.BuildContextSetup().Object)
+                .CreateItemStream(Database, Container, new PartitionKey("pk"), stream);
+
+            await Assert.ThrowsExceptionAsync<ArgumentException>(() => tx.CommitTransactionAsync(CancellationToken.None));
         }
 
         [TestMethod]
-        [Description("CreateItemStream with a null id must throw ArgumentNullException at the call site.")]
-        public void CreateItemStream_NullId_ThrowsArgumentNullException()
+        [DataRow(@"{""value"":1}")]
+        [DataRow(@"{""id"":""""}")]
+        [DataRow(@"{""id"":""   ""}")]
+        [Description("UpsertItemStream throws ArgumentException at commit time when the body has a missing, empty, or whitespace-only 'id'.")]
+        public async Task UpsertItemStream_InvalidBodyId_ThrowsAtCommit(string bodyJson)
         {
-            DistributedWriteTransaction tx = new DistributedWriteTransactionCore(this.BuildContextSetup().Object);
-            using MemoryStream stream = new MemoryStream(Encoding.UTF8.GetBytes(@"{""value"":1}"));
-            Assert.ThrowsException<ArgumentNullException>(() =>
-                tx.CreateItemStream(Database, Container, new PartitionKey("pk"), id: null, stream));
-        }
+            using MemoryStream stream = new MemoryStream(Encoding.UTF8.GetBytes(bodyJson));
+            DistributedWriteTransaction tx = new DistributedWriteTransactionCore(this.BuildContextSetup().Object)
+                .UpsertItemStream(Database, Container, new PartitionKey("pk"), stream);
 
-        [TestMethod]
-        [Description("UpsertItemStream with a whitespace id must throw ArgumentNullException at the call site.")]
-        public void UpsertItemStream_WhitespaceId_ThrowsArgumentNullException()
-        {
-            DistributedWriteTransaction tx = new DistributedWriteTransactionCore(this.BuildContextSetup().Object);
-            using MemoryStream stream = new MemoryStream(Encoding.UTF8.GetBytes(@"{""value"":1}"));
-            Assert.ThrowsException<ArgumentNullException>(() =>
-                tx.UpsertItemStream(Database, Container, new PartitionKey("pk"), id: "   ", stream));
+            await Assert.ThrowsExceptionAsync<ArgumentException>(() => tx.CommitTransactionAsync(CancellationToken.None));
         }
 
         // Helpers

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedWriteTransactionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedWriteTransactionTests.cs
@@ -458,10 +458,9 @@ namespace Microsoft.Azure.Cosmos.Tests
 
         private sealed class TestItem
         {
-            [System.Text.Json.Serialization.JsonPropertyName("id")]
+            [Newtonsoft.Json.JsonProperty("id")]
             public string Id { get; set; }
 
-            [System.Text.Json.Serialization.JsonPropertyName("value")]
             public string Value { get; set; }
 
             public TestItem() : this(Guid.NewGuid().ToString()) { }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedWriteTransactionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedWriteTransactionTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             DistributedWriteTransaction tx = this.NewTransaction();
             Assert.ThrowsException<ArgumentNullException>(
-                () => tx.CreateItem(null, Container, new PartitionKey("pk"), "item-id", new TestItem()));
+                () => tx.CreateItem(null, Container, new PartitionKey("pk"), new TestItem()));
         }
 
         [TestMethod]
@@ -45,7 +45,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             DistributedWriteTransaction tx = this.NewTransaction();
             Assert.ThrowsException<ArgumentNullException>(
-                () => tx.CreateItem(Database, null, new PartitionKey("pk"), "item-id", new TestItem()));
+                () => tx.CreateItem(Database, null, new PartitionKey("pk"), new TestItem()));
         }
 
         [TestMethod]
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             DistributedWriteTransaction tx = this.NewTransaction();
             Assert.ThrowsException<ArgumentNullException>(
-                () => tx.CreateItem<TestItem>(Database, Container, new PartitionKey("pk"), "item-id", null));
+                () => tx.CreateItem<TestItem>(Database, Container, new PartitionKey("pk"), null));
         }
 
         [TestMethod]
@@ -93,7 +93,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             DistributedWriteTransaction tx = this.NewTransaction();
             Assert.ThrowsException<ArgumentNullException>(
-                () => tx.CreateItemStream(Database, Container, new PartitionKey("pk"), "item-id", null));
+                () => tx.CreateItemStream(Database, Container, new PartitionKey("pk"), (Stream)null));
         }
 
         [TestMethod]
@@ -117,7 +117,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             DistributedWriteTransaction tx = this.NewTransaction();
             Assert.ThrowsException<ArgumentNullException>(
-                () => tx.UpsertItemStream(Database, Container, new PartitionKey("pk"), "item-id", null));
+                () => tx.UpsertItemStream(Database, Container, new PartitionKey("pk"), (Stream)null));
         }
 
         // Request structure
@@ -151,7 +151,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                     });
 
             await new DistributedWriteTransactionCore(contextMock.Object)
-                .CreateItem(Database, Container, new PartitionKey("pk"), "item-id", new TestItem())
+                .CreateItem(Database, Container, new PartitionKey("pk"), new TestItem("item-id"))
                 .CommitTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(ResourceType.DistributedTransactionBatch, capturedResourceType);
@@ -187,7 +187,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                     });
 
             await new DistributedWriteTransactionCore(contextMock.Object)
-                .CreateItem(Database, Container, new PartitionKey("pk"), "item-id", new TestItem())
+                .CreateItem(Database, Container, new PartitionKey("pk"), new TestItem("item-id"))
                 .CommitTransactionAsync(CancellationToken.None);
 
             Assert.IsNotNull(capturedToken, "Idempotency token header must be set.");
@@ -227,7 +227,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                     });
 
             DistributedTransactionResponse response = await new DistributedWriteTransactionCore(contextMock.Object)
-                .CreateItem(Database, Container, new PartitionKey("pk"), "item-id", new TestItem())
+                .CreateItem(Database, Container, new PartitionKey("pk"), new TestItem("item-id"))
                 .CommitTransactionAsync(CancellationToken.None);
 
             Assert.AreNotEqual(Guid.Empty, response.IdempotencyToken, "Response must carry the idempotency token.");
@@ -262,7 +262,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                     });
 
             await new DistributedWriteTransactionCore(contextMock.Object)
-                .CreateItem(Database, Container, new PartitionKey("pk1"), "id1", new TestItem("id1"))
+                .CreateItem(Database, Container, new PartitionKey("pk1"), new TestItem("id1"))
                 .ReplaceItem(Database, Container, new PartitionKey("pk2"), "id2", new TestItem("id2"))
                 .DeleteItem(Database, Container, new PartitionKey("pk3"), "id3")
                 .CommitTransactionAsync(CancellationToken.None);
@@ -306,11 +306,11 @@ namespace Microsoft.Azure.Cosmos.Tests
                     });
 
             await new DistributedWriteTransactionCore(contextMock.Object)
-                .CreateItem(Database, Container, new PartitionKey("pk"), "create", new TestItem("create"))
+                .CreateItem(Database, Container, new PartitionKey("pk"), new TestItem("create"))
                 .ReplaceItem(Database, Container, new PartitionKey("pk"), "replace", new TestItem("replace"))
                 .DeleteItem(Database, Container, new PartitionKey("pk"), "delete")
                 .PatchItem(Database, Container, new PartitionKey("pk"), "patch", new[] { PatchOperation.Add("/value", "v") })
-                .UpsertItem(Database, Container, new PartitionKey("pk"), "upsert", new TestItem("upsert"))
+                .UpsertItem(Database, Container, new PartitionKey("pk"), new TestItem("upsert"))
                 .CommitTransactionAsync(CancellationToken.None);
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
@@ -351,8 +351,8 @@ namespace Microsoft.Azure.Cosmos.Tests
                 .ReturnsAsync(BuildSuccessResponse(2));
 
             DistributedTransactionResponse response = await new DistributedWriteTransactionCore(contextMock.Object)
-                .CreateItem(Database, Container, new PartitionKey("pk1"), "id1", new TestItem("id1"))
-                .CreateItem(Database, Container, new PartitionKey("pk2"), "id2", new TestItem("id2"))
+                .CreateItem(Database, Container, new PartitionKey("pk1"), new TestItem("id1"))
+                .CreateItem(Database, Container, new PartitionKey("pk2"), new TestItem("id2"))
                 .CommitTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
@@ -380,7 +380,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 .ReturnsAsync(BuildErrorResponse(HttpStatusCode.Conflict));
 
             DistributedTransactionResponse response = await new DistributedWriteTransactionCore(contextMock.Object)
-                .CreateItem(Database, Container, new PartitionKey("pk"), "item-id", new TestItem())
+                .CreateItem(Database, Container, new PartitionKey("pk"), new TestItem("item-id"))
                 .CommitTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(HttpStatusCode.Conflict, response.StatusCode);


### PR DESCRIPTION
# Pull Request Template

## Description

> Extension of PR [[Internal] DTS: Adds required document id to all DTS operations
](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5793).
To ensure consistency with Create/Upsert operations in other SDK flows, this PR implements a solution that extracts id from the resource body instead of having users provide it explicitly.

This pull request refactors how item IDs are handled in distributed transaction operations for Azure Cosmos DB. The main change is that the `id` for Create and Upsert operations is now automatically extracted from the resource body (the serialized JSON), rather than being passed explicitly as a parameter. This affects both the implementation and the public API, and is validated with new and updated tests.

**API and Behavior Changes:**

* The `CreateItem` and `UpsertItem` methods in `DistributedWriteTransaction` and their corresponding stream overloads no longer require the `id` parameter. Instead, the item's `id` is read directly from the serialized resource body or stream payload. [[1]](diffhunk://#diff-f9ec0d1444fc185a1ddc561a0187fd6c980277b524f5449eb50fd95ef9fe3887L27-L35) [[2]](diffhunk://#diff-f9ec0d1444fc185a1ddc561a0187fd6c980277b524f5449eb50fd95ef9fe3887L45-L53) [[3]](diffhunk://#diff-f9ec0d1444fc185a1ddc561a0187fd6c980277b524f5449eb50fd95ef9fe3887L154-L162) [[4]](diffhunk://#diff-f9ec0d1444fc185a1ddc561a0187fd6c980277b524f5449eb50fd95ef9fe3887L173-L181)

* The implementation in `DistributedTransactionOperation` now includes logic to extract the `id` property from the top-level JSON object in the resource body for Create and Upsert operations. If the `id` is missing or empty, an exception is thrown. [[1]](diffhunk://#diff-30fceb3d3e008bbde11f8dd7453a6dcef707a5452f9e235a858068b93dd5e1dbR9-R10) [[2]](diffhunk://#diff-30fceb3d3e008bbde11f8dd7453a6dcef707a5452f9e235a858068b93dd5e1dbR20-R21) [[3]](diffhunk://#diff-30fceb3d3e008bbde11f8dd7453a6dcef707a5452f9e235a858068b93dd5e1dbR82-R163)

**Codebase Refactoring:**

* All usages and overrides of `CreateItem` and `UpsertItem` in `DistributedWriteTransactionCore` and related classes have been updated to remove the `id` parameter and associated validation. [[1]](diffhunk://#diff-8a48a060b9de00cc81904d4a3f5c9fb0d7085b2688b4744a5269db93ff072b6eL30-L35) [[2]](diffhunk://#diff-8a48a060b9de00cc81904d4a3f5c9fb0d7085b2688b4744a5269db93ff072b6eL45) [[3]](diffhunk://#diff-8a48a060b9de00cc81904d4a3f5c9fb0d7085b2688b4744a5269db93ff072b6eL55-L60) [[4]](diffhunk://#diff-8a48a060b9de00cc81904d4a3f5c9fb0d7085b2688b4744a5269db93ff072b6eL73) [[5]](diffhunk://#diff-8a48a060b9de00cc81904d4a3f5c9fb0d7085b2688b4744a5269db93ff072b6eL223-L228) [[6]](diffhunk://#diff-8a48a060b9de00cc81904d4a3f5c9fb0d7085b2688b4744a5269db93ff072b6eL238) [[7]](diffhunk://#diff-8a48a060b9de00cc81904d4a3f5c9fb0d7085b2688b4744a5269db93ff072b6eL248-L253) [[8]](diffhunk://#diff-8a48a060b9de00cc81904d4a3f5c9fb0d7085b2688b4744a5269db93ff072b6eL266)

**Testing:**

* A new test verifies that the `id` is correctly extracted from the resource body for both Create and Upsert operations.

* Existing tests have been updated to use the new overloads (without the `id` parameter) and to validate the correct serialization of operations. [[1]](diffhunk://#diff-ab125ecaef08e5023deceb8459c3ae5e9dcb9b09d6291254200b8822f6c7fc9fL72-R104) [[2]](diffhunk://#diff-ab125ecaef08e5023deceb8459c3ae5e9dcb9b09d6291254200b8822f6c7fc9fL98-R129) [[3]](diffhunk://#diff-ab125ecaef08e5023deceb8459c3ae5e9dcb9b09d6291254200b8822f6c7fc9fL125-R157) [[4]](diffhunk://#diff-ab125ecaef08e5023deceb8459c3ae5e9dcb9b09d6291254200b8822f6c7fc9fL152-R183)
