### PR TITLE
[Internal] DTS: Adds session-token support and typed response deserialization for transactions

### DIFF
--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedReadTransaction.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedReadTransaction.cs
@@ -13,6 +13,14 @@ namespace Microsoft.Azure.Cosmos
     /// Use <see cref="CosmosClient.CreateDistributedReadTransaction"/> to obtain an instance.
     /// Add read operations using <see cref="ReadItem"/> then call
     /// <see cref="DistributedTransaction.CommitTransactionAsync"/> to execute all reads atomically.
+    /// <para>
+    /// <b>Isolation semantics:</b> All reads execute under snapshot isolation so the results reflect a
+    /// consistent point in time across participating partitions.
+    /// </para>
+    /// <para>
+    /// <b>Result deserialization:</b> Use <see cref="DistributedTransactionResponse.GetOperationResultAtIndex{T}"/>
+    /// to deserialize a read operation response body into a typed object.
+    /// </para>
     /// </remarks>
 #if INTERNAL
     public

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionCommitter.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionCommitter.cs
@@ -182,7 +182,7 @@ namespace Microsoft.Azure.Cosmos
             // without getting ReadSessionNotAvailable.
             //
             // DTC spans multiple collections so the server embeds per-operation session tokens in the JSON body.
-            // DistributedTransactionOperationResult.FromJson assembles each token into canonical {pkRangeId}:{lsn} form.
+            // DistributedTransactionOperationResult.FromJson assembles each token into canonical SDK session-token
             if (response == null || response.Count == 0 || serverRequest == null || sessionContainer == null)
             {
                 return;
@@ -204,7 +204,7 @@ namespace Microsoft.Azure.Cosmos
                         continue;
                     }
 
-                    // SessionToken is already in canonical {pkRangeId}:{lsn} format, assembled by FromJson.
+                    // SessionToken is already in canonical SDK session-token format, assembled by FromJson.
                     // Note: each SetSessionToken call acquires a write lock on the SessionContainer.
                     // For a future optimization, consider a batch-update API on ISessionContainer to
                     // reduce lock acquisitions when multiple operations target the same collection.

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperation.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperation.cs
@@ -33,6 +33,7 @@ namespace Microsoft.Azure.Cosmos
             this.Container = container;
             this.Id = id;
             this.RequestOptions = requestOptions;
+            this.SessionToken = string.IsNullOrWhiteSpace(requestOptions?.SessionToken) ? null : requestOptions.SessionToken;
         }
 
         public PartitionKey PartitionKey { get; internal set; }

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperationResult.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperationResult.cs
@@ -113,6 +113,7 @@ namespace Microsoft.Azure.Cosmos
         public virtual Stream ResourceStream { get; internal set; }
 
         /// <summary>
+        /// Gets the number of request units consumed by this operation.
         /// </summary>
         [JsonInclude]
         [JsonPropertyName("requestCharge")]

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperationResult.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperationResult.cs
@@ -40,6 +40,7 @@ namespace Microsoft.Azure.Cosmos
             this.RequestCharge = other.RequestCharge;
             this.ActivityId = other.ActivityId;
             this.Trace = other.Trace;
+            this.SerializerCore = other.SerializerCore;
         }
 
         /// <summary>
@@ -102,6 +103,12 @@ namespace Microsoft.Azure.Cosmos
         /// Gets the resource stream associated with the operation result.
         /// The stream contains the raw response payload returned by the operation.
         /// </summary>
+        /// <remarks>
+        /// <b>Lifetime / ownership:</b> This stream is owned by the enclosing
+        /// <see cref="DistributedTransactionResponse"/> and will be disposed when that response is disposed.
+        /// Do not dispose it directly. To deserialize to a typed object, use
+        /// <see cref="DistributedTransactionResponse.GetOperationResultAtIndex{T}"/>.
+        /// </remarks>
         [JsonIgnore]
         public virtual Stream ResourceStream { get; internal set; }
 
@@ -135,10 +142,53 @@ namespace Microsoft.Azure.Cosmos
         [JsonIgnore]
         internal ITrace Trace { get; set; }
 
+        [JsonIgnore]
+        internal CosmosSerializerCore SerializerCore { get; set; }
+
         private static readonly JsonSerializerOptions CaseInsensitiveOptions = new JsonSerializerOptions
         {
             PropertyNameCaseInsensitive = true,
         };
