### PR TITLE
[Internal] DTS: Adds coordinator diagnosticString, CosmosDiagnostics, and OpenTelemetry support

### DIFF
--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedReadTransactionCore.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedReadTransactionCore.cs
@@ -8,6 +8,8 @@ namespace Microsoft.Azure.Cosmos
     using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Telemetry.OpenTelemetry;
+    using Microsoft.Azure.Cosmos.Tracing;
     using Microsoft.Azure.Documents;
 
     internal class DistributedReadTransactionCore : DistributedReadTransaction
@@ -44,14 +46,26 @@ namespace Microsoft.Azure.Cosmos
             return this;
         }
 
-        public override async Task<DistributedTransactionResponse> CommitTransactionAsync(
+        public override Task<DistributedTransactionResponse> CommitTransactionAsync(
             CancellationToken cancellationToken = default)
         {
-            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
-                operations: this.operations,
-                clientContext: this.clientContext);
+            return this.clientContext.OperationHelperAsync(
+                operationName: $"{nameof(DistributedReadTransaction)}.{nameof(CommitTransactionAsync)}",
+                containerName: null,
+                databaseName: null,
+                operationType: OperationType.CommitDistributedTransaction,
+                requestOptions: null,
+                task: (trace) =>
+                {
+                    DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
+                        operations: this.operations,
+                        clientContext: this.clientContext);
 
-            return await committer.CommitTransactionAsync(cancellationToken);
+                    return committer.CommitTransactionAsync(trace, cancellationToken);
+                },
+                openTelemetry: new (OpenTelemetryConstants.Operations.CommitDistributedReadTransaction,
+                                    (response) => new OpenTelemetryResponse(response)),
+                traceComponent: TraceComponent.Batch);
         }
 
         private static void ValidateContainerReference(string database, string collection)

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionCommitter.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionCommitter.cs
@@ -11,6 +11,7 @@ namespace Microsoft.Azure.Cosmos
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Core.Trace;
+    using Microsoft.Azure.Cosmos.Diagnostics;
     using Microsoft.Azure.Cosmos.Tracing;
     using Microsoft.Azure.Documents;
     using Microsoft.Azure.Documents.Collections;
@@ -48,7 +49,9 @@ namespace Microsoft.Azure.Cosmos
             this.delayProvider = delayProvider ?? Task.Delay;
         }
 
-        public async Task<DistributedTransactionResponse> CommitTransactionAsync(CancellationToken cancellationToken)
+        public async Task<DistributedTransactionResponse> CommitTransactionAsync(
+            ITrace trace,
+            CancellationToken cancellationToken)
         {
             try
             {
@@ -63,7 +66,7 @@ namespace Microsoft.Azure.Cosmos
                     this.clientContext.SerializerCore,
                     cancellationToken);
 
-                return await this.ExecuteCommitWithRetryAsync(serverRequest, cancellationToken);
+                return await this.ExecuteCommitWithRetryAsync(serverRequest, trace, cancellationToken);
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
@@ -74,50 +77,68 @@ namespace Microsoft.Azure.Cosmos
 
         private async Task<DistributedTransactionResponse> ExecuteCommitWithRetryAsync(
             DistributedTransactionServerRequest serverRequest,
+            ITrace parentTrace,
             CancellationToken cancellationToken)
         {
+            // Allocate once; the underlying parentTrace tree continues to accumulate per-attempt children.
+            CosmosTraceDiagnostics diagnostics = new CosmosTraceDiagnostics(parentTrace);
+
             int attempt = 0;
-            using (ITrace retryTrace = Trace.GetRootTrace("Distributed Transaction Commit", TraceComponent.Batch, TraceLevel.Info))
+            while (true)
             {
-                while (true)
+                cancellationToken.ThrowIfCancellationRequested();
+
+                DistributedTransactionResponse response = await this.ExecuteCommitAsync(serverRequest, parentTrace, cancellationToken);
+
+                if (response.IsSuccessStatusCode || !response.IsRetriable)
                 {
-                    cancellationToken.ThrowIfCancellationRequested();
-
-                    DistributedTransactionResponse response = await this.ExecuteCommitAsync(serverRequest, retryTrace, cancellationToken);
-
-                    if (response.IsSuccessStatusCode || !response.IsRetriable)
-                    {
-                        return response;
-                    }
-
-                    if (attempt >= DistributedTransactionCommitter.MaxIsRetriableRetryCount)
-                    {
-                        DefaultTrace.TraceWarning(
-                            $"Distributed transaction isRetriable retry budget exhausted after {attempt} attempts " +
-                            $"(StatusCode={response.StatusCode}). Returning last response.");
-                        return response;
-                    }
-
-                    // Use the maximum of the server hint and the locally-computed exponential backoff
-                    // to avoid retrying sooner than the server requested.
-                    TimeSpan computedDelay = DistributedTransactionRetryHelpers.ComputeBackoff(
-                        attempt,
-                        this.retryBaseDelay,
-                        TimeSpan.MaxValue,
-                        DistributedTransactionCommitter.RetryMaxExponent);
-
-                    TimeSpan delay = response.Headers?.RetryAfter is TimeSpan serverHint && serverHint > computedDelay
-                        ? serverHint
-                        : computedDelay;
-
-                    DefaultTrace.TraceWarning(
-                        $"Distributed transaction commit retriable (StatusCode={response.StatusCode}, IsRetriable={response.IsRetriable}, attempt {attempt + 1}, delayMs={(int)delay.TotalMilliseconds}). Retrying with idempotency token {serverRequest.IdempotencyToken}.");
-
-                    response.Dispose();
-                    attempt++;
-                    await this.delayProvider(delay, cancellationToken);
+                    response.Diagnostics = diagnostics;
+                    return response;
                 }
+
+                if (attempt >= DistributedTransactionCommitter.MaxIsRetriableRetryCount)
+                {
+                    DefaultTrace.TraceWarning(
+                        $"Distributed transaction isRetriable retry budget exhausted after {attempt} attempts " +
+                            $"(StatusCode={response.StatusCode}, DiagnosticString={TruncateForLog(response.DiagnosticString)}). Returning last response.");
+                    response.Diagnostics = diagnostics;
+                    return response;
+                }
+
+                // Use the maximum of the server hint and the locally-computed exponential backoff
+                // to avoid retrying sooner than the server requested.
+                TimeSpan computedDelay = DistributedTransactionRetryHelpers.ComputeBackoff(
+                    attempt,
+                    this.retryBaseDelay,
+                    TimeSpan.MaxValue,
+                    DistributedTransactionCommitter.RetryMaxExponent);
+
+                TimeSpan delay = response.Headers?.RetryAfter is TimeSpan serverHint && serverHint > computedDelay
+                    ? serverHint
+                    : computedDelay;
+
+                DefaultTrace.TraceWarning(
+                    $"Distributed transaction commit retriable (StatusCode={response.StatusCode}, IsRetriable={response.IsRetriable}, DiagnosticString={TruncateForLog(response.DiagnosticString)}, attempt {attempt + 1}, delayMs={(int)delay.TotalMilliseconds}). Retrying with idempotency token {serverRequest.IdempotencyToken}.");
+
+                response.Dispose();
+                attempt++;
+                await this.delayProvider(delay, cancellationToken);
             }
+        }
+
+        // Caps server-controlled diagnostic strings before they enter SDK trace logs to prevent
+        // log bloat and avoid newline-driven log-line interleaving.
+        private static string TruncateForLog(string value)
+        {
+            const int MaxLogLength = 256;
+            if (string.IsNullOrEmpty(value))
+            {
+                return value;
+            }
+
+            return value.Length <= MaxLogLength
+                ? value
+                : value.Substring(0, MaxLogLength) + "...[truncated]";
         }
 
         private async Task<DistributedTransactionResponse> ExecuteCommitAsync(

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionResponse.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionResponse.cs
@@ -123,6 +123,19 @@ namespace Microsoft.Azure.Cosmos
         /// </summary>
         public virtual bool IsRetriable { get; }
 
+        /// <summary>
+        /// Gets the diagnostic string from the coordinator describing the transaction outcome
+        /// </summary>
+        public virtual string DiagnosticString { get; private set; }
+
+        /// <summary>
+        /// Gets the client-side diagnostics for the distributed transaction, covering the full
+        /// retry loop and per-attempt spans (address resolution, network, retries, latency).
+        /// </summary>
+        /// <remarks>Non-null when the response is returned from <c>CommitTransactionAsync</c>. The SDK sets this property
+        /// before returning; callers should treat it as non-null in normal usage but guard defensively in edge cases.</remarks>
+        public virtual CosmosDiagnostics Diagnostics { get; internal set; }
+
         internal virtual SubStatusCodes SubStatusCode { get; }
 
         internal virtual CosmosSerializerCore SerializerCore { get; }
@@ -224,17 +237,22 @@ namespace Microsoft.Azure.Cosmos
 
                         if (responseMessage.IsSuccessStatusCode)
                         {
+                            string preservedDiagnosticString = response.DiagnosticString;
+                            SubStatusCodes wireSubStatusCode = responseMessage.Headers.SubStatusCode;
                             response.Dispose();
 
                             return new DistributedTransactionResponse(
                                 HttpStatusCode.InternalServerError,
-                                SubStatusCodes.Unknown,
+                                wireSubStatusCode,
                                 ClientResources.InvalidServerResponse,
                                 responseMessage.Headers,
                                 serverRequest.Operations,
                                 serializer,
                                 createResponseTrace,
-                                idempotencyToken);
+                                idempotencyToken)
+                            {
+                                DiagnosticString = preservedDiagnosticString,
+                            };
                         }
 
                         response.CreateAndPopulateResults(serverRequest.Operations, createResponseTrace);
@@ -303,6 +321,7 @@ namespace Microsoft.Azure.Cosmos
         {
             List<DistributedTransactionOperationResult> results = new List<DistributedTransactionOperationResult>();
             bool isRetriable = false;
+            string diagnosticString = null;
 
             JsonDocument responseJson;
             try
@@ -325,6 +344,12 @@ namespace Microsoft.Azure.Cosmos
                     isRetriableElement.ValueKind == JsonValueKind.True)
                 {
                     isRetriable = true;
+                }
+
+                if (root.TryGetProperty(DistributedTransactionSerializer.DiagnosticString, out JsonElement diagnosticStringElement) &&
+                    diagnosticStringElement.ValueKind == JsonValueKind.String)
+                {
+                    diagnosticString = diagnosticStringElement.GetString();
                 }
 
                 // Parse operation results from "operationResponses" array.
@@ -372,10 +397,22 @@ namespace Microsoft.Azure.Cosmos
                 }
             }
 
