### PR TITLE
[Internal] DTS: Adds partitionKeyRangeId to operation result to assemble valid session tokens in DTS

### DIFF
--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionCommitter.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionCommitter.cs
@@ -204,12 +204,6 @@ namespace Microsoft.Azure.Cosmos
                         continue;
                     }
 
-                    if (result.StatusCode == HttpStatusCode.NotFound
-                        && result.SubStatusCode == SubStatusCodes.ReadSessionNotAvailable)
-                    {
-                        continue;
-                    }
-
                     // SessionToken is already in canonical {pkRangeId}:{lsn} format, assembled by FromJson.
                     // Note: each SetSessionToken call acquires a write lock on the SessionContainer.
                     // For a future optimization, consider a batch-update API on ISessionContainer to

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionCommitter.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionCommitter.cs
@@ -193,10 +193,6 @@ namespace Microsoft.Azure.Cosmos
             for (int i = 0; i < response.Count; i++)
             {
                 DistributedTransactionOperationResult result = response[i];
-                if (result == null)
-                {
-                    continue;
-                }
 
                 DistributedTransactionOperation operation = null;
                 try

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionCommitter.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionCommitter.cs
@@ -181,10 +181,8 @@ namespace Microsoft.Azure.Cosmos
             // so that subsequent Session-consistency reads on the affected collections can use the latest token
             // without getting ReadSessionNotAvailable.
             //
-            // DTC spans multiple collections so the server embeds per-operation session
-            // tokens in the JSON body; those are already parsed into DistributedTransactionOperationResult.SessionToken,
-            // but we must explicitly push them into the SessionContainer.
-
+            // DTC spans multiple collections so the server embeds per-operation session tokens in the JSON body.
+            // DistributedTransactionOperationResult.FromJson assembles each token into canonical {pkRangeId}:{lsn} form.
             if (response == null || response.Count == 0 || serverRequest == null || sessionContainer == null)
             {
                 return;
@@ -195,49 +193,45 @@ namespace Microsoft.Azure.Cosmos
             for (int i = 0; i < response.Count; i++)
             {
                 DistributedTransactionOperationResult result = response[i];
-                DistributedTransactionOperation operation = serverRequest.Operations[result.Index];
-
-                if (string.IsNullOrEmpty(result.SessionToken) || string.IsNullOrEmpty(operation.CollectionResourceId))
+                DistributedTransactionOperation operation = null;
+                try
                 {
-                    continue;
-                }
+                    operation = serverRequest.Operations[result.Index];
 
-                if (result.StatusCode == HttpStatusCode.NotFound
-                    && result.SubStatusCode == SubStatusCodes.ReadSessionNotAvailable)
-                {
-                    continue;
-                }
-
-                // SessionContainer.SetSessionToken expects the token in {pkRangeId}:{lsn} format.
-                // The backend may send pkRangeId separately or the token may already be assembled.
-                string tokenForHeader = result.SessionToken;
-                if (tokenForHeader.IndexOf(':') < 0)
-                {
-                    // Token is LSN-only; we need pkRangeId to assemble the full format.
-                    if (string.IsNullOrWhiteSpace(result.PartitionKeyRangeId))
+                    if (string.IsNullOrEmpty(result.SessionToken) || string.IsNullOrEmpty(operation.CollectionResourceId))
                     {
-                        // Cannot form a valid session token without pkRangeId; silently skip merging
-                        // this operation's token but continue processing the rest of the response.
-                        DefaultTrace.TraceWarning(
-                            "DTC operation index {0} (collection {1}) returned LSN-only session token without partitionKeyRangeId; skipping session token merge.",
-                            result.Index,
-                            operation.CollectionResourceId);
                         continue;
                     }
 
-                    tokenForHeader = result.PartitionKeyRangeId + ":" + tokenForHeader;
+                    if (result.StatusCode == HttpStatusCode.NotFound
+                        && result.SubStatusCode == SubStatusCodes.ReadSessionNotAvailable)
+                    {
+                        continue;
+                    }
+
+                    // SessionToken is already in canonical {pkRangeId}:{lsn} format, assembled by FromJson.
+                    // Note: each SetSessionToken call acquires a write lock on the SessionContainer.
+                    // For a future optimization, consider a batch-update API on ISessionContainer to
+                    // reduce lock acquisitions when multiple operations target the same collection.
+                    headers.Clear();
+                    headers[HttpConstants.HttpHeaders.SessionToken] = result.SessionToken;
+
+                    sessionContainer.SetSessionToken(
+                        operation.CollectionResourceId,
+                        DistributedTransactionConstants.GetCollectionFullName(operation.Database, operation.Container),
+                        headers);
                 }
-
-                // Note: each SetSessionToken call acquires a write lock on the SessionContainer.
-                // For a future optimization, consider a batch-update API on ISessionContainer to
-                // reduce lock acquisitions when multiple operations target the same collection.
-                headers.Clear();
-                headers[HttpConstants.HttpHeaders.SessionToken] = tokenForHeader;
-
-                sessionContainer.SetSessionToken(
-                    operation.CollectionResourceId,
-                    DistributedTransactionConstants.GetCollectionFullName(operation.Database, operation.Container),
-                    headers);
+                catch (Exception ex)
+                {
+                    // Session-token bookkeeping must never fail a transaction the server already committed.
+                    // Log and continue so the remaining operations' tokens are still attempted.
+                    DefaultTrace.TraceWarning(
+                        "DTC session token merge failed for operation index {0} (collection {1}): [{2}] {3}",
+                        result.Index,
+                        operation?.CollectionResourceId ?? "<unknown>",
+                        ex.GetType().Name,
+                        ex.Message);
+                }
             }
         }
     }

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionCommitter.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionCommitter.cs
@@ -208,11 +208,31 @@ namespace Microsoft.Azure.Cosmos
                     continue;
                 }
 
+                // SessionContainer.SetSessionToken expects the token in {pkRangeId}:{lsn} format.
+                // The backend may send pkRangeId separately or the token may already be assembled.
+                string tokenForHeader = result.SessionToken;
+                if (tokenForHeader.IndexOf(':') < 0)
+                {
+                    // Token is LSN-only; we need pkRangeId to assemble the full format.
+                    if (string.IsNullOrWhiteSpace(result.PartitionKeyRangeId))
+                    {
+                        // Cannot form a valid session token without pkRangeId; silently skip merging
+                        // this operation's token but continue processing the rest of the response.
+                        DefaultTrace.TraceWarning(
+                            "DTC operation index {0} (collection {1}) returned LSN-only session token without partitionKeyRangeId; skipping session token merge.",
+                            result.Index,
+                            operation.CollectionResourceId);
+                        continue;
+                    }
+
+                    tokenForHeader = result.PartitionKeyRangeId + ":" + tokenForHeader;
+                }
+
                 // Note: each SetSessionToken call acquires a write lock on the SessionContainer.
                 // For a future optimization, consider a batch-update API on ISessionContainer to
                 // reduce lock acquisitions when multiple operations target the same collection.
                 headers.Clear();
