### PR TITLE
Client Encryption: Adds JsonProcessor knob and Newtonsoft/Stream test variations

### DIFF
--- a/Microsoft.Azure.Cosmos.Encryption.Custom/src/EncryptionOptions.cs
+++ b/Microsoft.Azure.Cosmos.Encryption.Custom/src/EncryptionOptions.cs
@@ -35,5 +35,17 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom
         /// Example of a path specification: /sensitive
         /// </summary>
         public IEnumerable<string> PathsToEncrypt { get; set; }
+
+        /// <summary>
+        /// Gets or sets the JSON processor to use for encryption of this operation.
+        /// </summary>
+        /// <remarks>
+        /// This controls the encrypt-side processor for the operation.
+        /// If <see cref="global::Microsoft.Azure.Cosmos.RequestOptions.Properties"/> contains the key "encryption-json-processor",
+        /// that value takes precedence over this setting.
+        /// Defaults to <see cref="JsonProcessor.Newtonsoft"/>.
+        /// <c>JsonProcessor.Stream</c> is available only in the .NET 8 package (net8.0 target framework).
+        /// </remarks>
+        public JsonProcessor JsonProcessor { get; set; } = JsonProcessor.Newtonsoft;
     }
 }

--- a/Microsoft.Azure.Cosmos.Encryption.Custom/src/EncryptionProcessor.cs
+++ b/Microsoft.Azure.Cosmos.Encryption.Custom/src/EncryptionProcessor.cs
@@ -73,7 +73,7 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom
                 input,
                 encryptor,
                 requestOptions.EncryptionOptions,
-                requestOptions.GetJsonProcessor(),
+                requestOptions.GetJsonProcessor(requestOptions.EncryptionOptions?.JsonProcessor ?? JsonProcessor.Newtonsoft),
                 diagnosticsContext,
                 cancellationToken);
         }
@@ -89,7 +89,7 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom
                 input,
                 encryptor,
                 requestOptions.EncryptionOptions,
-                requestOptions.GetJsonProcessor(),
+                requestOptions.GetJsonProcessor(requestOptions.EncryptionOptions?.JsonProcessor ?? JsonProcessor.Newtonsoft),
                 diagnosticsContext,
                 cancellationToken);
         }

--- a/Microsoft.Azure.Cosmos.Encryption.Custom/src/JsonProcessor.cs
+++ b/Microsoft.Azure.Cosmos.Encryption.Custom/src/JsonProcessor.cs
@@ -7,7 +7,7 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom
     /// <summary>
     /// API for JSON processing
     /// </summary>
-    internal enum JsonProcessor
+    public enum JsonProcessor
     {
         /// <summary>
         /// Newtonsoft.Json

--- a/Microsoft.Azure.Cosmos.Encryption.Custom/tests/EmulatorTests/MdeCustomEncryptionTests.cs
+++ b/Microsoft.Azure.Cosmos.Encryption.Custom/tests/EmulatorTests/MdeCustomEncryptionTests.cs
@@ -650,21 +650,20 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom.EmulatorTests
 
         private static EncryptionItemRequestOptions CreateEncryptionItemRequestOptions(string dekId, string encryptionAlgorithm, JsonProcessor jsonProcessor)
         {
-            EncryptionItemRequestOptions options = new ()
+            EncryptionOptions encryptionOptions = new EncryptionOptions
             {
-                EncryptionOptions = new EncryptionOptions
-                {
-                    DataEncryptionKeyId = dekId,
-                    EncryptionAlgorithm = encryptionAlgorithm,
-                    PathsToEncrypt = new List<string> { "/Sensitive" },
-                },
-                Properties = new Dictionary<string, object>
-                {
-                    { JsonProcessorRequestOptionsExtensions.JsonProcessorPropertyBagKey, jsonProcessor.ToString() }
-                }
+                DataEncryptionKeyId = dekId,
+                EncryptionAlgorithm = encryptionAlgorithm,
+                PathsToEncrypt = new List<string> { "/Sensitive" },
+#if NET8_0_OR_GREATER
+                JsonProcessor = jsonProcessor,
+#endif
             };
 
-            return options;
+            return new EncryptionItemRequestOptions
+            {
+                EncryptionOptions = encryptionOptions,
+            };
         }
 
         [TestMethod]
@@ -850,14 +849,19 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom.EmulatorTests
             }
         }
 
-        [TestMethod]
-        public async Task EncryptionCreateItem()
+        [DataTestMethod]
+        [DataRow(JsonProcessor.Newtonsoft)]
+#if NET8_0_OR_GREATER
+        [DataRow(JsonProcessor.Stream)]
+#endif
+        public async Task EncryptionCreateItem(JsonProcessor processor = JsonProcessor.Newtonsoft)
         {
-            TestDoc testDoc = await CreateItemAsync(encryptionContainer, dekId, TestDoc.PathsToEncrypt);
+            TestDoc testDoc = await CreateItemAsync(encryptionContainer, dekId, TestDoc.PathsToEncrypt, processor: processor);
 
-            await VerifyItemByReadAsync(encryptionContainer, testDoc);
+            ItemRequestOptions readOptions = GetReadItemRequestOptions(processor);
+            await VerifyItemByReadAsync(encryptionContainer, testDoc, requestOptions: readOptions);
 
-            await VerifyItemByReadStreamAsync(encryptionContainer, testDoc);
+            await VerifyItemByReadStreamAsync(encryptionContainer, testDoc, requestOptions: readOptions);
 
             TestDoc expectedDoc = new(testDoc);
 
@@ -867,13 +871,15 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom.EmulatorTests
             await MdeCustomEncryptionTests.ValidateQueryResultsAsync(
                 MdeCustomEncryptionTests.encryptionContainer,
                 query: null,
-                expectedDoc);
+                expectedDoc,
+                processor: processor);
 #endif
 
             await ValidateQueryResultsAsync(
                 encryptionContainer,
                 "SELECT * FROM c",
-                expectedDoc);
+                expectedDoc,
+                processor: processor);
 
             await ValidateQueryResultsAsync(
                 encryptionContainer,
@@ -882,12 +888,14 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom.EmulatorTests
                     expectedDoc.PK,
                     expectedDoc.Id,
                     expectedDoc.NonSensitive),