+            // Incorporate the coordinator's diagnosticString into the error message so it
+            // surfaces in response.ErrorMessage and any exception message the caller builds.
+            // Only merge on error responses — success responses must keep ErrorMessage null.
+            string effectiveErrorMessage = responseMessage.ErrorMessage;
+            bool isSuccessStatus = (int)finalStatusCode >= 200 && (int)finalStatusCode <= 299;
+            if (!isSuccessStatus && !string.IsNullOrWhiteSpace(diagnosticString))
+            {
+                effectiveErrorMessage = string.IsNullOrWhiteSpace(effectiveErrorMessage)
+                    ? diagnosticString
+                    : $"{effectiveErrorMessage} ({diagnosticString})";
+            }
+
             return new DistributedTransactionResponse(
                 finalStatusCode,
                 finalSubStatusCode,
-                responseMessage.ErrorMessage,
+                effectiveErrorMessage,
                 responseMessage.Headers,
                 serverRequest.Operations,
                 serializer,
@@ -383,7 +420,8 @@ namespace Microsoft.Azure.Cosmos
                 idempotencyToken,
                 isRetriable)
             {
-                results = results
+                results = results,
+                DiagnosticString = diagnosticString
             };
         }
 

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionSerializer.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionSerializer.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Azure.Cosmos
         internal const string ETag = "ifMatch";
         internal const string OperationType = "operationType";
         internal const string ResourceType = "resourceType";
+        internal const string DiagnosticString = "diagnosticString";
 
         /// <summary>
         /// Serializes a distributed transaction request body to a JSON stream.

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedWriteTransactionCore.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedWriteTransactionCore.cs
@@ -10,6 +10,8 @@ namespace Microsoft.Azure.Cosmos
     using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Telemetry.OpenTelemetry;
+    using Microsoft.Azure.Cosmos.Tracing;
     using Microsoft.Azure.Documents;
 
     internal class DistributedWriteTransactionCore : DistributedWriteTransaction
@@ -271,13 +273,25 @@ namespace Microsoft.Azure.Cosmos
             return this;
         }
 
-        public override async Task<DistributedTransactionResponse> CommitTransactionAsync(CancellationToken cancellationToken)
+        public override Task<DistributedTransactionResponse> CommitTransactionAsync(CancellationToken cancellationToken)
         {
-            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
-                operations: this.operations,
-                clientContext: this.clientContext);
+            return this.clientContext.OperationHelperAsync(
+                operationName: $"{nameof(DistributedWriteTransaction)}.{nameof(CommitTransactionAsync)}",
+                containerName: null,
+                databaseName: null,
+                operationType: OperationType.CommitDistributedTransaction,
+                requestOptions: null,
+                task: (trace) =>
+                {
+                    DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
+                        operations: this.operations,
+                        clientContext: this.clientContext);
 
-            return await committer.CommitTransactionAsync(cancellationToken);
+                    return committer.CommitTransactionAsync(trace, cancellationToken);
+                },
+                openTelemetry: new (OpenTelemetryConstants.Operations.CommitDistributedWriteTransaction,
+                                    (response) => new OpenTelemetryResponse(response)),
+                traceComponent: TraceComponent.Batch);
         }
 
         private static void ValidateContainerReference(string database, string collection)

--- a/Microsoft.Azure.Cosmos/src/Telemetry/OpenTelemetry/OpenTelemetryConstants.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/OpenTelemetry/OpenTelemetryConstants.cs
@@ -12,6 +12,10 @@ namespace Microsoft.Azure.Cosmos.Telemetry.OpenTelemetry
             public const string ExecuteBatch = "execute_batch";
             public const string ExecuteBulkPrefix = "bulk_";
 
+            // Distributed Transaction Operations
+            public const string CommitDistributedReadTransaction = "commit_distributed_read_transaction";
+            public const string CommitDistributedWriteTransaction = "commit_distributed_write_transaction";
+
             // Change feed operations
             public const string QueryChangeFeed = "query_change_feed";
             public const string QueryChangeFeedEstimator = "get_change_feed_processor_estimate";