-                headers[HttpConstants.HttpHeaders.SessionToken] = result.SessionToken;
+                headers[HttpConstants.HttpHeaders.SessionToken] = tokenForHeader;
 
                 sessionContainer.SetSessionToken(
                     operation.CollectionResourceId,

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionCommitter.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionCommitter.cs
@@ -193,6 +193,11 @@ namespace Microsoft.Azure.Cosmos
             for (int i = 0; i < response.Count; i++)
             {
                 DistributedTransactionOperationResult result = response[i];
+                if (result == null)
+                {
+                    continue;
+                }
+
                 DistributedTransactionOperation operation = null;
                 try
                 {
@@ -221,7 +226,7 @@ namespace Microsoft.Azure.Cosmos
                         DistributedTransactionConstants.GetCollectionFullName(operation.Database, operation.Container),
                         headers);
                 }
-                catch (Exception ex)
+                catch (Exception ex) when (ex is not OperationCanceledException)
                 {
                     // Session-token bookkeeping must never fail a transaction the server already committed.
                     // Log and continue so the remaining operations' tokens are still attempted.

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperationResult.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperationResult.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Azure.Cosmos
     using System.Net;
     using System.Text.Json;
     using System.Text.Json.Serialization;
+    using Microsoft.Azure.Cosmos.Core.Trace;
     using Microsoft.Azure.Cosmos.Tracing;
     using Microsoft.Azure.Documents;
 
@@ -91,9 +92,7 @@ namespace Microsoft.Azure.Cosmos
         public virtual string SessionToken { get; internal set; }
 
         /// <summary>
-        /// Gets the partition key range ID associated with the operation result.
-        /// When present, it is combined with <see cref="SessionToken"/> to form the
-        /// full session token in the format {partitionKeyRangeId}:{lsn}.
+        /// Gets the raw partition key range ID emitted by the server.
         /// </summary>
         [JsonInclude]
         [JsonPropertyName("partitionKeyRangeId")]
@@ -145,7 +144,7 @@ namespace Microsoft.Azure.Cosmos
         /// Creates a <see cref="DistributedTransactionOperationResult"/> from a JSON element.
         /// </summary>
         /// <param name="json">The JSON element containing the operation result.</param>
-        /// <returns>The deserialized operation result.</returns>
+        /// <returns>The deserialized operation result with a canonical session token.</returns>
         internal static DistributedTransactionOperationResult FromJson(JsonElement json)
         {
             DistributedTransactionOperationResult result = JsonSerializer.Deserialize<DistributedTransactionOperationResult>(json, DistributedTransactionOperationResult.CaseInsensitiveOptions);
@@ -162,6 +161,27 @@ namespace Microsoft.Azure.Cosmos
 
                 byte[] bytes = JsonSerializer.SerializeToUtf8Bytes(resourceBody);
                 result.ResourceStream = new MemoryStream(bytes, 0, bytes.Length, writable: false, publiclyVisible: true);
+            }
+
+            if (!string.IsNullOrEmpty(result.SessionToken))
+            {
+                // TODO(issue#5857): Remove null check once the coordinator starts emitting pkRangeId.
+                if (result.PartitionKeyRangeId == null)
+                {
+                    DefaultTrace.TraceWarning(
+                        "DTC operation index {0} returned session token without partitionKeyRangeId; session token will not be merged into the session container.",
+                        result.Index);
+                    result.SessionToken = null;
+                }
+                else if (string.IsNullOrWhiteSpace(result.PartitionKeyRangeId))
+                {
+                    throw new InvalidOperationException(
+                        $"DTC operation index {result.Index} returned an empty or whitespace partitionKeyRangeId; cannot assemble a valid session token.");
+                }
+                else
+                {
+                    result.SessionToken = result.PartitionKeyRangeId + ":" + result.SessionToken;
+                }
             }
 
             return result;

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperationResult.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperationResult.cs
@@ -35,6 +35,7 @@ namespace Microsoft.Azure.Cosmos
             this.ETag = other.ETag;
             this.ResourceStream = other.ResourceStream;
             this.SessionToken = other.SessionToken;
+            this.PartitionKeyRangeId = other.PartitionKeyRangeId;
             this.RequestCharge = other.RequestCharge;
             this.ActivityId = other.ActivityId;
             this.Trace = other.Trace;
@@ -88,6 +89,15 @@ namespace Microsoft.Azure.Cosmos
         [JsonInclude]
         [JsonPropertyName("sessionToken")]
         public virtual string SessionToken { get; internal set; }
+
+        /// <summary>
+        /// Gets the partition key range ID associated with the operation result.
+        /// When present, it is combined with <see cref="SessionToken"/> to form the
+        /// full session token in the format {partitionKeyRangeId}:{lsn}.
+        /// </summary>
+        [JsonInclude]
+        [JsonPropertyName("partitionKeyRangeId")]
+        public virtual string PartitionKeyRangeId { get; internal set; }
 
         /// <summary>
         /// Gets the resource stream associated with the operation result.

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperationResult.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperationResult.cs
@@ -147,7 +147,8 @@ namespace Microsoft.Azure.Cosmos
         /// <returns>The deserialized operation result with a canonical session token.</returns>
         internal static DistributedTransactionOperationResult FromJson(JsonElement json)
         {
-            DistributedTransactionOperationResult result = JsonSerializer.Deserialize<DistributedTransactionOperationResult>(json, DistributedTransactionOperationResult.CaseInsensitiveOptions);
+            DistributedTransactionOperationResult result = JsonSerializer.Deserialize<DistributedTransactionOperationResult>(json, DistributedTransactionOperationResult.CaseInsensitiveOptions)
+                ?? throw new JsonException($"Failed to deserialize DTC operation result: Deserialize returned null. JSON element kind: '{json.ValueKind}'.");
 
             if (json.TryGetProperty(DistributedTransactionSerializer.ResourceBody, out JsonElement resourceBody)
                 && resourceBody.ValueKind != JsonValueKind.Undefined
@@ -163,9 +164,13 @@ namespace Microsoft.Azure.Cosmos
                 result.ResourceStream = new MemoryStream(bytes, 0, bytes.Length, writable: false, publiclyVisible: true);
             }
 
-            if (!string.IsNullOrEmpty(result.SessionToken))
+            if (!string.IsNullOrWhiteSpace(result.SessionToken))
             {
-                if (!string.IsNullOrWhiteSpace(result.PartitionKeyRangeId))
+                if (result.SessionToken.IndexOf(':') >= 0)
+                {
+                    // Already in canonical {pkRangeId}:{lsn} form — leave as-is.
+                }
+                else if (!string.IsNullOrWhiteSpace(result.PartitionKeyRangeId))
                 {
                     result.SessionToken = result.PartitionKeyRangeId + ":" + result.SessionToken;
                 }
@@ -177,6 +182,11 @@ namespace Microsoft.Azure.Cosmos
                         result.PartitionKeyRangeId ?? "<absent>");
                     result.SessionToken = null;
                 }
+            }
+            else if (result.SessionToken != null)
+            {
+                // Normalize whitespace-only to null so downstream guards don't need to recheck.
+                result.SessionToken = null;
             }
 
             return result;

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperationResult.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperationResult.cs
@@ -165,22 +165,17 @@ namespace Microsoft.Azure.Cosmos
 
             if (!string.IsNullOrEmpty(result.SessionToken))
             {
-                // TODO(issue#5857): Remove null check once the coordinator starts emitting pkRangeId.
-                if (result.PartitionKeyRangeId == null)
+                if (!string.IsNullOrWhiteSpace(result.PartitionKeyRangeId))
                 {
-                    DefaultTrace.TraceWarning(
-                        "DTC operation index {0} returned session token without partitionKeyRangeId; session token will not be merged into the session container.",
-                        result.Index);
-                    result.SessionToken = null;
-                }
-                else if (string.IsNullOrWhiteSpace(result.PartitionKeyRangeId))
-                {
-                    throw new InvalidOperationException(
-                        $"DTC operation index {result.Index} returned an empty or whitespace partitionKeyRangeId; cannot assemble a valid session token.");
+                    result.SessionToken = result.PartitionKeyRangeId + ":" + result.SessionToken;
                 }
                 else
                 {
-                    result.SessionToken = result.PartitionKeyRangeId + ":" + result.SessionToken;
+                    DefaultTrace.TraceWarning(
+                        "DTC operation index {0} returned session token without a valid partitionKeyRangeId (value: '{1}'); session token will not be merged into the session container.",
+                        result.Index,
+                        result.PartitionKeyRangeId ?? "<absent>");
+                    result.SessionToken = null;
                 }
             }
 

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperationResult.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperationResult.cs
@@ -166,7 +166,8 @@ namespace Microsoft.Azure.Cosmos
 
             if (!string.IsNullOrWhiteSpace(result.SessionToken))
             {
-                if (result.SessionToken.IndexOf(':') >= 0)
+                int colonIndex = result.SessionToken.IndexOf(':');
+                if (colonIndex > 0 && colonIndex < result.SessionToken.Length - 1)
                 {
                     // Already in canonical {pkRangeId}:{lsn} form — leave as-is.
                 }

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionSerializer.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionSerializer.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Azure.Cosmos
         internal const string Index = "index";
         internal const string ResourceBody = "resourceBody";
         internal const string SessionToken = "sessionToken";
+        internal const string PartitionKeyRangeId = "partitionKeyRangeId";
         internal const string ETag = "ifMatch";
         internal const string OperationType = "operationType";
         internal const string ResourceType = "resourceType";

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/DistributedTransaction/DistributedTransactionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/DistributedTransaction/DistributedTransactionTests.cs
@@ -732,16 +732,26 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         // Session token handling
 
         [TestMethod]
-        [Description("Session tokens returned in DTC operation responses are merged into the client's session container, preventing ReadSessionNotAvailable errors on subsequent reads.")]
+        [Description("When DTC response carries a session token in the new wire format (LSN-only sessionToken + " +
+            "separate partitionKeyRangeId), the SDK assembles the canonical {pkRangeId}:{lsn} token and merges it " +
+            "into the session container so that subsequent Session-consistency reads succeed.")]
         public async Task ValidateSessionTokenMergedIntoDtcClient()
         {
             ToDoActivity seedDoc = ToDoActivity.CreateRandomToDoActivity();
             ItemResponse<ToDoActivity> seedResponse = await this.container.CreateItemAsync(seedDoc, new PartitionKey(seedDoc.pk), cancellationToken: this.cancellationToken);
 
-            string validSessionToken = seedResponse.Headers.Session;
-            Assert.IsFalse(string.IsNullOrEmpty(validSessionToken), "A valid session token must be obtained from the emulator for this test to be meaningful.");
+            string canonicalToken = seedResponse.Headers.Session;
+            Assert.IsFalse(string.IsNullOrEmpty(canonicalToken), "A valid session token must be obtained from the emulator for this test to be meaningful.");
 
-            string dtcMockResponse = $@"{{""operationResponses"":[{{""index"":0,""statusCode"":201,""sessionToken"":""{validSessionToken}""}}]}}";
+            // Split the canonical {pkRangeId}:{lsn} token into the two fields the DTC endpoint sends.
+            int colonIndex = canonicalToken.IndexOf(':');
+            Assert.IsTrue(colonIndex > 0, $"Emulator session token '{canonicalToken}' must be in {{pkRangeId}}:{{lsn}} format.");
+            string pkRangeId = canonicalToken.Substring(0, colonIndex);
+            string lsnOnly = canonicalToken.Substring(colonIndex + 1);
+
+            // Build a DTC mock response using the new wire contract: LSN-only in sessionToken,
+            // pkRangeId in a separate partitionKeyRangeId field.
+            string dtcMockResponse = $@"{{""operationResponses"":[{{""index"":0,""statusCode"":201,""sessionToken"":""{lsnOnly}"",""partitionKeyRangeId"":""{pkRangeId}""}}]}}";
 
             DistributedTransactionMockHandler handler = new DistributedTransactionMockHandler(
                 request => Task.FromResult(this.BuildMockResponse(HttpStatusCode.OK, dtcMockResponse)));
@@ -754,13 +764,17 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     ConsistencyLevel = Cosmos.ConsistencyLevel.Session,
                 });
 
-            ToDoActivity newDoc = ToDoActivity.CreateRandomToDoActivity();
+            // Use the same partition key as seedDoc so the DTC operation targets the same physical
+            // partition whose session token is carried in the mock response.
+            ToDoActivity newDoc = ToDoActivity.CreateRandomToDoActivity(pk: seedDoc.pk);
             DistributedTransactionResponse dtcResponse = await dtcClient
                 .CreateDistributedWriteTransaction()
                 .CreateItem(this.database.Id, this.container.Id, new PartitionKey(newDoc.pk), newDoc.id, newDoc)
                 .CommitTransactionAsync(this.cancellationToken);
 
             Assert.IsTrue(dtcResponse.IsSuccessStatusCode, "The simulated DTC commit should appear successful to the client.");
+            Assert.AreEqual(canonicalToken, dtcResponse[0].SessionToken,
+                "SessionToken must be assembled as {pkRangeId}:{lsn} from the two separate wire fields.");
 
             Container dtcContainer = dtcClient.GetContainer(this.database.Id, this.container.Id);
             try
@@ -782,6 +796,53 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     "ReadSessionNotAvailable (404/1002). This indicates that session token " +
                     "merging in DistributedTransactionCommitter is broken.");
             }
