### PR TITLE
[Internal] DTS: Adds double-commit guardrail to prevent idempotency token bypass

### DIFF
--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedReadTransactionCore.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedReadTransactionCore.cs
@@ -12,8 +12,14 @@ namespace Microsoft.Azure.Cosmos
 
     internal class DistributedReadTransactionCore : DistributedReadTransaction
     {
+        internal const string CommitAlreadyCalledMessage =
+            "CommitTransactionAsync has already been called on this transaction instance. " +
+            "A DistributedReadTransaction is single-use; to retry, construct a new " +
+            "DistributedReadTransaction with the same items.";
+
         private readonly CosmosClientContext clientContext;
         private readonly List<DistributedTransactionOperation> operations;
+        private int isCommitInvoked;
 
         internal DistributedReadTransactionCore(CosmosClientContext clientContext)
         {
@@ -44,9 +50,16 @@ namespace Microsoft.Azure.Cosmos
             return this;
         }
 
+        /// <inheritdoc/>
+        /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken"/> is cancelled before or during the commit.</exception>
         public override async Task<DistributedTransactionResponse> CommitTransactionAsync(
             CancellationToken cancellationToken = default)
         {
+            if (Interlocked.CompareExchange(ref this.isCommitInvoked, DistributedTransactionConstants.CommitStarted, DistributedTransactionConstants.CommitNotStarted) != DistributedTransactionConstants.CommitNotStarted)
+            {
+                throw new InvalidOperationException(CommitAlreadyCalledMessage);
+            }
+
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
                 operations: this.operations,
                 clientContext: this.clientContext);

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransaction.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransaction.cs
@@ -23,20 +23,14 @@ namespace Microsoft.Azure.Cosmos
         /// </summary>
         /// <remarks>
         /// This method is single-use: it can only be called once per transaction instance.
-        /// Each call generates a unique idempotency token that the server uses for duplicate
-        /// detection during the SDK's internal retries. A second call would generate a new
-        /// token and bypass that server-side duplicate detection, risking a double-commit.
-        /// <para>
-        /// If the call fails for any reason (including transient network failures, cancellation,
-        /// or non-retriable server errors), the transaction instance is permanently consumed.
-        /// To retry, construct a new transaction with the same operations. When the previous
-        /// commit's outcome is unknown, verify the resulting state before retrying to avoid
-        /// duplicate writes.
-        /// </para>
+        /// If the call fails for any reason (including transient network failures or cancellation),
+        /// the transaction instance is permanently consumed. To retry, construct a new transaction
+        /// with the same operations.
         /// </remarks>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
         /// <returns>A <see cref="Task{TResult}"/> containing a <see cref="DistributedTransactionResponse"/> that represents the result of the transaction.</returns>
         /// <exception cref="InvalidOperationException">Thrown if <see cref="CommitTransactionAsync"/> has already been called on this instance.</exception>
+        /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken"/> is cancelled before or during the commit.</exception>
         public abstract Task<DistributedTransactionResponse> CommitTransactionAsync(CancellationToken cancellationToken = default);
     }
 }

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransaction.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransaction.cs
@@ -21,8 +21,22 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Commits the distributed transaction.
         /// </summary>
+        /// <remarks>
+        /// This method is single-use: it can only be called once per transaction instance.
+        /// Each call generates a unique idempotency token that the server uses for duplicate
+        /// detection during the SDK's internal retries. A second call would generate a new
+        /// token and bypass that server-side duplicate detection, risking a double-commit.
+        /// <para>
+        /// If the call fails for any reason (including transient network failures, cancellation,
+        /// or non-retriable server errors), the transaction instance is permanently consumed.
+        /// To retry, construct a new transaction with the same operations. When the previous
+        /// commit's outcome is unknown, verify the resulting state before retrying to avoid
+        /// duplicate writes.
+        /// </para>
+        /// </remarks>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
         /// <returns>A <see cref="Task{TResult}"/> containing a <see cref="DistributedTransactionResponse"/> that represents the result of the transaction.</returns>