--- a/Microsoft.Azure.Cosmos/src/Telemetry/OpenTelemetry/OpenTelemetryResponse.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/OpenTelemetry/OpenTelemetryResponse.cs
@@ -31,7 +31,7 @@ namespace Microsoft.Azure.Cosmos
 
         internal OpenTelemetryResponse(DistributedTransactionResponse response)
            : this(
-                  statusCode: response.StatusCode,
+                  statusCode: (response ?? throw new ArgumentNullException(nameof(response))).StatusCode,
                   requestCharge: OpenTelemetryResponse.GetHeader(response)?.RequestCharge,
                   responseContentLength: null,
                   diagnostics: response.Diagnostics,

--- a/Microsoft.Azure.Cosmos/src/Telemetry/OpenTelemetry/OpenTelemetryResponse.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/OpenTelemetry/OpenTelemetryResponse.cs
@@ -29,6 +29,21 @@ namespace Microsoft.Azure.Cosmos
         {
         }
 
+        internal OpenTelemetryResponse(DistributedTransactionResponse response)
+           : this(
+                  statusCode: response.StatusCode,
+                  requestCharge: OpenTelemetryResponse.GetHeader(response)?.RequestCharge,
+                  responseContentLength: null,
+                  diagnostics: response.Diagnostics,
+                  itemCount: response.Count.ToString(),
+                  requestMessage: null,
+                  subStatusCode: OpenTelemetryResponse.GetHeader(response)?.SubStatusCode,
+                  activityId: OpenTelemetryResponse.GetHeader(response)?.ActivityId,
+                  correlationId: OpenTelemetryResponse.GetHeader(response)?.CorrelatedActivityId,
+                  batchSize: response.Count)
+        {
+        }
+
         internal OpenTelemetryResponse(ResponseMessage responseMessage, Func<SqlQuerySpec> querySpecFunc = null)
            : this(
                   statusCode: responseMessage.StatusCode,
@@ -106,6 +121,19 @@ namespace Microsoft.Azure.Cosmos
             catch (NotImplementedException ex)
             {
                 DefaultTrace.TraceVerbose("Failed to get headers from ResponseMessage. Exception: {0}", ex.Message);
+                return null;
+            }
+        }
+
+        private static Headers GetHeader(DistributedTransactionResponse response)
+        {
+            try
+            {
+                return response?.Headers;
+            }
+            catch (NotImplementedException ex)
+            {
+                DefaultTrace.TraceVerbose("Failed to get headers from DistributedTransactionResponse. Exception: {0}", ex.Message);
                 return null;
             }
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedReadTransactionCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedReadTransactionCoreTests.cs
@@ -6,6 +6,11 @@ namespace Microsoft.Azure.Cosmos.Tests
 {
     using System;
     using System.Collections.Generic;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Telemetry;
+    using Microsoft.Azure.Cosmos.Telemetry.OpenTelemetry;
+    using Microsoft.Azure.Cosmos.Tracing;
     using Microsoft.Azure.Documents;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Moq;
@@ -172,6 +177,53 @@ namespace Microsoft.Azure.Cosmos.Tests
 
             DistributedTransactionOperation op = GetOperations(txn)[0];
             Assert.AreSame(options, op.RequestOptions);
+        }
+
+        #endregion
+
+        #region OperationHelperAsync wiring
+
+        [TestMethod]
+        [Description("Verifies CommitTransactionAsync routes through OperationHelperAsync with the qualified operationName, the read-specific OTel constant, the CommitDistributedTransaction operation type, and TraceComponent.Batch.")]
+        public async Task CommitTransactionAsync_RoutesThroughOperationHelper_WithExpectedWiring()
+        {
+            string capturedOperationName = null;
+            OperationType capturedOperationType = default;
+            TraceComponent capturedTraceComponent = default;
+            string capturedOTelOperationName = null;
+
+            Mock<CosmosClientContext> contextMock = new Mock<CosmosClientContext>();
+            contextMock
+                .Setup(c => c.OperationHelperAsync<DistributedTransactionResponse>(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<OperationType>(),
+                    It.IsAny<RequestOptions>(),
+                    It.IsAny<Func<ITrace, Task<DistributedTransactionResponse>>>(),
+                    It.IsAny<(string OperationName, Func<DistributedTransactionResponse, OpenTelemetryAttributes> GetAttributes)?>(),
+                    It.IsAny<ResourceType?>(),
+                    It.IsAny<TraceComponent>(),
+                    It.IsAny<TraceLevel>()))
+                .Returns<string, string, string, OperationType, RequestOptions, Func<ITrace, Task<DistributedTransactionResponse>>, (string, Func<DistributedTransactionResponse, OpenTelemetryAttributes>)?, ResourceType?, TraceComponent, TraceLevel>(
+                    (operationName, containerName, databaseName, operationType, requestOptions, func, oTelTuple, resourceType, comp, level) =>
+                    {
+                        capturedOperationName = operationName;
+                        capturedOperationType = operationType;
+                        capturedTraceComponent = comp;
+                        capturedOTelOperationName = oTelTuple?.Item1;
+                        return Task.FromResult<DistributedTransactionResponse>(null);
+                    });
+
+            DistributedReadTransactionCore txn = new DistributedReadTransactionCore(contextMock.Object);
+            txn.ReadItem(Database, Collection, TestPartitionKey, ItemId);
+
+            await txn.CommitTransactionAsync(CancellationToken.None);
+
+            Assert.AreEqual($"{nameof(DistributedReadTransaction)}.{nameof(DistributedReadTransaction.CommitTransactionAsync)}", capturedOperationName);
+            Assert.AreEqual(OperationType.CommitDistributedTransaction, capturedOperationType);
+            Assert.AreEqual(TraceComponent.Batch, capturedTraceComponent);
+            Assert.AreEqual(OpenTelemetryConstants.Operations.CommitDistributedReadTransaction, capturedOTelOperationName);
         }
 
         #endregion

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionCommitterTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionCommitterTests.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------
+// ------------------------------------------------------------
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // ------------------------------------------------------------
 
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
                 operations, mockContext.Object);
 
-            await committer.CommitTransactionAsync(CancellationToken.None);
+            await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
 
             string storedToken = sessionContainer.GetSessionToken(DistributedTransactionConstants.GetCollectionFullName(DatabaseName, ContainerName));
             Assert.AreEqual(expectedToken, storedToken,
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
                 operations, mockContext.Object);
 
-            await committer.CommitTransactionAsync(CancellationToken.None);
+            await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
 
             string storedToken = sessionContainer.GetSessionToken(DistributedTransactionConstants.GetCollectionFullName(DatabaseName, ContainerName));
             Assert.IsTrue(string.IsNullOrEmpty(storedToken),
@@ -191,7 +191,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
                 operations, mockContext.Object);
 
-            await committer.CommitTransactionAsync(CancellationToken.None);
+            await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
 
             // Verify SetSessionToken was called once per operation with the correct collection identity.
             mockSessionContainer.Verify(
@@ -241,7 +241,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
                 operations, mockContext.Object);
 
-            DistributedTransactionResponse response = await committer.CommitTransactionAsync(CancellationToken.None);
+            DistributedTransactionResponse response = await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
 
             string storedToken = sessionContainer.GetSessionToken(DistributedTransactionConstants.GetCollectionFullName(DatabaseName, ContainerName));
             Assert.AreEqual(expectedToken, storedToken,
@@ -280,7 +280,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
                 operations, mockContext.Object);
 
-            await committer.CommitTransactionAsync(CancellationToken.None);
+            await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
 
             string storedToken = sessionContainer.GetSessionToken(DistributedTransactionConstants.GetCollectionFullName(DatabaseName, ContainerName));
             Assert.AreEqual(expectedToken, storedToken,
@@ -318,7 +318,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
                 operations, mockContext.Object);
 
-            await committer.CommitTransactionAsync(CancellationToken.None);
+            await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
 
             string storedToken = sessionContainer.GetSessionToken(DistributedTransactionConstants.GetCollectionFullName(DatabaseName, ContainerName));
             Assert.IsTrue(string.IsNullOrEmpty(storedToken),
@@ -360,7 +360,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
                 operations, mockContext.Object);
 
-            await committer.CommitTransactionAsync(CancellationToken.None);
+            await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
 
             string storedToken = sessionContainer.GetSessionToken(DistributedTransactionConstants.GetCollectionFullName(DatabaseName, ContainerName));
             Assert.IsTrue(string.IsNullOrEmpty(storedToken),
@@ -446,7 +446,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
                 operations, mockContext.Object);
 
-            await committer.CommitTransactionAsync(CancellationToken.None);
+            await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
 
             // op 0 (missing pkRangeId) must NOT have been merged.
             mockSessionContainer.Verify(
@@ -509,7 +509,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             DefaultTrace.TraceSource.Listeners.Add(listener);
             try
             {
-                await committer.CommitTransactionAsync(CancellationToken.None);
+                await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
             }
             finally
             {
@@ -591,7 +591,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                 operations, mockContext.Object);
 
             // Must not throw even though SetSessionToken throws internally.
-            DistributedTransactionResponse response = await committer.CommitTransactionAsync(CancellationToken.None);
+            DistributedTransactionResponse response = await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
             Assert.IsNotNull(response, "CommitTransactionAsync should return a response even when SetSessionToken throws.");
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
         }
@@ -632,7 +632,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                 operations, mockContext.Object);
 
             await Assert.ThrowsExceptionAsync<OperationCanceledException>(
-                () => committer.CommitTransactionAsync(CancellationToken.None),
+                () => committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None),
                 "OperationCanceledException from SetSessionToken must propagate, not be swallowed.");
         }
 
