### PR TITLE
[Internal] DTS: Adds AbortDistributedTransaction signal on commit cancellation

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ClientRetryPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/ClientRetryPolicy.cs
@@ -692,14 +692,14 @@ namespace Microsoft.Azure.Cosmos
 
             bool isCoordinatorRetriable =
                 statusCodeValue == (int)HttpStatusCode.RequestTimeout
-                || (statusCodeValue == (int)StatusCodes.RetryWith && subStatusCodeValue == DistributedTransactionConstants.DtcCoordinatorRaceConflict)
-                || (statusCodeValue == (int)StatusCodes.TooManyRequests && subStatusCodeValue == DistributedTransactionConstants.DtcLedgerThrottled);
+                || (statusCodeValue == (int)StatusCodes.RetryWith && subStatusCode == SubStatusCodes.DtcCoordinatorRaceConflict)
+                || (statusCodeValue == (int)StatusCodes.TooManyRequests && subStatusCode == SubStatusCodes.RUBudgetExceeded);
 
             bool isInfraFailure =
                 statusCodeValue == (int)HttpStatusCode.InternalServerError
-                && (subStatusCodeValue == DistributedTransactionConstants.DtcLedgerFailure
-                    || subStatusCodeValue == DistributedTransactionConstants.DtcAccountConfigFailure
-                    || subStatusCodeValue == DistributedTransactionConstants.DtcDispatchFailure);
+                && (subStatusCode == SubStatusCodes.DtcLedgerFailure
+                    || subStatusCode == SubStatusCodes.DtcAccountConfigFailure
+                    || subStatusCode == SubStatusCodes.DtcDispatchFailure);
 
             // Body-bearing response carries per-op isRetriable in JSON. The outer DistributedTransactionCommitter
             // loop owns retry; defer to avoid inner×outer amplification.

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionCommitter.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionCommitter.cs
@@ -210,7 +210,7 @@ namespace Microsoft.Azure.Cosmos
                             // 200 (Ok) means the transaction was already committed before the abort arrived — also expected.
                             // Anything else is a real failure worth warning about.
                             bool isExpectedOutcome = abortResponse.IsSuccessStatusCode
-                                || (int)abortResponse.StatusCode == DistributedTransactionConstants.HttpStatusTransactionAborted;
+                                || (int)abortResponse.StatusCode == (int)StatusCodes.TransactionAborted;
 
                             if (!isExpectedOutcome)
                             {

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionCommitter.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionCommitter.cs
@@ -22,12 +22,14 @@ namespace Microsoft.Azure.Cosmos
         internal const int MaxIsRetriableRetryCount = 10;
         private const int RetryMaxExponent = 5; // ~32 s max base delay before jitter
         private static readonly TimeSpan DefaultRetryBaseDelay = TimeSpan.FromSeconds(1);
+        internal static readonly TimeSpan DefaultAbortTimeout = TimeSpan.FromSeconds(30);
         private static readonly string ResourceUri = Paths.OperationsPathSegment + "/" + Paths.Operations_Dtc;
 
         private readonly IReadOnlyList<DistributedTransactionOperation> operations;
         private readonly CosmosClientContext clientContext;
         private readonly TimeSpan retryBaseDelay;
         private readonly Func<TimeSpan, CancellationToken, Task> delayProvider;
+        private readonly TimeSpan abortTimeout;
 
         public DistributedTransactionCommitter(
             IReadOnlyList<DistributedTransactionOperation> operations,
@@ -40,12 +42,14 @@ namespace Microsoft.Azure.Cosmos
             IReadOnlyList<DistributedTransactionOperation> operations,
             CosmosClientContext clientContext,
             TimeSpan retryBaseDelay,
-            Func<TimeSpan, CancellationToken, Task> delayProvider = null)
+            Func<TimeSpan, CancellationToken, Task> delayProvider = null,
+            TimeSpan? abortTimeout = null)
         {
             this.operations = operations ?? throw new ArgumentNullException(nameof(operations));
             this.clientContext = clientContext ?? throw new ArgumentNullException(nameof(clientContext));
             this.retryBaseDelay = retryBaseDelay;
             this.delayProvider = delayProvider ?? Task.Delay;
+            this.abortTimeout = abortTimeout ?? DistributedTransactionCommitter.DefaultAbortTimeout;
         }
 
         public async Task<DistributedTransactionResponse> CommitTransactionAsync(CancellationToken cancellationToken)
