### PR TITLE
Direct: Fixes Direct/TCP connection limit validation

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ConnectionPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/ConnectionPolicy.cs
@@ -23,6 +23,8 @@ namespace Microsoft.Azure.Cosmos
         private const int defaultMediaRequestTimeout = 300;
         private const int defaultMaxConcurrentFanoutRequests = 32;
         private const int defaultMaxConcurrentConnectionLimit = 50;
+        private const int minimumMaxRequestsPerTcpConnection = 4;
+        private const int minimumMaxTcpConnectionsPerEndpoint = 16;
 
         internal UserAgentContainer UserAgentContainer;
         private static ConnectionPolicy defaultPolicy;
@@ -30,6 +32,8 @@ namespace Microsoft.Azure.Cosmos
         private Protocol connectionProtocol;
         private ObservableCollection<string> preferredLocations;
         private ObservableCollection<Uri> accountInitializationCustomEndpoints;
+        private int? maxRequestsPerTcpConnection;
+        private int? maxTcpConnectionsPerEndpoint;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ConnectionPolicy"/> class to connect to the Azure Cosmos DB service.
@@ -468,8 +472,20 @@ namespace Microsoft.Azure.Cosmos
         /// </remarks>
         public int? MaxRequestsPerTcpConnection
         {
-            get;
-            set;
+            get
+            {
+                return this.maxRequestsPerTcpConnection;
+            }
+
+            set
+            {
+                ConnectionPolicy.ValidateDirectTcpConnectionLimit(
+                    value,
+                    ConnectionPolicy.minimumMaxRequestsPerTcpConnection,
+                    nameof(this.MaxRequestsPerTcpConnection));
+
+                this.maxRequestsPerTcpConnection = value;
+            }
         }
 
         /// <summary>
@@ -481,8 +497,20 @@ namespace Microsoft.Azure.Cosmos
         /// </value>
         public int? MaxTcpConnectionsPerEndpoint
         {
-            get;
-            set;
+            get
+            {
+                return this.maxTcpConnectionsPerEndpoint;
+            }
+
+            set
+            {
+                ConnectionPolicy.ValidateDirectTcpConnectionLimit(
+                    value,
+                    ConnectionPolicy.minimumMaxTcpConnectionsPerEndpoint,
+                    nameof(this.MaxTcpConnectionsPerEndpoint));
+
+                this.maxTcpConnectionsPerEndpoint = value;
+            }
         }
 
         /// <summary>
@@ -606,6 +634,20 @@ namespace Microsoft.Azure.Cosmos
         internal RetryWithConfiguration GetRetryWithConfiguration()
         {
             return this.RetryOptions?.GetRetryWithConfiguration();
+        }
+
+        private static void ValidateDirectTcpConnectionLimit(
+            int? value,
+            int minimumValue,
+            string settingName)
+        {
+            if (value.HasValue && value.Value < minimumValue)
+            {
+                throw new ArgumentOutOfRangeException(
+                    settingName,
+                    value.Value,
+                    $"{settingName} must be greater than or equal to {minimumValue}.");
+            }
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
@@ -49,6 +49,8 @@ namespace Microsoft.Azure.Cosmos
         /// Default Protocol mode
         /// </summary>
         private const Protocol DefaultProtocol = Protocol.Tcp;
+        private const int MinimumMaxRequestsPerTcpConnection = 4;
+        private const int MinimumMaxTcpConnectionsPerEndpoint = 16;
 
         private const string ConnectionStringAccountEndpoint = "AccountEndpoint";
         private const string ConnectionStringAccountKey = "AccountKey";
@@ -621,6 +623,14 @@ namespace Microsoft.Azure.Cosmos
             get => this.maxRequestsPerTcpConnection;
             set
             {
+                if (this.ConnectionMode == ConnectionMode.Direct)
+                {
+                    CosmosClientOptions.ValidateDirectTcpConnectionLimit(
+                        value,
+                        CosmosClientOptions.MinimumMaxRequestsPerTcpConnection,
+                        nameof(this.MaxRequestsPerTcpConnection));
+                }
+
                 this.maxRequestsPerTcpConnection = value;
                 this.ValidateDirectTCPSettings();
             }
@@ -638,6 +648,14 @@ namespace Microsoft.Azure.Cosmos
             get => this.maxTcpConnectionsPerEndpoint;
             set
             {
+                if (this.ConnectionMode == ConnectionMode.Direct)
+                {
+                    CosmosClientOptions.ValidateDirectTcpConnectionLimit(
+                        value,
+                        CosmosClientOptions.MinimumMaxTcpConnectionsPerEndpoint,
+                        nameof(this.MaxTcpConnectionsPerEndpoint));
+                }
+
                 this.maxTcpConnectionsPerEndpoint = value;
                 this.ValidateDirectTCPSettings();
             }
@@ -1328,6 +1346,29 @@ namespace Microsoft.Azure.Cosmos
             if (!string.IsNullOrEmpty(settingName))
             {
                 throw new ArgumentException($"{settingName} requires {nameof(this.ConnectionMode)} to be set to {nameof(ConnectionMode.Direct)}");
+            }
+
+            CosmosClientOptions.ValidateDirectTcpConnectionLimit(
+                this.MaxRequestsPerTcpConnection,
+                CosmosClientOptions.MinimumMaxRequestsPerTcpConnection,
+                nameof(this.MaxRequestsPerTcpConnection));
+            CosmosClientOptions.ValidateDirectTcpConnectionLimit(
+                this.MaxTcpConnectionsPerEndpoint,
+                CosmosClientOptions.MinimumMaxTcpConnectionsPerEndpoint,
+                nameof(this.MaxTcpConnectionsPerEndpoint));
+        }
+
+        private static void ValidateDirectTcpConnectionLimit(
+            int? value,
+            int minimumValue,
+            string settingName)
+        {
+            if (value.HasValue && value.Value < minimumValue)
+            {
+                throw new ArgumentOutOfRangeException(
+                    settingName,
+                    value.Value,
+                    $"{settingName} must be greater than or equal to {minimumValue}.");
             }
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
@@ -828,6 +828,61 @@ namespace Microsoft.Azure.Cosmos.Tests
         }
 
         [TestMethod]