+        }
+
+        [TestMethod]
+        [Description("When DTC response carries only an LSN-only sessionToken with no partitionKeyRangeId " +
+            "(current server behavior before coordinator update), the commit must succeed without throwing " +
+            "and the SDK silently skips merging the session token rather than crashing.")]
+        // TODO(issue#5857): Remove this test once the coordinator is updated to emit partitionKeyRangeId and the SDK no longer needs to handle its absence.
+        public async Task ValidateSessionTokenSkipped_WhenPartitionKeyRangeIdAbsent()
+        {
+            ToDoActivity seedDoc = ToDoActivity.CreateRandomToDoActivity();
+            ItemResponse<ToDoActivity> seedResponse = await this.container.CreateItemAsync(seedDoc, new PartitionKey(seedDoc.pk), cancellationToken: this.cancellationToken);
+
+            string canonicalToken = seedResponse.Headers.Session;
+            Assert.IsFalse(string.IsNullOrEmpty(canonicalToken), "A valid session token must be obtained from the emulator.");
+            int colonIndex = canonicalToken.IndexOf(':');
+            Assert.IsTrue(colonIndex > 0, $"Emulator session token '{canonicalToken}' must be in {{pkRangeId}}:{{lsn}} format.");
+            string lsnOnly = canonicalToken.Substring(colonIndex + 1);
+
+            // Current server behavior: LSN-only token, no partitionKeyRangeId field.
+            string dtcMockResponse = $@"{{""operationResponses"":[{{""index"":0,""statusCode"":201,""sessionToken"":""{lsnOnly}""}}]}}";
+
+            DistributedTransactionMockHandler handler = new DistributedTransactionMockHandler(
+                request => Task.FromResult(this.BuildMockResponse(HttpStatusCode.OK, dtcMockResponse)));
+
+            using CosmosClient dtcClient = TestCommon.CreateCosmosClient(
+                clientOptions: new CosmosClientOptions
+                {
+                    CustomHandlers = { handler },
+                    ConnectionMode = ConnectionMode.Gateway,
+                    ConsistencyLevel = Cosmos.ConsistencyLevel.Session,
+                });
+
+            // Use the same partition key as seedDoc for consistency.
+            ToDoActivity newDoc = ToDoActivity.CreateRandomToDoActivity(pk: seedDoc.pk);
+            DistributedTransactionResponse dtcResponse = await dtcClient
+                .CreateDistributedWriteTransaction()
+                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(newDoc.pk), newDoc.id, newDoc)
+                .CommitTransactionAsync(this.cancellationToken);
+
+            // Commit must succeed — this was the crash point before the fix (IndexOutOfRangeException
+            // in SessionContainer.SetSessionToken when it tried tokenParts[1] on an LSN-only token).
+            Assert.IsTrue(dtcResponse.IsSuccessStatusCode, "Commit must succeed even when partitionKeyRangeId is absent.");
+
+            // Session token must be null — FromJson nulls it out when pkRangeId is absent so that
+            // MergeSessionTokens skips the operation rather than passing a bad token to SetSessionToken.
+            Assert.IsNull(dtcResponse[0].SessionToken,
+                "SessionToken must be null when partitionKeyRangeId is absent; the SDK silently skips merging.");
         }
 
         // Read Transaction Tests

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionCommitterTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionCommitterTests.cs
@@ -631,6 +631,46 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
         }
 
+        [TestMethod]
+        [Description("When SetSessionToken throws OperationCanceledException, the exception must propagate — it must not be swallowed by the MergeSessionTokens catch block.")]
+        public async Task CommitTransactionAsync_PropagatesOperationCanceledException_FromSetSessionToken()
+        {
+            const string lsnOnly = "1#9#4=8#5=7";
+            const string pkRangeId = "0";
+
+            Mock<ISessionContainer> mockSessionContainer = new Mock<ISessionContainer>();
+            mockSessionContainer
+                .Setup(s => s.SetSessionToken(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<INameValueCollection>()))
+                .Throws(new OperationCanceledException("simulated cancellation in SetSessionToken"));
+
+            Mock<CosmosClientContext> mockContext = this.CreateMockContext(
+                mockSessionContainer.Object,
+                responseContent: BuildDtcResponseJson(
+                    new[] { (statusCode: 201, subStatusCode: (int?)null, sessionToken: lsnOnly, partitionKeyRangeId: pkRangeId) }),
+                statusCode: HttpStatusCode.OK);
+
+            List<DistributedTransactionOperation> operations = new List<DistributedTransactionOperation>
+            {
+                new DistributedTransactionOperation(
+                    OperationType.Create,
+                    operationIndex: 0,
+                    DatabaseName,
+                    ContainerName,
+                    new PartitionKey("pk1"),
+                    id: "doc1")
+            };
+
+            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
+                operations, mockContext.Object);
+
+            await Assert.ThrowsExceptionAsync<OperationCanceledException>(
+                () => committer.CommitTransactionAsync(CancellationToken.None),
+                "OperationCanceledException from SetSessionToken must propagate, not be swallowed.");
+        }
+
 
         [TestMethod]
         [Description("Verifies that a commit succeeds without retrying when the server returns a success response on the first attempt.")]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionCommitterTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionCommitterTests.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
 {
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.IO;
     using System.Linq;
     using System.Net;
@@ -13,6 +14,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Common;
+    using Microsoft.Azure.Cosmos.Core.Trace;
     using Microsoft.Azure.Cosmos.Tests;
     using Microsoft.Azure.Cosmos.Tracing;
     using Microsoft.Azure.Documents;
@@ -37,12 +39,14 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
         [Description("Verifies that when the DTC response carries a session token, the token is merged into the SessionContainer")]
         public async Task CommitTransactionAsync_MergesSessionTokensIntoSessionContainer()
         {
-            const string sessionToken = "0:1#9#4=8#5=7";
+            const string lsnOnly = "1#9#4=8#5=7";
+            const string pkRangeId = "0";
+            const string expectedToken = "0:1#9#4=8#5=7";
 
             SessionContainer sessionContainer = new SessionContainer("testhost");
 
             string responseJson = BuildDtcResponseJson(
-                new[] { (statusCode: 201, sessionToken) });
+                new[] { (statusCode: 201, subStatusCode: (int?)null, sessionToken: lsnOnly, partitionKeyRangeId: pkRangeId) });
 
             Mock<CosmosClientContext> mockContext = this.CreateMockContext(
                 sessionContainer,
@@ -66,8 +70,8 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             await committer.CommitTransactionAsync(CancellationToken.None);
 
             string storedToken = sessionContainer.GetSessionToken(DistributedTransactionConstants.GetCollectionFullName(DatabaseName, ContainerName));
-            Assert.AreEqual(sessionToken, storedToken,
-                "Session token should be merged into SessionContainer after a successful DTC commit.");
+            Assert.AreEqual(expectedToken, storedToken,
+                "Session token should be assembled as {pkRangeId}:{lsn} and merged into SessionContainer after a successful DTC commit.");
         }
 
         [TestMethod]
@@ -108,7 +112,9 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
         [Description("Verifies that the correct collectionRid and collectionFullname are passed to SetSessionToken for each operation")]
         public async Task CommitTransactionAsync_PassesCorrectCollectionToSetSessionToken()
         {
-            const string sessionToken = "0:1#5#4=3";
+            const string lsnOnly = "1#5#4=3";
+            const string pkRangeId = "0";
+            const string assembledToken = "0:1#5#4=3";
             const string container2 = "testcontainer2";
 
             string collectionRid1 = ResourceId.NewDocumentCollectionId(42, 129).DocumentCollectionId.ToString();
@@ -146,8 +152,8 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                     Encoding.UTF8.GetBytes(BuildDtcResponseJson(
                         new[]
                         {
-                            (statusCode: 200, sessionToken),
-                            (statusCode: 200, sessionToken),
+                            (statusCode: 200, subStatusCode: (int?)null, sessionToken: lsnOnly, partitionKeyRangeId: pkRangeId),
+                            (statusCode: 200, subStatusCode: (int?)null, sessionToken: lsnOnly, partitionKeyRangeId: pkRangeId),
                         })))
             };
             mockContext.Setup(c => c.ProcessResourceOperationStreamAsync(
@@ -192,7 +198,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                 s => s.SetSessionToken(
                     collectionRid1,
                    DistributedTransactionConstants.GetCollectionFullName(DatabaseName, ContainerName),
-                    It.Is<INameValueCollection>(h => h[HttpConstants.HttpHeaders.SessionToken] == sessionToken)),
+                    It.Is<INameValueCollection>(h => h[HttpConstants.HttpHeaders.SessionToken] == assembledToken)),
                 Times.Once,
                 "SetSessionToken should be called for the first operation with its collection RID and fullname.");
 
@@ -200,7 +206,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                 s => s.SetSessionToken(
                     collectionRid2,
                     DistributedTransactionConstants.GetCollectionFullName(DatabaseName, container2),
-                    It.Is<INameValueCollection>(h => h[HttpConstants.HttpHeaders.SessionToken] == sessionToken)),
+                    It.Is<INameValueCollection>(h => h[HttpConstants.HttpHeaders.SessionToken] == assembledToken)),
                 Times.Once,
                 "SetSessionToken should be called for the second operation with its collection RID and fullname.");
         }