-                expectedDoc);
+                expectedDoc,
+                processor: processor);
 
             await ValidateQueryResultsAsync(
                 encryptionContainer,
                 string.Format("SELECT * FROM c where c.Sensitive_IntFormat = '{0}'", testDoc.Sensitive_IntFormat),
-                expectedDoc: null);
+                expectedDoc: null,
+                processor: processor);
 
             await ValidateQueryResultsAsync(
                 encryptionContainer,
@@ -895,7 +903,8 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom.EmulatorTests
                     "select * from c where c.id = @theId and c.PK = @thePK")
                          .WithParameter("@theId", expectedDoc.Id)
                          .WithParameter("@thePK", expectedDoc.PK),
-                expectedDoc: expectedDoc);
+                expectedDoc: expectedDoc,
+                processor: processor);
 
             expectedDoc.Sensitive_NestedObjectFormatL1 = null;
             expectedDoc.Sensitive_ArrayFormat = null;
@@ -909,7 +918,8 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom.EmulatorTests
             await ValidateQueryResultsAsync(
                 encryptionContainer,
                 "SELECT c.id, c.PK, c.NonSensitive FROM c",
-                expectedDoc);
+                expectedDoc,
+                processor: processor);
         }
 
         [TestMethod]
@@ -921,14 +931,18 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom.EmulatorTests
             encryptableItem.DecryptableItem.GetItemAsync<TestDoc>();
         }
 
-        [TestMethod]
-        public async Task EncryptionCreateItemWithLazyDecryption()
+        [DataTestMethod]
+        [DataRow(JsonProcessor.Newtonsoft)]
+#if NET8_0_OR_GREATER
+        [DataRow(JsonProcessor.Stream)]
+#endif
+        public async Task EncryptionCreateItemWithLazyDecryption(JsonProcessor processor = JsonProcessor.Newtonsoft)
         {
             TestDoc testDoc = TestDoc.Create();
             ItemResponse<EncryptableItem<TestDoc>> createResponse = await encryptionContainer.CreateItemAsync(
                 new EncryptableItem<TestDoc>(testDoc),
                 new PartitionKey(testDoc.PK),
-                GetRequestOptions(dekId, TestDoc.PathsToEncrypt));
+                GetRequestOptions(dekId, TestDoc.PathsToEncrypt, processor: processor));
 
             Assert.AreEqual(HttpStatusCode.Created, createResponse.StatusCode);
             Assert.IsNotNull(createResponse.Resource);
@@ -940,7 +954,7 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom.EmulatorTests
             ItemResponse<EncryptableItemStream> createResponseStream = await encryptionContainer.CreateItemAsync(
                 new EncryptableItemStream(TestCommon.ToStream(testDoc1)),
                 new PartitionKey(testDoc1.PK),
-                GetRequestOptions(dekId, TestDoc.PathsToEncrypt));
+                GetRequestOptions(dekId, TestDoc.PathsToEncrypt, processor: processor));
 
             Assert.AreEqual(HttpStatusCode.Created, createResponseStream.StatusCode);
             Assert.IsNotNull(createResponseStream.Resource);
@@ -1113,17 +1127,23 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom.EmulatorTests
             await ValidateQueryResponseAsync(encryptionContainer);
         }
 
-        [TestMethod]
-        public async Task EncryptionRudItem()
+        [DataTestMethod]
+        [DataRow(JsonProcessor.Newtonsoft)]
+#if NET8_0_OR_GREATER
+        [DataRow(JsonProcessor.Stream)]
+#endif
+        public async Task EncryptionRudItem(JsonProcessor processor = JsonProcessor.Newtonsoft)
         {
             TestDoc testDoc = await UpsertItemAsync(
                 encryptionContainer,
                 TestDoc.Create(),
                 dekId,
                 TestDoc.PathsToEncrypt,
-                HttpStatusCode.Created);
+                HttpStatusCode.Created,
+                processor);
 
-            await VerifyItemByReadAsync(encryptionContainer, testDoc);
+            ItemRequestOptions readOptions = GetReadItemRequestOptions(processor);
+            await VerifyItemByReadAsync(encryptionContainer, testDoc, requestOptions: readOptions);
 
             testDoc.NonSensitive = Guid.NewGuid().ToString();
             testDoc.Sensitive_StringFormat = Guid.NewGuid().ToString();
@@ -1133,10 +1153,11 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom.EmulatorTests
                 testDoc,
                 dekId,
                 TestDoc.PathsToEncrypt,
-                HttpStatusCode.OK);
+                HttpStatusCode.OK,
+                processor);
             TestDoc updatedDoc = upsertResponse.Resource;
 
-            await VerifyItemByReadAsync(encryptionContainer, updatedDoc);
+            await VerifyItemByReadAsync(encryptionContainer, updatedDoc, requestOptions: readOptions);
 
             updatedDoc.NonSensitive = Guid.NewGuid().ToString();
             updatedDoc.Sensitive_StringFormat = Guid.NewGuid().ToString();
@@ -1146,28 +1167,35 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom.EmulatorTests
                 updatedDoc,
                 dekId,
                 TestDoc.PathsToEncrypt,
-                upsertResponse.ETag);
+                upsertResponse.ETag,
+                processor);
 
-            await VerifyItemByReadAsync(encryptionContainer, replacedDoc);
+            await VerifyItemByReadAsync(encryptionContainer, replacedDoc, requestOptions: readOptions);
 
             await DeleteItemAsync(encryptionContainer, replacedDoc);
         }
 
-        [TestMethod]
-        public async Task EncryptionRudItemLazyDecryption()
+        [DataTestMethod]
+        [DataRow(JsonProcessor.Newtonsoft)]
+#if NET8_0_OR_GREATER
+        [DataRow(JsonProcessor.Stream)]
+#endif
+        public async Task EncryptionRudItemLazyDecryption(JsonProcessor processor = JsonProcessor.Newtonsoft)
         {
             TestDoc testDoc = TestDoc.Create();
             // Upsert (item doesn't exist)
             ItemResponse<EncryptableItem<TestDoc>> upsertResponse = await encryptionContainer.UpsertItemAsync(
                 new EncryptableItem<TestDoc>(testDoc),
                 new PartitionKey(testDoc.PK),
-                GetRequestOptions(dekId, TestDoc.PathsToEncrypt));
+                GetRequestOptions(dekId, TestDoc.PathsToEncrypt, processor: processor));
 
             Assert.AreEqual(HttpStatusCode.Created, upsertResponse.StatusCode);
             Assert.IsNotNull(upsertResponse.Resource);
 
             await ValidateDecryptableItem(upsertResponse.Resource.DecryptableItem, testDoc);
-            await VerifyItemByReadAsync(encryptionContainer, testDoc);
+
+            ItemRequestOptions readOptions = GetReadItemRequestOptions(processor);
+            await VerifyItemByReadAsync(encryptionContainer, testDoc, requestOptions: readOptions);
 
             // Upsert with stream (item exists)
             testDoc.NonSensitive = Guid.NewGuid().ToString();