@@ -653,7 +653,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
 
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(CreateTestOperations(), mockContext.Object, TimeSpan.Zero);
 
-            using (DistributedTransactionResponse response = await committer.CommitTransactionAsync(CancellationToken.None))
+            using (DistributedTransactionResponse response = await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None))
             {
                 Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
                 Assert.IsTrue(response.IsSuccessStatusCode);
@@ -683,7 +683,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
 
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(CreateTestOperations(), mockContext.Object, TimeSpan.Zero);
 
-            using (DistributedTransactionResponse response = await committer.CommitTransactionAsync(CancellationToken.None))
+            using (DistributedTransactionResponse response = await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None))
             {
                 Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
                 Assert.IsTrue(response.IsSuccessStatusCode);
@@ -719,7 +719,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                     TimeSpan.FromMilliseconds(1));
 
                 await Assert.ThrowsExceptionAsync<OperationCanceledException>(
-                    () => committer.CommitTransactionAsync(cts.Token));
+                    () => committer.CommitTransactionAsync(NoOpTrace.Singleton, cts.Token));
 
                 // Retries continue until the cancellation token fires (before exhausting the budget).
                 Assert.AreEqual(3, callCount);
@@ -753,7 +753,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                 retryBaseDelay: TimeSpan.Zero,
                 delayProvider: captureDelay);
 
-            using (DistributedTransactionResponse response = await committer.CommitTransactionAsync(CancellationToken.None))
+            using (DistributedTransactionResponse response = await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None))
             {
                 // MaxIsRetriableRetryCount (10) retries + 1 final call that hits the budget check = 11 total calls.
                 Assert.AreEqual(DistributedTransactionCommitter.MaxIsRetriableRetryCount + 1, callCount,
@@ -764,6 +764,8 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                     "The returned response must be the last non-success response.");
                 Assert.IsTrue(response.IsRetriable,
                     "The returned response must still have IsRetriable=true (budget exhausted, not a new response).");
+                Assert.IsNotNull(response.Diagnostics,
+                    "Diagnostics must not be null when the retry budget is exhausted — this is the most important failure path to have diagnostics on.");
             }
         }
 
@@ -792,7 +794,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(CreateTestOperations(), mockContext.Object, TimeSpan.Zero);
 
             CosmosException thrown = await Assert.ThrowsExceptionAsync<CosmosException>(
-                () => committer.CommitTransactionAsync(CancellationToken.None));
+                () => committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None));
 
             Assert.AreEqual((HttpStatusCode)statusCode, thrown.StatusCode);
             Assert.AreEqual(1, callCount);
@@ -820,7 +822,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
 
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(CreateTestOperations(), mockContext.Object, TimeSpan.Zero);
 
-            using (DistributedTransactionResponse response = await committer.CommitTransactionAsync(CancellationToken.None))
+            using (DistributedTransactionResponse response = await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None))
             {
                 Assert.AreEqual((HttpStatusCode)statusCode, response.StatusCode);
                 Assert.IsFalse(response.IsSuccessStatusCode);
@@ -845,7 +847,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                 DistributedTransactionCommitter committer = new DistributedTransactionCommitter(CreateTestOperations(), mockContext.Object, TimeSpan.Zero);
 
                 await Assert.ThrowsExceptionAsync<OperationCanceledException>(
-                    () => committer.CommitTransactionAsync(cts.Token));
+                    () => committer.CommitTransactionAsync(NoOpTrace.Singleton, cts.Token));
 
                 this.VerifyProcessResourceOperationCallCount(mockContext, Times.Never());
             }
@@ -876,7 +878,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                     TimeSpan.FromMilliseconds(500));
 
                 await Assert.ThrowsExceptionAsync<OperationCanceledException>(
-                    () => committer.CommitTransactionAsync(cts.Token));
+                    () => committer.CommitTransactionAsync(NoOpTrace.Singleton, cts.Token));
 
                 Assert.AreEqual(1, callCount);
             }
@@ -903,7 +905,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
 
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(CreateTestOperations(), mockContext.Object, TimeSpan.Zero);
 
-            using (DistributedTransactionResponse response = await committer.CommitTransactionAsync(CancellationToken.None))
+            using (DistributedTransactionResponse response = await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None))
             {
                 // 3 retriable failures + 1 success = 4 total calls.
                 Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
@@ -929,7 +931,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(CreateTestOperations(), mockContext.Object, TimeSpan.Zero);
 
             IOException ex = await Assert.ThrowsExceptionAsync<IOException>(
-                () => committer.CommitTransactionAsync(CancellationToken.None));
+                () => committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None));
 
             Assert.AreEqual("Network error", ex.Message);
             Assert.AreEqual(1, callCount);
@@ -985,7 +987,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                 mockContext.Object,
                 TimeSpan.Zero);
 
-            using (DistributedTransactionResponse response = await committer.CommitTransactionAsync(CancellationToken.None))
+            using (DistributedTransactionResponse response = await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None))
             {
                 Assert.IsTrue(response.IsSuccessStatusCode);
                 Assert.AreEqual(3, callCount);
@@ -1021,7 +1023,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
 
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(CreateTestOperations(), mockContext.Object, TimeSpan.Zero);
 
-            using (DistributedTransactionResponse response = await committer.CommitTransactionAsync(CancellationToken.None))
+            using (DistributedTransactionResponse response = await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None))
             {
                 Assert.AreEqual((HttpStatusCode)statusCode, response.StatusCode);
                 Assert.AreEqual(1, callCount, "Envelope response without a DTX sub-status code must not be retried.");
@@ -1050,7 +1052,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
 
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(CreateTestOperations(), mockContext.Object, TimeSpan.Zero);
 
-            using (DistributedTransactionResponse response = await committer.CommitTransactionAsync(CancellationToken.None))
+            using (DistributedTransactionResponse response = await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None))
             {
                 Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
                 Assert.AreEqual(1, callCount, $"Validation failure 400/{subStatusCode} must not be retried.");
@@ -1090,7 +1092,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                 retryBaseDelay: baseDelay,
                 delayProvider: captureDelay);
 
-            using (DistributedTransactionResponse response = await committer.CommitTransactionAsync(CancellationToken.None))
+            using (DistributedTransactionResponse response = await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None))
             {
                 Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             }