@@ -245,13 +251,15 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
         public async Task CommitTransactionAsync_MergesSessionTokens_OnFailureResponse()
         {
             // Deliberately distinct from the success-path token so a copy-paste regression would be caught.
-            const string sessionToken = "0:1#3#4=2#5=1";
+            const string lsnOnly = "1#3#4=2#5=1";
+            const string pkRangeId = "0";
+            const string expectedToken = "0:1#3#4=2#5=1";
 
             SessionContainer sessionContainer = new SessionContainer("testhost");
 
             Mock<CosmosClientContext> mockContext = this.CreateMockContext(
                 sessionContainer,
-                responseContent: BuildDtcResponseJson(new[] { (statusCode: 409, sessionToken) }),
+                responseContent: BuildDtcResponseJson(new[] { (statusCode: 409, subStatusCode: (int?)null, sessionToken: lsnOnly, partitionKeyRangeId: pkRangeId) }),
                 statusCode: HttpStatusCode.Conflict);
 
             List<DistributedTransactionOperation> operations = new List<DistributedTransactionOperation>
@@ -271,7 +279,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             DistributedTransactionResponse response = await committer.CommitTransactionAsync(CancellationToken.None);
 
             string storedToken = sessionContainer.GetSessionToken(DistributedTransactionConstants.GetCollectionFullName(DatabaseName, ContainerName));
-            Assert.AreEqual(sessionToken, storedToken,
+            Assert.AreEqual(expectedToken, storedToken,
                 "Session token should still be merged even when the DTC response indicates a failure.");
         }
 
@@ -315,14 +323,14 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
         }
 
         [TestMethod]
-        [Description("When session token is LSN-only and partitionKeyRangeId is absent, merge is silently skipped")]
+        [Description("When partitionKeyRangeId is absent, merge is silently skipped")]
         public async Task CommitTransactionAsync_SkipsMerge_WhenLsnOnlyAndPartitionKeyRangeIdIsAbsent()
         {
             const string lsnOnly = "1#9#4=8#5=7";
 
             SessionContainer sessionContainer = new SessionContainer("testhost");
 
-            // No partitionKeyRangeId, and sessionToken has no ':' (LSN-only)
+            // No partitionKeyRangeId; session token is LSN-only (as always returned by the endpoint)
             string responseJson = BuildDtcResponseJson(
                 new[] { (statusCode: 201, subStatusCode: (int?)null, sessionToken: lsnOnly, partitionKeyRangeId: (string)null) });
 
@@ -349,91 +357,18 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
 
             string storedToken = sessionContainer.GetSessionToken(DistributedTransactionConstants.GetCollectionFullName(DatabaseName, ContainerName));
             Assert.IsTrue(string.IsNullOrEmpty(storedToken),
-                "SessionContainer should not be updated when partitionKeyRangeId is absent and session token is LSN-only.");
+                "SessionContainer should not be updated when partitionKeyRangeId is absent.");
         }
 
-        [TestMethod]
-        [Description("When session token already contains ':' (fully assembled), it is used as-is even without partitionKeyRangeId")]
-        public async Task CommitTransactionAsync_UsesPreAssembledSessionToken_WhenAlreadyContainsColon()
-        {
-            const string preAssembledToken = "0:1#9#4=8#5=7";
-
-            SessionContainer sessionContainer = new SessionContainer("testhost");
-
-            // Token already contains ':', so no pkRangeId needed
-            string responseJson = BuildDtcResponseJson(
-                new[] { (statusCode: 201, subStatusCode: (int?)null, sessionToken: preAssembledToken, partitionKeyRangeId: (string)null) });
-
-            Mock<CosmosClientContext> mockContext = this.CreateMockContext(
-                sessionContainer,
-                responseContent: responseJson,
-                statusCode: HttpStatusCode.OK);
-
-            List<DistributedTransactionOperation> operations = new List<DistributedTransactionOperation>
-            {
-                new DistributedTransactionOperation(
-                    OperationType.Create,
-                    operationIndex: 0,
-                    DatabaseName,
-                    ContainerName,
-                    new PartitionKey("pk1"),
-                    id: "doc1")
-            };
-
-            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
-                operations, mockContext.Object);
-
-            await committer.CommitTransactionAsync(CancellationToken.None);
-
-            string storedToken = sessionContainer.GetSessionToken(DistributedTransactionConstants.GetCollectionFullName(DatabaseName, ContainerName));
-            Assert.AreEqual(preAssembledToken, storedToken,
-                "Pre-assembled session token (with ':') should be used as-is.");
-        }
-
-        [TestMethod]
-        [Description("When session token already contains ':' AND partitionKeyRangeId is also present, the pre-assembled token takes precedence")]
-        public async Task CommitTransactionAsync_PreAssembledTokenTakesPrecedence_WhenBothTokenAndPartitionKeyRangeIdPresent()
-        {
-            const string preAssembledToken = "0:1#9#4=8#5=7";
-            const string differentPkRangeId = "5"; // would produce "5:1#9#4=8#5=7" if incorrectly used
-
-            SessionContainer sessionContainer = new SessionContainer("testhost");
-
-            string responseJson = BuildDtcResponseJson(
-                new[] { (statusCode: 201, subStatusCode: (int?)null, sessionToken: preAssembledToken, partitionKeyRangeId: differentPkRangeId) });
-
-            Mock<CosmosClientContext> mockContext = this.CreateMockContext(
-                sessionContainer,
-                responseContent: responseJson,
-                statusCode: HttpStatusCode.OK);
-
-            List<DistributedTransactionOperation> operations = new List<DistributedTransactionOperation>
-            {
-                new DistributedTransactionOperation(
-                    OperationType.Create,
-                    operationIndex: 0,
-                    DatabaseName,
-                    ContainerName,
-                    new PartitionKey("pk1"),
-                    id: "doc1")
-            };
-
-            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
-                operations, mockContext.Object);
-
-            await committer.CommitTransactionAsync(CancellationToken.None);
-
-            string storedToken = sessionContainer.GetSessionToken(DistributedTransactionConstants.GetCollectionFullName(DatabaseName, ContainerName));
-            Assert.AreEqual(preAssembledToken, storedToken,
-                "Pre-assembled session token (containing ':') must be used as-is; partitionKeyRangeId should not be prepended again.");
-        }
 
         [DataTestMethod]
         [DataRow("", DisplayName = "Empty string partitionKeyRangeId")]
         [DataRow(" ", DisplayName = "Whitespace-only partitionKeyRangeId")]
         [DataRow("   ", DisplayName = "Multiple whitespace partitionKeyRangeId")]
-        [Description("When partitionKeyRangeId is empty or whitespace-only and session token is LSN-only, merge is silently skipped")]
-        public async Task CommitTransactionAsync_SkipsMerge_WhenPartitionKeyRangeIdIsEmptyOrWhitespace(string pkRangeId)
+        [Description("When partitionKeyRangeId is present but empty or whitespace, the commit fails with " +
+                     "InvalidOperationException because the server response violates the wire contract " +
+                     "(present field must be a non-blank pkRangeId).")]
+        public async Task CommitTransactionAsync_Throws_WhenPartitionKeyRangeIdIsEmptyOrWhitespace(string pkRangeId)
         {
             const string lsnOnly = "1#9#4=8#5=7";
 
@@ -461,14 +396,244 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
                 operations, mockContext.Object);
 
-            await committer.CommitTransactionAsync(CancellationToken.None);
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+                () => committer.CommitTransactionAsync(CancellationToken.None),
+                $"Commit must throw InvalidOperationException when partitionKeyRangeId is '{pkRangeId}' (present but empty/whitespace).");
 
             string storedToken = sessionContainer.GetSessionToken(DistributedTransactionConstants.GetCollectionFullName(DatabaseName, ContainerName));
             Assert.IsTrue(string.IsNullOrEmpty(storedToken),
-                $"SessionContainer should not be updated when partitionKeyRangeId is '{pkRangeId}' (empty/whitespace).");
+                "SessionContainer must not be updated when the response is rejected.");
         }
 
         // ─── Retry / Spec-Compliance Tests ─────────────────────────────────────