@@ -1176,13 +1204,13 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom.EmulatorTests
             ItemResponse<EncryptableItemStream> upsertResponseStream = await encryptionContainer.UpsertItemAsync(
                 new EncryptableItemStream(TestCommon.ToStream(testDoc)),
                 new PartitionKey(testDoc.PK),
-                GetRequestOptions(dekId, TestDoc.PathsToEncrypt));
+                GetRequestOptions(dekId, TestDoc.PathsToEncrypt, processor: processor));
 
             Assert.AreEqual(HttpStatusCode.OK, upsertResponseStream.StatusCode);
             Assert.IsNotNull(upsertResponseStream.Resource);
 
             await ValidateDecryptableItem(upsertResponseStream.Resource.DecryptableItem, testDoc);
-            await VerifyItemByReadAsync(encryptionContainer, testDoc);
+            await VerifyItemByReadAsync(encryptionContainer, testDoc, requestOptions: readOptions);
 
             // replace
             testDoc.NonSensitive = Guid.NewGuid().ToString();
@@ -1192,13 +1220,13 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom.EmulatorTests
                 new EncryptableItemStream(TestCommon.ToStream(testDoc)),
                 testDoc.Id,
                 new PartitionKey(testDoc.PK),
-                GetRequestOptions(dekId, TestDoc.PathsToEncrypt, upsertResponseStream.ETag));
+                GetRequestOptions(dekId, TestDoc.PathsToEncrypt, upsertResponseStream.ETag, processor: processor));
 
             Assert.AreEqual(HttpStatusCode.OK, replaceResponseStream.StatusCode);
             Assert.IsNotNull(replaceResponseStream.Resource);
 
             await ValidateDecryptableItem(replaceResponseStream.Resource.DecryptableItem, testDoc);
-            await VerifyItemByReadAsync(encryptionContainer, testDoc);
+            await VerifyItemByReadAsync(encryptionContainer, testDoc, requestOptions: readOptions);
 
             await DeleteItemAsync(encryptionContainer, testDoc);
         }
@@ -1328,8 +1356,12 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom.EmulatorTests
             await Task.WhenAll(tasks);
         }
 
