### PR TITLE
Pipelines: Adds Encryption SDK GA + Preview parity to PR, nightly, and rolling

### DIFF
--- a/azure-pipelines-nightly.yml
+++ b/azure-pipelines-nightly.yml
@@ -47,3 +47,19 @@ stages:
         OutputPath: '$(Build.ArtifactStagingDirectory)/bin/AnyCPU/$(BuildConfiguration)/Microsoft.Azure.Cosmos'
         BlobVersion: 'nightly-preview'
         CleanupFolder: true
+
+# Run the preview-flag build (which includes the Encryption / Encryption.Custom
+# SDK-source project-ref + NuGet-surface parity builds added in PR #5798) on
+# the nightly schedule so any newly-added abstract member on Container under
+# #if PREVIEW that lacks an unconditional override in EncryptionContainer is
+# caught off-PR as well.
+- stage:
+  displayName: Preview parity build
+  variables:
+    Codeql.BuildIdentifier: preview_parity
+  jobs:
+    - template:  templates/build-preview.yml
+      parameters:
+        BuildConfiguration: Release
+        Arguments: ' '
+        VmImage: $(VmImage)

--- a/azure-pipelines-rolling.yml
+++ b/azure-pipelines-rolling.yml
@@ -44,3 +44,14 @@ jobs:
     IncludePerformance: true
     IncludeCoverage: true
 
+# Run the preview-flag build (which includes the Encryption / Encryption.Custom
+# SDK-source project-ref + NuGet-surface parity builds added in PR #5798) on
+# the rolling schedule so any newly-added abstract member on Container under
+# #if PREVIEW that lacks an unconditional override in EncryptionContainer is
+# caught off-PR as well.
+- template:  templates/build-preview.yml
+  parameters:
+    BuildConfiguration: Release
+    Arguments: ' '
+    VmImage: $(VmImage)
+

--- a/templates/build-preview.yml
+++ b/templates/build-preview.yml
@@ -90,6 +90,27 @@ jobs:
       arguments: -p:Optimize=true -p:IsPreview=true -p:SdkProjectRef=true -p:DefineSdkProjectRefSymbol=false
       versioningScheme: OFF
 
+  # GA-surface parity check: build Microsoft.Azure.Cosmos.Encryption against
+  # main SDK source with IsPreview unset (so neither PREVIEW nor
+  # ENCRYPTIONPREVIEW is defined) and SDKPROJECTREF off. This matches the
+  # exact preprocessor surface the shipped GA NuGet is built with. The
+  # preview-only parity step above does NOT cover this surface because
+  # IsPreview=true defines ENCRYPTIONPREVIEW (Directory.Build.props), which
+  # pulls in #if ENCRYPTIONPREVIEW-gated overrides that do not ship in the
+  # GA NuGet. Any new abstract member promoted to GA on Container that lacks
+  # an unconditional (or non-ENCRYPTIONPREVIEW-gated) override in
+  # EncryptionContainer will produce a CS0534 here. See PR #5825 (FFCF GA
+  # promotion) for a concrete miss the preview-only parity build let through.
+  - task: DotNetCoreCLI@2
+    displayName: Build Microsoft.Azure.Cosmos.Encryption (GA NuGet-surface parity vs main SDK source)
+    inputs:
+      command: build
+      configuration: $(parameters.BuildConfiguration)
+      nugetConfigPath: NuGet.config
+      projects: Microsoft.Azure.Cosmos.Encryption/src/Microsoft.Azure.Cosmos.Encryption.csproj
+      arguments: -p:Optimize=true -p:SdkProjectRef=true -p:DefineSdkProjectRefSymbol=false
+      versioningScheme: OFF
+
 - job:
   displayName: Preview Encryption EmulatorTests ${{ parameters.BuildConfiguration }}
   timeoutInMinutes: 60
@@ -177,6 +198,12 @@ jobs:
       projects: Microsoft.Azure.Cosmos.Encryption.Custom/src/Microsoft.Azure.Cosmos.Encryption.Custom.csproj
       arguments: -p:Optimize=true -p:IsPreview=true -p:SdkProjectRef=true -p:DefineSdkProjectRefSymbol=false
       versioningScheme: OFF
+
+  # Note: no GA NuGet-surface parity step for Encryption.Custom. The Custom
+  # csproj package-references Microsoft.Azure.Cosmos 3.41.0-preview.0
+  # unconditionally (no IsPreview-gated alternative reference), so the
+  # shipped Custom NuGet is always built against a preview SDK surface and
+  # has no GA NuGet surface to validate.
 
 - job:
   displayName: Preview Tests ${{ parameters.BuildConfiguration }}

--- a/templates/static-tools-encryption-custom.yml
+++ b/templates/static-tools-encryption-custom.yml
@@ -61,6 +61,12 @@ jobs:
       arguments: '-p:Optimize=true -p:IsPreview=true -p:SdkProjectRef=true -p:DefineSdkProjectRefSymbol=false --configuration Release'
       versioningScheme: OFF
 
+  # Note: no GA NuGet-surface parity step for Encryption.Custom. The Custom
+  # csproj package-references Microsoft.Azure.Cosmos 3.41.0-preview.0
+  # unconditionally (no IsPreview-gated alternative reference), so the
+  # shipped Custom NuGet is always built against a preview SDK surface and
+  # has no GA NuGet surface to validate.
+
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-binskim.BinSkim@4
     displayName: 'BinSkim'
     condition: eq(1,2) #disablng as nuget repo failing