+
+        [TestMethod]
+        [Description("m8: In a multi-operation response, an op whose pkRangeId is absent is skipped while " +
+                     "subsequent ops with pkRangeId still have their session tokens merged correctly.")]
+        public async Task CommitTransactionAsync_MultiOp_SkipsOpWithMissingPkRangeId_MergesRemainingOps()
+        {
+            const string lsnOnly = "1#9#4=8#5=7";
+            const string pkRangeId = "0";
+            const string assembledToken = "0:1#9#4=8#5=7";
+            const string container2 = "testcontainer2";
+
+            string collectionRid1 = ResourceId.NewDocumentCollectionId(42, 129).DocumentCollectionId.ToString();
+            string collectionRid2 = ResourceId.NewDocumentCollectionId(42, 200).DocumentCollectionId.ToString();
+
+            Mock<ISessionContainer> mockSessionContainer = new Mock<ISessionContainer>();
+
+            MockDocumentClient documentClient = new MockDocumentClient
+            {
+                sessionContainer = mockSessionContainer.Object
+            };
+
+            ContainerProperties containerProperties1 = ContainerProperties.CreateWithResourceId(collectionRid1);
+            containerProperties1.PartitionKeyPath = "/pk";
+            ContainerProperties containerProperties2 = ContainerProperties.CreateWithResourceId(collectionRid2);
+            containerProperties2.PartitionKeyPath = "/pk";
+
+            Mock<CosmosClientContext> mockContext = new Mock<CosmosClientContext>();
+            mockContext.Setup(c => c.DocumentClient).Returns(documentClient);
+            mockContext.Setup(c => c.SerializerCore).Returns(MockCosmosUtil.Serializer);
+            mockContext.Setup(c => c.GetCachedContainerPropertiesAsync(
+                    DistributedTransactionConstants.GetCollectionFullName(DatabaseName, ContainerName),
+                    It.IsAny<ITrace>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(containerProperties1);
+            mockContext.Setup(c => c.GetCachedContainerPropertiesAsync(
+                    DistributedTransactionConstants.GetCollectionFullName(DatabaseName, container2),
+                    It.IsAny<ITrace>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(containerProperties2);
+
+            // op 0: missing pkRangeId — should be skipped (SessionToken nulled in FromJson)
+            // op 1: has pkRangeId — should be merged
+            string responseJson = BuildDtcResponseJson(new[]
+            {
+                (statusCode: 201, subStatusCode: (int?)null, sessionToken: lsnOnly, partitionKeyRangeId: (string)null),
+                (statusCode: 201, subStatusCode: (int?)null, sessionToken: lsnOnly, partitionKeyRangeId: pkRangeId),
+            });
+
+            ResponseMessage responseMessage = new ResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new MemoryStream(Encoding.UTF8.GetBytes(responseJson))
+            };
+
+            mockContext.Setup(c => c.ProcessResourceOperationStreamAsync(
+                    It.IsAny<string>(),
+                    ResourceType.DistributedTransactionBatch,
+                    OperationType.CommitDistributedTransaction,
+                    It.IsAny<RequestOptions>(),
+                    It.IsAny<ContainerInternal>(),
+                    It.IsAny<Cosmos.PartitionKey?>(),
+                    It.IsAny<string>(),
+                    It.IsAny<Stream>(),
+                    It.IsAny<Action<RequestMessage>>(),
+                    It.IsAny<ITrace>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(responseMessage);
+
+            List<DistributedTransactionOperation> operations = new List<DistributedTransactionOperation>
+            {
+                new DistributedTransactionOperation(
+                    OperationType.Create, operationIndex: 0,
+                    DatabaseName, ContainerName, new PartitionKey("pk1"), id: "doc1"),
+                new DistributedTransactionOperation(
+                    OperationType.Create, operationIndex: 1,
+                    DatabaseName, container2, new PartitionKey("pk2"), id: "doc2"),
+            };
+
+            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
+                operations, mockContext.Object);
+
+            await committer.CommitTransactionAsync(CancellationToken.None);
+
+            // op 0 (missing pkRangeId) must NOT have been merged.
+            mockSessionContainer.Verify(
+                s => s.SetSessionToken(
+                    collectionRid1,
+                    DistributedTransactionConstants.GetCollectionFullName(DatabaseName, ContainerName),
+                    It.IsAny<INameValueCollection>()),
+                Times.Never,
+                "SetSessionToken must not be called for an operation whose pkRangeId is absent.");
+
+            // op 1 (has pkRangeId) must have been merged with the assembled token.
+            mockSessionContainer.Verify(
+                s => s.SetSessionToken(
+                    collectionRid2,
+                    DistributedTransactionConstants.GetCollectionFullName(DatabaseName, container2),
+                    It.Is<INameValueCollection>(h => h[HttpConstants.HttpHeaders.SessionToken] == assembledToken)),
+                Times.Once,
+                "SetSessionToken must be called for the operation that has pkRangeId, with the assembled token.");
+        }
+
+        [TestMethod]
+        [Description("m9: When an operation result has no partitionKeyRangeId, FromJson emits a TraceWarning " +
+                     "so the skip is observable in diagnostic traces.")]
+        public async Task CommitTransactionAsync_EmitsTraceWarning_WhenPartitionKeyRangeIdIsAbsent()
+        {
+            const string lsnOnly = "1#9#4=8#5=7";
+
+            SessionContainer sessionContainer = new SessionContainer("testhost");
+
+            string responseJson = BuildDtcResponseJson(
+                new[] { (statusCode: 201, subStatusCode: (int?)null, sessionToken: lsnOnly, partitionKeyRangeId: (string)null) });
+
+            Mock<CosmosClientContext> mockContext = this.CreateMockContext(
+                sessionContainer,
+                responseContent: responseJson,
+                statusCode: HttpStatusCode.OK);
+
+            List<DistributedTransactionOperation> operations = new List<DistributedTransactionOperation>
+            {
+                new DistributedTransactionOperation(
+                    OperationType.Create, operationIndex: 0,
+                    DatabaseName, ContainerName, new PartitionKey("pk1"), id: "doc1")
+            };
+
+            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
+                operations, mockContext.Object);
+
+            List<string> capturedWarnings = new List<string>();
+            System.Diagnostics.TraceListener listener = new DelegatingTraceListener(
+                (eventType, message) =>
+                {
+                    if (eventType == System.Diagnostics.TraceEventType.Warning)
+                    {
+                        capturedWarnings.Add(message);
+                    }
+                });
+
+            System.Diagnostics.SourceLevels previousLevel = DefaultTrace.TraceSource.Switch.Level;
+            DefaultTrace.TraceSource.Switch.Level = System.Diagnostics.SourceLevels.All;
+            DefaultTrace.TraceSource.Listeners.Add(listener);
+            try
+            {
+                await committer.CommitTransactionAsync(CancellationToken.None);
+            }
+            finally
+            {
+                DefaultTrace.TraceSource.Listeners.Remove(listener);
+                DefaultTrace.TraceSource.Switch.Level = previousLevel;
+            }
+
+            Assert.IsTrue(
+                capturedWarnings.Any(m => m.Contains("partitionKeyRangeId")),
+                "A TraceWarning mentioning 'partitionKeyRangeId' should be emitted when pkRangeId is absent.");
+        }
+
+
+        [TestMethod]
+        [Description("When SetSessionToken throws, the exception is swallowed and CommitTransactionAsync still returns the response rather than rethrowing")]
+        public async Task CommitTransactionAsync_SwallowsSetSessionTokenException()
+        {
+            const string lsnOnly = "1#9#4=8#5=7";
+            const string pkRangeId = "0";
+
+            Mock<ISessionContainer> mockSessionContainer = new Mock<ISessionContainer>();
+            mockSessionContainer
+                .Setup(s => s.SetSessionToken(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<INameValueCollection>()))
+                .Throws(new InvalidOperationException("simulated SetSessionToken failure"));
+
+            MockDocumentClient documentClient = new MockDocumentClient
+            {
+                sessionContainer = mockSessionContainer.Object
+            };
+
+            ContainerProperties containerProperties = ContainerProperties.CreateWithResourceId(CollectionResourceId);
+            containerProperties.Id = "TestContainerId";
+            containerProperties.PartitionKeyPath = "/pk";
+
+            Mock<CosmosClientContext> mockContext = new Mock<CosmosClientContext>();
+            mockContext.Setup(c => c.DocumentClient).Returns(documentClient);
+            mockContext.Setup(c => c.SerializerCore).Returns(MockCosmosUtil.Serializer);
+            mockContext.Setup(c => c.GetCachedContainerPropertiesAsync(
+                    It.IsAny<string>(), It.IsAny<ITrace>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(containerProperties);
+
+            string responseJson = BuildDtcResponseJson(
+                new[] { (statusCode: 201, subStatusCode: (int?)null, sessionToken: lsnOnly, partitionKeyRangeId: pkRangeId) });
+
+            ResponseMessage responseMessage = new ResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new MemoryStream(Encoding.UTF8.GetBytes(responseJson))
+            };
+
+            mockContext.Setup(c => c.ProcessResourceOperationStreamAsync(
+                    It.IsAny<string>(),
+                    ResourceType.DistributedTransactionBatch,
+                    OperationType.CommitDistributedTransaction,
+                    It.IsAny<RequestOptions>(),
+                    It.IsAny<ContainerInternal>(),
+                    It.IsAny<Cosmos.PartitionKey?>(),
+                    It.IsAny<string>(),
+                    It.IsAny<Stream>(),
+                    It.IsAny<Action<RequestMessage>>(),
+                    It.IsAny<ITrace>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(responseMessage);
+
+            List<DistributedTransactionOperation> operations = new List<DistributedTransactionOperation>
+            {
+                new DistributedTransactionOperation(
+                    OperationType.Create,
+                    operationIndex: 0,
+                    DatabaseName,
+                    ContainerName,
+                    new PartitionKey("pk1"),
+                    id: "doc1")
+            };
+
+            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
+                operations, mockContext.Object);
+
+            // Must not throw even though SetSessionToken throws internally.
+            DistributedTransactionResponse response = await committer.CommitTransactionAsync(CancellationToken.None);
+            Assert.IsNotNull(response, "CommitTransactionAsync should return a response even when SetSessionToken throws.");
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+        }
+
 
         [TestMethod]
         [Description("Verifies that a commit succeeds without retrying when the server returns a success response on the first attempt.")]
@@ -1183,6 +1348,36 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             ResponseMessage message = new ResponseMessage(statusCode);
             message.Headers.SubStatusCodeLiteral = subStatusCode.ToString();
             return message;
+        }
+
+        /// <summary>
+        /// A <see cref="System.Diagnostics.TraceListener"/> that forwards each event to a delegate,
+        /// used in tests to assert that specific trace messages are emitted.
+        /// </summary>
+        private sealed class DelegatingTraceListener : System.Diagnostics.TraceListener
+        {
+            private readonly Action<System.Diagnostics.TraceEventType, string> onEvent;
+
+            public DelegatingTraceListener(Action<System.Diagnostics.TraceEventType, string> onEvent)
+                => this.onEvent = onEvent;
+
+            public override void Write(string message) { }
+
+            public override void WriteLine(string message) { }
+
+            public override void TraceEvent(
+                System.Diagnostics.TraceEventCache eventCache,
+                string source,
+                System.Diagnostics.TraceEventType eventType,
+                int id,
+                string format,
+                params object[] args)
+            {
+                string message = args != null && args.Length > 0
+                    ? string.Format(System.Globalization.CultureInfo.InvariantCulture, format, args)
+                    : format;
+                this.onEvent(eventType, message);
+            }
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionCommitterTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionCommitterTests.cs
@@ -365,10 +365,9 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
         [DataRow("", DisplayName = "Empty string partitionKeyRangeId")]
         [DataRow(" ", DisplayName = "Whitespace-only partitionKeyRangeId")]
         [DataRow("   ", DisplayName = "Multiple whitespace partitionKeyRangeId")]
-        [Description("When partitionKeyRangeId is present but empty or whitespace, the commit fails with " +
-                     "InvalidOperationException because the server response violates the wire contract " +
-                     "(present field must be a non-blank pkRangeId).")]
-        public async Task CommitTransactionAsync_Throws_WhenPartitionKeyRangeIdIsEmptyOrWhitespace(string pkRangeId)
+        [Description("When partitionKeyRangeId is present but empty or whitespace, merge is silently skipped. " +
+                     "The server has no validation on this field; throwing would risk failing a committed transaction.")]
+        public async Task CommitTransactionAsync_SkipsMerge_WhenPartitionKeyRangeIdIsEmptyOrWhitespace(string pkRangeId)
         {
             const string lsnOnly = "1#9#4=8#5=7";
 
@@ -396,13 +395,11 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
                 operations, mockContext.Object);
 
-            await Assert.ThrowsExceptionAsync<InvalidOperationException>(
-                () => committer.CommitTransactionAsync(CancellationToken.None),
-                $"Commit must throw InvalidOperationException when partitionKeyRangeId is '{pkRangeId}' (present but empty/whitespace).");
+            await committer.CommitTransactionAsync(CancellationToken.None);
 
             string storedToken = sessionContainer.GetSessionToken(DistributedTransactionConstants.GetCollectionFullName(DatabaseName, ContainerName));
             Assert.IsTrue(string.IsNullOrEmpty(storedToken),
-                "SessionContainer must not be updated when the response is rejected.");
+                $"SessionContainer should not be updated when partitionKeyRangeId is '{pkRangeId}' (empty/whitespace).");
         }
 
         // ─── Retry / Spec-Compliance Tests ─────────────────────────────────────

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionCommitterTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionCommitterTests.cs
@@ -212,41 +212,6 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
         }
 
         [TestMethod]
-        [Description("Verifies that 404/1002 (ReadSessionNotAvailable) operation results are excluded from session token merging")]
-        public async Task CommitTransactionAsync_SkipsMerge_When404ReadSessionNotAvailable()
-        {
-            const string sessionToken = "0:1#9#4=8#5=7";
-            const int readSessionNotAvailableSubStatus = 1002;
-
-            SessionContainer sessionContainer = new SessionContainer("testhost");
-
-            Mock<CosmosClientContext> mockContext = this.CreateMockContext(
-                sessionContainer,
-                responseContent: BuildDtcResponseJson(new[] { (statusCode: 404, subStatusCode: (int?)readSessionNotAvailableSubStatus, sessionToken) }),
-                statusCode: HttpStatusCode.NotFound);
-
-            List<DistributedTransactionOperation> operations = new List<DistributedTransactionOperation>
-            {
-                new DistributedTransactionOperation(
-                    OperationType.Create,
-                    operationIndex: 0,
-                    DatabaseName,
-                    ContainerName,
-                    new PartitionKey("pk1"),
-                    id: "doc1")
-            };
-
-            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
-                operations, mockContext.Object);
-
-            await committer.CommitTransactionAsync(CancellationToken.None);
-
-            string storedToken = sessionContainer.GetSessionToken(DistributedTransactionConstants.GetCollectionFullName(DatabaseName, ContainerName));
-            Assert.IsTrue(string.IsNullOrEmpty(storedToken),
-                "Session token should NOT be merged for 404/ReadSessionNotAvailable operation results.");
-        }
-
-        [TestMethod]
         [Description("Verifies that session tokens are still merged into the SessionContainer even when the DTC response indicates a failure")]
         public async Task CommitTransactionAsync_MergesSessionTokens_OnFailureResponse()
         {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionCommitterTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionCommitterTests.cs
@@ -275,6 +275,199 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                 "Session token should still be merged even when the DTC response indicates a failure.");
         }
 