-        [TestMethod]
-        public async Task EncryptionTransactionBatchCrud()
+        [DataTestMethod]
+        [DataRow(JsonProcessor.Newtonsoft)]
+#if NET8_0_OR_GREATER
+        [DataRow(JsonProcessor.Stream)]
+#endif
+        public async Task EncryptionTransactionBatchCrud(JsonProcessor processor = JsonProcessor.Newtonsoft)
         {
             string partitionKey = "thePK";
             string dek1 = dekId;
@@ -1341,35 +1373,35 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom.EmulatorTests
             TestDoc doc3ToCreate = TestDoc.Create(partitionKey);
             TestDoc doc4ToCreate = TestDoc.Create(partitionKey);
 
-            ItemResponse<TestDoc> doc1ToReplaceCreateResponse = await CreateItemAsync(encryptionContainer, dek1, TestDoc.PathsToEncrypt, partitionKey);
+            ItemResponse<TestDoc> doc1ToReplaceCreateResponse = await CreateItemAsync(encryptionContainer, dek1, TestDoc.PathsToEncrypt, partitionKey, processor: processor);
             TestDoc doc1ToReplace = doc1ToReplaceCreateResponse.Resource;
             doc1ToReplace.NonSensitive = Guid.NewGuid().ToString();
             doc1ToReplace.Sensitive_StringFormat = Guid.NewGuid().ToString();
 
-            TestDoc doc2ToReplace = await CreateItemAsync(encryptionContainer, dek2, TestDoc.PathsToEncrypt, partitionKey);
+            TestDoc doc2ToReplace = await CreateItemAsync(encryptionContainer, dek2, TestDoc.PathsToEncrypt, partitionKey, processor: processor);
             doc2ToReplace.NonSensitive = Guid.NewGuid().ToString();
             doc2ToReplace.Sensitive_StringFormat = Guid.NewGuid().ToString();
 
-            TestDoc doc1ToUpsert = await CreateItemAsync(encryptionContainer, dek2, TestDoc.PathsToEncrypt, partitionKey);
+            TestDoc doc1ToUpsert = await CreateItemAsync(encryptionContainer, dek2, TestDoc.PathsToEncrypt, partitionKey, processor: processor);
             doc1ToUpsert.NonSensitive = Guid.NewGuid().ToString();
             doc1ToUpsert.Sensitive_StringFormat = Guid.NewGuid().ToString();
 
-            TestDoc doc2ToUpsert = await CreateItemAsync(encryptionContainer, dek1, TestDoc.PathsToEncrypt, partitionKey);
+            TestDoc doc2ToUpsert = await CreateItemAsync(encryptionContainer, dek1, TestDoc.PathsToEncrypt, partitionKey, processor: processor);
             doc2ToUpsert.NonSensitive = Guid.NewGuid().ToString();
             doc2ToUpsert.Sensitive_StringFormat = Guid.NewGuid().ToString();
 
-            TestDoc docToDelete = await CreateItemAsync(encryptionContainer, dek1, TestDoc.PathsToEncrypt, partitionKey);
+            TestDoc docToDelete = await CreateItemAsync(encryptionContainer, dek1, TestDoc.PathsToEncrypt, partitionKey, processor: processor);
 
             TransactionalBatchResponse batchResponse = await encryptionContainer.CreateTransactionalBatch(new PartitionKey(partitionKey))
-                .CreateItem(doc1ToCreate, GetBatchItemRequestOptions(dek1, TestDoc.PathsToEncrypt))
-                .CreateItemStream(doc2ToCreate.ToStream(), GetBatchItemRequestOptions(dek2, TestDoc.PathsToEncrypt))
-                .ReplaceItem(doc1ToReplace.Id, doc1ToReplace, GetBatchItemRequestOptions(dek2, TestDoc.PathsToEncrypt, doc1ToReplaceCreateResponse.ETag))
+                .CreateItem(doc1ToCreate, GetBatchItemRequestOptions(dek1, TestDoc.PathsToEncrypt, processor: processor))
+                .CreateItemStream(doc2ToCreate.ToStream(), GetBatchItemRequestOptions(dek2, TestDoc.PathsToEncrypt, processor: processor))
+                .ReplaceItem(doc1ToReplace.Id, doc1ToReplace, GetBatchItemRequestOptions(dek2, TestDoc.PathsToEncrypt, doc1ToReplaceCreateResponse.ETag, processor))
                 .CreateItem(doc3ToCreate)
-                .CreateItem(doc4ToCreate, GetBatchItemRequestOptions(dek1, new List<string>())) // empty PathsToEncrypt list
-                .ReplaceItemStream(doc2ToReplace.Id, doc2ToReplace.ToStream(), GetBatchItemRequestOptions(dek2, TestDoc.PathsToEncrypt))
-                .UpsertItem(doc1ToUpsert, GetBatchItemRequestOptions(dek1, TestDoc.PathsToEncrypt))
+                .CreateItem(doc4ToCreate, GetBatchItemRequestOptions(dek1, new List<string>(), processor: processor)) // empty PathsToEncrypt list
+                .ReplaceItemStream(doc2ToReplace.Id, doc2ToReplace.ToStream(), GetBatchItemRequestOptions(dek2, TestDoc.PathsToEncrypt, processor: processor))
+                .UpsertItem(doc1ToUpsert, GetBatchItemRequestOptions(dek1, TestDoc.PathsToEncrypt, processor: processor))
                 .DeleteItem(docToDelete.Id)
-                .UpsertItemStream(doc2ToUpsert.ToStream(), GetBatchItemRequestOptions(dek2, TestDoc.PathsToEncrypt))
+                .UpsertItemStream(doc2ToUpsert.ToStream(), GetBatchItemRequestOptions(dek2, TestDoc.PathsToEncrypt, processor: processor))
                 .ExecuteAsync();
 
             Assert.AreEqual(HttpStatusCode.OK, batchResponse.StatusCode);
@@ -1398,14 +1430,15 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom.EmulatorTests
             TransactionalBatchOperationResult<TestDoc> doc8 = batchResponse.GetOperationResultAtIndex<TestDoc>(8);
             VerifyExpectedDocResponse(doc2ToUpsert, doc8.Resource);
 
-            await VerifyItemByReadAsync(encryptionContainer, doc1ToCreate);
-            await VerifyItemByReadAsync(encryptionContainer, doc2ToCreate, dekId: dek2);
-            await VerifyItemByReadAsync(encryptionContainer, doc3ToCreate, isDocDecrypted: false);
-            await VerifyItemByReadAsync(encryptionContainer, doc4ToCreate, isDocDecrypted: false);
-            await VerifyItemByReadAsync(encryptionContainer, doc1ToReplace, dekId: dek2);
-            await VerifyItemByReadAsync(encryptionContainer, doc2ToReplace, dekId: dek2);
-            await VerifyItemByReadAsync(encryptionContainer, doc1ToUpsert);
-            await VerifyItemByReadAsync(encryptionContainer, doc2ToUpsert, dekId: dek2);
+            ItemRequestOptions readOptions = GetReadItemRequestOptions(processor);
+            await VerifyItemByReadAsync(encryptionContainer, doc1ToCreate, requestOptions: readOptions);
+            await VerifyItemByReadAsync(encryptionContainer, doc2ToCreate, requestOptions: readOptions, dekId: dek2);
+            await VerifyItemByReadAsync(encryptionContainer, doc3ToCreate, requestOptions: readOptions, isDocDecrypted: false);
+            await VerifyItemByReadAsync(encryptionContainer, doc4ToCreate, requestOptions: readOptions, isDocDecrypted: false);
+            await VerifyItemByReadAsync(encryptionContainer, doc1ToReplace, requestOptions: readOptions, dekId: dek2);
+            await VerifyItemByReadAsync(encryptionContainer, doc2ToReplace, requestOptions: readOptions, dekId: dek2);
+            await VerifyItemByReadAsync(encryptionContainer, doc1ToUpsert, requestOptions: readOptions);
+            await VerifyItemByReadAsync(encryptionContainer, doc2ToUpsert, requestOptions: readOptions, dekId: dek2);
 
             ResponseMessage readResponseMessage = await encryptionContainer.ReadItemStreamAsync(docToDelete.Id, new PartitionKey(docToDelete.PK));
             Assert.AreEqual(HttpStatusCode.NotFound, readResponseMessage.StatusCode);
@@ -1617,7 +1650,8 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom.EmulatorTests
             TestDoc expectedDoc = null,
             QueryDefinition queryDefinition = null,
             List<string> pathsEncrypted = null,
-            bool legacyAlgo = false)
+            bool legacyAlgo = false,
+            JsonProcessor processor = JsonProcessor.Newtonsoft)
         {
             QueryRequestOptions requestOptions = expectedDoc != null
                 ? new QueryRequestOptions()
@@ -1625,6 +1659,17 @@ namespace Microsoft.Azure.Cosmos.Encryption.Custom.EmulatorTests
                     PartitionKey = new PartitionKey(expectedDoc.PK),
                 }
                 : null;
+
+#if NET8_0_OR_GREATER
+            if (processor == JsonProcessor.Stream)
+            {
+                requestOptions ??= new QueryRequestOptions();
+                requestOptions.Properties = new Dictionary<string, object>
+                {
+                    { JsonProcessorRequestOptionsExtensions.JsonProcessorPropertyBagKey, "Stream" }
+                };
+            }
+#endif
 
             FeedIterator<TestDoc> queryResponseIterator;
             FeedIterator<DecryptableItem> queryResponseIteratorForLazyDecryption;
@@ -2179,12 +2224,13 @@ cancellationToken) =>
             TestDoc testDoc,
             string dekId,
             List<string> pathsToEncrypt,
-            HttpStatusCode expectedStatusCode)
+            HttpStatusCode expectedStatusCode,
+            JsonProcessor processor = JsonProcessor.Newtonsoft)
         {
             ItemResponse<TestDoc> upsertResponse = await container.UpsertItemAsync(
                 testDoc,
                 new PartitionKey(testDoc.PK),
-                GetRequestOptions(dekId, pathsToEncrypt));
+                GetRequestOptions(dekId, pathsToEncrypt, processor: processor));
             Assert.AreEqual(expectedStatusCode, upsertResponse.StatusCode);
             VerifyExpectedDocResponse(testDoc, upsertResponse.Resource);
             return upsertResponse;
@@ -2195,13 +2241,14 @@ cancellationToken) =>
             string dekId,
             List<string> pathsToEncrypt,
             string partitionKey = null,