--- a/templates/static-tools-encryption.yml
+++ b/templates/static-tools-encryption.yml
@@ -56,6 +56,23 @@ jobs:
       arguments: '-p:Optimize=true -p:IsPreview=true -p:SdkProjectRef=true -p:DefineSdkProjectRefSymbol=false --configuration Release'
       versioningScheme: OFF
 
+  # GA-surface parity check: same as above but with IsPreview unset, so
+  # neither PREVIEW nor ENCRYPTIONPREVIEW is defined. This matches the
+  # exact preprocessor surface the shipped GA NuGet is built with. The
+  # preview-only parity step above does NOT cover this surface because
+  # IsPreview=true defines ENCRYPTIONPREVIEW (Directory.Build.props), which
+  # pulls in #if ENCRYPTIONPREVIEW-gated overrides that do not ship in the
+  # GA NuGet. See PR #5825 (FFCF GA promotion) for a miss the preview-only
+  # parity build let through.
+  - task: DotNetCoreCLI@2
+    displayName: Build Microsoft.Azure.Cosmos.Encryption (GA NuGet-surface parity vs main SDK source)
+    inputs:
+      command: build
+      nugetConfigPath: NuGet.config
+      projects: Microsoft.Azure.Cosmos.Encryption/src/Microsoft.Azure.Cosmos.Encryption.csproj
+      arguments: '-p:Optimize=true -p:SdkProjectRef=true -p:DefineSdkProjectRefSymbol=false --configuration Release'
+      versioningScheme: OFF
+
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-binskim.BinSkim@4
     displayName: 'BinSkim'
     condition: eq(1,2) #disablng as nuget repo failing


### PR DESCRIPTION
## Problem

PR #5798 added the Encryption / Encryption.Custom SDK-source project-ref + NuGet-surface parity builds to `templates/build-preview.yml` so the PR-validation pipeline catches any newly-added abstract member on `Container` under `#if PREVIEW` that lacks an unconditional override in `EncryptionContainer` (the class of defect behind #5783).

Those parity steps have **two gaps**:

### Gap 1 — They do not run on nightly or rolling

| Pipeline | File | Currently runs `build-preview.yml`? |
|---|---|---|
| PR validation | `azure-pipelines.yml` | ✅ (added in #5798) |
| Nightly | `azure-pipelines-nightly.yml` | ❌ |
| Rolling | `azure-pipelines-rolling.yml` | ❌ |

So a defect introduced via a path that bypasses PR validation (force-merge, retroactive SDK change, build-config drift) would not be caught until the next encryption release-gate run.

### Gap 2 — The Encryption parity build does not cover the GA NuGet surface

PR #5798's parity step always sets `-p:IsPreview=true`. Per `Directory.Build.props:16`, that defines both `PREVIEW` **and** `ENCRYPTIONPREVIEW`. So `#if ENCRYPTIONPREVIEW`-gated overrides in `EncryptionContainer` get compiled in — even though they do **not** ship in the GA NuGet of `Microsoft.Azure.Cosmos.Encryption` (which uses package reference `[3.51.0,)` when `IsPreview` is unset).

**Concrete miss — PR #5825**: that PR promotes `Container.GetChangeFeedProcessorBuilderWithAllVersionsAndDeletes<T>` from `#if PREVIEW` to GA-unconditional. The Encryption override is gated `#if ENCRYPTIONPREVIEW || SDKPROJECTREF`. The Preview parity build defined `ENCRYPTIONPREVIEW` and went green; the author then had to push three follow-up "fix the guard" commits (`c0b56b14e`, `a0347ebb7`, `907d5a41d`) once the build broke downstream.

Reproduced at PR #5825 head (`907d5a41d`):

```
dotnet build Microsoft.Azure.Cosmos.Encryption.csproj -c Release \
  -p:SdkProjectRef=true -p:DefineSdkProjectRefSymbol=false

error CS0534: 'EncryptionContainer' does not implement inherited abstract
member 'Container.GetChangeFeedProcessorBuilderWithAllVersionsAndDeletes<T>(...)'
Build FAILED.
```

The same command on `main` succeeds (0 errors), so the new step does not regress current `main`.

## Change

### Commit 1 — wire `build-preview.yml` into the off-PR pipelines

* `azure-pipelines-nightly.yml` — new `Preview parity build` stage invoking `templates/build-preview.yml`.
* `azure-pipelines-rolling.yml` — additional `templates/build-preview.yml` job alongside the existing `build-test.yml` runs.

### Commit 2 — add a GA NuGet-surface parity step for `Microsoft.Azure.Cosmos.Encryption`

Adds a second parity step alongside the existing Preview one in:

* `templates/build-preview.yml` (Encryption Project Ref SDK Preview job)
* `templates/static-tools-encryption.yml`

The new step omits `-p:IsPreview`, so neither `PREVIEW` nor `ENCRYPTIONPREVIEW` is defined — matching the exact preprocessor surface of the shipped GA NuGet — while still linking against the latest SDK source via `-p:SdkProjectRef=true`.

No GA parity step is added for `Microsoft.Azure.Cosmos.Encryption.Custom`: its csproj package-references `Microsoft.Azure.Cosmos 3.41.0-preview.0` unconditionally, so it has no GA NuGet surface to validate. A documenting note is added in both Custom templates.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Closing issues

Follow-up to #5798. Related to #5783, #5825.