+        [TestMethod]
+        [Description("When session token is LSN-only and partitionKeyRangeId is present, the token is assembled as {pkRangeId}:{lsn}")]
+        public async Task CommitTransactionAsync_AssemblesSessionToken_WhenPartitionKeyRangeIdIsPresent()
+        {
+            const string lsnOnly = "1#9#4=8#5=7";
+            const string pkRangeId = "0";
+            const string expectedToken = "0:1#9#4=8#5=7";
+
+            SessionContainer sessionContainer = new SessionContainer("testhost");
+
+            string responseJson = BuildDtcResponseJson(
+                new[] { (statusCode: 201, subStatusCode: (int?)null, sessionToken: lsnOnly, partitionKeyRangeId: pkRangeId) });
+
+            Mock<CosmosClientContext> mockContext = this.CreateMockContext(
+                sessionContainer,
+                responseContent: responseJson,
+                statusCode: HttpStatusCode.OK);
+
+            List<DistributedTransactionOperation> operations = new List<DistributedTransactionOperation>
+            {
+                new DistributedTransactionOperation(
+                    OperationType.Create,
+                    operationIndex: 0,
+                    DatabaseName,
+                    ContainerName,
+                    new PartitionKey("pk1"),
+                    id: "doc1")
+            };
+
+            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
+                operations, mockContext.Object);
+
+            await committer.CommitTransactionAsync(CancellationToken.None);
+
+            string storedToken = sessionContainer.GetSessionToken(DistributedTransactionConstants.GetCollectionFullName(DatabaseName, ContainerName));
+            Assert.AreEqual(expectedToken, storedToken,
+                "Session token should be assembled as {pkRangeId}:{lsn} when partitionKeyRangeId is present.");
+        }
+
+        [TestMethod]
+        [Description("When session token is LSN-only and partitionKeyRangeId is absent, merge is silently skipped")]
+        public async Task CommitTransactionAsync_SkipsMerge_WhenLsnOnlyAndPartitionKeyRangeIdIsAbsent()
+        {
+            const string lsnOnly = "1#9#4=8#5=7";
+
+            SessionContainer sessionContainer = new SessionContainer("testhost");
+
+            // No partitionKeyRangeId, and sessionToken has no ':' (LSN-only)
+            string responseJson = BuildDtcResponseJson(
+                new[] { (statusCode: 201, subStatusCode: (int?)null, sessionToken: lsnOnly, partitionKeyRangeId: (string)null) });
+
+            Mock<CosmosClientContext> mockContext = this.CreateMockContext(
+                sessionContainer,
+                responseContent: responseJson,
+                statusCode: HttpStatusCode.OK);
+
+            List<DistributedTransactionOperation> operations = new List<DistributedTransactionOperation>
+            {
+                new DistributedTransactionOperation(
+                    OperationType.Create,
+                    operationIndex: 0,
+                    DatabaseName,
+                    ContainerName,
+                    new PartitionKey("pk1"),
+                    id: "doc1")
+            };
+
+            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
+                operations, mockContext.Object);
+
+            await committer.CommitTransactionAsync(CancellationToken.None);
+
+            string storedToken = sessionContainer.GetSessionToken(DistributedTransactionConstants.GetCollectionFullName(DatabaseName, ContainerName));
+            Assert.IsTrue(string.IsNullOrEmpty(storedToken),
+                "SessionContainer should not be updated when partitionKeyRangeId is absent and session token is LSN-only.");
+        }
+
+        [TestMethod]
+        [Description("When session token already contains ':' (fully assembled), it is used as-is even without partitionKeyRangeId")]
+        public async Task CommitTransactionAsync_UsesPreAssembledSessionToken_WhenAlreadyContainsColon()
+        {
+            const string preAssembledToken = "0:1#9#4=8#5=7";
+
+            SessionContainer sessionContainer = new SessionContainer("testhost");
+
+            // Token already contains ':', so no pkRangeId needed
+            string responseJson = BuildDtcResponseJson(
+                new[] { (statusCode: 201, subStatusCode: (int?)null, sessionToken: preAssembledToken, partitionKeyRangeId: (string)null) });
+
+            Mock<CosmosClientContext> mockContext = this.CreateMockContext(
+                sessionContainer,
+                responseContent: responseJson,
+                statusCode: HttpStatusCode.OK);
+
+            List<DistributedTransactionOperation> operations = new List<DistributedTransactionOperation>
+            {
+                new DistributedTransactionOperation(
+                    OperationType.Create,
+                    operationIndex: 0,
+                    DatabaseName,
+                    ContainerName,
+                    new PartitionKey("pk1"),
+                    id: "doc1")
+            };
+
+            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
+                operations, mockContext.Object);
+
+            await committer.CommitTransactionAsync(CancellationToken.None);
+
+            string storedToken = sessionContainer.GetSessionToken(DistributedTransactionConstants.GetCollectionFullName(DatabaseName, ContainerName));
+            Assert.AreEqual(preAssembledToken, storedToken,
+                "Pre-assembled session token (with ':') should be used as-is.");
+        }
+
+        [TestMethod]
+        [Description("When session token already contains ':' AND partitionKeyRangeId is also present, the pre-assembled token takes precedence")]
+        public async Task CommitTransactionAsync_PreAssembledTokenTakesPrecedence_WhenBothTokenAndPartitionKeyRangeIdPresent()
+        {
+            const string preAssembledToken = "0:1#9#4=8#5=7";
+            const string differentPkRangeId = "5"; // would produce "5:1#9#4=8#5=7" if incorrectly used
+
+            SessionContainer sessionContainer = new SessionContainer("testhost");
+
+            string responseJson = BuildDtcResponseJson(
+                new[] { (statusCode: 201, subStatusCode: (int?)null, sessionToken: preAssembledToken, partitionKeyRangeId: differentPkRangeId) });
+
+            Mock<CosmosClientContext> mockContext = this.CreateMockContext(
+                sessionContainer,
+                responseContent: responseJson,
+                statusCode: HttpStatusCode.OK);
+
+            List<DistributedTransactionOperation> operations = new List<DistributedTransactionOperation>
+            {
+                new DistributedTransactionOperation(
+                    OperationType.Create,
+                    operationIndex: 0,
+                    DatabaseName,
+                    ContainerName,
+                    new PartitionKey("pk1"),
+                    id: "doc1")
+            };
+
+            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
+                operations, mockContext.Object);
+
+            await committer.CommitTransactionAsync(CancellationToken.None);
+
+            string storedToken = sessionContainer.GetSessionToken(DistributedTransactionConstants.GetCollectionFullName(DatabaseName, ContainerName));
+            Assert.AreEqual(preAssembledToken, storedToken,
+                "Pre-assembled session token (containing ':') must be used as-is; partitionKeyRangeId should not be prepended again.");
+        }
+
+        [DataTestMethod]
+        [DataRow("", DisplayName = "Empty string partitionKeyRangeId")]
+        [DataRow(" ", DisplayName = "Whitespace-only partitionKeyRangeId")]
+        [DataRow("   ", DisplayName = "Multiple whitespace partitionKeyRangeId")]
+        [Description("When partitionKeyRangeId is empty or whitespace-only and session token is LSN-only, merge is silently skipped")]
+        public async Task CommitTransactionAsync_SkipsMerge_WhenPartitionKeyRangeIdIsEmptyOrWhitespace(string pkRangeId)
+        {
+            const string lsnOnly = "1#9#4=8#5=7";
+
+            SessionContainer sessionContainer = new SessionContainer("testhost");
+
+            string responseJson = BuildDtcResponseJson(
+                new[] { (statusCode: 201, subStatusCode: (int?)null, sessionToken: lsnOnly, partitionKeyRangeId: pkRangeId) });
+
+            Mock<CosmosClientContext> mockContext = this.CreateMockContext(
+                sessionContainer,
+                responseContent: responseJson,
+                statusCode: HttpStatusCode.OK);
+
+            List<DistributedTransactionOperation> operations = new List<DistributedTransactionOperation>
+            {
+                new DistributedTransactionOperation(
+                    OperationType.Create,
+                    operationIndex: 0,
+                    DatabaseName,
+                    ContainerName,
+                    new PartitionKey("pk1"),
+                    id: "doc1")
+            };
+
+            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
+                operations, mockContext.Object);
+
+            await committer.CommitTransactionAsync(CancellationToken.None);
+
+            string storedToken = sessionContainer.GetSessionToken(DistributedTransactionConstants.GetCollectionFullName(DatabaseName, ContainerName));
+            Assert.IsTrue(string.IsNullOrEmpty(storedToken),
+                $"SessionContainer should not be updated when partitionKeyRangeId is '{pkRangeId}' (empty/whitespace).");
+        }
+
         // ─── Retry / Spec-Compliance Tests ─────────────────────────────────────
 
         [TestMethod]