@@ -129,18 +133,29 @@ namespace Microsoft.Azure.Cosmos
             {
                 using (MemoryStream bodyStream = serverRequest.CreateBodyStream())
                 {
-                    ResponseMessage responseMessage = await this.clientContext.ProcessResourceOperationStreamAsync(
-                        resourceUri: DistributedTransactionCommitter.ResourceUri,
-                        resourceType: ResourceType.DistributedTransactionBatch,
-                        operationType: OperationType.CommitDistributedTransaction,
-                        requestOptions: null,
-                        cosmosContainerCore: null,
-                        partitionKey: null,
-                        itemId: null,
-                        streamPayload: bodyStream,
-                        requestEnricher: requestMessage => DistributedTransactionCommitter.EnrichRequestMessage(requestMessage, serverRequest),
-                        trace: attemptTrace,
-                        cancellationToken: cancellationToken);
+                    ResponseMessage responseMessage;
+                    try
+                    {
+                        responseMessage = await this.clientContext.ProcessResourceOperationStreamAsync(
+                            resourceUri: DistributedTransactionCommitter.ResourceUri,
+                            resourceType: ResourceType.DistributedTransactionBatch,
+                            operationType: OperationType.CommitDistributedTransaction,
+                            requestOptions: null,
+                            cosmosContainerCore: null,
+                            partitionKey: null,
+                            itemId: null,
+                            streamPayload: bodyStream,
+                            requestEnricher: requestMessage => DistributedTransactionCommitter.EnrichRequestMessage(requestMessage, serverRequest),
+                            trace: attemptTrace,
+                            cancellationToken: cancellationToken);
+                    }
+                    catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                    {
+                        // The commit request was in-flight when the caller cancelled. Signal the coordinator
+                        // to abort the transaction so it can roll back any in-progress changes.
+                        await this.TrySendAbortSignalAsync(serverRequest, attemptTrace).ConfigureAwait(false);
+                        throw;
+                    }
 
                     using (responseMessage)
                     {
@@ -157,6 +172,73 @@ namespace Microsoft.Azure.Cosmos
                             this.clientContext.DocumentClient?.sessionContainer);
 
                         return response;
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Best-effort abort signal: sends an <see cref="OperationType.AbortDistributedTransaction"/> request to the
+        /// coordinator using the same idempotency token and operations body so the coordinator can roll back any
+        /// in-progress changes. The coordinator requires the full operations body (identical to the commit request)
+        /// to identify and abort the transaction — an empty body is rejected as invalid.
+        /// Errors are logged and swallowed — the caller will rethrow the original <see cref="OperationCanceledException"/>.
+        /// </summary>
+        private async Task TrySendAbortSignalAsync(DistributedTransactionServerRequest serverRequest, ITrace parentTrace)
+        {
+            using (ITrace abortTrace = parentTrace.StartChild("Abort Distributed Transaction", TraceComponent.Batch, TraceLevel.Info))
+            {
+                using (CancellationTokenSource abortCts = new CancellationTokenSource(this.abortTimeout))
+                {
+                    try
+                    {
+                        using (MemoryStream abortBodyStream = serverRequest.CreateBodyStream())
+                        using (ResponseMessage abortResponse = await this.clientContext.ProcessResourceOperationStreamAsync(
+                            resourceUri: DistributedTransactionCommitter.ResourceUri,
+                            resourceType: ResourceType.DistributedTransactionBatch,
+                            operationType: OperationType.AbortDistributedTransaction,
+                            requestOptions: null,
+                            cosmosContainerCore: null,
+                            partitionKey: null,
+                            itemId: null,
+                            streamPayload: abortBodyStream,
+                            requestEnricher: requestMessage => DistributedTransactionCommitter.EnrichRequestMessage(requestMessage, serverRequest),
+                            trace: abortTrace,
+                            cancellationToken: abortCts.Token).ConfigureAwait(false))
+                        {
+                            // 452 (TransactionAborted) is the coordinator's expected success response for an abort signal.
+                            // 200 (Ok) means the transaction was already committed before the abort arrived — also expected.
+                            // Anything else is a real failure worth warning about.
+                            bool isExpectedOutcome = abortResponse.IsSuccessStatusCode
+                                || (int)abortResponse.StatusCode == DistributedTransactionConstants.HttpStatusTransactionAborted;
+
+                            if (!isExpectedOutcome)
+                            {
+                                DefaultTrace.TraceWarning(
+                                    $"DTC abort signal returned unexpected status (StatusCode={(int)abortResponse.StatusCode}, IdempotencyToken={serverRequest.IdempotencyToken}).");
+                            }
+                            else
+                            {
+                                DefaultTrace.TraceInformation(
+                                    $"DTC abort signal acknowledged (StatusCode={(int)abortResponse.StatusCode}, IdempotencyToken={serverRequest.IdempotencyToken}).");
+                            }
+                        }
+                    }
+                    catch (OperationCanceledException oce) when (abortCts.IsCancellationRequested)
+                    {
+                        // Abort timed out — log and continue so the caller's OperationCanceledException propagates.
+                        // Filter checks abortCts state (not token identity) because the gateway pipeline may wrap
+                        // abortCts.Token in a linked CancellationTokenSource, so the thrown OCE can carry the
+                        // linked token rather than abortCts.Token itself.
+                        DefaultTrace.TraceWarning(
+                            $"DTC abort signal timed out after {this.abortTimeout.TotalSeconds}s (IdempotencyToken={serverRequest.IdempotencyToken}): {oce.Message}");
+                    }
+                    catch (Exception ex)
+                    {
+                        // Best-effort: log and ignore all other failures (non-OCE and OCEs not caused by the
+                        // abort timeout). The outer caller rethrows the original OperationCanceledException.
+                        DefaultTrace.TraceWarning(
+                            $"DTC abort signal failed (IdempotencyToken={serverRequest.IdempotencyToken}): [{ex.GetType().Name}] {ex.Message}");
                     }
                 }
             }

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionConstants.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionConstants.cs
@@ -8,17 +8,6 @@ namespace Microsoft.Azure.Cosmos
 
     internal static class DistributedTransactionConstants
     {
-        // DTX envelope sub-status codes. The full status/body matrix and the inner-vs-outer retry ownership
-        // is documented at the call site in ClientRetryPolicy.ShouldRetryDtxRequest.
-        internal const int DtcCoordinatorRaceConflict = 5352; // 449 sub-status: coordinator ETag race
-        internal const int DtcLedgerThrottled = 3200;          // 429 sub-status: ledger backpressure
-        internal const int DtcLedgerFailure = 5411;            // 500 sub-status: ledger infra failure
-        internal const int DtcAccountConfigFailure = 5412;     // 500 sub-status: account-config infra failure
-        internal const int DtcDispatchFailure = 5413;          // 500 sub-status: dispatch infra failure
-
-        // Custom HTTP status codes returned by the DTC coordinator (non-standard, outside the 200-299 range).
-        internal const int HttpStatusTransactionAborted = 452;  // coordinator aborted the transaction (expected abort response)
-
         internal static bool IsDistributedTransactionRequest(OperationType operationType, ResourceType resourceType)
         {
             return (operationType == OperationType.CommitDistributedTransaction

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionConstants.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionConstants.cs
@@ -16,9 +16,13 @@ namespace Microsoft.Azure.Cosmos
         internal const int DtcAccountConfigFailure = 5412;     // 500 sub-status: account-config infra failure
         internal const int DtcDispatchFailure = 5413;          // 500 sub-status: dispatch infra failure
 
+        // Custom HTTP status codes returned by the DTC coordinator (non-standard, outside the 200-299 range).
+        internal const int HttpStatusTransactionAborted = 452;  // coordinator aborted the transaction (expected abort response)
+
         internal static bool IsDistributedTransactionRequest(OperationType operationType, ResourceType resourceType)
         {
-            return operationType == OperationType.CommitDistributedTransaction
+            return (operationType == OperationType.CommitDistributedTransaction
+                    || operationType == OperationType.AbortDistributedTransaction)
                 && resourceType == ResourceType.DistributedTransactionBatch;
         }
 

--- a/Microsoft.Azure.Cosmos/src/GatewayStoreClient.cs
+++ b/Microsoft.Azure.Cosmos/src/GatewayStoreClient.cs
@@ -283,6 +283,7 @@ namespace Microsoft.Azure.Cosmos
                 request.OperationType == OperationType.SqlQuery ||
                 request.OperationType == OperationType.Batch ||
                 request.OperationType == OperationType.CommitDistributedTransaction ||
+                request.OperationType == OperationType.AbortDistributedTransaction ||
                 request.OperationType == OperationType.ExecuteJavaScript ||
                 request.OperationType == OperationType.QueryPlan ||
                 (request.ResourceType == ResourceType.PartitionKey && request.OperationType == OperationType.Delete))

--- a/Microsoft.Azure.Cosmos/src/Handler/RequestInvokerHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/RequestInvokerHandler.cs
@@ -399,6 +399,7 @@ namespace Microsoft.Azure.Cosmos.Handlers
                 operationType == OperationType.QueryPlan ||
                 operationType == OperationType.Batch ||
                 operationType == OperationType.CommitDistributedTransaction ||
+                operationType == OperationType.AbortDistributedTransaction ||
                 operationType == OperationType.ExecuteJavaScript ||
                 operationType == OperationType.CompleteUserTransaction ||
                 (resourceType == ResourceType.PartitionKey && operationType == OperationType.Delete))

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ClientRetryPolicyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ClientRetryPolicyTests.cs
@@ -1002,7 +1002,7 @@
             policy.OnBeforeSendRequest(request);
 
             ResponseMessage response = new ResponseMessage((HttpStatusCode)StatusCodes.RetryWith);
-            response.Headers.SubStatusCodeLiteral = DistributedTransactionConstants.DtcCoordinatorRaceConflict.ToString();
+            response.Headers.SubStatusCodeLiteral = ((int)SubStatusCodes.DtcCoordinatorRaceConflict).ToString();
 
             ShouldRetryResult result = await policy.ShouldRetryAsync(response, CancellationToken.None);
 
@@ -1027,7 +1027,7 @@
             policy.OnBeforeSendRequest(request);
 
             ResponseMessage response = new ResponseMessage((HttpStatusCode)StatusCodes.RetryWith);
-            response.Headers.SubStatusCodeLiteral = DistributedTransactionConstants.DtcCoordinatorRaceConflict.ToString();
+            response.Headers.SubStatusCodeLiteral = ((int)SubStatusCodes.DtcCoordinatorRaceConflict).ToString();
             response.Headers.RetryAfterLiteral = ((long)serverRetryAfter.TotalMilliseconds).ToString();
 
             ShouldRetryResult result = await policy.ShouldRetryAsync(response, CancellationToken.None);
@@ -1037,9 +1037,9 @@
         }
 
         [DataTestMethod]
-        [DataRow(DistributedTransactionConstants.DtcLedgerFailure, DisplayName = "500/5411 LedgerFailure")]
-        [DataRow(DistributedTransactionConstants.DtcAccountConfigFailure, DisplayName = "500/5412 AccountConfigFailure")]
-        [DataRow(DistributedTransactionConstants.DtcDispatchFailure, DisplayName = "500/5413 DispatchFailure")]
+        [DataRow((int)SubStatusCodes.DtcLedgerFailure, DisplayName = "500/5411 LedgerFailure")]
+        [DataRow((int)SubStatusCodes.DtcAccountConfigFailure, DisplayName = "500/5412 AccountConfigFailure")]
+        [DataRow((int)SubStatusCodes.DtcDispatchFailure, DisplayName = "500/5413 DispatchFailure")]
         public async Task DtxRequest_500_InfraFailure_ShouldRetry(int subStatusCode)
         {
             const bool enableEndpointDiscovery = true;
@@ -1083,9 +1083,9 @@
         }
 
         [DataTestMethod]
-        [DataRow(DistributedTransactionConstants.DtcLedgerFailure, DisplayName = "500/5411 LedgerFailure")]
-        [DataRow(DistributedTransactionConstants.DtcAccountConfigFailure, DisplayName = "500/5412 AccountConfigFailure")]
-        [DataRow(DistributedTransactionConstants.DtcDispatchFailure, DisplayName = "500/5413 DispatchFailure")]
+        [DataRow((int)SubStatusCodes.DtcLedgerFailure, DisplayName = "500/5411 LedgerFailure")]
+        [DataRow((int)SubStatusCodes.DtcAccountConfigFailure, DisplayName = "500/5412 AccountConfigFailure")]
+        [DataRow((int)SubStatusCodes.DtcDispatchFailure, DisplayName = "500/5413 DispatchFailure")]
         public async Task NonDtxWriteRequest_500_DtcSubStatus_ShouldNotRetry(int subStatusCode)
         {
             const bool enableEndpointDiscovery = true;
@@ -1141,7 +1141,7 @@
         [DataTestMethod]
         [Description("CRP must defer body-bearing envelope responses (408 and 449/5352) to the outer DistributedTransactionCommitter loop so the two retry budgets do not amplify each other.")]
         [DataRow((int)HttpStatusCode.RequestTimeout, 0, DisplayName = "408 with body deferred to outer loop")]
-        [DataRow((int)StatusCodes.RetryWith, DistributedTransactionConstants.DtcCoordinatorRaceConflict, DisplayName = "449/5352 with body deferred to outer loop")]
+        [DataRow((int)StatusCodes.RetryWith, (int)SubStatusCodes.DtcCoordinatorRaceConflict, DisplayName = "449/5352 with body deferred to outer loop")]
         public async Task DtxRequest_WithBody_DeferredToOuterLoop(int statusCode, int subStatusCode)
         {
             const bool enableEndpointDiscovery = true;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ClientRetryPolicyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ClientRetryPolicyTests.cs
@@ -1186,10 +1186,42 @@
                 "CRP's inner retry budget must NOT have been consumed by the deferred body-bearing calls; an empty-body response should still trigger an inner retry.");
         }
 
+        [TestMethod]
+        [Description("AbortDistributedTransaction requests must be recognised as DTX requests by ClientRetryPolicy " +
+                     "so that session-token injection is bypassed and the DTX retry code path is taken.")]
+        public async Task AbortDtxRequest_408_ShouldRetry_SameBehaviorAsCommit()
+        {
+            const bool enableEndpointDiscovery = true;
+            using GlobalEndpointManager endpointManager = this.Initialize(
+                useMultipleWriteLocations: false,
+                enableEndpointDiscovery: enableEndpointDiscovery,
+                isPreferredLocationsListEmpty: false,
+                enforceSingleMasterSingleWriteLocation: true);
+
+            ClientRetryPolicy policy = new ClientRetryPolicy(endpointManager, this.partitionKeyRangeLocationCache, new RetryOptions(), enableEndpointDiscovery, false);
+            DocumentServiceRequest request = ClientRetryPolicyTests.CreateAbortDtxRequest();
+            policy.OnBeforeSendRequest(request);
+
+            // An abort 408 triggers the same inner-loop DTX retry as a commit 408
+            ResponseMessage response = new ResponseMessage(HttpStatusCode.RequestTimeout);
+            ShouldRetryResult result = await policy.ShouldRetryAsync(response, CancellationToken.None);
+
+            Assert.IsTrue(result.ShouldRetry,
+                "Abort DTX 408 must be retried — the abort request is idempotent and safe to re-send.");
+        }
+
         private static DocumentServiceRequest CreateDtxRequest()
         {
             return DocumentServiceRequest.Create(
                 OperationType.CommitDistributedTransaction,
+                ResourceType.DistributedTransactionBatch,
+                AuthorizationTokenType.PrimaryMasterKey);
+        }
+
+        private static DocumentServiceRequest CreateAbortDtxRequest()
+        {
+            return DocumentServiceRequest.Create(
+                OperationType.AbortDistributedTransaction,
                 ResourceType.DistributedTransactionBatch,
                 AuthorizationTokenType.PrimaryMasterKey);
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionCommitterTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionCommitterTests.cs
@@ -1122,6 +1122,462 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                 "Delay beyond maxExponent must still use the capped exponent, producing a similar magnitude.");
         }
 
+        // ─── Abort tests ───────────────────────────────────────────────────────
+
+        [TestMethod]
+        [Description("When the in-flight commit call is cancelled, the committer fires AbortDistributedTransaction " +
+                     "exactly once before rethrowing the OperationCanceledException.")]
+        public async Task AbortTransaction_FiredWhenCommitIsCancelledMidFlight()
+        {
+            using (CancellationTokenSource cts = new CancellationTokenSource())
+            {
+                int abortCallCount = 0;
+                Mock<CosmosClientContext> mockContext = this.CreateMockClientContext();
+
+                // Commit: cancel mid-flight and return a cancelled task
+                mockContext
+                    .Setup(c => c.ProcessResourceOperationStreamAsync(
+                        It.IsAny<string>(), It.IsAny<ResourceType>(),
+                        OperationType.CommitDistributedTransaction,
+                        It.IsAny<RequestOptions>(), It.IsAny<ContainerInternal>(),
+                        It.IsAny<Cosmos.PartitionKey?>(), It.IsAny<string>(),
+                        It.IsAny<Stream>(), It.IsAny<Action<RequestMessage>>(),
+                        It.IsAny<ITrace>(), It.IsAny<CancellationToken>()))
+                    .Returns(() =>
+                    {
+                        cts.Cancel();
+                        return Task.FromCanceled<ResponseMessage>(cts.Token);
+                    });
+
+                // Abort: succeed and count the call
+                mockContext
+                    .Setup(c => c.ProcessResourceOperationStreamAsync(
+                        It.IsAny<string>(), It.IsAny<ResourceType>(),
+                        OperationType.AbortDistributedTransaction,
+                        It.IsAny<RequestOptions>(), It.IsAny<ContainerInternal>(),
+                        It.IsAny<Cosmos.PartitionKey?>(), It.IsAny<string>(),
+                        It.IsAny<Stream>(), It.IsAny<Action<RequestMessage>>(),
+                        It.IsAny<ITrace>(), It.IsAny<CancellationToken>()))
+                    .Callback(() => abortCallCount++)
+                    .ReturnsAsync(new ResponseMessage(HttpStatusCode.OK));
+
+                DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
+                    CreateTestOperations(), mockContext.Object, TimeSpan.Zero, null,
+                    abortTimeout: TimeSpan.FromSeconds(5));
+
+                await Assert.ThrowsExceptionAsync<TaskCanceledException>(
+                    () => committer.CommitTransactionAsync(cts.Token));
+
+                Assert.AreEqual(1, abortCallCount,
+                    "Abort must be sent exactly once when the in-flight commit is cancelled.");
+            }
+        }
+
+        [TestMethod]
+        [Description("The abort request must carry the same idempotency token as the original commit request " +
+                     "so the coordinator can identify the in-progress transaction.")]
+        public async Task AbortTransaction_UsesOriginalIdempotencyToken()
+        {
+            using (CancellationTokenSource cts = new CancellationTokenSource())
+            {
+                Mock<CosmosClientContext> mockContext = this.CreateMockClientContext();
+
+                string capturedCommitToken = null;
+                string capturedAbortToken = null;
+
+                mockContext
+                    .Setup(c => c.ProcessResourceOperationStreamAsync(
+                        It.IsAny<string>(), It.IsAny<ResourceType>(),
+                        OperationType.CommitDistributedTransaction,
+                        It.IsAny<RequestOptions>(), It.IsAny<ContainerInternal>(),
+                        It.IsAny<Cosmos.PartitionKey?>(), It.IsAny<string>(),
+                        It.IsAny<Stream>(), It.IsAny<Action<RequestMessage>>(),
+                        It.IsAny<ITrace>(), It.IsAny<CancellationToken>()))
+                    .Callback<string, ResourceType, OperationType, RequestOptions, ContainerInternal, Cosmos.PartitionKey?, string, Stream, Action<RequestMessage>, ITrace, CancellationToken>(
+                        (_, _, _, _, _, _, _, _, enricher, _, _) =>
+                        {
+                            RequestMessage req = new RequestMessage
+                            {
+                                ResourceType = ResourceType.DistributedTransactionBatch,
+                                OperationType = OperationType.CommitDistributedTransaction,
+                            };
+                            enricher(req);
+                            capturedCommitToken = req.Headers[HttpConstants.HttpHeaders.IdempotencyToken];
+                            cts.Cancel();
+                        })
+                    .Returns(() => Task.FromCanceled<ResponseMessage>(cts.Token));
+
+                mockContext
+                    .Setup(c => c.ProcessResourceOperationStreamAsync(
+                        It.IsAny<string>(), It.IsAny<ResourceType>(),
+                        OperationType.AbortDistributedTransaction,
+                        It.IsAny<RequestOptions>(), It.IsAny<ContainerInternal>(),
+                        It.IsAny<Cosmos.PartitionKey?>(), It.IsAny<string>(),
+                        It.IsAny<Stream>(), It.IsAny<Action<RequestMessage>>(),
+                        It.IsAny<ITrace>(), It.IsAny<CancellationToken>()))
+                    .Callback<string, ResourceType, OperationType, RequestOptions, ContainerInternal, Cosmos.PartitionKey?, string, Stream, Action<RequestMessage>, ITrace, CancellationToken>(
+                        (_, _, _, _, _, _, _, _, enricher, _, _) =>
+                        {
+                            RequestMessage req = new RequestMessage
+                            {
+                                ResourceType = ResourceType.DistributedTransactionBatch,
+                                OperationType = OperationType.AbortDistributedTransaction,
+                            };
+                            enricher(req);
+                            capturedAbortToken = req.Headers[HttpConstants.HttpHeaders.IdempotencyToken];
+                        })
+                    .ReturnsAsync(new ResponseMessage(HttpStatusCode.OK));
+
+                DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
+                    CreateTestOperations(), mockContext.Object, TimeSpan.Zero, null,
+                    abortTimeout: TimeSpan.FromSeconds(5));
+
+                await Assert.ThrowsExceptionAsync<TaskCanceledException>(
+                    () => committer.CommitTransactionAsync(cts.Token));
+
+                Assert.IsNotNull(capturedCommitToken, "Commit token must have been captured.");
+                Assert.AreEqual(capturedCommitToken, capturedAbortToken,
+                    "Abort must use the same idempotency token as the original commit request.");
+            }
+        }
+
+        [TestMethod]
+        [Description("The abort request must use OperationType.AbortDistributedTransaction and send the operations body " +
+                     "(same as commit) — an empty body is rejected by the coordinator.")]
+        public async Task AbortTransaction_UsesAbortOperationType_AndSendsOperationsBody()
+        {
+            using (CancellationTokenSource cts = new CancellationTokenSource())
+            {
+                Mock<CosmosClientContext> mockContext = this.CreateMockClientContext();
+
+                OperationType? capturedAbortOpType = null;
+                long capturedAbortStreamLength = -1; // capture length inside callback before stream is disposed
+
+                mockContext
+                    .Setup(c => c.ProcessResourceOperationStreamAsync(
+                        It.IsAny<string>(), It.IsAny<ResourceType>(),
+                        OperationType.CommitDistributedTransaction,
+                        It.IsAny<RequestOptions>(), It.IsAny<ContainerInternal>(),
+                        It.IsAny<Cosmos.PartitionKey?>(), It.IsAny<string>(),
+                        It.IsAny<Stream>(), It.IsAny<Action<RequestMessage>>(),
+                        It.IsAny<ITrace>(), It.IsAny<CancellationToken>()))
+                    .Returns(() =>
+                    {
+                        cts.Cancel();
+                        return Task.FromCanceled<ResponseMessage>(cts.Token);
+                    });
+
+                mockContext
+                    .Setup(c => c.ProcessResourceOperationStreamAsync(
+                        It.IsAny<string>(), It.IsAny<ResourceType>(),
+                        OperationType.AbortDistributedTransaction,
+                        It.IsAny<RequestOptions>(), It.IsAny<ContainerInternal>(),
+                        It.IsAny<Cosmos.PartitionKey?>(), It.IsAny<string>(),
+                        It.IsAny<Stream>(), It.IsAny<Action<RequestMessage>>(),
+                        It.IsAny<ITrace>(), It.IsAny<CancellationToken>()))
+                    .Callback<string, ResourceType, OperationType, RequestOptions, ContainerInternal, Cosmos.PartitionKey?, string, Stream, Action<RequestMessage>, ITrace, CancellationToken>(
+                        (_, _, opType, _, _, _, _, stream, _, _, _) =>
+                        {
+                            capturedAbortOpType = opType;
+                            // Capture Length here — the stream is owned and disposed by TrySendAbortSignalAsync
+                            // after the call returns, so accessing it after CommitTransactionAsync completes
+                            // would throw ObjectDisposedException.
+                            capturedAbortStreamLength = stream?.Length ?? -1;
+                        })
+                    .ReturnsAsync(new ResponseMessage(HttpStatusCode.OK));
+
+                DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
+                    CreateTestOperations(), mockContext.Object, TimeSpan.Zero, null,
+                    abortTimeout: TimeSpan.FromSeconds(5));
+
+                await Assert.ThrowsExceptionAsync<TaskCanceledException>(
+                    () => committer.CommitTransactionAsync(cts.Token));
+
+                Assert.AreEqual(OperationType.AbortDistributedTransaction, capturedAbortOpType,
+                    "Abort must use OperationType.AbortDistributedTransaction.");
+                Assert.IsTrue(capturedAbortStreamLength > 0,
+                    "Abort body stream must be non-empty — coordinator rejects empty bodies with InvalidRntbdRequest_UnexpectedPayload.");
+            }
+        }
+
+        [TestMethod]
+        [Description("The original OperationCanceledException must propagate to the caller even when the abort signal succeeds.")]
+        public async Task AbortTransaction_OriginalCancelExceptionPropagates_WhenAbortSucceeds()
+        {
+            using (CancellationTokenSource cts = new CancellationTokenSource())
+            {
+                Mock<CosmosClientContext> mockContext = this.CreateMockClientContext();
+
+                mockContext
+                    .Setup(c => c.ProcessResourceOperationStreamAsync(
+                        It.IsAny<string>(), It.IsAny<ResourceType>(),
+                        OperationType.CommitDistributedTransaction,
+                        It.IsAny<RequestOptions>(), It.IsAny<ContainerInternal>(),
+                        It.IsAny<Cosmos.PartitionKey?>(), It.IsAny<string>(),
+                        It.IsAny<Stream>(), It.IsAny<Action<RequestMessage>>(),
+                        It.IsAny<ITrace>(), It.IsAny<CancellationToken>()))
+                    .Returns(() => { cts.Cancel(); return Task.FromCanceled<ResponseMessage>(cts.Token); });
+
+                mockContext
+                    .Setup(c => c.ProcessResourceOperationStreamAsync(
+                        It.IsAny<string>(), It.IsAny<ResourceType>(),
+                        OperationType.AbortDistributedTransaction,
+                        It.IsAny<RequestOptions>(), It.IsAny<ContainerInternal>(),
+                        It.IsAny<Cosmos.PartitionKey?>(), It.IsAny<string>(),
+                        It.IsAny<Stream>(), It.IsAny<Action<RequestMessage>>(),
+                        It.IsAny<ITrace>(), It.IsAny<CancellationToken>()))
+                    .ReturnsAsync(new ResponseMessage(HttpStatusCode.OK));
+
+                DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
+                    CreateTestOperations(), mockContext.Object, TimeSpan.Zero, null,
+                    abortTimeout: TimeSpan.FromSeconds(5));
+
+                TaskCanceledException thrown = await Assert.ThrowsExceptionAsync<TaskCanceledException>(
+                    () => committer.CommitTransactionAsync(cts.Token));
+
+                Assert.AreEqual(cts.Token, thrown.CancellationToken,
+                    "The original OperationCanceledException (with the caller's token) must propagate even when abort succeeds.");
+            }
+        }
+
+        [TestMethod]
+        [Description("HTTP 452 (TransactionAborted) is the coordinator's expected success response for an abort signal. " +
+                     "It must NOT be treated as a failure — the OCE must propagate normally.")]
+        public async Task AbortTransaction_CoordinatorReturns452TransactionAborted_TreatedAsSuccess()
+        {
+            using (CancellationTokenSource cts = new CancellationTokenSource())
+            {
+                Mock<CosmosClientContext> mockContext = this.CreateMockClientContext();
+                int abortCallCount = 0;
+
+                mockContext
+                    .Setup(c => c.ProcessResourceOperationStreamAsync(
+                        It.IsAny<string>(), It.IsAny<ResourceType>(),
+                        OperationType.CommitDistributedTransaction,
+                        It.IsAny<RequestOptions>(), It.IsAny<ContainerInternal>(),
+                        It.IsAny<Cosmos.PartitionKey?>(), It.IsAny<string>(),
+                        It.IsAny<Stream>(), It.IsAny<Action<RequestMessage>>(),
+                        It.IsAny<ITrace>(), It.IsAny<CancellationToken>()))
+                    .Returns(() => { cts.Cancel(); return Task.FromCanceled<ResponseMessage>(cts.Token); });
+
+                // Coordinator returns 452 TransactionAborted — the expected outcome for a successful abort
+                mockContext
+                    .Setup(c => c.ProcessResourceOperationStreamAsync(
+                        It.IsAny<string>(), It.IsAny<ResourceType>(),
+                        OperationType.AbortDistributedTransaction,
+                        It.IsAny<RequestOptions>(), It.IsAny<ContainerInternal>(),
+                        It.IsAny<Cosmos.PartitionKey?>(), It.IsAny<string>(),
+                        It.IsAny<Stream>(), It.IsAny<Action<RequestMessage>>(),
+                        It.IsAny<ITrace>(), It.IsAny<CancellationToken>()))
+                    .Callback(() => abortCallCount++)
+                    .ReturnsAsync(new ResponseMessage((HttpStatusCode)DistributedTransactionConstants.HttpStatusTransactionAborted));
+
+                DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
+                    CreateTestOperations(), mockContext.Object, TimeSpan.Zero, null,
+                    abortTimeout: TimeSpan.FromSeconds(5));
+
+                TaskCanceledException thrown = await Assert.ThrowsExceptionAsync<TaskCanceledException>(
+                    () => committer.CommitTransactionAsync(cts.Token));
+
+                Assert.AreEqual(1, abortCallCount, "Abort must fire exactly once.");
+                Assert.AreEqual(cts.Token, thrown.CancellationToken,
+                    "The original OCE must propagate even when abort returns 452 TransactionAborted.");
+            }
+        }
+
+        [TestMethod]
+        [Description("The original OperationCanceledException must propagate even when the abort signal itself fails " +
+                     "(abort is best-effort and must never suppress the cancellation).")]
+        public async Task AbortTransaction_OriginalCancelExceptionPropagates_WhenAbortFails()
+        {
+            using (CancellationTokenSource cts = new CancellationTokenSource())
+            {
+                Mock<CosmosClientContext> mockContext = this.CreateMockClientContext();
+
+                mockContext
+                    .Setup(c => c.ProcessResourceOperationStreamAsync(
+                        It.IsAny<string>(), It.IsAny<ResourceType>(),
+                        OperationType.CommitDistributedTransaction,
+                        It.IsAny<RequestOptions>(), It.IsAny<ContainerInternal>(),
+                        It.IsAny<Cosmos.PartitionKey?>(), It.IsAny<string>(),
+                        It.IsAny<Stream>(), It.IsAny<Action<RequestMessage>>(),
+                        It.IsAny<ITrace>(), It.IsAny<CancellationToken>()))
+                    .Returns(() => { cts.Cancel(); return Task.FromCanceled<ResponseMessage>(cts.Token); });
+
+                // Abort: simulate a network failure
+                mockContext
+                    .Setup(c => c.ProcessResourceOperationStreamAsync(
+                        It.IsAny<string>(), It.IsAny<ResourceType>(),
+                        OperationType.AbortDistributedTransaction,
+                        It.IsAny<RequestOptions>(), It.IsAny<ContainerInternal>(),
+                        It.IsAny<Cosmos.PartitionKey?>(), It.IsAny<string>(),
+                        It.IsAny<Stream>(), It.IsAny<Action<RequestMessage>>(),
+                        It.IsAny<ITrace>(), It.IsAny<CancellationToken>()))
+                    .ThrowsAsync(new IOException("simulated abort network failure"));
+
+                DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
+                    CreateTestOperations(), mockContext.Object, TimeSpan.Zero, null,
+                    abortTimeout: TimeSpan.FromSeconds(5));
+
+                // The caller must see the original cancellation, not the abort's IOException.
+                TaskCanceledException thrown = await Assert.ThrowsExceptionAsync<TaskCanceledException>(
+                    () => committer.CommitTransactionAsync(cts.Token));
+
+                Assert.AreEqual(cts.Token, thrown.CancellationToken,
+                    "The original OperationCanceledException must propagate even when abort throws.");
+            }
+        }
+
+        [TestMethod]
+        [Description("When the cancellation token is pre-cancelled before CommitTransactionAsync is called, " +
+                     "the commit never reaches the coordinator, so no abort signal must be sent.")]
+        public async Task AbortTransaction_NotFired_WhenPreCancelledBeforeCommitRequest()
+        {
+            using (CancellationTokenSource cts = new CancellationTokenSource())
+            {
+                cts.Cancel(); // pre-cancel
+
+                Mock<CosmosClientContext> mockContext = this.CreateMockClientContext();
+
+                // Neither commit nor abort should be called.
+                mockContext
+                    .Setup(c => c.ProcessResourceOperationStreamAsync(
+                        It.IsAny<string>(), It.IsAny<ResourceType>(), It.IsAny<OperationType>(),
+                        It.IsAny<RequestOptions>(), It.IsAny<ContainerInternal>(),
+                        It.IsAny<Cosmos.PartitionKey?>(), It.IsAny<string>(),
+                        It.IsAny<Stream>(), It.IsAny<Action<RequestMessage>>(),
+                        It.IsAny<ITrace>(), It.IsAny<CancellationToken>()))
+                    .Throws(new InvalidOperationException("ProcessResourceOperationStreamAsync must not be called on a pre-cancelled token."));
+
+                DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
+                    CreateTestOperations(), mockContext.Object, TimeSpan.Zero, null,
+                    abortTimeout: TimeSpan.FromSeconds(5));
+
+                await Assert.ThrowsExceptionAsync<OperationCanceledException>(
+                    () => committer.CommitTransactionAsync(cts.Token));
+
+                // Verify neither commit nor abort was called
+                mockContext.Verify(c => c.ProcessResourceOperationStreamAsync(
+                    It.IsAny<string>(), It.IsAny<ResourceType>(), It.IsAny<OperationType>(),
+                    It.IsAny<RequestOptions>(), It.IsAny<ContainerInternal>(),
+                    It.IsAny<Cosmos.PartitionKey?>(), It.IsAny<string>(),
+                    It.IsAny<Stream>(), It.IsAny<Action<RequestMessage>>(),
+                    It.IsAny<ITrace>(), It.IsAny<CancellationToken>()), Times.Never,
+                    "No request should be sent when the token is already cancelled before the commit starts.");
+            }
+        }
+
+        [TestMethod]
+        [Description("When the commit succeeds without cancellation, no abort signal must be sent.")]
+        public async Task AbortTransaction_NotFired_WhenCommitSucceeds()
+        {
+            Mock<CosmosClientContext> mockContext = this.CreateMockClientContext();
+            this.SetupProcessResourceOperation(mockContext, () => Task.FromResult(CreateSuccessResponseMessage(operationCount: 1)));
+
+            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
+                CreateTestOperations(), mockContext.Object, TimeSpan.Zero, null,
+                abortTimeout: TimeSpan.FromSeconds(5));
+
+            using (DistributedTransactionResponse response = await committer.CommitTransactionAsync(CancellationToken.None))
+            {
+                Assert.IsTrue(response.IsSuccessStatusCode);
+            }
+
+            // Verify abort was never sent
+            mockContext.Verify(c => c.ProcessResourceOperationStreamAsync(
+                It.IsAny<string>(), It.IsAny<ResourceType>(),
+                OperationType.AbortDistributedTransaction,
+                It.IsAny<RequestOptions>(), It.IsAny<ContainerInternal>(),
+                It.IsAny<Cosmos.PartitionKey?>(), It.IsAny<string>(),
+                It.IsAny<Stream>(), It.IsAny<Action<RequestMessage>>(),
+                It.IsAny<ITrace>(), It.IsAny<CancellationToken>()), Times.Never,
+                "Abort must not be sent when the commit completes successfully.");
+        }
+
+        [TestMethod]
+        [Description("When the abort HTTP call hangs beyond the abort timeout, the original OperationCanceledException " +
+                     "must still propagate — the abort timeout must not block the caller indefinitely.")]
+        public async Task AbortTransaction_RespectsAbortTimeout()
+        {
+            using (CancellationTokenSource cts = new CancellationTokenSource())
+            {
+                Mock<CosmosClientContext> mockContext = this.CreateMockClientContext();
+
+                mockContext
+                    .Setup(c => c.ProcessResourceOperationStreamAsync(
+                        It.IsAny<string>(), It.IsAny<ResourceType>(),
+                        OperationType.CommitDistributedTransaction,
+                        It.IsAny<RequestOptions>(), It.IsAny<ContainerInternal>(),
+                        It.IsAny<Cosmos.PartitionKey?>(), It.IsAny<string>(),
+                        It.IsAny<Stream>(), It.IsAny<Action<RequestMessage>>(),
+                        It.IsAny<ITrace>(), It.IsAny<CancellationToken>()))
+                    .Returns(() => { cts.Cancel(); return Task.FromCanceled<ResponseMessage>(cts.Token); });
+
+                // Abort: respond to the abort's own CancellationToken (honours abort timeout)
+                mockContext
+                    .Setup(c => c.ProcessResourceOperationStreamAsync(
+                        It.IsAny<string>(), It.IsAny<ResourceType>(),
+                        OperationType.AbortDistributedTransaction,
+                        It.IsAny<RequestOptions>(), It.IsAny<ContainerInternal>(),
+                        It.IsAny<Cosmos.PartitionKey?>(), It.IsAny<string>(),
+                        It.IsAny<Stream>(), It.IsAny<Action<RequestMessage>>(),
+                        It.IsAny<ITrace>(), It.IsAny<CancellationToken>()))
+                    .Returns<string, ResourceType, OperationType, RequestOptions, ContainerInternal, Cosmos.PartitionKey?, string, Stream, Action<RequestMessage>, ITrace, CancellationToken>(
+                        (_, _, _, _, _, _, _, _, _, _, abortCt) =>
+                        {
+                            TaskCompletionSource<ResponseMessage> tcs = new TaskCompletionSource<ResponseMessage>();
+                            abortCt.Register(() => tcs.TrySetCanceled(abortCt));
+                            return tcs.Task; // never completes unless abort token fires
+                        });
+
+                // Very short abort timeout (50 ms) so the test completes quickly.
+                DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
+                    CreateTestOperations(), mockContext.Object, TimeSpan.Zero, null,
+                    abortTimeout: TimeSpan.FromMilliseconds(50));
+
+                TaskCanceledException thrown = await Assert.ThrowsExceptionAsync<TaskCanceledException>(
+                    () => committer.CommitTransactionAsync(cts.Token));
+
+                // Even though abort timed out, the original commit cancellation propagates.
+                Assert.AreEqual(cts.Token, thrown.CancellationToken,
+                    "The caller's OperationCanceledException must propagate even when the abort times out.");
+            }
+        }
+
+        [TestMethod]
+        [Description("When the commit call throws a non-cancellation exception (e.g. IOException), no abort signal " +
+                     "must be sent — abort is only for in-flight cancellation, not generic commit failures.")]
+        public async Task AbortTransaction_NotFired_WhenCommitThrowsNonCancellationException()
+        {
+            Mock<CosmosClientContext> mockContext = this.CreateMockClientContext();
+
+            mockContext
+                .Setup(c => c.ProcessResourceOperationStreamAsync(
+                    It.IsAny<string>(), It.IsAny<ResourceType>(),
+                    OperationType.CommitDistributedTransaction,
+                    It.IsAny<RequestOptions>(), It.IsAny<ContainerInternal>(),
+                    It.IsAny<Cosmos.PartitionKey?>(), It.IsAny<string>(),
+                    It.IsAny<Stream>(), It.IsAny<Action<RequestMessage>>(),
+                    It.IsAny<ITrace>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new IOException("simulated commit network failure"));
+
+            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
+                CreateTestOperations(), mockContext.Object, TimeSpan.Zero, null,
+                abortTimeout: TimeSpan.FromSeconds(5));
+
+            await Assert.ThrowsExceptionAsync<IOException>(
+                () => committer.CommitTransactionAsync(CancellationToken.None));
+
+            mockContext.Verify(c => c.ProcessResourceOperationStreamAsync(
+                It.IsAny<string>(), It.IsAny<ResourceType>(),
+                OperationType.AbortDistributedTransaction,
+                It.IsAny<RequestOptions>(), It.IsAny<ContainerInternal>(),
+                It.IsAny<Cosmos.PartitionKey?>(), It.IsAny<string>(),
+                It.IsAny<Stream>(), It.IsAny<Action<RequestMessage>>(),
+                It.IsAny<ITrace>(), It.IsAny<CancellationToken>()), Times.Never,
+                "Abort must not be sent when the commit throws a non-cancellation exception.");
+        }
+
         // ─── Helpers ───────────────────────────────────────────────────────────
 
         private static string BuildDtcResponseJson(

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionCommitterTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionCommitterTests.cs
@@ -1370,7 +1370,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                         It.IsAny<Stream>(), It.IsAny<Action<RequestMessage>>(),
                         It.IsAny<ITrace>(), It.IsAny<CancellationToken>()))
                     .Callback(() => abortCallCount++)