-            bool legacyAlgo = false)
+            bool legacyAlgo = false,
+            JsonProcessor processor = JsonProcessor.Newtonsoft)
         {
             TestDoc testDoc = TestDoc.Create(partitionKey);
             ItemResponse<TestDoc> createResponse = await container.CreateItemAsync(
                 testDoc,
                 new PartitionKey(testDoc.PK),
-                GetRequestOptions(dekId, pathsToEncrypt, legacyAlgo: legacyAlgo));
+                GetRequestOptions(dekId, pathsToEncrypt, legacyAlgo: legacyAlgo, processor: processor));
             Assert.AreEqual(HttpStatusCode.Created, createResponse.StatusCode);
             VerifyExpectedDocResponse(testDoc, createResponse.Resource);
             return createResponse;
@@ -2212,13 +2259,14 @@ cancellationToken) =>
             TestDoc testDoc,
             string dekId,
             List<string> pathsToEncrypt,
-            string etag = null)
+            string etag = null,
+            JsonProcessor processor = JsonProcessor.Newtonsoft)
         {
             ItemResponse<TestDoc> replaceResponse = await encryptedContainer.ReplaceItemAsync(
                 testDoc,
                 testDoc.Id,
                 new PartitionKey(testDoc.PK),
-                GetRequestOptions(dekId, pathsToEncrypt, etag));
+                GetRequestOptions(dekId, pathsToEncrypt, etag, processor: processor));
 
             Assert.AreEqual(HttpStatusCode.OK, replaceResponse.StatusCode);
 
@@ -2244,36 +2292,52 @@ cancellationToken) =>
             string dekId,
             List<string> pathsToEncrypt,
             string ifMatchEtag = null,
-            bool legacyAlgo = false)
+            bool legacyAlgo = false,
+            JsonProcessor processor = JsonProcessor.Newtonsoft)
         {
-            if (!legacyAlgo)
+            EncryptionOptions encryptionOptions = legacyAlgo ? GetLegacyEncryptionOptions(dekId, pathsToEncrypt) : GetEncryptionOptions(dekId, pathsToEncrypt);
+#if NET8_0_OR_GREATER
+            encryptionOptions.JsonProcessor = processor;
+#endif
+            return new EncryptionItemRequestOptions
             {
-                return new EncryptionItemRequestOptions
-                {
-                    EncryptionOptions = GetEncryptionOptions(dekId, pathsToEncrypt),
-                    IfMatchEtag = ifMatchEtag
-                };
-            }
-            else
-            {
-                return new EncryptionItemRequestOptions
-                {
-                    EncryptionOptions = GetLegacyEncryptionOptions(dekId, pathsToEncrypt),
-                    IfMatchEtag = ifMatchEtag
-                };
-            }
+                EncryptionOptions = encryptionOptions,
+                IfMatchEtag = ifMatchEtag
+            };
         }
 
         private static EncryptionTransactionalBatchItemRequestOptions GetBatchItemRequestOptions(
             string dekId,
             List<string> pathsToEncrypt,
-            string ifMatchEtag = null)
+            string ifMatchEtag = null,
+            JsonProcessor processor = JsonProcessor.Newtonsoft)
         {
+            EncryptionOptions encryptionOptions = GetEncryptionOptions(dekId, pathsToEncrypt);
+#if NET8_0_OR_GREATER
+            encryptionOptions.JsonProcessor = processor;
+#endif
             return new EncryptionTransactionalBatchItemRequestOptions
             {
-                EncryptionOptions = GetEncryptionOptions(dekId, pathsToEncrypt),
+                EncryptionOptions = encryptionOptions,
                 IfMatchEtag = ifMatchEtag
             };
+        }
+
+        private static ItemRequestOptions GetReadItemRequestOptions(JsonProcessor processor)
+        {
+#if NET8_0_OR_GREATER
+            if (processor == JsonProcessor.Stream)
+            {
+                return new ItemRequestOptions
+                {
+                    Properties = new Dictionary<string, object>
+                    {
+                        { JsonProcessorRequestOptionsExtensions.JsonProcessorPropertyBagKey, "Stream" }
+                    }
+                };
+            }
+#endif
+            return null;
         }
 
         private static EncryptionOptions GetEncryptionOptions(
@@ -2984,7 +3048,7 @@ cancellationToken) =>
                 expectedDoc);
 
             // create Items with New Algorithm
-            await this.EncryptionCreateItem();
+            await this.EncryptionCreateItem(JsonProcessor.Newtonsoft);
 
             // read back Data Items encrypted with Old Algorithm
             await VerifyItemByReadAsync(encryptionContainer, testDoc, dekId: legacydekId);
@@ -2999,7 +3063,7 @@ cancellationToken) =>
             await VerifyItemByReadStreamAsync(encryptionContainer, testDoc2);
 
             // create Items with New Algorithm
-            await this.EncryptionCreateItem();
+            await this.EncryptionCreateItem(JsonProcessor.Newtonsoft);
 
             // read back Data Items encrypted with Old Algorithm
             await VerifyItemByReadAsync(encryptionContainer, testDoc2, dekId: legacydekId);

--- a/Microsoft.Azure.Cosmos.Encryption.Custom/tests/Microsoft.Azure.Cosmos.Encryption.Custom.Tests/Contracts/DotNetSDKEncryptionCustomAPI.net6.json
+++ b/Microsoft.Azure.Cosmos.Encryption.Custom/tests/Microsoft.Azure.Cosmos.Encryption.Custom.Tests/Contracts/DotNetSDKEncryptionCustomAPI.net6.json
@@ -979,6 +979,18 @@
     "Microsoft.Azure.Cosmos.Encryption.Custom.EncryptionOptions;System.Object;IsAbstract:False;IsSealed:True;IsInterface:False;IsEnum:False;IsClass:True;IsValueType:False;IsNested:False;IsGenericType:False;IsSerializable:False": {
       "Subclasses": {},
       "Members": {
+        "Microsoft.Azure.Cosmos.Encryption.Custom.JsonProcessor get_JsonProcessor()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Encryption.Custom.JsonProcessor get_JsonProcessor();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "Microsoft.Azure.Cosmos.Encryption.Custom.JsonProcessor JsonProcessor": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Encryption.Custom.JsonProcessor JsonProcessor;CanRead:True;CanWrite:True;Microsoft.Azure.Cosmos.Encryption.Custom.JsonProcessor get_JsonProcessor();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;Void set_JsonProcessor(Microsoft.Azure.Cosmos.Encryption.Custom.JsonProcessor);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
         "System.Collections.Generic.IEnumerable`1[System.String] get_PathsToEncrypt()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
           "Type": "Method",
           "Attributes": [
@@ -1033,6 +1045,13 @@
             "CompilerGeneratedAttribute"
           ],
           "MethodInfo": "Void set_EncryptionAlgorithm(System.String);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "Void set_JsonProcessor(Microsoft.Azure.Cosmos.Encryption.Custom.JsonProcessor)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_JsonProcessor(Microsoft.Azure.Cosmos.Encryption.Custom.JsonProcessor);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
         },
         "Void set_PathsToEncrypt(System.Collections.Generic.IEnumerable`1[System.String])[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
           "Type": "Method",
@@ -1136,6 +1155,22 @@
           "Type": "Method",
           "Attributes": [],
           "MethodInfo": "System.Threading.Tasks.Task`1[System.Byte[]] EncryptAsync(Byte[], System.String, System.String, System.Threading.CancellationToken);IsAbstract:True;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "Microsoft.Azure.Cosmos.Encryption.Custom.JsonProcessor;System.Enum;IsAbstract:False;IsSealed:True;IsInterface:False;IsEnum:True;IsClass:False;IsValueType:True;IsNested:False;IsGenericType:False;IsSerializable:True": {
+      "Subclasses": {},
+      "Members": {
+        "Int32 value__": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": "Int32 value__;IsInitOnly:False;IsStatic:False;"
+        },
+        "Microsoft.Azure.Cosmos.Encryption.Custom.JsonProcessor Newtonsoft": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Encryption.Custom.JsonProcessor Newtonsoft;IsInitOnly:False;IsStatic:True;"
         }
       },
       "NestedTypes": {}