@@ -1120,6 +1122,114 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                 capturedDelays[maxExponent + 1].TotalMilliseconds >= cappedBase * 0.5
                 && capturedDelays[maxExponent + 1].TotalMilliseconds <= cappedBase * 1.5,
                 "Delay beyond maxExponent must still use the capped exponent, producing a similar magnitude.");
+        }
+
+        // ─── Diagnostics ──────────────────────────────────────────────────────────
+
+        [TestMethod]
+        [Description("Verifies that the response Diagnostics is non-null and covers the caller's trace span on a successful single-attempt commit.")]
+        public async Task CommitTransactionAsync_Diagnostics_IsNonNullOnSuccess()
+        {
+            Mock<CosmosClientContext> mockContext = this.CreateMockClientContext();
+            this.SetupProcessResourceOperation(
+                mockContext,
+                () => Task.FromResult(CreateSuccessResponseMessage(operationCount: 1)));
+
+            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
+                CreateTestOperations(), mockContext.Object, TimeSpan.Zero);
+
+            using (ITrace trace = Trace.GetRootTrace("CommitDistributedTransaction", TraceComponent.Batch, TraceLevel.Info))
+            using (DistributedTransactionResponse response = await committer.CommitTransactionAsync(trace, CancellationToken.None))
+            {
+                Assert.IsNotNull(response.Diagnostics, "Diagnostics must not be null.");
+                string diagnosticText = response.Diagnostics.ToString();
+                Assert.IsFalse(string.IsNullOrEmpty(diagnosticText), "Diagnostics.ToString() must not be empty.");
+                Assert.IsTrue(diagnosticText.Contains("CommitDistributedTransaction"),
+                    "Diagnostics must be rooted at the caller-supplied parent trace, not a sibling root allocated by the committer.");
+                Assert.IsTrue(diagnosticText.Contains("Execute Distributed Transaction Commit"),
+                    "Diagnostics must contain the per-attempt span.");
+            }
+        }
+
+        [TestMethod]
+        [Description("Verifies that Diagnostics spans all retry attempts — the caller's trace is attached to the final returned response even after multiple isRetriable retries.")]
+        public async Task CommitTransactionAsync_Diagnostics_CoversRetryAttempts()
+        {
+            int callCount = 0;
+            Mock<CosmosClientContext> mockContext = this.CreateMockClientContext();
+            this.SetupProcessResourceOperation(
+                mockContext,
+                () =>
+                {
+                    callCount++;
+                    return callCount < 3
+                        ? Task.FromResult(CreateRetriableErrorResponseMessage())
+                        : Task.FromResult(CreateSuccessResponseMessage(operationCount: 1));
+                });
+
+            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
+                CreateTestOperations(), mockContext.Object, TimeSpan.Zero);
+
+            using (ITrace trace = Trace.GetRootTrace("CommitDistributedTransaction", TraceComponent.Batch, TraceLevel.Info))
+            using (DistributedTransactionResponse response = await committer.CommitTransactionAsync(trace, CancellationToken.None))
+            {
+                Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+                Assert.IsNotNull(response.Diagnostics, "Diagnostics must not be null after retries.");
+                string diagnosticText = response.Diagnostics.ToString();
+                Assert.IsTrue(diagnosticText.Contains("CommitDistributedTransaction"),
+                    "Diagnostics must be rooted at the caller-supplied parent trace across all retry attempts.");
+                Assert.IsTrue(diagnosticText.Contains("Execute Distributed Transaction Commit"),
+                    "Diagnostics must contain per-attempt spans covering the full commit flow.");
+            }
+        }
+
+        [TestMethod]
+        [Description("Verifies that DiagnosticString parsed from the wire response body is correctly propagated through CommitTransactionAsync — protects against accidental omission of the property assignment in the object initializer.")]
+        public async Task CommitTransactionAsync_DiagnosticString_PropagatedFromWireResponse()
+        {
+            const string expectedDiagnosticString = "TransactionAbortedByCoordinator";
+            Mock<CosmosClientContext> mockContext = this.CreateMockClientContext();
+            this.SetupProcessResourceOperation(
+                mockContext,
+                () => Task.FromResult(CreateResponseMessageWithDiagnosticString(
+                    HttpStatusCode.Conflict,
+                    operationCount: 1,
+                    diagnosticString: expectedDiagnosticString)));
+
+            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
+                CreateTestOperations(), mockContext.Object, TimeSpan.Zero);
+
+            using (DistributedTransactionResponse response = await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None))
+            {
+                Assert.AreEqual(expectedDiagnosticString, response.DiagnosticString,
+                    "DiagnosticString must be propagated from the wire response body through CommitTransactionAsync.");
+            }
+        }
+
+        [TestMethod]
+        [Description("Verifies that DiagnosticString from a successful commit is propagated through CommitTransactionAsync and does NOT leak into ErrorMessage (which must remain null on success).")]
+        public async Task CommitTransactionAsync_DiagnosticString_PropagatedOnSuccess_DoesNotPolluteErrorMessage()
+        {
+            const string expectedDiagnosticString = "TransactionCommitted";
+            Mock<CosmosClientContext> mockContext = this.CreateMockClientContext();
+            this.SetupProcessResourceOperation(
+                mockContext,
+                () => Task.FromResult(CreateResponseMessageWithDiagnosticString(
+                    HttpStatusCode.OK,
+                    operationCount: 1,
+                    diagnosticString: expectedDiagnosticString)));
+
+            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
+                CreateTestOperations(), mockContext.Object, TimeSpan.Zero);
+
+            using (DistributedTransactionResponse response = await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None))
+            {
+                Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+                Assert.AreEqual(expectedDiagnosticString, response.DiagnosticString,
+                    "DiagnosticString must be propagated even on a successful commit.");
+                Assert.IsNull(response.ErrorMessage,
+                    "ErrorMessage must remain null on success — the diagnostic string must NOT be merged into ErrorMessage on 2xx responses.");
+            }
         }
 
         // ─── Helpers ───────────────────────────────────────────────────────────
@@ -1341,6 +1451,31 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             return new ResponseMessage(HttpStatusCode.ServiceUnavailable)
             {
                 Content = new MemoryStream(Encoding.UTF8.GetBytes(json))
+            };
+        }
+
+        private static ResponseMessage CreateResponseMessageWithDiagnosticString(
+            HttpStatusCode statusCode,
+            int operationCount,
+            string diagnosticString)
+        {
+            StringBuilder json = new StringBuilder();
+            json.Append($"{{\"diagnosticString\":\"{diagnosticString}\",\"operationResponses\":[");
+            for (int i = 0; i < operationCount; i++)
+            {
+                if (i > 0)
+                {
+                    json.Append(",");
+                }
+
+                json.Append($"{{\"index\":{i},\"statusCode\":{(int)statusCode},\"subStatusCode\":0}}");
+            }
+
+            json.Append("]}");
+
+            return new ResponseMessage(statusCode)
+            {
+                Content = new MemoryStream(Encoding.UTF8.GetBytes(json.ToString()))
             };
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionResponseTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionResponseTests.cs
@@ -166,6 +166,29 @@ namespace Microsoft.Azure.Cosmos.Tests
         }
 
         [TestMethod]