-                    .ReturnsAsync(new ResponseMessage((HttpStatusCode)DistributedTransactionConstants.HttpStatusTransactionAborted));
+                    .ReturnsAsync(new ResponseMessage((HttpStatusCode)StatusCodes.TransactionAborted));
 
                 DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
                     CreateTestOperations(), mockContext.Object, TimeSpan.Zero, null,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/HandlerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/HandlerTests.cs
@@ -1321,5 +1321,29 @@ namespace Microsoft.Azure.Cosmos.Tests
             await invoker.SendAsync(requestMessage, new CancellationToken());
         }
 
+        [TestMethod]
+        [Description("AbortDistributedTransaction must map to HTTP POST so the abort signal reaches the gateway correctly.")]
+        public void GetHttpMethod_AbortDistributedTransaction_ReturnsPost()
+        {
+            HttpMethod method = RequestInvokerHandler.GetHttpMethod(
+                ResourceType.DistributedTransactionBatch,
+                OperationType.AbortDistributedTransaction);
+
+            Assert.AreEqual(HttpMethod.Post, method,
+                "AbortDistributedTransaction must map to HTTP POST, matching CommitDistributedTransaction.");
+        }
+
+        [TestMethod]
+        [Description("CommitDistributedTransaction must map to HTTP POST — verifies the existing behaviour is unchanged after the Abort change.")]
+        public void GetHttpMethod_CommitDistributedTransaction_ReturnsPost()
+        {
+            HttpMethod method = RequestInvokerHandler.GetHttpMethod(
+                ResourceType.DistributedTransactionBatch,
+                OperationType.CommitDistributedTransaction);
+
+            Assert.AreEqual(HttpMethod.Post, method,
+                "CommitDistributedTransaction must continue to map to HTTP POST.");
+        }
+
     }
 }