--- a/Microsoft.Azure.Cosmos.Encryption.Custom/tests/Microsoft.Azure.Cosmos.Encryption.Custom.Tests/Contracts/DotNetSDKEncryptionCustomAPI.net8.json
+++ b/Microsoft.Azure.Cosmos.Encryption.Custom/tests/Microsoft.Azure.Cosmos.Encryption.Custom.Tests/Contracts/DotNetSDKEncryptionCustomAPI.net8.json
@@ -979,6 +979,18 @@
     "Microsoft.Azure.Cosmos.Encryption.Custom.EncryptionOptions;System.Object;IsAbstract:False;IsSealed:True;IsInterface:False;IsEnum:False;IsClass:True;IsValueType:False;IsNested:False;IsGenericType:False;IsSerializable:False": {
       "Subclasses": {},
       "Members": {
+        "Microsoft.Azure.Cosmos.Encryption.Custom.JsonProcessor get_JsonProcessor()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Encryption.Custom.JsonProcessor get_JsonProcessor();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "Microsoft.Azure.Cosmos.Encryption.Custom.JsonProcessor JsonProcessor": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Encryption.Custom.JsonProcessor JsonProcessor;CanRead:True;CanWrite:True;Microsoft.Azure.Cosmos.Encryption.Custom.JsonProcessor get_JsonProcessor();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;Void set_JsonProcessor(Microsoft.Azure.Cosmos.Encryption.Custom.JsonProcessor);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
         "System.Collections.Generic.IEnumerable`1[System.String] get_PathsToEncrypt()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
           "Type": "Method",
           "Attributes": [
@@ -1033,6 +1045,13 @@
             "CompilerGeneratedAttribute"
           ],
           "MethodInfo": "Void set_EncryptionAlgorithm(System.String);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "Void set_JsonProcessor(Microsoft.Azure.Cosmos.Encryption.Custom.JsonProcessor)[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_JsonProcessor(Microsoft.Azure.Cosmos.Encryption.Custom.JsonProcessor);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
         },
         "Void set_PathsToEncrypt(System.Collections.Generic.IEnumerable`1[System.String])[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
           "Type": "Method",
@@ -1136,6 +1155,27 @@
           "Type": "Method",
           "Attributes": [],
           "MethodInfo": "System.Threading.Tasks.Task`1[System.Byte[]] EncryptAsync(Byte[], System.String, System.String, System.Threading.CancellationToken);IsAbstract:True;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        }
+      },
+      "NestedTypes": {}
+    },
+    "Microsoft.Azure.Cosmos.Encryption.Custom.JsonProcessor;System.Enum;IsAbstract:False;IsSealed:True;IsInterface:False;IsEnum:True;IsClass:False;IsValueType:True;IsNested:False;IsGenericType:False;IsSerializable:True": {
+      "Subclasses": {},
+      "Members": {
+        "Int32 value__": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": "Int32 value__;IsInitOnly:False;IsStatic:False;"
+        },
+        "Microsoft.Azure.Cosmos.Encryption.Custom.JsonProcessor Newtonsoft": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Encryption.Custom.JsonProcessor Newtonsoft;IsInitOnly:False;IsStatic:True;"
+        },
+        "Microsoft.Azure.Cosmos.Encryption.Custom.JsonProcessor Stream": {
+          "Type": "Field",
+          "Attributes": [],
+          "MethodInfo": "Microsoft.Azure.Cosmos.Encryption.Custom.JsonProcessor Stream;IsInitOnly:False;IsStatic:True;"
         }
       },
       "NestedTypes": {}

--- a/Microsoft.Azure.Cosmos.Encryption.Custom/tests/Microsoft.Azure.Cosmos.Encryption.Custom.Tests/EncryptionProcessorTests.cs
+++ b/Microsoft.Azure.Cosmos.Encryption.Custom/tests/Microsoft.Azure.Cosmos.Encryption.Custom.Tests/EncryptionProcessorTests.cs
@@ -224,6 +224,95 @@ namespace Microsoft.Azure.Cosmos.Encryption.Tests
                 Assert.IsTrue(ex.Message.IndexOf("not supported", StringComparison.OrdinalIgnoreCase) >= 0, $"Unexpected message: {ex.Message}");
             }
         }