+
+        /// <summary>
+        /// Returns a fresh <see cref="Stream"/> that exposes the same bytes as <paramref name="source"/>
+        /// without affecting the source stream's position or lifetime.
+        /// </summary>
+        internal static Stream CreateSnapshot(Stream source)
+        {
+            // Fast path for standard MemoryStream.
+            if (source is MemoryStream ms
+                && ms.GetType() == typeof(MemoryStream)
+                && ms.TryGetBuffer(out ArraySegment<byte> buffer))
+            {
+                return new MemoryStream(
+                    buffer: buffer.Array,
+                    index: buffer.Offset,
+                    count: buffer.Count,
+                    writable: false,
+                    publiclyVisible: true);
+            }
+
+            // Fallback for other stream types. For seekable streams the position is reset
+            // before and after copying. Non-seekable streams are copied from their current
+            // position, which is acceptable here because the only producer of ResourceStream
+            // is a freshly-created MemoryStream at position 0 (see FromJson).
+            if (source.CanSeek)
+            {
+                source.Position = 0;
+            }
+
+            MemoryStream copy = new MemoryStream();
+            source.CopyTo(copy);
+            copy.Position = 0;
+
+            if (source.CanSeek)
+            {
+                source.Position = 0;
+            }
+
+            return copy;
+        }
 
         /// <summary>
         /// Creates a <see cref="DistributedTransactionOperationResult"/> from a JSON element.
@@ -192,5 +242,39 @@ namespace Microsoft.Azure.Cosmos
 
             return result;
         }