+        [Description("When a count-mismatch synthetic 500 is built, the sub-status code from the wire header must be preserved rather than discarded as Unknown.")]
+        public async Task FromResponseMessage_CountMismatch_SuccessStatus_PreservesWireSubStatusCode()
+        {
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 2);
+
+            // 2 operations submitted but server returns only 1 result — triggers the synthetic 500 path.
+            string json = @"{""operationResponses"":[{""index"":0,""statusCode"":201}]}";
+            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.OK, json);
+            responseMessage.Headers.SubStatusCode = (SubStatusCodes)1009; // a non-Unknown sub-status code
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            Assert.AreEqual(HttpStatusCode.InternalServerError, response.StatusCode);
+            Assert.AreEqual((SubStatusCodes)1009, response.SubStatusCode,
+                "The wire sub-status code must be preserved in the synthetic 500 response rather than replaced with Unknown.");
+        }
+
+        [TestMethod]
         [Description("When the server returns fewer results than submitted operations and the HTTP status is an error, results are padded.")]
         public async Task FromResponseMessage_CountMismatch_FewerResults_ErrorStatus_PadsResults()
         {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionResponseTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionResponseTests.cs
@@ -739,7 +739,252 @@ namespace Microsoft.Azure.Cosmos.Tests
             Assert.AreEqual(expected, response.IsRetriable);
         }
 