@@ -768,11 +961,18 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             (int statusCode, string sessionToken)[] operations)
         {
             return BuildDtcResponseJson(
-                operations.Select(o => (o.statusCode, subStatusCode: (int?)null, o.sessionToken)).ToArray());
+                operations.Select(o => (o.statusCode, subStatusCode: (int?)null, o.sessionToken, partitionKeyRangeId: (string)null)).ToArray());
         }
 
         private static string BuildDtcResponseJson(
             (int statusCode, int? subStatusCode, string sessionToken)[] operations)
+        {
+            return BuildDtcResponseJson(
+                operations.Select(o => (o.statusCode, o.subStatusCode, o.sessionToken, partitionKeyRangeId: (string)null)).ToArray());
+        }
+
+        private static string BuildDtcResponseJson(
+            (int statusCode, int? subStatusCode, string sessionToken, string partitionKeyRangeId)[] operations)
         {
             StringBuilder sb = new StringBuilder();
             sb.Append(@"{""operationResponses"":[");
@@ -792,6 +992,11 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                 if (operations[i].sessionToken != null)
                 {
                     sb.Append($@",""{DistributedTransactionSerializer.SessionToken}"":""{operations[i].sessionToken}""");
+                }
+
+                if (operations[i].partitionKeyRangeId != null)
+                {
+                    sb.Append($@",""{DistributedTransactionSerializer.PartitionKeyRangeId}"":""{operations[i].partitionKeyRangeId}""");
                 }
 
                 sb.Append('}');

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionResponseTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionResponseTests.cs
@@ -557,13 +557,15 @@ namespace Microsoft.Azure.Cosmos.Tests
         }
 
         [TestMethod]
-        [Description("SessionToken deserializes from the 'sessionToken' JSON property.")]
+        [Description("SessionToken is assembled as {pkRangeId}:{lsn} from the separate 'sessionToken' (LSN-only) and 'partitionKeyRangeId' JSON fields.")]
         public async Task FromResponseMessage_OperationResult_SessionToken_DeserializesCorrectly()
         {
+            const string lsnOnly = "12345";
+            const string pkRangeId = "0";
             const string expectedSessionToken = "0:12345";
             DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
 
-            string json = $@"{{""operationResponses"":[{{""index"":0,""statusCode"":201,""sessionToken"":""{expectedSessionToken}""}}]}}";
+            string json = $@"{{""operationResponses"":[{{""index"":0,""statusCode"":201,""sessionToken"":""{lsnOnly}"",""partitionKeyRangeId"":""{pkRangeId}""}}]}}";
             ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.OK, json);
 
             DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
@@ -574,7 +576,74 @@ namespace Microsoft.Azure.Cosmos.Tests
                 CancellationToken.None);
 
             Assert.AreEqual(expectedSessionToken, response[0].SessionToken,
-                "SessionToken must equal the value from the JSON 'sessionToken' field.");
+                "SessionToken must be assembled as {pkRangeId}:{lsn} from the two separate JSON fields.");
+        }
+
+        [TestMethod]
+        [Description("When partitionKeyRangeId is absent, FromJson sets SessionToken to null so MergeSessionTokens skips the operation.")]
+        // TODO(issue#5857): Remove once the coordinator starts emitting partitionKeyRangeId for all operations.
+        public async Task FromResponseMessage_OperationResult_SessionToken_NullWhenPartitionKeyRangeIdAbsent()
+        {
+            const string lsnOnly = "12345";
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
+
+            // partitionKeyRangeId field is omitted — current server behavior
+            string json = $@"{{""operationResponses"":[{{""index"":0,""statusCode"":201,""sessionToken"":""{lsnOnly}""}}]}}";
+            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.OK, json);
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            Assert.IsNull(response[0].SessionToken,
+                "SessionToken must be null when partitionKeyRangeId is absent so the merge is skipped.");
+        }
+
+        [DataTestMethod]
+        [DataRow("", DisplayName = "Empty string partitionKeyRangeId")]
+        [DataRow(" ", DisplayName = "Whitespace-only partitionKeyRangeId")]
+        [DataRow("   ", DisplayName = "Multiple spaces partitionKeyRangeId")]
+        [Description("When partitionKeyRangeId is present but empty or whitespace, FromJson throws JsonException because the server sent an explicitly invalid value.")]
+        public async Task FromResponseMessage_OperationResult_ThrowsWhenPartitionKeyRangeIdIsBlank(string pkRangeId)
+        {
+            const string lsnOnly = "12345";
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
+
+            string json = $@"{{""operationResponses"":[{{""index"":0,""statusCode"":201,""sessionToken"":""{lsnOnly}"",""partitionKeyRangeId"":""{pkRangeId}""}}]}}";
+            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.OK, json);
+
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+                () => DistributedTransactionResponse.FromResponseMessageAsync(
+                    responseMessage,
+                    serverRequest,
+                    MockCosmosUtil.Serializer,
+                    NoOpTrace.Singleton,
+                    CancellationToken.None),
+                $"FromJson must throw InvalidOperationException when partitionKeyRangeId is '{pkRangeId}' (present but empty/whitespace).");
+        }
+
+        [TestMethod]
+        [Description("When sessionToken is absent entirely, SessionToken remains null regardless of partitionKeyRangeId.")]
+        public async Task FromResponseMessage_OperationResult_SessionToken_NullWhenSessionTokenFieldAbsent()
+        {
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
+
+            // Neither sessionToken nor partitionKeyRangeId present
+            string json = @"{""operationResponses"":[{""index"":0,""statusCode"":201}]}";
+            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.OK, json);
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            Assert.IsNull(response[0].SessionToken,
+                "SessionToken must be null when the sessionToken JSON field is absent.");
         }
 
         // IsRetriable parsing

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionResponseTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionResponseTests.cs
@@ -606,8 +606,10 @@ namespace Microsoft.Azure.Cosmos.Tests
         [DataRow("", DisplayName = "Empty string partitionKeyRangeId")]
         [DataRow(" ", DisplayName = "Whitespace-only partitionKeyRangeId")]
         [DataRow("   ", DisplayName = "Multiple spaces partitionKeyRangeId")]
-        [Description("When partitionKeyRangeId is present but empty or whitespace, FromJson throws JsonException because the server sent an explicitly invalid value.")]
-        public async Task FromResponseMessage_OperationResult_ThrowsWhenPartitionKeyRangeIdIsBlank(string pkRangeId)
+        [Description("When partitionKeyRangeId is present but empty or whitespace, FromJson sets SessionToken to null " +
+                     "so MergeSessionTokens skips the operation. The server has no validation on this field and can " +
+                     "send blank values; failing the commit would be worse than skipping the merge.")]
+        public async Task FromResponseMessage_OperationResult_SessionToken_NullWhenPartitionKeyRangeIdIsBlank(string pkRangeId)
         {
             const string lsnOnly = "12345";
             DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
@@ -615,14 +617,15 @@ namespace Microsoft.Azure.Cosmos.Tests
             string json = $@"{{""operationResponses"":[{{""index"":0,""statusCode"":201,""sessionToken"":""{lsnOnly}"",""partitionKeyRangeId"":""{pkRangeId}""}}]}}";
             ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.OK, json);
 