+    }
+
+    /// <summary>
+    /// Represents a typed result for a specific operation that was part of a <see cref="DistributedTransaction"/> request.
+    /// </summary>
+    /// <typeparam name="T">The type to which the resource body was deserialized.</typeparam>
+#pragma warning disable SA1402 // File may only contain a single type
+#if INTERNAL
+    public
+#else
+    internal
+#endif
+    class DistributedTransactionOperationResult<T> : DistributedTransactionOperationResult
+#pragma warning restore SA1402 // File may only contain a single type
+    {
+        internal DistributedTransactionOperationResult(DistributedTransactionOperationResult result, T resource)
+            : base(result)
+        {
+            this.Resource = resource;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="DistributedTransactionOperationResult{T}"/> class.
+        /// </summary>
+        protected DistributedTransactionOperationResult()
+        {
+        }
+
+        /// <summary>
+        /// Gets the resource deserialized from the operation response body.
+        /// Returns <c>default</c> when the server did not return a resource body for the operation
+        /// (for example, a delete operation or a failed operation).
+        /// </summary>
+        public virtual T Resource { get; set; }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperationResult.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperationResult.cs
@@ -113,25 +113,17 @@ namespace Microsoft.Azure.Cosmos
         public virtual Stream ResourceStream { get; internal set; }
 
         /// <summary>
-        /// Request charge in request units for the operation.
         /// </summary>
         [JsonInclude]
         [JsonPropertyName("requestCharge")]
         public virtual double RequestCharge { get; internal set; }
 
-        [JsonIgnore]
-        internal virtual SubStatusCodes SubStatusCode { get; set; }
-
         /// <summary>
-        /// Gets the sub-status code value as an unsigned integer.
+        /// Gets the sub-status code for the operation.
         /// </summary>
         [JsonInclude]
         [JsonPropertyName("subStatusCode")]
-        public virtual uint SubStatusCodeValue
-        {
-            get => (uint)this.SubStatusCode;
-            internal set => this.SubStatusCode = (SubStatusCodes)value;
-        }
+        public virtual SubStatusCodes SubStatusCode { get; internal set; }
 
         /// <summary>
         /// ActivityId related to the operation.
@@ -219,7 +211,7 @@ namespace Microsoft.Azure.Cosmos
                 int colonIndex = result.SessionToken.IndexOf(':');
                 if (colonIndex > 0 && colonIndex < result.SessionToken.Length - 1)
                 {
-                    // Already in canonical {pkRangeId}:{lsn} form — leave as-is.
+                    // Already in canonical SDK session-token format — leave as-is.
                 }
                 else if (!string.IsNullOrWhiteSpace(result.PartitionKeyRangeId))
                 {

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperationResult.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperationResult.cs
@@ -119,12 +119,19 @@ namespace Microsoft.Azure.Cosmos
         [JsonPropertyName("requestCharge")]
         public virtual double RequestCharge { get; internal set; }
 
+        [JsonIgnore]
+        internal virtual SubStatusCodes SubStatusCode { get; set; }
+
         /// <summary>
-        /// Gets the sub-status code for the operation.
+        /// Gets the sub-status code value as an unsigned integer.
         /// </summary>
         [JsonInclude]
         [JsonPropertyName("subStatusCode")]
-        public virtual SubStatusCodes SubStatusCode { get; internal set; }
+        public virtual uint SubStatusCodeValue
+        {
+            get => (uint)this.SubStatusCode;
+            internal set => this.SubStatusCode = (SubStatusCodes)value;
+        }
 
         /// <summary>
         /// ActivityId related to the operation.

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionRequestOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionRequestOptions.cs
@@ -19,7 +19,8 @@ namespace Microsoft.Azure.Cosmos
         /// Gets or sets the session token for this individual operation.
         /// </summary>
         /// <value>
-        /// The session token, in <c>{partitionKeyRangeId}:{lsn}</c> format, for the partition targeted by this operation.
+        /// An opaque session token previously returned by the SDK (for example, from
+        /// <see cref="DistributedTransactionOperationResult.SessionToken"/>); do not parse or construct manually.
         /// </value>
         /// <remarks>
         /// Because a distributed transaction spans multiple partitions, each operation must supply its own session token

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionRequestOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionRequestOptions.cs
@@ -5,7 +5,8 @@
 namespace Microsoft.Azure.Cosmos
 {
     /// <summary>
-    /// <see cref="RequestOptions"/> that apply to an operation within a <see cref="DistributedWriteTransaction"/>.
+    /// <see cref="RequestOptions"/> that apply to an operation within a <see cref="DistributedWriteTransaction"/>
+    /// or <see cref="DistributedReadTransaction"/>.
     /// </summary>
 #if INTERNAL
     public
@@ -14,5 +15,21 @@ namespace Microsoft.Azure.Cosmos
 #endif
     class DistributedTransactionRequestOptions : RequestOptions
     {
+        /// <summary>
+        /// Gets or sets the session token for this individual operation.
+        /// </summary>
+        /// <value>
+        /// The session token, in <c>{partitionKeyRangeId}:{lsn}</c> format, for the partition targeted by this operation.
+        /// </value>
+        /// <remarks>
+        /// Because a distributed transaction spans multiple partitions, each operation must supply its own session token
+        /// rather than a single commit-level token.  The token is serialized into the request body alongside the operation
+        /// and used by the server to enforce read-your-own-writes consistency for that specific partition.
+        /// <para>
+        /// Obtain the token from a prior <see cref="DistributedTransactionOperationResult.SessionToken"/> or from
+        /// the session token surface of another SDK response that targeted the same partition.
+        /// </para>
+        /// </remarks>
+        public string SessionToken { get; set; }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionResponse.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionResponse.cs
@@ -79,6 +79,47 @@ namespace Microsoft.Azure.Cosmos
         }
 
         /// <summary>
+        /// Gets the result of the operation at the provided index in the transaction — the returned result
+        /// has a <see cref="DistributedTransactionOperationResult{T}.Resource"/> of type <typeparamref name="T"/>.
+        /// </summary>
+        /// <typeparam name="T">The type to which the resource body should be deserialized.</typeparam>
+        /// <param name="index">Zero-based index of the operation in the transaction whose result is returned.</param>
+        /// <returns>
+        /// A <see cref="DistributedTransactionOperationResult{T}"/> whose <c>Resource</c> is the deserialized item,
+        /// or <c>default(<typeparamref name="T"/>)</c> when the server did not return a body for that operation.
+        /// </returns>
+        /// <remarks>
+        /// The underlying <see cref="DistributedTransactionOperationResult.ResourceStream"/> is left intact and
+        /// remains readable after this call, so this method may be invoked multiple times (with the same or
+        /// different <typeparamref name="T"/>) for the same index, and direct access via the indexer continues
+        /// to work afterwards.
+        /// </remarks>
+        public virtual DistributedTransactionOperationResult<T> GetOperationResultAtIndex<T>(int index)
+        {
+            this.ThrowIfDisposed();
+
+            DistributedTransactionOperationResult result = this[index];
+
+            T resource = default;
+            if (result.ResourceStream != null)
+            {
+                if (this.SerializerCore == null)
+                {
+                    throw new InvalidOperationException(
+                        "A serializer is required to deserialize the operation resource but none was set on this response.");
+                }
+
+                // CosmosSerializer.FromStream<T> takes ownership of (and disposes) its input stream.
+                // Create an independent snapshot so this method is safe to call multiple times and
+                // the caller can still access ResourceStream directly.
+                using Stream snapshot = DistributedTransactionOperationResult.CreateSnapshot(result.ResourceStream);
+                resource = this.SerializerCore.FromStream<T>(snapshot);
+            }
+
+            return new DistributedTransactionOperationResult<T>(result, resource);
+        }
+
+        /// <summary>
         /// Gets the headers associated with the distributed transaction response.
         /// </summary>
         public virtual Headers Headers { get; }
@@ -340,6 +381,7 @@ namespace Microsoft.Azure.Cosmos
                             DistributedTransactionOperationResult operationResult = DistributedTransactionOperationResult.FromJson(operationElement);
                             operationResult.Trace = trace;
                             operationResult.ActivityId = responseMessage.Headers.ActivityId;
+                            operationResult.SerializerCore = serializer;
                             results.Add(operationResult);
                         }
                     }
@@ -399,7 +441,8 @@ namespace Microsoft.Azure.Cosmos
                 {
                     SubStatusCode = this.SubStatusCode,
                     ActivityId = this.ActivityId,
-                    Trace = trace
+                    Trace = trace,
+                    SerializerCore = this.SerializerCore,
                 });
             }
         }

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedWriteTransactionCore.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedWriteTransactionCore.cs
@@ -271,7 +271,7 @@ namespace Microsoft.Azure.Cosmos
             return this;
         }
 