+        /// <exception cref="InvalidOperationException">Thrown if <see cref="CommitTransactionAsync"/> has already been called on this instance.</exception>
         public abstract Task<DistributedTransactionResponse> CommitTransactionAsync(CancellationToken cancellationToken = default);
     }
 }

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionConstants.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionConstants.cs
@@ -8,6 +8,10 @@ namespace Microsoft.Azure.Cosmos
 
     internal static class DistributedTransactionConstants
     {
+        // Commit guard: values used with Interlocked.CompareExchange to enforce single-use semantics.
+        internal const int CommitNotStarted = 0;
+        internal const int CommitStarted = 1;
+
         // DTX envelope sub-status codes. The full status/body matrix and the inner-vs-outer retry ownership
         // is documented at the call site in ClientRetryPolicy.ShouldRetryDtxRequest.
         internal const int DtcCoordinatorRaceConflict = 5352; // 449 sub-status: coordinator ETag race

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedWriteTransactionCore.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedWriteTransactionCore.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Azure.Cosmos
     {
         private readonly CosmosClientContext clientContext;
         private readonly List<DistributedTransactionOperation> operations;
+        private int commitCalled;
 
         internal DistributedWriteTransactionCore(CosmosClientContext clientContext)
         {
@@ -273,6 +274,17 @@ namespace Microsoft.Azure.Cosmos
 
         public override async Task<DistributedTransactionResponse> CommitTransactionAsync(CancellationToken cancellationToken)
         {
+            if (Interlocked.CompareExchange(ref this.commitCalled, 1, 0) != 0)
+            {
+                throw new InvalidOperationException(
+                    "CommitTransactionAsync has already been called on this transaction instance. " +
+                    "A DistributedWriteTransaction is single-use because each commit generates a new " +
+                    "idempotency token; a second call would bypass server-side duplicate detection and " +
+                    "risk a double-commit. To retry, construct a new DistributedWriteTransaction with " +
+                    "the same operations. If the previous commit's outcome is unknown (e.g., cancellation " +
+                    "or network failure), verify the resulting state before retrying to avoid duplicate writes.");
+            }
+
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
                 operations: this.operations,
                 clientContext: this.clientContext);

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedWriteTransactionCore.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedWriteTransactionCore.cs
@@ -14,9 +14,17 @@ namespace Microsoft.Azure.Cosmos
 
     internal class DistributedWriteTransactionCore : DistributedWriteTransaction
     {
+        internal const string CommitAlreadyCalledMessage =
+            "CommitTransactionAsync has already been called on this transaction instance. " +
+            "A DistributedWriteTransaction is single-use because each commit generates a new " +
+            "idempotency token; a second call would bypass server-side duplicate detection and " +
+            "risk a double-commit. To retry, construct a new DistributedWriteTransaction with " +
+            "the same operations. If the previous commit's outcome is unknown (e.g., cancellation " +
+            "or network failure), verify the resulting state before retrying to avoid duplicate writes.";
+
         private readonly CosmosClientContext clientContext;
         private readonly List<DistributedTransactionOperation> operations;
-        private int commitCalled;
+        private int isCommitInvoked;
 
         internal DistributedWriteTransactionCore(CosmosClientContext clientContext)
         {
@@ -272,17 +280,22 @@ namespace Microsoft.Azure.Cosmos
             return this;
         }
 
+        /// <inheritdoc/>
+        /// <remarks>
+        /// Each call to <see cref="DistributedTransaction.CommitTransactionAsync"/> generates a unique
+        /// idempotency token that the server uses for duplicate detection during the SDK's internal
+        /// retries. A second call would generate a new token and bypass that server-side duplicate
+        /// detection, risking a double-commit. When the previous commit's outcome is unknown
+        /// (e.g., cancellation or network failure), verify the resulting state before retrying
+        /// to avoid duplicate writes.
+        /// </remarks>
+        /// <exception cref="InvalidOperationException">Thrown if <see cref="DistributedTransaction.CommitTransactionAsync"/> has already been called on this instance.</exception>
+        /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken"/> is cancelled before or during the commit.</exception>
         public override async Task<DistributedTransactionResponse> CommitTransactionAsync(CancellationToken cancellationToken)
         {
-            if (Interlocked.CompareExchange(ref this.commitCalled, 1, 0) != 0)
+            if (Interlocked.CompareExchange(ref this.isCommitInvoked, DistributedTransactionConstants.CommitStarted, DistributedTransactionConstants.CommitNotStarted) != DistributedTransactionConstants.CommitNotStarted)
             {
-                throw new InvalidOperationException(
-                    "CommitTransactionAsync has already been called on this transaction instance. " +
-                    "A DistributedWriteTransaction is single-use because each commit generates a new " +
-                    "idempotency token; a second call would bypass server-side duplicate detection and " +
-                    "risk a double-commit. To retry, construct a new DistributedWriteTransaction with " +
-                    "the same operations. If the previous commit's outcome is unknown (e.g., cancellation " +
-                    "or network failure), verify the resulting state before retrying to avoid duplicate writes.");
+                throw new InvalidOperationException(CommitAlreadyCalledMessage);
             }
 
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedReadTransactionCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedReadTransactionCoreTests.cs
@@ -6,6 +6,12 @@ namespace Microsoft.Azure.Cosmos.Tests
 {
     using System;
     using System.Collections.Generic;
+    using System.IO;
+    using System.Net;
+    using System.Text;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Tracing;
     using Microsoft.Azure.Documents;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Moq;
@@ -176,6 +182,138 @@ namespace Microsoft.Azure.Cosmos.Tests
 
         #endregion
 
+        #region Double-commit guard
+
+        [TestMethod]
+        public async Task CommitAsync_CalledTwice_ThrowsInvalidOperationException()
+        {
+            Mock<CosmosClientContext> contextMock = this.BuildContextSetup();
+            contextMock
+                .Setup(c => c.ProcessResourceOperationStreamAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<ResourceType>(),
+                    It.IsAny<OperationType>(),
+                    It.IsAny<RequestOptions>(),
+                    It.IsAny<ContainerInternal>(),
+                    It.IsAny<CosmosPK?>(),
+                    It.IsAny<string>(),
+                    It.IsAny<Stream>(),
+                    It.IsAny<Action<RequestMessage>>(),
+                    It.IsAny<ITrace>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(BuildReadSuccessResponse(1));
+
+            DistributedReadTransaction tx = new DistributedReadTransactionCore(contextMock.Object)
+                .ReadItem(Database, Collection, TestPartitionKey, ItemId);
+
+            DistributedTransactionResponse response = await tx.CommitTransactionAsync(CancellationToken.None);
+            Assert.IsTrue(response.IsSuccessStatusCode);
+
+            InvalidOperationException ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+                () => tx.CommitTransactionAsync(CancellationToken.None));
+            Assert.AreEqual(DistributedReadTransactionCore.CommitAlreadyCalledMessage, ex.Message);
+        }
+
+        [TestMethod]
+        public async Task CommitAsync_CalledAfterFailedCommit_ThrowsInvalidOperationException()
+        {
+            Mock<CosmosClientContext> contextMock = this.BuildContextSetup();
+            contextMock
+                .Setup(c => c.ProcessResourceOperationStreamAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<ResourceType>(),
+                    It.IsAny<OperationType>(),
+                    It.IsAny<RequestOptions>(),
+                    It.IsAny<ContainerInternal>(),
+                    It.IsAny<CosmosPK?>(),
+                    It.IsAny<string>(),
+                    It.IsAny<Stream>(),
+                    It.IsAny<Action<RequestMessage>>(),
+                    It.IsAny<ITrace>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(BuildReadErrorResponse(HttpStatusCode.ServiceUnavailable));
+
+            DistributedReadTransaction tx = new DistributedReadTransactionCore(contextMock.Object)
+                .ReadItem(Database, Collection, TestPartitionKey, ItemId);
+
+            // First commit returns a server error — instance is still consumed.
+            DistributedTransactionResponse response = await tx.CommitTransactionAsync(CancellationToken.None);
+            Assert.IsFalse(response.IsSuccessStatusCode);
+
+            InvalidOperationException ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+                () => tx.CommitTransactionAsync(CancellationToken.None));
+            Assert.AreEqual(DistributedReadTransactionCore.CommitAlreadyCalledMessage, ex.Message);
+        }
+
+        [TestMethod]
+        [Description("Verifies that only one of N concurrent callers wins the Interlocked.CompareExchange gate. " +
+                     "Uses Task.Run + ManualResetEventSlim to provide genuine cross-thread concurrency.")]
+        public async Task CommitAsync_ConcurrentCalls_OnlyOneSucceeds()
+        {
+            int invocationCount = 0;
+
+            Mock<CosmosClientContext> contextMock = this.BuildContextSetup();
+            contextMock
+                .Setup(c => c.ProcessResourceOperationStreamAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<ResourceType>(),
+                    It.IsAny<OperationType>(),
+                    It.IsAny<RequestOptions>(),
+                    It.IsAny<ContainerInternal>(),
+                    It.IsAny<CosmosPK?>(),
+                    It.IsAny<string>(),
+                    It.IsAny<Stream>(),
+                    It.IsAny<Action<RequestMessage>>(),
+                    It.IsAny<ITrace>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns<string, ResourceType, OperationType, RequestOptions, ContainerInternal, CosmosPK?, string, Stream, Action<RequestMessage>, ITrace, CancellationToken>(
+                    async (uri, resType, opType, opts, container, pk, itemId, stream, enricher, trace, ct) =>
+                    {
+                        Interlocked.Increment(ref invocationCount);
+                        await Task.Delay(50, ct);
+                        return BuildReadSuccessResponse(1);
+                    });
+
+            DistributedReadTransaction tx = new DistributedReadTransactionCore(contextMock.Object)
+                .ReadItem(Database, Collection, TestPartitionKey, ItemId);
+
+            const int RacerCount = 16;
+            using ManualResetEventSlim gate = new ManualResetEventSlim(initialState: false);
+
+            Task<DistributedTransactionResponse>[] tasks = new Task<DistributedTransactionResponse>[RacerCount];
+            for (int i = 0; i < RacerCount; i++)
+            {
+                tasks[i] = Task.Run(async () =>
+                {
+                    gate.Wait();
+                    return await tx.CommitTransactionAsync(CancellationToken.None);
+                });
+            }
+
+            gate.Set();
+
+            int successCount = 0;
+            int rejectedCount = 0;
+            foreach (Task<DistributedTransactionResponse> t in tasks)
+            {
+                try
+                {
+                    await t;
+                    successCount++;
+                }
+                catch (InvalidOperationException)
+                {
+                    rejectedCount++;
+                }
+            }
+
+            Assert.AreEqual(1, successCount, "Exactly one racer should win the CompareExchange.");
+            Assert.AreEqual(RacerCount - 1, rejectedCount, "All other racers should be rejected by the guard.");
+            Assert.AreEqual(1, invocationCount, "The underlying commit pipeline must only fire once.");
+        }
+
+        #endregion
+
         /// <summary>
         /// Reflective helper to access the private operations list for assertion purposes.
         /// </summary>
@@ -184,6 +322,55 @@ namespace Microsoft.Azure.Cosmos.Tests
             System.Reflection.FieldInfo field = typeof(DistributedReadTransactionCore)
                 .GetField("operations", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
             return (IReadOnlyList<DistributedTransactionOperation>)field.GetValue(txn);
+        }
+
+        private Mock<CosmosClientContext> BuildContextSetup()
+        {
+            ContainerProperties containerProps = ContainerProperties.CreateWithResourceId("ccZ1ANCszwk=");
+            containerProps.PartitionKeyPath = "/pk";
+
+            Mock<CosmosClientContext> contextMock = new Mock<CosmosClientContext>();
+
+            contextMock
+                .Setup(c => c.DocumentClient)
+                .Returns(new MockDocumentClient());
+
+            contextMock
+                .Setup(c => c.SerializerCore)
+                .Returns(MockCosmosUtil.Serializer);
+
+            contextMock
+                .Setup(c => c.GetCachedContainerPropertiesAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<ITrace>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(containerProps);
+
+            return contextMock;
+        }
+
+        private static ResponseMessage BuildReadSuccessResponse(int operationCount)
+        {
+            List<string> results = new List<string>();
+            for (int i = 0; i < operationCount; i++)
+            {
+                results.Add($@"{{""index"":{i},""statusCode"":200}}");
+            }
+
+            string json = $@"{{""operationResponses"":[{string.Join(",", results)}]}}";
+            return new ResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new MemoryStream(Encoding.UTF8.GetBytes(json))
+            };
+        }
+
+        private static ResponseMessage BuildReadErrorResponse(HttpStatusCode statusCode)
+        {
+            string json = $@"{{""operationResponses"":[{{""index"":0,""statusCode"":{(int)statusCode}}}]}}";
+            return new ResponseMessage(statusCode)
+            {
+                Content = new MemoryStream(Encoding.UTF8.GetBytes(json))
+            };
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedWriteTransactionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedWriteTransactionTests.cs
@@ -387,6 +387,209 @@ namespace Microsoft.Azure.Cosmos.Tests
             Assert.IsFalse(response.IsSuccessStatusCode);
         }
 
+        // Double-commit guard
+
+        [TestMethod]
+        public async Task CommitAsync_CalledTwice_ThrowsInvalidOperationException()
+        {
+            Mock<CosmosClientContext> contextMock = this.BuildContextSetup();
+            contextMock
+                .Setup(c => c.ProcessResourceOperationStreamAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<ResourceType>(),
+                    It.IsAny<OperationType>(),
+                    It.IsAny<RequestOptions>(),
+                    It.IsAny<ContainerInternal>(),
+                    It.IsAny<PartitionKey?>(),
+                    It.IsAny<string>(),
+                    It.IsAny<Stream>(),
+                    It.IsAny<Action<RequestMessage>>(),
+                    It.IsAny<ITrace>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(BuildSuccessResponse(1));
+
+            DistributedWriteTransaction tx = new DistributedWriteTransactionCore(contextMock.Object)
+                .CreateItem(Database, Container, new PartitionKey("pk"), "item-id", new TestItem());
+
+            // First commit should succeed
+            DistributedTransactionResponse response = await tx.CommitTransactionAsync(CancellationToken.None);
+            Assert.IsTrue(response.IsSuccessStatusCode);
+
+            // Second commit must throw
+            InvalidOperationException ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+                () => tx.CommitTransactionAsync(CancellationToken.None));
+            Assert.IsTrue(ex.Message.Contains("already been called"));
+            Assert.IsTrue(ex.Message.Contains("construct a new DistributedWriteTransaction"),
+                "Error message should direct callers to the correct retry pattern.");
+        }
+
+        [TestMethod]
+        public async Task CommitAsync_CalledAfterFailedCommit_ThrowsInvalidOperationException()
+        {
+            Mock<CosmosClientContext> contextMock = this.BuildContextSetup();
+            contextMock
+                .Setup(c => c.ProcessResourceOperationStreamAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<ResourceType>(),
+                    It.IsAny<OperationType>(),
+                    It.IsAny<RequestOptions>(),
+                    It.IsAny<ContainerInternal>(),
+                    It.IsAny<PartitionKey?>(),
+                    It.IsAny<string>(),
+                    It.IsAny<Stream>(),
+                    It.IsAny<Action<RequestMessage>>(),
+                    It.IsAny<ITrace>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(BuildErrorResponse(HttpStatusCode.Conflict));
+
+            DistributedWriteTransaction tx = new DistributedWriteTransactionCore(contextMock.Object)
+                .CreateItem(Database, Container, new PartitionKey("pk"), "item-id", new TestItem());
+
+            // First commit returns an error (but the call was made — idempotency token was consumed)
+            DistributedTransactionResponse response = await tx.CommitTransactionAsync(CancellationToken.None);
+            Assert.IsFalse(response.IsSuccessStatusCode);
+
+            // Second commit must still throw — the token was already issued
+            InvalidOperationException ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+                () => tx.CommitTransactionAsync(CancellationToken.None));
+            Assert.IsTrue(ex.Message.Contains("already been called"));
+        }
+
+        [TestMethod]
+        [Description("Verifies that a transient network exception during commit still consumes the transaction instance. " +
+                     "Callers cannot distinguish 'request never sent' from 'request reached server, response lost', " +
+                     "so retrying with a fresh token would risk a double-commit.")]
+        public async Task CommitAsync_TransientExceptionFromNetwork_StillConsumesTransaction()
+        {
+            int invocationCount = 0;
+
+            Mock<CosmosClientContext> contextMock = this.BuildContextSetup();
+            contextMock
+                .Setup(c => c.ProcessResourceOperationStreamAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<ResourceType>(),
+                    It.IsAny<OperationType>(),
+                    It.IsAny<RequestOptions>(),
+                    It.IsAny<ContainerInternal>(),
+                    It.IsAny<PartitionKey?>(),
+                    It.IsAny<string>(),
+                    It.IsAny<Stream>(),
+                    It.IsAny<Action<RequestMessage>>(),
+                    It.IsAny<ITrace>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns<string, ResourceType, OperationType, RequestOptions, ContainerInternal, PartitionKey?, string, Stream, Action<RequestMessage>, ITrace, CancellationToken>(
+                    (uri, resType, opType, opts, container, pk, itemId, stream, enricher, trace, ct) =>
+                    {
+                        Interlocked.Increment(ref invocationCount);
+                        throw new HttpRequestException("Simulated transient network failure");
+                    });
+
+            DistributedWriteTransaction tx = new DistributedWriteTransactionCore(contextMock.Object)
+                .CreateItem(Database, Container, new PartitionKey("pk"), "item-id", new TestItem());
+
+            // First commit attempt: a transient network exception escapes to the caller.
+            await Assert.ThrowsExceptionAsync<HttpRequestException>(
+                () => tx.CommitTransactionAsync(CancellationToken.None));
+
+            // Second commit attempt: must throw InvalidOperationException, NOT re-attempt the network call.
+            // The SDK has no way to know whether the first attempt's request reached the server,
+            // so a retry with a new idempotency token would risk a double-commit.
+            InvalidOperationException ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+                () => tx.CommitTransactionAsync(CancellationToken.None));
+            Assert.IsTrue(ex.Message.Contains("already been called"));
+            Assert.AreEqual(1, invocationCount, "Second call must not re-attempt the network operation.");
+        }
+
+        [TestMethod]
+        [Description("Verifies that user-initiated cancellation during commit still consumes the transaction instance.")]
+        public async Task CommitAsync_CancelledDuringCommit_StillConsumesTransaction()
+        {
+            using CancellationTokenSource cts = new CancellationTokenSource();
+            int invocationCount = 0;
+
+            Mock<CosmosClientContext> contextMock = this.BuildContextSetup();
+            contextMock
+                .Setup(c => c.ProcessResourceOperationStreamAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<ResourceType>(),
+                    It.IsAny<OperationType>(),
+                    It.IsAny<RequestOptions>(),
+                    It.IsAny<ContainerInternal>(),
+                    It.IsAny<PartitionKey?>(),
+                    It.IsAny<string>(),
+                    It.IsAny<Stream>(),
+                    It.IsAny<Action<RequestMessage>>(),
+                    It.IsAny<ITrace>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns<string, ResourceType, OperationType, RequestOptions, ContainerInternal, PartitionKey?, string, Stream, Action<RequestMessage>, ITrace, CancellationToken>(
+                    (uri, resType, opType, opts, container, pk, itemId, stream, enricher, trace, ct) =>
+                    {
+                        Interlocked.Increment(ref invocationCount);
+                        cts.Cancel();
+                        ct.ThrowIfCancellationRequested();
+                        return Task.FromResult(BuildSuccessResponse(1));
+                    });
+
+            DistributedWriteTransaction tx = new DistributedWriteTransactionCore(contextMock.Object)
+                .CreateItem(Database, Container, new PartitionKey("pk"), "item-id", new TestItem());
+
+            await Assert.ThrowsExceptionAsync<OperationCanceledException>(
+                () => tx.CommitTransactionAsync(cts.Token));
+
+            // Retry with a fresh CancellationToken should still be rejected.
+            InvalidOperationException ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+                () => tx.CommitTransactionAsync(CancellationToken.None));
+            Assert.IsTrue(ex.Message.Contains("already been called"));
+            Assert.AreEqual(1, invocationCount, "Second call must not re-attempt the network operation.");
+        }
+
+        [TestMethod]
+        public async Task CommitAsync_ConcurrentCalls_OnlyOneSucceeds()
+        {
+            int invocationCount = 0;
+
+            Mock<CosmosClientContext> contextMock = this.BuildContextSetup();
+            contextMock
+                .Setup(c => c.ProcessResourceOperationStreamAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<ResourceType>(),
+                    It.IsAny<OperationType>(),
+                    It.IsAny<RequestOptions>(),
+                    It.IsAny<ContainerInternal>(),
+                    It.IsAny<PartitionKey?>(),
+                    It.IsAny<string>(),
+                    It.IsAny<Stream>(),
+                    It.IsAny<Action<RequestMessage>>(),
+                    It.IsAny<ITrace>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns<string, ResourceType, OperationType, RequestOptions, ContainerInternal, PartitionKey?, string, Stream, Action<RequestMessage>, ITrace, CancellationToken>(
+                    async (uri, resType, opType, opts, container, pk, itemId, stream, enricher, trace, ct) =>
+                    {
+                        Interlocked.Increment(ref invocationCount);
+                        await Task.Delay(50, ct);
+                        return BuildSuccessResponse(1);
+                    });
+
+            DistributedWriteTransaction tx = new DistributedWriteTransactionCore(contextMock.Object)
+                .CreateItem(Database, Container, new PartitionKey("pk"), "item-id", new TestItem());
+
+            Task<DistributedTransactionResponse> task1 = tx.CommitTransactionAsync(CancellationToken.None);
+            Task<DistributedTransactionResponse> task2 = tx.CommitTransactionAsync(CancellationToken.None);
+
+            Exception caughtException = null;
+            try
+            {
+                await Task.WhenAll(task1, task2);
+            }
+            catch (InvalidOperationException ex)
+            {
+                caughtException = ex;
+            }
+
+            Assert.IsNotNull(caughtException, "One of the concurrent calls must throw InvalidOperationException.");
+            Assert.AreEqual(1, invocationCount, "Only one commit request should reach the network.");
+        }
+
         // Helpers
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedWriteTransactionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedWriteTransactionTests.cs
@@ -418,9 +418,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             // Second commit must throw
             InvalidOperationException ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
                 () => tx.CommitTransactionAsync(CancellationToken.None));
-            Assert.IsTrue(ex.Message.Contains("already been called"));
-            Assert.IsTrue(ex.Message.Contains("construct a new DistributedWriteTransaction"),
-                "Error message should direct callers to the correct retry pattern.");
+            Assert.AreEqual(DistributedWriteTransactionCore.CommitAlreadyCalledMessage, ex.Message);
         }
 
         [TestMethod]
@@ -452,7 +450,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             // Second commit must still throw — the token was already issued
             InvalidOperationException ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
                 () => tx.CommitTransactionAsync(CancellationToken.None));
-            Assert.IsTrue(ex.Message.Contains("already been called"));
+            Assert.AreEqual(DistributedWriteTransactionCore.CommitAlreadyCalledMessage, ex.Message);
         }
 
         [TestMethod]
@@ -496,7 +494,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             // so a retry with a new idempotency token would risk a double-commit.
             InvalidOperationException ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
                 () => tx.CommitTransactionAsync(CancellationToken.None));
-            Assert.IsTrue(ex.Message.Contains("already been called"));
+            Assert.AreEqual(DistributedWriteTransactionCore.CommitAlreadyCalledMessage, ex.Message);
             Assert.AreEqual(1, invocationCount, "Second call must not re-attempt the network operation.");
         }
 
@@ -539,11 +537,14 @@ namespace Microsoft.Azure.Cosmos.Tests
             // Retry with a fresh CancellationToken should still be rejected.
             InvalidOperationException ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
                 () => tx.CommitTransactionAsync(CancellationToken.None));
-            Assert.IsTrue(ex.Message.Contains("already been called"));
+            Assert.AreEqual(DistributedWriteTransactionCore.CommitAlreadyCalledMessage, ex.Message);
             Assert.AreEqual(1, invocationCount, "Second call must not re-attempt the network operation.");
         }
 
         [TestMethod]