-            await Assert.ThrowsExceptionAsync<InvalidOperationException>(
-                () => DistributedTransactionResponse.FromResponseMessageAsync(
-                    responseMessage,
-                    serverRequest,
-                    MockCosmosUtil.Serializer,
-                    NoOpTrace.Singleton,
-                    CancellationToken.None),
-                $"FromJson must throw InvalidOperationException when partitionKeyRangeId is '{pkRangeId}' (present but empty/whitespace).");
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            Assert.IsNull(response[0].SessionToken,
+                $"SessionToken must be null when partitionKeyRangeId is '{pkRangeId}' (empty/whitespace) so the merge is safely skipped.");
         }
 
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionResponseTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionResponseTests.cs
@@ -650,15 +650,16 @@ namespace Microsoft.Azure.Cosmos.Tests
                 $"SessionToken must be null when the sessionToken value is whitespace ('{whitespaceToken}').");
         }
 
-        [TestMethod]
-        [Description("When sessionToken already contains a colon (canonical form), FromJson leaves it as-is even without partitionKeyRangeId.")]
-        public async Task FromResponseMessage_OperationResult_SessionToken_PreservedWhenAlreadyCanonical()
+        [DataTestMethod]
+        [DataRow("0:-1#425344#1=12345", "0:-1#425344#1=12345", DisplayName = "Well-formed canonical token preserved")]
+        [DataRow("3:500", "3:500", DisplayName = "Simple pkRangeId:lsn preserved")]
+        [Description("When sessionToken is already in canonical {pkRangeId}:{lsn} form (colon at position > 0 with content on both sides), FromJson leaves it as-is even without partitionKeyRangeId.")]
+        public async Task FromResponseMessage_OperationResult_SessionToken_PreservedWhenAlreadyCanonical(string token, string expected)
         {
-            const string canonicalToken = "0:-1#425344#1=12345";
             DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
 
             // sessionToken is already canonical; partitionKeyRangeId is absent
-            string json = $@"{{""operationResponses"":[{{""index"":0,""statusCode"":201,""sessionToken"":""{canonicalToken}""}}]}}";
+            string json = $@"{{""operationResponses"":[{{""index"":0,""statusCode"":201,""sessionToken"":""{token}""}}]}}";
             ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.OK, json);
 
             DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
@@ -668,8 +669,30 @@ namespace Microsoft.Azure.Cosmos.Tests
                 NoOpTrace.Singleton,
                 CancellationToken.None);
 
-            Assert.AreEqual(canonicalToken, response[0].SessionToken,
-                "A session token that already contains ':' must be left as-is (already canonical).");
+            Assert.AreEqual(expected, response[0].SessionToken,
+                $"A well-formed canonical token '{token}' must be left as-is.");
+        }
+
+        [DataTestMethod]
+        [DataRow(":-1#425344", "3", DisplayName = "Leading colon (no pkRangeId) — not canonical, assembles with pkRangeId")]
+        [DataRow("3:", "5", DisplayName = "Trailing colon only (no LSN) — not canonical, assembles with pkRangeId")]
+        [Description("Session tokens with a colon at position 0 or at the last character are not valid canonical tokens — they get assembled with the provided partitionKeyRangeId.")]
+        public async Task FromResponseMessage_OperationResult_SessionToken_AssembledWhenColonIsAtEdge(string token, string pkRangeId)
+        {
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
+
+            string json = $@"{{""operationResponses"":[{{""index"":0,""statusCode"":201,""sessionToken"":""{token}"",""partitionKeyRangeId"":""{pkRangeId}""}}]}}";
+            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.OK, json);
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            Assert.AreEqual(pkRangeId + ":" + token, response[0].SessionToken,
+                $"A token with edge colon '{token}' must be assembled with pkRangeId '{pkRangeId}'.");
         }
 
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionResponseTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionResponseTests.cs
@@ -628,6 +628,50 @@ namespace Microsoft.Azure.Cosmos.Tests
                 $"SessionToken must be null when partitionKeyRangeId is '{pkRangeId}' (empty/whitespace) so the merge is safely skipped.");
         }
 
+        [DataTestMethod]
+        [DataRow(" ", DisplayName = "Single space sessionToken")]
+        [DataRow("   ", DisplayName = "Multiple spaces sessionToken")]
+        [Description("When sessionToken is whitespace-only, FromJson treats it the same as absent — SessionToken remains null.")]
+        public async Task FromResponseMessage_OperationResult_SessionToken_NullWhenSessionTokenIsWhitespace(string whitespaceToken)
+        {
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
+
+            string json = $@"{{""operationResponses"":[{{""index"":0,""statusCode"":201,""sessionToken"":""{whitespaceToken}"",""partitionKeyRangeId"":""0""}}]}}";
+            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.OK, json);
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            Assert.IsNull(response[0].SessionToken,
+                $"SessionToken must be null when the sessionToken value is whitespace ('{whitespaceToken}').");
+        }
+
+        [TestMethod]
+        [Description("When sessionToken already contains a colon (canonical form), FromJson leaves it as-is even without partitionKeyRangeId.")]
+        public async Task FromResponseMessage_OperationResult_SessionToken_PreservedWhenAlreadyCanonical()
+        {
+            const string canonicalToken = "0:-1#425344#1=12345";
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
+
+            // sessionToken is already canonical; partitionKeyRangeId is absent
+            string json = $@"{{""operationResponses"":[{{""index"":0,""statusCode"":201,""sessionToken"":""{canonicalToken}""}}]}}";
+            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.OK, json);
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            Assert.AreEqual(canonicalToken, response[0].SessionToken,
+                "A session token that already contains ':' must be left as-is (already canonical).");
+        }
+
         [TestMethod]
         [Description("When sessionToken is absent entirely, SessionToken remains null regardless of partitionKeyRangeId.")]
         public async Task FromResponseMessage_OperationResult_SessionToken_NullWhenSessionTokenFieldAbsent()


### PR DESCRIPTION
## Description

### Problem

Distributed transaction (DTC) operation-level session tokens are sent by the coordinator as **raw LSN vectors** (e.g., `"-1#425344#1=12345"`) without the `{pkRangeId}:` prefix. `SessionContainer.SetSessionToken()` unconditionally does `Split(':')[1]` on the token — an LSN-only token has no colon, so `tokenParts` has length 1, causing an **`IndexOutOfRangeException`** that escapes and surfaces a committed transaction as failed to the caller.

### Fix

Add a `partitionKeyRangeId` field to `DistributedTransactionOperationResult` and assemble the canonical `{pkRangeId}:{lsn}` session token in `FromJson()` before it reaches `SessionContainer`.

### Design Decisions

1. **Assembly happens in `FromJson()`, not `MergeSessionTokens()`**
   The token is assembled at parse time so that `result.SessionToken` is always in canonical form (or null) by the time any downstream code reads it. This keeps `MergeSessionTokens` simple — it just sets the header.

2. **Warn + null (skip merge) when `partitionKeyRangeId` is absent/blank — no throw**
   The DTC coordinator currently **never sends `partitionKeyRangeId`** (tracked by [#5857](https://github.com/Azure/azure-cosmos-dotnet-v3/issues/5857)). Once the coordinator update ships, both fields will always be present and the null-path will be removed.

   We considered throwing `InvalidOperationException` on blank `partitionKeyRangeId`, but rejected it because:
   - The server-side `SetPartitionKeyRangeId()` has **zero validation** — it can legitimately be null or empty (e.g., master resource operations, partition startup, aborted transactions where `SDKResponseBuilder.cpp:193` explicitly sets empty string).
   - All non-DTC SDK modes handle null/empty pkRangeId **without throwing**: Gateway mode omits the header entirely; Direct mode falls back to the request's token prefix or hardcodes `"0"`.
   - Throwing would transform the exact crash class this PR fixes (committed tx → exception) into a different but equally bad failure.

3. **Known limitation: stale-read window when pkRangeId is absent**
   When `partitionKeyRangeId` is absent (current coordinator behavior), `SessionToken` is set to null → session token merge is skipped → `SessionContainer` retains the previous LSN for that partition. A subsequent session-consistent read may be served by a replica that hasn't yet replicated the DTC commit. This is a **strict improvement** over the pre-fix crash (committed tx surfacing as failed) and is transient — replication lag is typically milliseconds, and any other write to the same partition advances the token past the gap. This will be fully resolved when the coordinator always sends `partitionKeyRangeId` ([#5857](https://github.com/Azure/azure-cosmos-dotnet-v3/issues/5857)).

### Changes

| File | Change |
|---|---|
| `DistributedTransactionOperationResult.cs` | Add `PartitionKeyRangeId` JSON property. `FromJson()` assembles `{pkRangeId}:{lsn}` when valid, else warns and sets `SessionToken = null`. Removed unused `using System.ComponentModel`. |
| `DistributedTransactionSerializer.cs` | Add `PartitionKeyRangeId` constant for the JSON field name. |
| `DistributedTransactionCommitter.cs` | Widen try/catch to wrap entire per-operation body including `Operations[result.Index]`. Improve catch diagnostics. Token is already canonical from `FromJson()` — `MergeSessionTokens` just sets the header. |
| `DistributedTransactionResponseTests.cs` | Add 5 parser tests: pkRangeId absent, blank (empty/whitespace ×3 via DataRow), sessionToken field absent. |
| `DistributedTransactionCommitterTests.cs` | Add end-to-end committer tests: blank pkRangeId → commit succeeds, session container not updated. |
| `DistributedTransactionTests.cs` (emulator) | Update `ValidateSessionTokenMergedIntoDtcClient` to use new wire format. Add `ValidateSessionTokenSkipped_WhenPartitionKeyRangeIdAbsent`. Both tests use matching PKs for partition alignment. |

### Wire Contract (Transitional)

```
Current coordinator behavior:
  sessionToken:        always sent (raw LSN vector, e.g., "-1#425344#1=12345")
  partitionKeyRangeId: never sent

Future coordinator behavior (issue #5857):
  sessionToken:        always sent (raw LSN vector)
  partitionKeyRangeId: always sent (e.g., "3")

SDK assembly:
  Both present + valid  → "{pkRangeId}:{lsn}" (canonical)
  pkRangeId absent/blank → warn + null (skip merge)
  sessionToken absent    → no assembly needed (no merge)
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)