-        public override async Task<DistributedTransactionResponse> CommitTransactionAsync(CancellationToken cancellationToken)
+        public override async Task<DistributedTransactionResponse> CommitTransactionAsync(CancellationToken cancellationToken = default)
         {
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
                 operations: this.operations,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionCommitterTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionCommitterTests.cs
@@ -1169,7 +1169,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             };
 
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(operations, mockContext.Object);
-            await committer.CommitTransactionAsync(CancellationToken.None);
+            await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
 
             Assert.IsNotNull(capturedBody, "Request body must have been captured.");
             string bodyJson = Encoding.UTF8.GetString(capturedBody);
@@ -1207,7 +1207,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                 .ReturnsAsync(CreateSuccessResponseMessage(operationCount: 1));
 
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(CreateTestOperations(), mockContext.Object);
-            await committer.CommitTransactionAsync(CancellationToken.None);
+            await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
 
             Assert.IsNotNull(capturedBody);
             string bodyJson = Encoding.UTF8.GetString(capturedBody);
@@ -1260,7 +1260,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             };
 
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(operations, mockContext.Object);
-            await committer.CommitTransactionAsync(CancellationToken.None);
+            await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
 
             Assert.IsNotNull(capturedBody);
             string bodyJson = Encoding.UTF8.GetString(capturedBody);
@@ -1313,7 +1313,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             };
 
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(operations, mockContext.Object);
-            await committer.CommitTransactionAsync(CancellationToken.None);
+            await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
 
             Assert.IsNotNull(capturedBody);
             string bodyJson = Encoding.UTF8.GetString(capturedBody);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionCommitterTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionCommitterTests.cs
@@ -1122,6 +1122,205 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                 "Delay beyond maxExponent must still use the capped exponent, producing a similar magnitude.");
         }
 