+
+        [DataTestMethod]
+        [DataRow(JsonProcessor.Newtonsoft)]
+        [DataRow(JsonProcessor.Stream)]
+        public async Task EncryptDecryptRoundtrip_EncryptionOptionsJsonProcessor(JsonProcessor processor)
+        {
+            TestDoc doc = TestDoc.Create();
+            EncryptionOptions opts = new()
+            {
+                DataEncryptionKeyId = DekId,
+#pragma warning disable CS0618
+                EncryptionAlgorithm = CosmosEncryptionAlgorithm.MdeAeadAes256CbcHmac256Randomized,
+#pragma warning restore CS0618
+                PathsToEncrypt = TestDoc.PathsToEncrypt,
+                JsonProcessor = processor,
+            };
+
+            EncryptionItemRequestOptions requestOptions = new() { EncryptionOptions = opts };
+
+            CosmosDiagnosticsContext diagEncrypt = CosmosDiagnosticsContext.Create(null);
+            Stream encrypted = await EncryptionProcessor.EncryptAsync(doc.ToStream(), mockEncryptor.Object, requestOptions, diagEncrypt, CancellationToken.None);
+            encrypted.Position = 0;
+
+            CosmosDiagnosticsContext diagDecrypt = CosmosDiagnosticsContext.Create(null);
+            (Stream decrypted, DecryptionContext ctx) = await EncryptionProcessor.DecryptAsync(encrypted, mockEncryptor.Object, diagDecrypt, CancellationToken.None);
+
+            decrypted.Position = 0;
+            JObject decryptedObj = EncryptionProcessor.BaseSerializer.FromStream<JObject>(decrypted);
+            Assert.AreEqual(doc.SensitiveStr, decryptedObj.Property(nameof(TestDoc.SensitiveStr)).Value.Value<string>());
+            Assert.IsNull(decryptedObj.Property(Constants.EncryptedInfo));
+            Assert.IsNotNull(ctx);
+        }
+
+        [TestMethod]
+        public async Task RequestOptionsOverride_WinsOver_EncryptionOptionsJsonProcessor()
+        {
+            TestDoc doc = TestDoc.Create();
+            EncryptionOptions opts = new()
+            {
+                DataEncryptionKeyId = DekId,
+#pragma warning disable CS0618
+                EncryptionAlgorithm = CosmosEncryptionAlgorithm.MdeAeadAes256CbcHmac256Randomized,
+#pragma warning restore CS0618
+                PathsToEncrypt = TestDoc.PathsToEncrypt,
+                JsonProcessor = JsonProcessor.Newtonsoft, // override below should win
+            };
+
+            EncryptionItemRequestOptions requestOptions = new()
+            {
+                EncryptionOptions = opts,
+                Properties = new Dictionary<string, object>
+                {
+                    { JsonProcessorRequestOptionsExtensions.JsonProcessorPropertyBagKey, JsonProcessor.Stream }
+                }
+            };
+
+            List<Activity> capturedActivities = new List<Activity>();
+            using ActivityListener listener = new ActivityListener
+            {
+                ShouldListenTo = (activitySource) => activitySource.Name == "Microsoft.Azure.Cosmos.Encryption.Custom",
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+                ActivityStarted = activity => { lock (capturedActivities) { capturedActivities.Add(activity); } }
+            };
+            ActivitySource.AddActivityListener(listener);
+
+            CosmosDiagnosticsContext diagEncrypt = CosmosDiagnosticsContext.Create(null);
+            Stream encrypted = await EncryptionProcessor.EncryptAsync(doc.ToStream(), mockEncryptor.Object, requestOptions, diagEncrypt, CancellationToken.None);
+            encrypted.Position = 0;
+
+            // Activity assertion: override (Stream) should have been used for encrypt
+            string expectedScope = CosmosDiagnosticsContext.ScopeEncryptModeSelectionPrefix + JsonProcessor.Stream;
+            lock (capturedActivities)
+            {
+                Assert.IsTrue(capturedActivities.Any(a => a.DisplayName == expectedScope),
+                    $"Expected Stream encrypt scope '{expectedScope}' to be used (override should win). Activities: {string.Join(", ", capturedActivities.Select(a => a.DisplayName))}");
+            }
+
+            // Full roundtrip: decrypt using the same requestOptions override and verify payload
+            CosmosDiagnosticsContext diagDecrypt = CosmosDiagnosticsContext.Create(null);
+            (Stream decrypted, DecryptionContext ctx) = await EncryptionProcessor.DecryptAsync(encrypted, mockEncryptor.Object, diagDecrypt, requestOptions, CancellationToken.None);
+
+            decrypted.Position = 0;
+            JObject decryptedObj = EncryptionProcessor.BaseSerializer.FromStream<JObject>(decrypted);
+
+            Assert.AreEqual(doc.SensitiveStr, decryptedObj.Property(nameof(TestDoc.SensitiveStr)).Value.Value<string>());
+            Assert.AreEqual(doc.SensitiveInt, decryptedObj.Property(nameof(TestDoc.SensitiveInt)).Value.Value<int>());
+            Assert.IsNull(decryptedObj.Property(Constants.EncryptedInfo), "_ei should be absent after decryption");
+            Assert.IsNotNull(ctx, "DecryptionContext should be non-null");
+        }
 #endif
     }
 }

--- a/Microsoft.Azure.Cosmos.Encryption.Custom/tests/Microsoft.Azure.Cosmos.Encryption.Custom.Tests/LegacyEncryptionProcessorTests.cs
+++ b/Microsoft.Azure.Cosmos.Encryption.Custom/tests/Microsoft.Azure.Cosmos.Encryption.Custom.Tests/LegacyEncryptionProcessorTests.cs
@@ -38,10 +38,11 @@ namespace Microsoft.Azure.Cosmos.Encryption.Tests
             LegacyEncryptionProcessorTests.mockEncryptor = TestEncryptorFactory.CreateLegacy(dekId);
         }
 
-        [TestMethod]
-        [DynamicData(nameof(JsonProcessors))]
-
-        internal async Task InvalidPathToEncrypt(JsonProcessor jsonProcessor)
+        // Legacy encryption (AEAes256CbcHmacSha256Randomized) is Newtonsoft-only by design;
+        // JsonProcessor.Stream is not exercised in these roundtrip tests intentionally.
+        [DataTestMethod]
+        [DataRow(JsonProcessor.Newtonsoft)]
+        public async Task InvalidPathToEncrypt(JsonProcessor processor)
         {
             TestDoc testDoc = TestDoc.Create();
             EncryptionOptions encryptionOptionsWithInvalidPathToEncrypt = new ()
@@ -55,7 +56,7 @@ namespace Microsoft.Azure.Cosmos.Encryption.Tests
                     testDoc.ToStream(),
                     LegacyEncryptionProcessorTests.mockEncryptor.Object,
                     encryptionOptionsWithInvalidPathToEncrypt,
-                    jsonProcessor,
+                    processor,
                     new CosmosDiagnosticsContext(),
                     CancellationToken.None);
 
@@ -75,14 +76,14 @@ namespace Microsoft.Azure.Cosmos.Encryption.Tests
                 invalidPathsConfigured: true);
         }
 