+        [Description("Verifies that only one of N concurrent callers wins the Interlocked.CompareExchange gate. " +
+                     "Uses Task.Run + ManualResetEventSlim so that all racers hit CommitTransactionAsync from " +
+                     "separate thread-pool threads simultaneously, providing genuine concurrency coverage.")]
         public async Task CommitAsync_ConcurrentCalls_OnlyOneSucceeds()
         {
             int invocationCount = 0;
@@ -573,21 +574,43 @@ namespace Microsoft.Azure.Cosmos.Tests
             DistributedWriteTransaction tx = new DistributedWriteTransactionCore(contextMock.Object)
                 .CreateItem(Database, Container, new PartitionKey("pk"), "item-id", new TestItem());
 
-            Task<DistributedTransactionResponse> task1 = tx.CommitTransactionAsync(CancellationToken.None);
-            Task<DistributedTransactionResponse> task2 = tx.CommitTransactionAsync(CancellationToken.None);
+            const int RacerCount = 16;
+            using ManualResetEventSlim gate = new ManualResetEventSlim(initialState: false);
 
-            Exception caughtException = null;
-            try
+            // Spawn all racers on separate thread-pool threads, each blocked on the gate.
+            Task<DistributedTransactionResponse>[] tasks = new Task<DistributedTransactionResponse>[RacerCount];
+            for (int i = 0; i < RacerCount; i++)
             {
-                await Task.WhenAll(task1, task2);
-            }
-            catch (InvalidOperationException ex)
-            {
-                caughtException = ex;
+                tasks[i] = Task.Run(async () =>
+                {
+                    gate.Wait();
+                    return await tx.CommitTransactionAsync(CancellationToken.None);
+                });
             }
 
-            Assert.IsNotNull(caughtException, "One of the concurrent calls must throw InvalidOperationException.");
-            Assert.AreEqual(1, invocationCount, "Only one commit request should reach the network.");
+            gate.Set(); // release all racers simultaneously
+
+            int successCount = 0;
+            int rejectedCount = 0;
+            foreach (Task<DistributedTransactionResponse> t in tasks)
+            {
+                try
+                {
+                    await t;
+                    successCount++;
+                }
+                catch (InvalidOperationException)
+                {
+                    rejectedCount++;
+                }
+            }
+
+            Assert.AreEqual(1, successCount, "Exactly one racer should win the CompareExchange.");
+            Assert.AreEqual(RacerCount - 1, rejectedCount, "All other racers should be rejected by the guard.");
+            // This assertion is the key atomicity proof: without Interlocked, two threads could
+            // both read isCommitInvoked==CommitNotStarted before either writes CommitStarted,
+            // and invocationCount would be >1.
+            Assert.AreEqual(1, invocationCount, "The underlying commit pipeline must only fire once.");
         }
 
         // Helpers


### PR DESCRIPTION
# Pull Request Template

## Description

Adds an Interlocked-based execute-once guard to DistributedWriteTransactionCore.CommitTransactionAsync() that throws InvalidOperationException on subsequent calls. Each CommitTransactionAsync() generates a new idempotency token (Guid), so calling it twice on the same instance would bypass server-side duplicate detection and risk a double-commit. The guard ensures only the first call proceeds.

Changes:
- DistributedWriteTransactionCore: Added 'commitCalled' field with Interlocked.CompareExchange guard
- DistributedTransaction: Updated CommitTransactionAsync xmldoc with remarks and exception documentation
- DistributedWriteTransactionTests: Added 3 tests covering sequential double-call, post-failure double-call, and concurrent race condition scenarios

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber

## Changelog

- [ ] I have added a changelog entry under `### Unreleased` in `changelog.md`
  for the user-facing impact of this change.
- [X] No changelog entry is required because this PR is one of:
  documentation-only, test-only, CI / build-only, or a pure internal refactor
  with no observable customer impact.

If the second box is checked, briefly justify here:

> Feature not public yet