-        // ThrowIfDisposed guards on Count and GetEnumerator
+        // DiagnosticString parsing
+
+        [TestMethod]
+        [Description("DiagnosticString deserializes from the 'diagnosticString' JSON property.")]
+        public async Task FromResponseMessage_DiagnosticString_DeserializesCorrectly()
+        {
+            const string expectedDiagnosticString = "TransactionCommitted";
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
+
+            string json = $@"{{""diagnosticString"":""{expectedDiagnosticString}"",""operationResponses"":[{{""index"":0,""statusCode"":200}}]}}";
+            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.OK, json);
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            Assert.AreEqual(expectedDiagnosticString, response.DiagnosticString,
+                "DiagnosticString must equal the value from the JSON 'diagnosticString' field.");
+            Assert.IsNull(response.ErrorMessage,
+                "ErrorMessage must be null on a 200 OK response, even when diagnosticString is present.");
+        }
+
+        [TestMethod]
+        [Description("DiagnosticString is null when the field is absent from the JSON body.")]
+        public async Task FromResponseMessage_DiagnosticString_AbsentInJson_IsNull()
+        {
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
+            string json = @"{""operationResponses"":[{""index"":0,""statusCode"":201}]}";
+            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.OK, json);
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            Assert.IsNull(response.DiagnosticString,
+                "DiagnosticString must be null when absent from the JSON body.");
+        }
+
+        [TestMethod]
+        [Description("Diagnostics is null after FromResponseMessageAsync — the committer is responsible for setting it with the full retry-tree trace.")]
+        public async Task FromResponseMessage_Diagnostics_IsNull_BeforeCommitterSetsIt()
+        {
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
+            string json = @"{""operationResponses"":[{""index"":0,""statusCode"":200}]}";
+            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.OK, json);
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            Assert.IsNull(response.Diagnostics,
+                "Diagnostics should be null before the committer sets it with the full retry-tree trace.");
+        }
+
+        [TestMethod]
+        [Description("ErrorMessage appends DiagnosticString in parentheses when the HTTP error message is also present.")]
+        public async Task FromResponseMessage_DiagnosticString_AppendedToErrorMessage()
+        {
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
+            string json = @"{""diagnosticString"":""TransactionAborted"",""operationResponses"":[{""index"":0,""statusCode"":409}]}";
+
+            ResponseMessage responseMessage = new ResponseMessage(HttpStatusCode.Conflict, errorMessage: "Transaction was aborted by coordinator")
+            {
+                Content = new MemoryStream(Encoding.UTF8.GetBytes(json))
+            };
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            Assert.IsTrue(response.ErrorMessage.Contains("Transaction was aborted by coordinator"),
+                "ErrorMessage must contain the original HTTP error message.");
+            Assert.IsTrue(response.ErrorMessage.Contains("TransactionAborted"),
+                "ErrorMessage must contain the coordinator's diagnosticString.");
+        }
+
+        [TestMethod]
+        [Description("ErrorMessage is set to DiagnosticString alone when the HTTP error message is absent.")]
+        public async Task FromResponseMessage_DiagnosticString_UsedAsFallbackErrorMessage()
+        {
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
+            string json = @"{""diagnosticString"":""LedgerForbidden"",""operationResponses"":[{""index"":0,""statusCode"":403}]}";
+            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.Forbidden, json);
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            Assert.AreEqual("LedgerForbidden", response.ErrorMessage,
+                "ErrorMessage must equal DiagnosticString when no HTTP error message is present.");
+        }
+
+        [TestMethod]
+        [Description("Empty diagnosticString must not produce malformed parentheses in ErrorMessage — treated same as absent.")]
+        public async Task FromResponseMessage_DiagnosticString_Empty_DoesNotAppendEmptyParens()
+        {
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
+            string json = @"{""diagnosticString"":"""",""operationResponses"":[{""index"":0,""statusCode"":409}]}";
+
+            ResponseMessage responseMessage = new ResponseMessage(HttpStatusCode.Conflict, errorMessage: "Transaction aborted")
+            {
+                Content = new MemoryStream(Encoding.UTF8.GetBytes(json))
+            };
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            Assert.IsFalse(response.ErrorMessage.Contains("()"),
+                "Empty diagnosticString must not produce malformed '()' in ErrorMessage.");
+        }
+
+        [DataTestMethod]
+        [DataRow("   ", "(   )", DisplayName = "spaces only")]
+        [DataRow("\\t", "(\t)", DisplayName = "tab only")]
+        [DataRow("\\n", "(\n)", DisplayName = "newline only")]
+        [DataRow(" \\t\\r\\n ", "( \t\r\n )", DisplayName = "mixed whitespace")]
+        [Description("Whitespace-only diagnosticString must not produce malformed ErrorMessage — treated same as absent.")]
+        public async Task FromResponseMessage_DiagnosticString_WhitespaceOnly_DoesNotPollutErrorMessage(
+            string jsonEscapedWhitespace,
+            string forbiddenAppendix)
+        {
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
+            string json = $@"{{""diagnosticString"":""{jsonEscapedWhitespace}"",""operationResponses"":[{{""index"":0,""statusCode"":409}}]}}";
+
+            ResponseMessage responseMessage = new ResponseMessage(HttpStatusCode.Conflict, errorMessage: "Transaction aborted")
+            {
+                Content = new MemoryStream(Encoding.UTF8.GetBytes(json))
+            };
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            Assert.IsTrue(response.ErrorMessage.Contains("Transaction aborted"),
+                $"Original HTTP error message must be preserved. Actual: {response.ErrorMessage}");
+            Assert.IsFalse(response.ErrorMessage.Contains(forbiddenAppendix),
+                $"Whitespace-only diagnosticString must not produce malformed '{forbiddenAppendix}' appendix in ErrorMessage. Actual: {response.ErrorMessage}");
+        }
+
+        [TestMethod]
+        [Description("Diagnostic strings containing internal whitespace (but non-whitespace characters) must still be merged into ErrorMessage.")]
+        public async Task FromResponseMessage_DiagnosticString_WithInternalWhitespace_IsMerged()
+        {
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
+            const string diagnostic = "Transaction aborted by coordinator";
+            string json = $@"{{""diagnosticString"":""{diagnostic}"",""operationResponses"":[{{""index"":0,""statusCode"":409}}]}}";
+
+            ResponseMessage responseMessage = new ResponseMessage(HttpStatusCode.Conflict, errorMessage: "HttpFailure")
+            {
+                Content = new MemoryStream(Encoding.UTF8.GetBytes(json))
+            };
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            Assert.IsTrue(response.ErrorMessage.Contains("HttpFailure"),
+                $"Original HTTP error message must be preserved. Actual: {response.ErrorMessage}");
+            Assert.IsTrue(response.ErrorMessage.Contains($"({diagnostic})"),
+                $"Diagnostic strings with internal whitespace must be merged as '({diagnostic})' into ErrorMessage. Actual: {response.ErrorMessage}");
+        }
+
+        [TestMethod]
+        [Description("When a 207 MultiStatus (success-range wire status) is promoted to a per-operation error code, the ErrorMessage merge must honor the post-promotion status — i.e. diagnosticString MUST be merged because finalStatusCode is now an error.")]
+        public async Task FromResponseMessage_DiagnosticString_MergedAfterMultiStatusPromotion()
+        {
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 2);
+            const string diagnostic = "OperationConflict";
+
+            // Wire status is 207 (success range), but op #1 is 409 — finalStatusCode promotes to 409.
+            string json = $@"{{""diagnosticString"":""{diagnostic}"",""operationResponses"":[{{""index"":0,""statusCode"":201}},{{""index"":1,""statusCode"":409}}]}}";
+
+            // Wire ResponseMessage with a 207 MultiStatus and no errorMessage on the wire (success-range responses
+            // typically don't carry one). The merge must still kick in based on the *promoted* finalStatusCode (409).
+            ResponseMessage responseMessage = new ResponseMessage((HttpStatusCode)StatusCodes.MultiStatus)
+            {
+                Content = new MemoryStream(Encoding.UTF8.GetBytes(json))
+            };
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            Assert.AreEqual(HttpStatusCode.Conflict, response.StatusCode,
+                "Promotion must move finalStatusCode to 409 (the first failing op).");
+            Assert.AreEqual(diagnostic, response.ErrorMessage,
+                "Because finalStatusCode is now an error (post-promotion), the diagnosticString must be merged into ErrorMessage.");
+        }
+
+        [TestMethod]
+        [Description("When a 207 MultiStatus has only successful per-operation results (no promotion), finalStatusCode remains in success range and diagnosticString must NOT pollute ErrorMessage.")]
+        public async Task FromResponseMessage_DiagnosticString_NotMerged_WhenMultiStatusHasNoPromotion()
+        {
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 2);
+            const string diagnostic = "TransactionCommitted";
+
+            // Both ops succeed; no promotion — finalStatusCode stays at 207 (success).
+            string json = $@"{{""diagnosticString"":""{diagnostic}"",""operationResponses"":[{{""index"":0,""statusCode"":201}},{{""index"":1,""statusCode"":200}}]}}";
+
+            ResponseMessage responseMessage = new ResponseMessage((HttpStatusCode)StatusCodes.MultiStatus)
+            {
+                Content = new MemoryStream(Encoding.UTF8.GetBytes(json))
+            };
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            Assert.AreEqual((HttpStatusCode)StatusCodes.MultiStatus, response.StatusCode,
+                "No promotion expected — finalStatusCode must remain 207.");
+            Assert.IsNull(response.ErrorMessage,
+                "ErrorMessage must remain null on success-range finalStatusCode, even when diagnosticString is present.");
+        }
+
+
 
         [TestMethod]
         [Description("Count after Dispose() must not throw — pre-existing safer behavior on main. Returns 0 because Dispose nulls the underlying list.")]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionSerializerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionSerializerTests.cs
@@ -600,6 +600,21 @@ namespace Microsoft.Azure.Cosmos.Tests
                     It.IsAny<CancellationToken>()))
                 .ReturnsAsync(containerProps);
 
+            contextMock
+                .Setup(c => c.OperationHelperAsync<DistributedTransactionResponse>(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<OperationType>(),
+                    It.IsAny<RequestOptions>(),
+                    It.IsAny<Func<ITrace, Task<DistributedTransactionResponse>>>(),
+                    It.IsAny<(string OperationName, Func<DistributedTransactionResponse, Microsoft.Azure.Cosmos.Telemetry.OpenTelemetryAttributes> GetAttributes)?>(),
+                    It.IsAny<ResourceType?>(),
+                    It.IsAny<TraceComponent>(),
+                    It.IsAny<TraceLevel>()))
+                .Returns<string, string, string, OperationType, RequestOptions, Func<ITrace, Task<DistributedTransactionResponse>>, (string, Func<DistributedTransactionResponse, Microsoft.Azure.Cosmos.Telemetry.OpenTelemetryAttributes>)?, ResourceType?, TraceComponent, TraceLevel>(
+                    (operationName, containerName, databaseName, operationType, requestOptions, func, oTelFunc, resourceType, comp, level) => func(NoOpTrace.Singleton));
+
             return contextMock;
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedWriteTransactionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedWriteTransactionTests.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Azure.Cosmos.Tests
     using System.Text.Json;
     using System.Threading;
     using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Telemetry.OpenTelemetry;
     using Microsoft.Azure.Cosmos.Tracing;
     using Microsoft.Azure.Documents;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -385,6 +386,48 @@ namespace Microsoft.Azure.Cosmos.Tests
 
             Assert.AreEqual(HttpStatusCode.Conflict, response.StatusCode);
             Assert.IsFalse(response.IsSuccessStatusCode);
+        }
+
+        [TestMethod]
+        [Description("CommitTransactionAsync must route through OperationHelperAsync with the correct operation name, OperationType, TraceComponent, and OTel operation name for the write path — ensuring the write path is distinct from the read path.")]
+        public async Task CommitTransactionAsync_RoutesThroughOperationHelper_WithExpectedWiring()
+        {
+            string capturedOperationName = null;
+            OperationType capturedOperationType = default;
+            TraceComponent capturedTraceComponent = default;
+            string capturedOTelOperationName = null;
+
+            Mock<CosmosClientContext> contextMock = new Mock<CosmosClientContext>();
+            contextMock
+                .Setup(c => c.OperationHelperAsync<DistributedTransactionResponse>(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<OperationType>(),
+                    It.IsAny<RequestOptions>(),
+                    It.IsAny<Func<ITrace, Task<DistributedTransactionResponse>>>(),
+                    It.IsAny<(string OperationName, Func<DistributedTransactionResponse, Microsoft.Azure.Cosmos.Telemetry.OpenTelemetryAttributes> GetAttributes)?>(),
+                    It.IsAny<ResourceType?>(),
+                    It.IsAny<TraceComponent>(),
+                    It.IsAny<TraceLevel>()))
+                .Returns<string, string, string, OperationType, RequestOptions, Func<ITrace, Task<DistributedTransactionResponse>>, (string, Func<DistributedTransactionResponse, Microsoft.Azure.Cosmos.Telemetry.OpenTelemetryAttributes>)?, ResourceType?, TraceComponent, TraceLevel>(
+                    (operationName, containerName, databaseName, operationType, requestOptions, func, oTelTuple, resourceType, comp, level) =>
+                    {
+                        capturedOperationName = operationName;
+                        capturedOperationType = operationType;
+                        capturedTraceComponent = comp;
+                        capturedOTelOperationName = oTelTuple?.Item1;
+                        return Task.FromResult<DistributedTransactionResponse>(null);
+                    });
+
+            await new DistributedWriteTransactionCore(contextMock.Object)
+                .CreateItem(Database, Container, new PartitionKey("pk"), "id", new TestItem())
+                .CommitTransactionAsync(CancellationToken.None);
+
+            Assert.AreEqual($"{nameof(DistributedWriteTransaction)}.{nameof(DistributedWriteTransaction.CommitTransactionAsync)}", capturedOperationName);
+            Assert.AreEqual(OperationType.CommitDistributedTransaction, capturedOperationType);
+            Assert.AreEqual(TraceComponent.Batch, capturedTraceComponent);
+            Assert.AreEqual(OpenTelemetryConstants.Operations.CommitDistributedWriteTransaction, capturedOTelOperationName);
         }
 
         // Helpers

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedWriteTransactionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedWriteTransactionTests.cs
@@ -429,6 +429,21 @@ namespace Microsoft.Azure.Cosmos.Tests
                     It.IsAny<CancellationToken>()))
                 .ReturnsAsync(containerProps);
 
+            contextMock
+                .Setup(c => c.OperationHelperAsync<DistributedTransactionResponse>(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<OperationType>(),
+                    It.IsAny<RequestOptions>(),
+                    It.IsAny<Func<ITrace, Task<DistributedTransactionResponse>>>(),
+                    It.IsAny<(string OperationName, Func<DistributedTransactionResponse, Microsoft.Azure.Cosmos.Telemetry.OpenTelemetryAttributes> GetAttributes)?>(),
+                    It.IsAny<ResourceType?>(),
+                    It.IsAny<TraceComponent>(),
+                    It.IsAny<TraceLevel>()))
+                .Returns<string, string, string, OperationType, RequestOptions, Func<ITrace, Task<DistributedTransactionResponse>>, (string, Func<DistributedTransactionResponse, Microsoft.Azure.Cosmos.Telemetry.OpenTelemetryAttributes>)?, ResourceType?, TraceComponent, TraceLevel>(
+                    (operationName, containerName, databaseName, operationType, requestOptions, func, oTelFunc, resourceType, comp, level) => func(NoOpTrace.Singleton));
+
             return contextMock;
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Telemetry/OpenTelemetryRecorderTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Telemetry/OpenTelemetryRecorderTests.cs
@@ -63,7 +63,6 @@ namespace Microsoft.Azure.Cosmos.Tests.Telemetry
                 "DocumentFeedResponse`1",// Part of dead code
                 "CosmosQuotaResponse",// Part of dead code
                 "StoredProcedureResponse`1", // Not supported as of now
-                "DistributedTransactionResponse" // // Distributed transaction response in internal as of now
             };
 
             // This dictionary contains a Key-Value pair where the Key represents the Response Type compatible with Open Telemetry Response, and the corresponding Value is a mocked instance.
@@ -89,6 +88,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Telemetry
                 { "TriggerResponse", new Mock<TriggerResponse>().Object },
                 { "UserDefinedFunctionResponse", new Mock<UserDefinedFunctionResponse>().Object },
                 { "HedgingResponse", "HedgingResponse" },
+                { "DistributedTransactionResponse", new Mock<DistributedTransactionResponse>().Object },
             };
 
             Assembly asm = OpenTelemetryRecorderTests.GetAssemblyLocally(DllName);
@@ -173,6 +173,10 @@ namespace Microsoft.Azure.Cosmos.Tests.Telemetry
                         "HedgingResponse",
                         hedgingResponse,
                         "HedgingResponse is only used internally in the CrossRegionHedgingAvailabilityStrategy and is never returned. No support Needed.");
+                }
+                else if (instance is DistributedTransactionResponse distributedTransactionResponse)
+                {
+                    _ = new OpenTelemetryResponse(distributedTransactionResponse);
                 }
                 else
                 {


### PR DESCRIPTION
# Pull Request Template

## Description


This pull request enhances distributed transaction support in the Cosmos DB SDK with improved diagnostics, tracing, and error handling. The changes introduce comprehensive diagnostic collection for distributed transaction commits, ensure that diagnostic information is consistently propagated and logged, and add safeguards for session token management. These improvements make distributed transactions more observable and robust, especially in failure and retry scenarios.

**Diagnostics and Tracing Enhancements:**

* Added `DiagnosticString` and `Diagnostics` properties to `DistributedTransactionResponse`, ensuring detailed coordinator and client-side diagnostics are available to callers. The diagnostic string is now surfaced in error messages for failed transactions. [[1]](diffhunk://#diff-2115107c88c6a1f6a4b4bce64e055f821eb64b82ba0813f4e55ad60a015aae87R126-R137) [[2]](diffhunk://#diff-2115107c88c6a1f6a4b4bce64e055f821eb64b82ba0813f4e55ad60a015aae87R322) [[3]](diffhunk://#diff-2115107c88c6a1f6a4b4bce64e055f821eb64b82ba0813f4e55ad60a015aae87R347-R352) [[4]](diffhunk://#diff-2115107c88c6a1f6a4b4bce64e055f821eb64b82ba0813f4e55ad60a015aae87R398-R422)
* Integrated OpenTelemetry tracing and improved operation helper usage in both `DistributedReadTransactionCore` and `DistributedWriteTransactionCore`, capturing richer telemetry and associating traces with distributed transaction commits. [[1]](diffhunk://#diff-6163326bb8cc03946b105c2171cea56bb35233a11e1c4134084a30117b7e4619R11-R12) [[2]](diffhunk://#diff-8a48a060b9de00cc81904d4a3f5c9fb0d7085b2688b4744a5269db93ff072b6eR13-R14) [[3]](diffhunk://#diff-6163326bb8cc03946b105c2171cea56bb35233a11e1c4134084a30117b7e4619L47-R68) [[4]](diffhunk://#diff-8a48a060b9de00cc81904d4a3f5c9fb0d7085b2688b4744a5269db93ff072b6eL274-R294) [[5]](diffhunk://#diff-dcbc1967f14470915aa8905f983909e89d64a162c0b60cd3e0a6b57f213483cdR15-R18)
* Updated `DistributedTransactionCommitter` to accept an `ITrace` for commit operations, accumulate diagnostics across retries, and ensure diagnostics are attached to the final response. [[1]](diffhunk://#diff-8da7da32691191fb49279546f3936019368f6db95a04a7992f6fb1e065ffa074R14) [[2]](diffhunk://#diff-8da7da32691191fb49279546f3936019368f6db95a04a7992f6fb1e065ffa074L51-R54) [[3]](diffhunk://#diff-8da7da32691191fb49279546f3936019368f6db95a04a7992f6fb1e065ffa074L66-R69) [[4]](diffhunk://#diff-8da7da32691191fb49279546f3936019368f6db95a04a7992f6fb1e065ffa074R80-R104)

**Error Handling and Logging Improvements:**

* Added truncation for potentially large diagnostic strings before logging to prevent log bloat and interleaving, with a dedicated utility method.
* Improved session token merging logic to handle out-of-range indices and exceptions gracefully, logging warnings without failing already-committed transactions. [[1]](diffhunk://#diff-8da7da32691191fb49279546f3936019368f6db95a04a7992f6fb1e065ffa074R219-R226) [[2]](diffhunk://#diff-8da7da32691191fb49279546f3936019368f6db95a04a7992f6fb1e065ffa074R246-R261)

**Serialization and Deserialization Robustness:**

* Ensured that deserialization of `DistributedTransactionOperationResult` fails fast with a clear exception if the result is null, improving reliability.
* Added support for the `diagnosticString` property in distributed transaction serialization and deserialization.

**Response Construction Consistency:**

* Ensured that the preserved diagnostic string is propagated when constructing new `DistributedTransactionResponse` instances from response messages. [[1]](diffhunk://#diff-2115107c88c6a1f6a4b4bce64e055f821eb64b82ba0813f4e55ad60a015aae87R239) [[2]](diffhunk://#diff-2115107c88c6a1f6a4b4bce64e055f821eb64b82ba0813f4e55ad60a015aae87L237-R253)

These changes collectively make distributed transactions more transparent, easier to troubleshoot, and safer in production environments.

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber

## Changelog

- [ ] I have added a changelog entry under `### Unreleased` in `changelog.md`
  for the user-facing impact of this change.
- [X] No changelog entry is required because this PR is one of:
  documentation-only, test-only, CI / build-only, or a pure internal refactor
  with no observable customer impact.

If the second box is checked, briefly justify here:

> This feature is still not accessible to the public