-        [TestMethod]
-        [DynamicData(nameof(JsonProcessors))]
-        internal async Task EncryptDecryptPropertyWithNullValue(JsonProcessor jsonProcessor)
+        [DataTestMethod]
+        [DataRow(JsonProcessor.Newtonsoft)]
+        public async Task EncryptDecryptPropertyWithNullValue(JsonProcessor processor)
         {
             TestDoc testDoc = TestDoc.Create();
             testDoc.SensitiveStr = null;
 
-            JObject encryptedDoc = await LegacyEncryptionProcessorTests.VerifyEncryptionSucceeded(testDoc, jsonProcessor);
+            JObject encryptedDoc = await LegacyEncryptionProcessorTests.VerifyEncryptionSucceeded(testDoc, processor);
 
             (JObject decryptedDoc, DecryptionContext decryptionContext) = await EncryptionProcessor.DecryptAsync(
                 encryptedDoc,
@@ -97,13 +98,13 @@ namespace Microsoft.Azure.Cosmos.Encryption.Tests
                 decryptionContext);
         }
 
-        [TestMethod]
-        [DynamicData(nameof(JsonProcessors))]
-        internal async Task ValidateEncryptDecryptDocument(JsonProcessor jsonProcessor)
+        [DataTestMethod]
+        [DataRow(JsonProcessor.Newtonsoft)]
+        public async Task ValidateEncryptDecryptDocument(JsonProcessor processor)
         {
             TestDoc testDoc = TestDoc.Create();
 
-            JObject encryptedDoc = await LegacyEncryptionProcessorTests.VerifyEncryptionSucceeded(testDoc, jsonProcessor);
+            JObject encryptedDoc = await LegacyEncryptionProcessorTests.VerifyEncryptionSucceeded(testDoc, processor);
 
             (JObject decryptedDoc, DecryptionContext decryptionContext) = await EncryptionProcessor.DecryptAsync(
                 encryptedDoc,
@@ -118,9 +119,9 @@ namespace Microsoft.Azure.Cosmos.Encryption.Tests
                 decryptionContext);
         }
 
-        [TestMethod]
-        [DynamicData(nameof(JsonProcessors))]
-        internal async Task ValidateDecryptStream(JsonProcessor jsonProcessor)
+        [DataTestMethod]
+        [DataRow(JsonProcessor.Newtonsoft)]
+        public async Task ValidateDecryptStream(JsonProcessor processor)
         {
             TestDoc testDoc = TestDoc.Create();
 
@@ -128,7 +129,7 @@ namespace Microsoft.Azure.Cosmos.Encryption.Tests
                 testDoc.ToStream(),
                 LegacyEncryptionProcessorTests.mockEncryptor.Object,
                 LegacyEncryptionProcessorTests.encryptionOptions,
-                jsonProcessor,
+                processor,
                 new CosmosDiagnosticsContext(),
                 CancellationToken.None);
 
@@ -164,13 +165,13 @@ namespace Microsoft.Azure.Cosmos.Encryption.Tests
             Assert.IsNull(decryptionContext);
         }
 
-        private static async Task<JObject> VerifyEncryptionSucceeded(TestDoc testDoc, JsonProcessor jsonProcessor)
+        private static async Task<JObject> VerifyEncryptionSucceeded(TestDoc testDoc, JsonProcessor processor)
         {
             Stream encryptedStream = await EncryptionProcessor.EncryptAsync(
                 testDoc.ToStream(),
                 LegacyEncryptionProcessorTests.mockEncryptor.Object,
                 LegacyEncryptionProcessorTests.encryptionOptions,
-                jsonProcessor,
+                processor,
                 new CosmosDiagnosticsContext(),
                 CancellationToken.None);
 
@@ -223,16 +224,6 @@ namespace Microsoft.Azure.Cosmos.Encryption.Tests
             }
         }
 
-        public static IEnumerable<object[]> JsonProcessors
-        {
-            get
-            {
-                    yield return new object[] { JsonProcessor.Newtonsoft };
-#if NET8_0_OR_GREATER
-                    yield return new object[] { JsonProcessor.Stream };
-#endif
-            }
-        }
     }
 
 #pragma warning restore CS0618 // Type or member is obsolete


### PR DESCRIPTION
## Summary
- reintroduce a typed `EncryptionOptions.JsonProcessor` opt-in while keeping the default `JsonProcessor.Newtonsoft`
- keep `RequestOptions.Properties["encryption-json-processor"]` working as the cross-cutting override, with explicit precedence over the typed property
- validate Newtonsoft and Stream side-by-side in unit tests and emulator roundtrip coverage, while keeping legacy encryption tests Newtonsoft-only by design
- update Encryption.Custom public API contract baselines for both net6 and net8

## Rationale
PR #5454 removed `EncryptionOptions.JsonProcessor` because the processor could already be supplied through `RequestOptions.Properties`, and that property-bag path still matters for decrypt/query request options that do not carry `EncryptionOptions`.

This change restores a typed, opt-in encrypt-side knob on `EncryptionOptions` for callers that want an explicit per-operation choice without changing the production default. The property defaults to `Newtonsoft`, and the existing property-bag override still wins when both are set so the existing decrypt/query override path remains the single consistent escape hatch across request option types.

## Test coverage
- `Microsoft.Azure.Cosmos.Encryption.Custom.Tests`
  - restored/added typed JsonProcessor coverage and precedence validation
  - fixed legacy test discovery so the Newtonsoft-only legacy roundtrips execute again
- `Microsoft.Azure.Cosmos.Encryption.Custom.EmulatorTests`
  - parameterized key create/read/RUD/transactional batch roundtrip tests across `Newtonsoft` and `Stream`
  - read/query Stream selection still uses `RequestOptions.Properties` so decrypt-side coverage stays aligned with the current public surface

## Validation
- `dotnet restore Microsoft.Azure.Cosmos.sln`
- `dotnet build Microsoft.Azure.Cosmos.Encryption.Custom\src\Microsoft.Azure.Cosmos.Encryption.Custom.csproj -c Release`
- `dotnet build Microsoft.Azure.Cosmos.Encryption.Custom\tests\Microsoft.Azure.Cosmos.Encryption.Custom.Tests\Microsoft.Azure.Cosmos.Encryption.Custom.Tests.csproj -c Release`
- `dotnet test Microsoft.Azure.Cosmos.Encryption.Custom\tests\Microsoft.Azure.Cosmos.Encryption.Custom.Tests\Microsoft.Azure.Cosmos.Encryption.Custom.Tests.csproj -c Release --nologo`
- `dotnet build Microsoft.Azure.Cosmos.Encryption.Custom\tests\EmulatorTests\Microsoft.Azure.Cosmos.Encryption.Custom.EmulatorTests.csproj -c Release`

## Notes
- Emulator tests were built but not executed locally.
- No failing Stream-pipeline variations were observed in the exercised unit coverage.