+        public void VerifyCosmosClientOptionsDirectTcpConnectionLimitsValidateMinimumValues()
+        {
+            CosmosClientOptions cosmosClientOptions = new CosmosClientOptions()
+            {
+                ConnectionMode = ConnectionMode.Direct
+            };
+
+            cosmosClientOptions.MaxTcpConnectionsPerEndpoint = null;
+            Assert.IsNull(cosmosClientOptions.MaxTcpConnectionsPerEndpoint);
+
+            cosmosClientOptions.MaxTcpConnectionsPerEndpoint = 16;
+            Assert.AreEqual(16, cosmosClientOptions.MaxTcpConnectionsPerEndpoint);
+
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => cosmosClientOptions.MaxTcpConnectionsPerEndpoint = 15);
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => cosmosClientOptions.MaxTcpConnectionsPerEndpoint = 0);
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => cosmosClientOptions.MaxTcpConnectionsPerEndpoint = -1);
+
+            cosmosClientOptions.MaxRequestsPerTcpConnection = null;
+            Assert.IsNull(cosmosClientOptions.MaxRequestsPerTcpConnection);
+
+            cosmosClientOptions.MaxRequestsPerTcpConnection = 4;
+            Assert.AreEqual(4, cosmosClientOptions.MaxRequestsPerTcpConnection);
+
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => cosmosClientOptions.MaxRequestsPerTcpConnection = 3);
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => cosmosClientOptions.MaxRequestsPerTcpConnection = 0);
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => cosmosClientOptions.MaxRequestsPerTcpConnection = -1);
+        }
+
+        [TestMethod]
+        public void VerifyConnectionPolicyDirectTcpConnectionLimitsValidateMinimumValues()
+        {
+            ConnectionPolicy connectionPolicy = new ConnectionPolicy();
+
+            connectionPolicy.MaxTcpConnectionsPerEndpoint = null;
+            Assert.IsNull(connectionPolicy.MaxTcpConnectionsPerEndpoint);
+
+            connectionPolicy.MaxTcpConnectionsPerEndpoint = 16;
+            Assert.AreEqual(16, connectionPolicy.MaxTcpConnectionsPerEndpoint);
+
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => connectionPolicy.MaxTcpConnectionsPerEndpoint = 15);
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => connectionPolicy.MaxTcpConnectionsPerEndpoint = 0);
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => connectionPolicy.MaxTcpConnectionsPerEndpoint = -1);
+
+            connectionPolicy.MaxRequestsPerTcpConnection = null;
+            Assert.IsNull(connectionPolicy.MaxRequestsPerTcpConnection);
+
+            connectionPolicy.MaxRequestsPerTcpConnection = 4;
+            Assert.AreEqual(4, connectionPolicy.MaxRequestsPerTcpConnection);
+
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => connectionPolicy.MaxRequestsPerTcpConnection = 3);
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => connectionPolicy.MaxRequestsPerTcpConnection = 0);
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => connectionPolicy.MaxRequestsPerTcpConnection = -1);
+        }
+
+        [TestMethod]
         public void VerifyHttpClientFactoryBlockedWithConnectionLimit()
         {
             CosmosClientOptions cosmosClientOptions = new CosmosClientOptions()

--- a/changelog.md
+++ b/changelog.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Bugs Fixed
 
+- Fixes Direct/TCP connection limit options to reject values below their documented minimums. See [PR 5883](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5883).
+
 #### Other Changes
 
 ### <a name="3.61.0-preview.0"/> [3.61.0-preview.0](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.61.0-preview.0) - 2026-5-18


### PR DESCRIPTION
## Summary
- Validates `MaxRequestsPerTcpConnection` rejects values below the documented minimum of 4.
- Validates `MaxTcpConnectionsPerEndpoint` rejects values below the documented minimum of 16.
- Covers both `CosmosClientOptions` and `ConnectionPolicy` paths.

## Fixes
  - Fixes #5878

## Tests
- `DOTNET_ROLL_FORWARD=Major dotnet test Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Microsoft.Azure.Cosmos.Tests.csproj --filter "VerifyCosmosClientOptionsDirectTcpConnectionLimitsValidateMinimumValues|VerifyConnectionPolicyDirectTcpConnectionLimitsValidateMinimumValues" --no-restore /p:EnableSourceControlManagerQueries=false`
- `DOTNET_ROLL_FORWARD=Major dotnet test Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Microsoft.Azure.Cosmos.Tests.csproj --filter "CosmosClientOptionsUnitTests" --no-restore /p:EnableSourceControlManagerQueries=false`