### PR DESCRIPTION
# Pull Request Template

## Description

This pull request improves the reliability and correctness of distributed transaction abort handling in the Cosmos DB SDK. It introduces a best-effort abort signal when a commit is canceled, ensures abort requests are handled consistently throughout the stack, and adds comprehensive tests to verify these behaviors.

When CommitTransactionAsync is cancelled while the in-flight HTTP request to the coordinator is in progress, the SDK now sends a AbortDistributedTransaction request using the same idempotency token so the coordinator can roll back any in-progress changes. The original OperationCanceledException always propagates to the caller; the abort signal is fire-and-forget with a configurable 30-second timeout.

**Distributed Transaction Abort Handling:**

* Added a best-effort abort signal in `DistributedTransactionCommitter`: when a commit operation is canceled, the code now sends an abort request to the coordinator to roll back any in-progress changes. This includes a new `TrySendAbortSignalAsync` method, a configurable abort timeout, and robust logging for abort outcomes. [[1]](diffhunk://#diff-8da7da32691191fb49279546f3936019368f6db95a04a7992f6fb1e065ffa074R25-R32) [[2]](diffhunk://#diff-8da7da32691191fb49279546f3936019368f6db95a04a7992f6fb1e065ffa074L43-R52) [[3]](diffhunk://#diff-8da7da32691191fb49279546f3936019368f6db95a04a7992f6fb1e065ffa074L132-R139) [[4]](diffhunk://#diff-8da7da32691191fb49279546f3936019368f6db95a04a7992f6fb1e065ffa074R151-R158) [[5]](diffhunk://#diff-8da7da32691191fb49279546f3936019368f6db95a04a7992f6fb1e065ffa074R180-R246)

**Core SDK and Protocol Updates:**

* Updated HTTP method and request handling to support `AbortDistributedTransaction` operations, ensuring they are recognized as distributed transaction requests and mapped to HTTP POST like commit operations. [[1]](diffhunk://#diff-2184809dc755140d4323b7008d49e34a21a962cfd634a8f990c66f307f4dbd6aR286) [[2]](diffhunk://#diff-3f93aff3daf641a0dd88add0fd676ec71e1af50c59404f98753a716e5901bb21R402) [[3]](diffhunk://#diff-142016342192e6f7886247b7e3c0ea6d1b92400a322a3c4b336b5a34867aa765R19-R25)

**Retry and Sub-Status Handling Refactor:**

* Sub-status code checks in retry logic have been refactored to use the `SubStatusCodes` enum instead of integer constants, improving code clarity and reducing the risk of mismatches. [[1]](diffhunk://#diff-2b056512ca285b1d95e025e31f60345059fa92d958becc38f90a6fb54ce1bbb4L695-R702) [[2]](diffhunk://#diff-142016342192e6f7886247b7e3c0ea6d1b92400a322a3c4b336b5a34867aa765L11-R14)

**Testing Improvements:**

* Added new tests to verify that abort requests are retried appropriately and mapped to HTTP POST, and that commit request behavior remains unchanged. [[1]](diffhunk://#diff-d3fdfdc5d4f4d8af2c2cc463d928285680e7695861422ef2e3330d1a956807e1R1189-R1212) [[2]](diffhunk://#diff-d3fdfdc5d4f4d8af2c2cc463d928285680e7695861422ef2e3330d1a956807e1R1221-R1228) [[3]](diffhunk://#diff-ee35617871a82f0c4e8caffa698f717c8284f46bb7d5f6ba840a27ee5da9c38eR1324-R1347)


## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber

## Changelog

- [ ] I have added a changelog entry under `### Unreleased` in `changelog.md`
  for the user-facing impact of this change.
- [X] No changelog entry is required because this PR is one of:
  documentation-only, test-only, CI / build-only, or a pure internal refactor
  with no observable customer impact.

If the second box is checked, briefly justify here:

> This feature is still not accessible to public use