+        // ─── Per-operation session token tests ────────────────────────────────
+
+        [TestMethod]
+        [Description("A SessionToken set on DistributedTransactionRequestOptions is propagated to the operation's SessionToken field and serialized in the request body JSON.")]
+        public async Task CommitTransactionAsync_PerOperationSessionToken_IsSerializedInRequestBody()
+        {
+            const string expectedToken = "0:1#9#4=8#5=7";
+            byte[] capturedBody = null;
+
+            Mock<CosmosClientContext> mockContext = this.CreateMockClientContext();
+            mockContext
+                .Setup(c => c.ProcessResourceOperationStreamAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<ResourceType>(),
+                    It.IsAny<OperationType>(),
+                    It.IsAny<RequestOptions>(),
+                    It.IsAny<ContainerInternal>(),
+                    It.IsAny<Cosmos.PartitionKey?>(),
+                    It.IsAny<string>(),
+                    It.IsAny<Stream>(),
+                    It.IsAny<Action<RequestMessage>>(),
+                    It.IsAny<ITrace>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback<string, ResourceType, OperationType, RequestOptions, ContainerInternal, Cosmos.PartitionKey?, string, Stream, Action<RequestMessage>, ITrace, CancellationToken>(
+                    (_, _, _, _, _, _, _, stream, _, _, _) =>
+                    {
+                        using MemoryStream copy = new MemoryStream();
+                        stream.CopyTo(copy);
+                        capturedBody = copy.ToArray();
+                    })
+                .ReturnsAsync(CreateSuccessResponseMessage(operationCount: 1));
+
+            List<DistributedTransactionOperation> operations = new List<DistributedTransactionOperation>
+            {
+                new DistributedTransactionOperation(
+                    OperationType.Create,
+                    operationIndex: 0,
+                    DatabaseName,
+                    ContainerName,
+                    new PartitionKey("pk1"),
+                    id: "doc1",
+                    requestOptions: new DistributedTransactionRequestOptions { SessionToken = expectedToken })
+            };
+
+            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(operations, mockContext.Object);
+            await committer.CommitTransactionAsync(CancellationToken.None);
+
+            Assert.IsNotNull(capturedBody, "Request body must have been captured.");
+            string bodyJson = Encoding.UTF8.GetString(capturedBody);
+            Assert.IsTrue(bodyJson.Contains($"\"sessionToken\":\"{expectedToken}\""),
+                $"Per-operation session token '{expectedToken}' must appear in the serialized request body. Body was: {bodyJson}");
+        }
+
+        [TestMethod]
+        [Description("When no SessionToken is set on the per-operation options, no sessionToken field appears in the serialized request body.")]
+        public async Task CommitTransactionAsync_NoPerOperationSessionToken_OmitsFieldFromRequestBody()
+        {
+            byte[] capturedBody = null;
+
+            Mock<CosmosClientContext> mockContext = this.CreateMockClientContext();
+            mockContext
+                .Setup(c => c.ProcessResourceOperationStreamAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<ResourceType>(),
+                    It.IsAny<OperationType>(),
+                    It.IsAny<RequestOptions>(),
+                    It.IsAny<ContainerInternal>(),
+                    It.IsAny<Cosmos.PartitionKey?>(),
+                    It.IsAny<string>(),
+                    It.IsAny<Stream>(),
+                    It.IsAny<Action<RequestMessage>>(),
+                    It.IsAny<ITrace>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback<string, ResourceType, OperationType, RequestOptions, ContainerInternal, Cosmos.PartitionKey?, string, Stream, Action<RequestMessage>, ITrace, CancellationToken>(
+                    (_, _, _, _, _, _, _, stream, _, _, _) =>
+                    {
+                        using MemoryStream copy = new MemoryStream();
+                        stream.CopyTo(copy);
+                        capturedBody = copy.ToArray();
+                    })
+                .ReturnsAsync(CreateSuccessResponseMessage(operationCount: 1));
+
+            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(CreateTestOperations(), mockContext.Object);
+            await committer.CommitTransactionAsync(CancellationToken.None);
+
+            Assert.IsNotNull(capturedBody);
+            string bodyJson = Encoding.UTF8.GetString(capturedBody);
+            Assert.IsFalse(bodyJson.Contains("\"sessionToken\""),
+                $"sessionToken field must be absent when no per-operation session token is set. Body was: {bodyJson}");
+        }
+
+        [DataTestMethod]
+        [DataRow("", DisplayName = "Empty string session token")]
+        [DataRow(" ", DisplayName = "Single space session token")]
+        [DataRow("   ", DisplayName = "Multi-space session token")]
+        [Description("A whitespace-only or empty SessionToken on DistributedTransactionRequestOptions must be treated as absent and must not appear in the serialized request body.")]
+        public async Task CommitTransactionAsync_WhitespaceOrEmptyPerOperationSessionToken_OmitsFieldFromRequestBody(string sessionToken)
+        {
+            byte[] capturedBody = null;
+
+            Mock<CosmosClientContext> mockContext = this.CreateMockClientContext();
+            mockContext
+                .Setup(c => c.ProcessResourceOperationStreamAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<ResourceType>(),
+                    It.IsAny<OperationType>(),
+                    It.IsAny<RequestOptions>(),
+                    It.IsAny<ContainerInternal>(),
+                    It.IsAny<Cosmos.PartitionKey?>(),
+                    It.IsAny<string>(),
+                    It.IsAny<Stream>(),
+                    It.IsAny<Action<RequestMessage>>(),
+                    It.IsAny<ITrace>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback<string, ResourceType, OperationType, RequestOptions, ContainerInternal, Cosmos.PartitionKey?, string, Stream, Action<RequestMessage>, ITrace, CancellationToken>(
+                    (_, _, _, _, _, _, _, stream, _, _, _) =>
+                    {
+                        using MemoryStream copy = new MemoryStream();
+                        stream.CopyTo(copy);
+                        capturedBody = copy.ToArray();
+                    })
+                .ReturnsAsync(CreateSuccessResponseMessage(operationCount: 1));
+
+            List<DistributedTransactionOperation> operations = new List<DistributedTransactionOperation>
+            {
+                new DistributedTransactionOperation(
+                    OperationType.Create,
+                    operationIndex: 0,
+                    DatabaseName,
+                    ContainerName,
+                    new PartitionKey("pk1"),
+                    id: "doc1",
+                    requestOptions: new DistributedTransactionRequestOptions { SessionToken = sessionToken })
+            };
+
+            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(operations, mockContext.Object);
+            await committer.CommitTransactionAsync(CancellationToken.None);
+
+            Assert.IsNotNull(capturedBody);
+            string bodyJson = Encoding.UTF8.GetString(capturedBody);
+            Assert.IsFalse(bodyJson.Contains("\"sessionToken\""),
+                $"sessionToken field must be absent for whitespace/empty token '{sessionToken}'. Body was: {bodyJson}");
+        }
+
+        [TestMethod]
+        [Description("Each operation independently carries its own session token in the request body.")]
+        public async Task CommitTransactionAsync_MultipleOperations_EachCarriesOwnSessionToken()
+        {
+            const string token1 = "0:1#5";
+            const string token2 = "1:2#8";
+
+            byte[] capturedBody = null;
+
+            Mock<CosmosClientContext> mockContext = this.CreateMockClientContext();
+            mockContext
+                .Setup(c => c.ProcessResourceOperationStreamAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<ResourceType>(),
+                    It.IsAny<OperationType>(),
+                    It.IsAny<RequestOptions>(),
+                    It.IsAny<ContainerInternal>(),
+                    It.IsAny<Cosmos.PartitionKey?>(),
+                    It.IsAny<string>(),
+                    It.IsAny<Stream>(),
+                    It.IsAny<Action<RequestMessage>>(),
+                    It.IsAny<ITrace>(),
+                    It.IsAny<CancellationToken>()))
+                .Callback<string, ResourceType, OperationType, RequestOptions, ContainerInternal, Cosmos.PartitionKey?, string, Stream, Action<RequestMessage>, ITrace, CancellationToken>(
+                    (_, _, _, _, _, _, _, stream, _, _, _) =>
+                    {
+                        using MemoryStream copy = new MemoryStream();
+                        stream.CopyTo(copy);
+                        capturedBody = copy.ToArray();
+                    })
+                .ReturnsAsync(CreateSuccessResponseMessage(operationCount: 2));
+
+            List<DistributedTransactionOperation> operations = new List<DistributedTransactionOperation>
+            {
+                new DistributedTransactionOperation(
+                    OperationType.Create, 0, DatabaseName, ContainerName,
+                    new PartitionKey("pk1"), id: "doc1",
+                    requestOptions: new DistributedTransactionRequestOptions { SessionToken = token1 }),
+                new DistributedTransactionOperation(
+                    OperationType.Create, 1, DatabaseName, "container2",
+                    new PartitionKey("pk2"), id: "doc2",
+                    requestOptions: new DistributedTransactionRequestOptions { SessionToken = token2 }),
+            };
+
+            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(operations, mockContext.Object);
+            await committer.CommitTransactionAsync(CancellationToken.None);
+
+            Assert.IsNotNull(capturedBody);
+            string bodyJson = Encoding.UTF8.GetString(capturedBody);
+            Assert.IsTrue(bodyJson.Contains($"\"sessionToken\":\"{token1}\""),
+                $"token1 must appear in request body. Body: {bodyJson}");
+            Assert.IsTrue(bodyJson.Contains($"\"sessionToken\":\"{token2}\""),
+                $"token2 must appear in request body. Body: {bodyJson}");
+        }
+
         // ─── Helpers ───────────────────────────────────────────────────────────
 
         private static string BuildDtcResponseJson(

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionResponseTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionResponseTests.cs
@@ -788,7 +788,243 @@ namespace Microsoft.Azure.Cosmos.Tests
             Assert.AreEqual(0, enumerated, "Enumeration after disposal must yield no items without throwing.");
         }
 
+        // GetOperationResultAtIndex<T>
+
+        [TestMethod]
+        [Description("GetOperationResultAtIndex<T> deserializes the resource body into the requested type.")]
+        public async Task GetOperationResultAtIndex_WithResourceBody_DeserializesResource()
+        {
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
+
+            // JSON with a resourceBody field that contains a simple document
+            string json = @"{""operationResponses"":[{""index"":0,""statusCode"":200,""resourceBody"":{""id"":""item1"",""value"":42}}]}";
+            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.OK, json);
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            DistributedTransactionOperationResult<TestDocument> typed = response.GetOperationResultAtIndex<TestDocument>(0);
+
+            Assert.IsNotNull(typed.Resource, "Resource must be deserialized when a resourceBody is present.");
+            Assert.AreEqual("item1", typed.Resource.Id);
+            Assert.AreEqual(42, typed.Resource.Value);
+        }
+
+        [TestMethod]
+        [Description("GetOperationResultAtIndex<T> returns default(T) when the operation has no resource body.")]
+        public async Task GetOperationResultAtIndex_WithoutResourceBody_ResourceIsDefault()
+        {
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
+
+            string json = @"{""operationResponses"":[{""index"":0,""statusCode"":204}]}";
+            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.OK, json);
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            DistributedTransactionOperationResult<TestDocument> typed = response.GetOperationResultAtIndex<TestDocument>(0);
+
+            Assert.IsNull(typed.Resource, "Resource must be null/default when no resourceBody was returned.");
+            Assert.AreEqual(HttpStatusCode.NoContent, typed.StatusCode);
+        }
+
+        [TestMethod]
+        [Description("GetOperationResultAtIndex<T> preserves all base DistributedTransactionOperationResult fields on the typed wrapper.")]
+        public async Task GetOperationResultAtIndex_PreservesBaseFields()
+        {
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
+
+            string json = @"{""operationResponses"":[{""index"":0,""statusCode"":200,""etag"":""\""abc\"""",""requestCharge"":1.5,""resourceBody"":{""id"":""x"",""value"":1}}]}";
+            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.OK, json);
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            DistributedTransactionOperationResult<TestDocument> typed = response.GetOperationResultAtIndex<TestDocument>(0);
+
+            Assert.AreEqual(HttpStatusCode.OK, typed.StatusCode);
+            Assert.AreEqual("\"abc\"", typed.ETag);
+            Assert.AreEqual(1.5, typed.RequestCharge);
+        }
+
+        [TestMethod]
+        [Description("GetOperationResultAtIndex<T> after Dispose throws ObjectDisposedException.")]
+        public async Task GetOperationResultAtIndex_AfterDispose_ThrowsObjectDisposedException()
+        {
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
+            string json = @"{""operationResponses"":[{""index"":0,""statusCode"":200}]}";
+            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.OK, json);
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            response.Dispose();
+
+            Assert.ThrowsException<ObjectDisposedException>(() => response.GetOperationResultAtIndex<TestDocument>(0));
+        }
+
+        [TestMethod]
+        [Description("GetOperationResultAtIndex<T> with an out-of-range index throws ArgumentOutOfRangeException.")]
+        public async Task GetOperationResultAtIndex_OutOfRangeIndex_ThrowsArgumentOutOfRangeException()
+        {
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
+            string json = @"{""operationResponses"":[{""index"":0,""statusCode"":200}]}";
+            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.OK, json);
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => response.GetOperationResultAtIndex<TestDocument>(99));
+        }
+
+        [TestMethod]
+        [Description("GetOperationResultAtIndex<T> can be invoked repeatedly on the same index and must yield the same deserialized resource each time without disposing the underlying ResourceStream.")]
+        public async Task GetOperationResultAtIndex_CalledTwice_BothCallsSucceedAndStreamRemainsReadable()
+        {
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
+            string json = @"{""operationResponses"":[{""index"":0,""statusCode"":200,""resourceBody"":{""id"":""dup"",""value"":7}}]}";
+            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.OK, json);
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            DistributedTransactionOperationResult<TestDocument> first = response.GetOperationResultAtIndex<TestDocument>(0);
+            DistributedTransactionOperationResult<TestDocument> second = response.GetOperationResultAtIndex<TestDocument>(0);
+
+            Assert.IsNotNull(first.Resource);
+            Assert.IsNotNull(second.Resource);
+            Assert.AreEqual("dup", first.Resource.Id);
+            Assert.AreEqual("dup", second.Resource.Id);
+            Assert.AreEqual(7, first.Resource.Value);
+            Assert.AreEqual(7, second.Resource.Value);
+
+            // After two typed reads, the original ResourceStream must still be readable.
+            using StreamReader reader = new StreamReader(response[0].ResourceStream);
+            string raw = reader.ReadToEnd();
+            StringAssert.Contains(raw, "\"id\":\"dup\"", "Underlying ResourceStream must remain readable after GetOperationResultAtIndex<T>.");
+        }
+
+        [TestMethod]
+        [Description("Reading response[index].ResourceStream directly after GetOperationResultAtIndex<T> must still return the original bytes.")]
+        public async Task GetOperationResultAtIndex_FollowedByDirectStreamRead_StreamIsIntact()
+        {
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
+            string json = @"{""operationResponses"":[{""index"":0,""statusCode"":200,""resourceBody"":{""id"":""x"",""value"":99}}]}";
+            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.OK, json);
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            _ = response.GetOperationResultAtIndex<TestDocument>(0);
+
+            Stream stream = response[0].ResourceStream;
+            Assert.IsNotNull(stream);
+            stream.Position = 0;
+            using StreamReader reader = new StreamReader(stream);
+            string raw = reader.ReadToEnd();
+            Assert.AreEqual(@"{""id"":""x"",""value"":99}", raw);
+        }
+
+        [TestMethod]
+        [Description("Calling Dispose() after GetOperationResultAtIndex<T> must still successfully release the ResourceStream and must be safe to call multiple times.")]
+        public async Task GetOperationResultAtIndex_FollowedByDispose_DoesNotThrow()
+        {
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
+            string json = @"{""operationResponses"":[{""index"":0,""statusCode"":200,""resourceBody"":{""id"":""z"",""value"":1}}]}";
+            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.OK, json);
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            _ = response.GetOperationResultAtIndex<TestDocument>(0);
+
+            response.Dispose();
+            response.Dispose(); // must remain idempotent
+
+            Assert.ThrowsException<ObjectDisposedException>(() => response.GetOperationResultAtIndex<TestDocument>(0));
+        }
+
+        [TestMethod]
+        [Description("GetOperationResultAtIndex<T> throws InvalidOperationException when no serializer is available but a resource body is present.")]
+        public async Task GetOperationResultAtIndex_NullSerializer_WithResourceBody_ThrowsInvalidOperationException()
+        {
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
+            string json = @"{""operationResponses"":[{""index"":0,""statusCode"":200,""resourceBody"":{""id"":""x"",""value"":1}}]}";
+            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.OK, json);
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                serializer: null,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            Assert.ThrowsException<InvalidOperationException>(
+                () => response.GetOperationResultAtIndex<TestDocument>(0));
+        }
+
+        [TestMethod]
+        [Description("GetOperationResultAtIndex<T> with a null serializer returns default(T) when there is no resource body to deserialize.")]
+        public async Task GetOperationResultAtIndex_NullSerializer_WithoutResourceBody_ReturnsDefault()
+        {
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
+            string json = @"{""operationResponses"":[{""index"":0,""statusCode"":204}]}";
+            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.OK, json);
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                serializer: null,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            DistributedTransactionOperationResult<TestDocument> typed = response.GetOperationResultAtIndex<TestDocument>(0);
+
+            Assert.IsNull(typed.Resource);
+        }
+
         // Helpers
+
+        private sealed class TestDocument
+        {
+            [System.Text.Json.Serialization.JsonPropertyName("id")]
+            public string Id { get; set; }
+
+            [System.Text.Json.Serialization.JsonPropertyName("value")]
+            public int Value { get; set; }
+        }
 
         /// <summary>
         /// Builds a <see cref="DistributedTransactionServerRequest"/> with <paramref name="operationCount"/>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionResponseTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionResponseTests.cs
@@ -492,7 +492,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         // Operation result property deserialization
 
         [TestMethod]
-        [Description("SubStatusCodeValue deserializes from the 'subStatusCode' JSON property and is accessible as both uint and SubStatusCodes enum.")]
+        [Description("SubStatusCode deserializes from the 'subStatusCode' JSON property as a SubStatusCodes enum value.")]
         public async Task FromResponseMessage_OperationResult_SubStatusCode_DeserializesCorrectly()
         {
             const uint expectedSubStatusCode = 449; // RetryWith
@@ -508,10 +508,8 @@ namespace Microsoft.Azure.Cosmos.Tests
                 NoOpTrace.Singleton,
                 CancellationToken.None);
 
-            Assert.AreEqual(expectedSubStatusCode, response[0].SubStatusCodeValue,
-                "SubStatusCodeValue must equal the uint value from the JSON 'subStatusCode' field.");
             Assert.AreEqual((SubStatusCodes)expectedSubStatusCode, response[0].SubStatusCode,
-                "SubStatusCode enum must be the cast of the uint value.");
+                "SubStatusCode must equal the enum cast of the uint value from the JSON 'subStatusCode' field.");
         }
 
         [TestMethod]


### PR DESCRIPTION
# Pull Request Template

## Description

This pull request introduces several improvements and new features to the distributed transactions API in the Azure Cosmos DB SDK, with a focus on enhancing typed deserialization of operation results, streamlining session token handling, and improving documentation and usability. The most important changes are outlined below:

**Typed Deserialization and Result Handling:**
- Added a generic `DistributedTransactionOperationResult<T>` class, enabling easy access to deserialized resources from distributed transaction operations. This is returned by the new `GetOperationResultAtIndex<T>(int index)` method on `DistributedTransactionResponse`, which safely deserializes the resource body into the requested type without affecting the underlying stream. [[1]](diffhunk://#diff-31f1a4f3f77bbf984d36bb6ba94c05c0013b4f52e38334787ed61f2418c60334R246-R279) [[2]](diffhunk://#diff-2115107c88c6a1f6a4b4bce64e055f821eb64b82ba0813f4e55ad60a015aae87R81-R121)
- Introduced a `CreateSnapshot` utility method to produce independent copies of resource streams, ensuring that repeated deserialization or direct stream access remain safe and side-effect free.

**Session Token Management:**
- Added a `SessionToken` property to `DistributedTransactionRequestOptions`, allowing each operation in a distributed transaction to specify its own session token for partition-level consistency. This is now set when constructing a `DistributedTransactionOperation`. [[1]](diffhunk://#diff-5c56bac65a7d03185857db755486c5cd5fde48f373e0d28354c450a28b7af30eR18-R33) [[2]](diffhunk://#diff-30fceb3d3e008bbde11f8dd7453a6dcef707a5452f9e235a858068b93dd5e1dbR36)
- Updated documentation to clarify how session tokens should be obtained and used for distributed transactions.

**API Usability and Documentation:**
- Improved XML documentation for distributed read transactions, clarifying snapshot isolation semantics and providing guidance on result deserialization with the new APIs.
- Added remarks to `ResourceStream` property documentation to clarify ownership and correct usage patterns.

**Internal Consistency and Plumbing:**
- Ensured that the serializer is consistently propagated and available for deserialization in all relevant operation result and response objects. [[1]](diffhunk://#diff-31f1a4f3f77bbf984d36bb6ba94c05c0013b4f52e38334787ed61f2418c60334R43) [[2]](diffhunk://#diff-2115107c88c6a1f6a4b4bce64e055f821eb64b82ba0813f4e55ad60a015aae87R384) [[3]](diffhunk://#diff-2115107c88c6a1f6a4b4bce64e055f821eb64b82ba0813f4e55ad60a015aae87L402-R445)

**Minor Improvements:**
- Made the `CommitTransactionAsync` method's `CancellationToken` parameter optional for improved developer ergonomics.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber

## Changelog

- [ ] I have added a changelog entry under `### Unreleased` in `changelog.md`
  for the user-facing impact of this change.
- [X] No changelog entry is required because this PR is one of:
  documentation-only, test-only, CI / build-only, or a pure internal refactor
  with no observable customer impact.

If the second box is checked, briefly justify here:

> Feature not public yet
