### PR TITLE
Direct: Fixes missing minimum value validation for MaxTcpConnectionsPerEndpoint

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ConnectionPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/ConnectionPolicy.cs
@@ -30,7 +30,6 @@ namespace Microsoft.Azure.Cosmos
         private Protocol connectionProtocol;
         private ObservableCollection<string> preferredLocations;
         private ObservableCollection<Uri> accountInitializationCustomEndpoints;
-        private TimeSpan? openTcpConnectionTimeout;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ConnectionPolicy"/> class to connect to the Azure Cosmos DB service.
@@ -452,23 +451,12 @@ namespace Microsoft.Azure.Cosmos
         /// values in [<see cref="TimeSpan.Zero"/>, 1 second) are treated as 0 (use <see cref="RequestTimeout"/>)
         /// and values greater than or equal to 1 second are rounded up to the nearest whole second
         /// (for example, 2.3 seconds becomes 3 seconds).
+        /// Negative values are invalid and will be reset to the default with a warning log.
         /// </remarks>
-        /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="value"/> is negative.</exception>
         public TimeSpan? OpenTcpConnectionTimeout
         {
-            get => this.openTcpConnectionTimeout;
-            set
-            {
-                if (value.HasValue && value.Value < TimeSpan.Zero)
-                {
-                    throw new ArgumentOutOfRangeException(
-                        nameof(this.OpenTcpConnectionTimeout),
-                        value,
-                        $"{nameof(this.OpenTcpConnectionTimeout)} must be greater than or equal to {nameof(TimeSpan)}.{nameof(TimeSpan.Zero)}.");
-                }
-
-                this.openTcpConnectionTimeout = value;
-            }
+            get;
+            set;
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/ConnectionPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/ConnectionPolicy.cs
@@ -451,7 +451,7 @@ namespace Microsoft.Azure.Cosmos
         /// The supplied <see cref="TimeSpan"/> is preserved unchanged on this property. At the transport boundary,
         /// values in [<see cref="TimeSpan.Zero"/>, 1 second) are treated as 0 (use <see cref="RequestTimeout"/>)
         /// and values greater than or equal to 1 second are rounded up to the nearest whole second
-        /// (for example, 2.5 seconds becomes 3 seconds).
+        /// (for example, 2.3 seconds becomes 3 seconds).
         /// </remarks>
         /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="value"/> is negative.</exception>
         public TimeSpan? OpenTcpConnectionTimeout

--- a/Microsoft.Azure.Cosmos/src/ConnectionPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/ConnectionPolicy.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Azure.Cosmos
         private Protocol connectionProtocol;
         private ObservableCollection<string> preferredLocations;
         private ObservableCollection<Uri> accountInitializationCustomEndpoints;
+        private TimeSpan? openTcpConnectionTimeout;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ConnectionPolicy"/> class to connect to the Azure Cosmos DB service.
@@ -447,11 +448,27 @@ namespace Microsoft.Azure.Cosmos
         /// </value>
         /// <remarks>
         /// When the time elapses, the attempt is cancelled and an error is returned. Longer timeouts will delay retries and failures.
+        /// The supplied <see cref="TimeSpan"/> is preserved unchanged on this property. At the transport boundary,
+        /// values in [<see cref="TimeSpan.Zero"/>, 1 second) are treated as 0 (use <see cref="RequestTimeout"/>)
+        /// and values greater than or equal to 1 second are rounded up to the nearest whole second
+        /// (for example, 2.5 seconds becomes 3 seconds).
         /// </remarks>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="value"/> is negative.</exception>
         public TimeSpan? OpenTcpConnectionTimeout
         {
-            get;
-            set;
+            get => this.openTcpConnectionTimeout;
+            set
+            {
+                if (value.HasValue && value.Value < TimeSpan.Zero)
+                {
+                    throw new ArgumentOutOfRangeException(
+                        nameof(this.OpenTcpConnectionTimeout),
+                        value,
+                        $"{nameof(this.OpenTcpConnectionTimeout)} must be greater than or equal to {nameof(TimeSpan)}.{nameof(TimeSpan.Zero)}.");
+                }
+
+                this.openTcpConnectionTimeout = value;
+            }
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
@@ -13,6 +13,7 @@ namespace Microsoft.Azure.Cosmos
     using System.Net.Http;
     using System.Net.Security;
     using System.Security.Cryptography.X509Certificates;
+    using Microsoft.Azure.Cosmos.Core.Trace;
     using Microsoft.Azure.Cosmos.FaultInjection;
     using Microsoft.Azure.Cosmos.Fluent;
     using Microsoft.Azure.Documents;
@@ -607,21 +608,13 @@ namespace Microsoft.Azure.Cosmos
         /// (for example, 2.3 seconds becomes 3 seconds).
         /// </item>
         /// </list>
+        /// Negative values are invalid and will be reset to the default with a warning log.
         /// </remarks>
-        /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="value"/> is negative.</exception>
         public TimeSpan? OpenTcpConnectionTimeout
         {
             get => this.openTcpConnectionTimeout;
             set
             {
-                if (value.HasValue && value.Value < TimeSpan.Zero)
-                {
-                    throw new ArgumentOutOfRangeException(
-                        nameof(this.OpenTcpConnectionTimeout),
-                        value,
-                        $"{nameof(this.OpenTcpConnectionTimeout)} must be greater than or equal to {nameof(TimeSpan)}.{nameof(TimeSpan.Zero)}.");
-                }
-
                 this.openTcpConnectionTimeout = value;
                 this.ValidateDirectTCPSettings();
             }
@@ -1351,6 +1344,15 @@ namespace Microsoft.Azure.Cosmos
             if (!string.IsNullOrEmpty(settingName))
             {
                 throw new ArgumentException($"{settingName} requires {nameof(this.ConnectionMode)} to be set to {nameof(ConnectionMode.Direct)}");
+            }
+
+            if (this.OpenTcpConnectionTimeout.HasValue && this.OpenTcpConnectionTimeout.Value < TimeSpan.Zero)
+            {
+                DefaultTrace.TraceWarning(
+                    "{0} is set to a negative value ({1}). Negative values are invalid; resetting to default.",
+                    nameof(this.OpenTcpConnectionTimeout),
+                    this.OpenTcpConnectionTimeout.Value);
+                this.openTcpConnectionTimeout = null;
             }
         }
 

--- a/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
@@ -593,12 +593,35 @@ namespace Microsoft.Azure.Cosmos
         /// </value>
         /// <remarks>
         /// When the time elapses, the attempt is cancelled and an error is returned. Longer timeouts will delay retries and failures.
+        /// <para>
+        /// The supplied <see cref="TimeSpan"/> is preserved unchanged on this property. At the
+        /// transport boundary the value is converted to whole seconds:
+        /// </para>
+        /// <list type="bullet">
+        /// <item>
+        /// Values in [<see cref="TimeSpan.Zero"/>, 1 second) are treated as 0, causing the
+        /// configured <see cref="RequestTimeout"/> to be used as the open-connection timeout.
+        /// </item>
+        /// <item>
+        /// Values greater than or equal to 1 second are rounded up to the nearest whole second
+        /// (for example, 2.5 seconds becomes 3 seconds).
+        /// </item>
+        /// </list>
         /// </remarks>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown when <paramref name="value"/> is negative.</exception>
         public TimeSpan? OpenTcpConnectionTimeout
         {
             get => this.openTcpConnectionTimeout;
             set
             {
+                if (value.HasValue && value.Value < TimeSpan.Zero)
+                {
+                    throw new ArgumentOutOfRangeException(
+                        nameof(this.OpenTcpConnectionTimeout),
+                        value,
+                        $"{nameof(this.OpenTcpConnectionTimeout)} must be greater than or equal to {nameof(TimeSpan)}.{nameof(TimeSpan.Zero)}.");
+                }
+
                 this.openTcpConnectionTimeout = value;
                 this.ValidateDirectTCPSettings();
             }

--- a/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
@@ -1354,6 +1354,15 @@ namespace Microsoft.Azure.Cosmos
                     this.OpenTcpConnectionTimeout.Value);
                 this.openTcpConnectionTimeout = null;
             }
+
+            if (this.maxTcpConnectionsPerEndpoint.HasValue && this.maxTcpConnectionsPerEndpoint.Value < 16)
+            {
+                DefaultTrace.TraceWarning(
+                    "{0} is set to a value less than the minimum ({1}). Values below 16 are invalid; resetting to default (null).",
+                    nameof(this.MaxTcpConnectionsPerEndpoint),
+                    this.maxTcpConnectionsPerEndpoint.Value);
+                this.maxTcpConnectionsPerEndpoint = null;
+            }
         }
 
         internal UserAgentContainer CreateUserAgentContainerWithFeatures(int clientId)

--- a/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
@@ -604,7 +604,7 @@ namespace Microsoft.Azure.Cosmos
         /// </item>
         /// <item>
         /// Values greater than or equal to 1 second are rounded up to the nearest whole second
-        /// (for example, 2.5 seconds becomes 3 seconds).
+        /// (for example, 2.3 seconds becomes 3 seconds).
         /// </item>
         /// </list>
         /// </remarks>

--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -927,7 +927,12 @@ namespace Microsoft.Azure.Cosmos
 
                 if (connectionPolicy.OpenTcpConnectionTimeout.HasValue)
                 {
-                    this.openConnectionTimeoutInSeconds = (int)connectionPolicy.OpenTcpConnectionTimeout.Value.TotalSeconds;
+                    // Values in [TimeSpan.Zero, 1 second) become 0 (use RequestTimeout).
+                    // Values >= 1 second round up to the nearest whole second.
+                    TimeSpan openTcpConnectionTimeout = connectionPolicy.OpenTcpConnectionTimeout.Value;
+                    this.openConnectionTimeoutInSeconds = openTcpConnectionTimeout < TimeSpan.FromSeconds(1)
+                        ? 0
+                        : (int)Math.Ceiling(openTcpConnectionTimeout.TotalSeconds);
                 }
 
                 if (connectionPolicy.MaxRequestsPerTcpConnection.HasValue)

--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -928,11 +928,12 @@ namespace Microsoft.Azure.Cosmos
                 if (connectionPolicy.OpenTcpConnectionTimeout.HasValue)
                 {
                     // Values in [TimeSpan.Zero, 1 second) become 0 (use RequestTimeout).
-                    // Values >= 1 second round up to the nearest whole second.
+                    // Values >= 1 second round up to the nearest whole second, clamped to int.MaxValue.
                     TimeSpan openTcpConnectionTimeout = connectionPolicy.OpenTcpConnectionTimeout.Value;
+                    double ceilingSeconds = Math.Ceiling(openTcpConnectionTimeout.TotalSeconds);
                     this.openConnectionTimeoutInSeconds = openTcpConnectionTimeout < TimeSpan.FromSeconds(1)
                         ? 0
-                        : (int)Math.Ceiling(openTcpConnectionTimeout.TotalSeconds);
+                        : ceilingSeconds > int.MaxValue ? int.MaxValue : (int)ceilingSeconds;
                 }
 
                 if (connectionPolicy.MaxRequestsPerTcpConnection.HasValue)

--- a/Microsoft.Azure.Cosmos/src/Fluent/CosmosClientBuilder.cs
+++ b/Microsoft.Azure.Cosmos/src/Fluent/CosmosClientBuilder.cs
@@ -438,7 +438,7 @@ namespace Microsoft.Azure.Cosmos.Fluent
         /// At the transport boundary, values in [<see cref="TimeSpan.Zero"/>, 1 second) are treated as 0
         /// (use the configured request timeout). Values greater than or equal to 1 second are rounded up to
         /// the nearest whole second (for example, 2.3 seconds becomes 3 seconds).
-        /// Negative values throw <see cref="ArgumentOutOfRangeException"/>.
+        /// Negative values are invalid and will be reset to the default with a warning log.
         /// </param>
         /// <param name="maxRequestsPerTcpConnection">
         /// Controls the number of requests allowed simultaneously over a single TCP connection. When more requests are in flight simultaneously, the direct/TCP client will open additional connections.

--- a/Microsoft.Azure.Cosmos/src/Fluent/CosmosClientBuilder.cs
+++ b/Microsoft.Azure.Cosmos/src/Fluent/CosmosClientBuilder.cs
@@ -437,7 +437,7 @@ namespace Microsoft.Azure.Cosmos.Fluent
         /// When the time elapses, the attempt is cancelled and an error is returned. Longer timeouts will delay retries and failures.
         /// At the transport boundary, values in [<see cref="TimeSpan.Zero"/>, 1 second) are treated as 0
         /// (use the configured request timeout). Values greater than or equal to 1 second are rounded up to
-        /// the nearest whole second (for example, 2.5 seconds becomes 3 seconds).
+        /// the nearest whole second (for example, 2.3 seconds becomes 3 seconds).
         /// Negative values throw <see cref="ArgumentOutOfRangeException"/>.
         /// </param>
         /// <param name="maxRequestsPerTcpConnection">

--- a/Microsoft.Azure.Cosmos/src/Fluent/CosmosClientBuilder.cs
+++ b/Microsoft.Azure.Cosmos/src/Fluent/CosmosClientBuilder.cs
@@ -435,6 +435,10 @@ namespace Microsoft.Azure.Cosmos.Fluent
         /// Controls the amount of time allowed for trying to establish a connection.
         /// The default timeout is 5 seconds. Recommended values are greater than or equal to 5 seconds.
         /// When the time elapses, the attempt is cancelled and an error is returned. Longer timeouts will delay retries and failures.
+        /// At the transport boundary, values in [<see cref="TimeSpan.Zero"/>, 1 second) are treated as 0
+        /// (use the configured request timeout). Values greater than or equal to 1 second are rounded up to
+        /// the nearest whole second (for example, 2.5 seconds becomes 3 seconds).
+        /// Negative values throw <see cref="ArgumentOutOfRangeException"/>.
         /// </param>
         /// <param name="maxRequestsPerTcpConnection">
         /// Controls the number of requests allowed simultaneously over a single TCP connection. When more requests are in flight simultaneously, the direct/TCP client will open additional connections.

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
@@ -828,6 +828,181 @@ namespace Microsoft.Azure.Cosmos.Tests
         }
 
         [TestMethod]
+        public void OpenTcpConnectionTimeout_NegativeTimeSpan_Throws()
+        {
+            CosmosClientOptions options = new CosmosClientOptions
+            {
+                ConnectionMode = ConnectionMode.Direct,
+            };
+
+            Assert.ThrowsException<ArgumentOutOfRangeException>(
+                () => options.OpenTcpConnectionTimeout = TimeSpan.FromMilliseconds(-1));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(
+                () => options.OpenTcpConnectionTimeout = TimeSpan.FromSeconds(-30));
+        }
+
+        [TestMethod]
+        public void OpenTcpConnectionTimeout_Zero_IsAllowed_AndRoundTripsThroughConnectionPolicy()
+        {
+            CosmosClientOptions options = new CosmosClientOptions
+            {
+                ConnectionMode = ConnectionMode.Direct,
+                OpenTcpConnectionTimeout = TimeSpan.Zero,
+            };
+
+            ConnectionPolicy policy = options.GetConnectionPolicy(clientId: 0);
+            Assert.AreEqual(TimeSpan.Zero, policy.OpenTcpConnectionTimeout);
+        }
+
+        [TestMethod]
+        public void OpenTcpConnectionTimeout_SubSecond_NormalizesToZero_InRntbdConfig()
+        {
+            CosmosClientOptions options = new CosmosClientOptions
+            {
+                ConnectionMode = ConnectionMode.Direct,
+                OpenTcpConnectionTimeout = TimeSpan.FromMilliseconds(500),
+            };
+
+            ConnectionPolicy policy = options.GetConnectionPolicy(clientId: 0);
+            CosmosClientBuilder builder = new CosmosClientBuilder(
+                accountEndpoint: AccountEndpoint,
+                authKeyOrResourceToken: MockCosmosUtil.RandomInvalidCorrectlyFormatedAuthKey);
+            CosmosClient cosmosClient = builder.Build(new MockDocumentClient(connectionPolicy: policy));
+
+            Microsoft.Azure.Cosmos.Tracing.TraceData.RntbdConnectionConfig tcpConfig =
+                cosmosClient.ClientConfigurationTraceDatum.RntbdConnectionConfig;
+
+            Assert.AreEqual(
+                0,
+                tcpConfig.ConnectionTimeout,
+                "Sub-second OpenTcpConnectionTimeout must surface as 0 seconds (fall back to request timeout).");
+        }
+
+        [TestMethod]
+        public void OpenTcpConnectionTimeout_ExactlyOneSecond_PreservedInRntbdConfig()
+        {
+            CosmosClientOptions options = new CosmosClientOptions
+            {
+                ConnectionMode = ConnectionMode.Direct,
+                OpenTcpConnectionTimeout = TimeSpan.FromSeconds(1),
+            };
+
+            ConnectionPolicy policy = options.GetConnectionPolicy(clientId: 0);
+            CosmosClientBuilder builder = new CosmosClientBuilder(
+                accountEndpoint: AccountEndpoint,
+                authKeyOrResourceToken: MockCosmosUtil.RandomInvalidCorrectlyFormatedAuthKey);
+            CosmosClient cosmosClient = builder.Build(new MockDocumentClient(connectionPolicy: policy));
+
+            Microsoft.Azure.Cosmos.Tracing.TraceData.RntbdConnectionConfig tcpConfig =
+                cosmosClient.ClientConfigurationTraceDatum.RntbdConnectionConfig;
+
+            Assert.AreEqual(1, tcpConfig.ConnectionTimeout);
+        }
+
+        [TestMethod]
+        public void OpenTcpConnectionTimeout_WholeSeconds_PreservedInRntbdConfig()
+        {
+            CosmosClientOptions options = new CosmosClientOptions
+            {
+                ConnectionMode = ConnectionMode.Direct,
+                OpenTcpConnectionTimeout = TimeSpan.FromSeconds(7),
+            };
+
+            ConnectionPolicy policy = options.GetConnectionPolicy(clientId: 0);
+            CosmosClientBuilder builder = new CosmosClientBuilder(
+                accountEndpoint: AccountEndpoint,
+                authKeyOrResourceToken: MockCosmosUtil.RandomInvalidCorrectlyFormatedAuthKey);
+            CosmosClient cosmosClient = builder.Build(new MockDocumentClient(connectionPolicy: policy));
+
+            Microsoft.Azure.Cosmos.Tracing.TraceData.RntbdConnectionConfig tcpConfig =
+                cosmosClient.ClientConfigurationTraceDatum.RntbdConnectionConfig;
+
+            Assert.AreEqual(7, tcpConfig.ConnectionTimeout);
+        }
+
+        [TestMethod]
+        public void OpenTcpConnectionTimeout_Fractional_RoundsUpInRntbdConfig()
+        {
+            CosmosClientOptions options = new CosmosClientOptions
+            {
+                ConnectionMode = ConnectionMode.Direct,
+                OpenTcpConnectionTimeout = TimeSpan.FromSeconds(2.5),
+            };
+
+            ConnectionPolicy policy = options.GetConnectionPolicy(clientId: 0);
+            CosmosClientBuilder builder = new CosmosClientBuilder(
+                accountEndpoint: AccountEndpoint,
+                authKeyOrResourceToken: MockCosmosUtil.RandomInvalidCorrectlyFormatedAuthKey);
+            CosmosClient cosmosClient = builder.Build(new MockDocumentClient(connectionPolicy: policy));
+
+            Microsoft.Azure.Cosmos.Tracing.TraceData.RntbdConnectionConfig tcpConfig =
+                cosmosClient.ClientConfigurationTraceDatum.RntbdConnectionConfig;
+
+            Assert.AreEqual(
+                3,
+                tcpConfig.ConnectionTimeout,
+                "Fractional OpenTcpConnectionTimeout (>= 1s) rounds up to the nearest whole second at the transport boundary.");
+        }
+
+        [TestMethod]
+        public void OpenTcpConnectionTimeout_JustOverOneSecond_RoundsUpInRntbdConfig()
+        {
+            CosmosClientOptions options = new CosmosClientOptions
+            {
+                ConnectionMode = ConnectionMode.Direct,
+                OpenTcpConnectionTimeout = TimeSpan.FromMilliseconds(1001),
+            };
+
+            ConnectionPolicy policy = options.GetConnectionPolicy(clientId: 0);
+            CosmosClientBuilder builder = new CosmosClientBuilder(
+                accountEndpoint: AccountEndpoint,
+                authKeyOrResourceToken: MockCosmosUtil.RandomInvalidCorrectlyFormatedAuthKey);
+            CosmosClient cosmosClient = builder.Build(new MockDocumentClient(connectionPolicy: policy));
+
+            Microsoft.Azure.Cosmos.Tracing.TraceData.RntbdConnectionConfig tcpConfig =
+                cosmosClient.ClientConfigurationTraceDatum.RntbdConnectionConfig;
+
+            Assert.AreEqual(
+                2,
+                tcpConfig.ConnectionTimeout,
+                "1.001s rounds up to 2s at the transport boundary.");
+        }
+
+        [TestMethod]
+        public void OpenTcpConnectionTimeout_Fractional_PreservedOnConnectionPolicyTimeSpan()
+        {
+            TimeSpan customerSupplied = TimeSpan.FromSeconds(2.5);
+            CosmosClientOptions options = new CosmosClientOptions
+            {
+                ConnectionMode = ConnectionMode.Direct,
+                OpenTcpConnectionTimeout = customerSupplied,
+            };
+
+            Assert.AreEqual(
+                customerSupplied,
+                options.OpenTcpConnectionTimeout,
+                "CosmosClientOptions preserves the supplied TimeSpan unchanged.");
+
+            ConnectionPolicy policy = options.GetConnectionPolicy(clientId: 0);
+            Assert.AreEqual(
+                customerSupplied,
+                policy.OpenTcpConnectionTimeout,
+                "ConnectionPolicy preserves the supplied TimeSpan unchanged.");
+        }
+
+        [TestMethod]
+        public void WithConnectionModeDirect_NegativeOpenTcpTimeout_Throws()
+        {
+            CosmosClientBuilder builder = new CosmosClientBuilder(
+                accountEndpoint: AccountEndpoint,
+                authKeyOrResourceToken: MockCosmosUtil.RandomInvalidCorrectlyFormatedAuthKey);
+
+            Assert.ThrowsException<ArgumentOutOfRangeException>(
+                () => builder.WithConnectionModeDirect(
+                    openTcpConnectionTimeout: TimeSpan.FromSeconds(-1)));
+        }
+
+        [TestMethod]
         public void VerifyHttpClientFactoryBlockedWithConnectionLimit()
         {
             CosmosClientOptions cosmosClientOptions = new CosmosClientOptions()

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
@@ -828,17 +828,19 @@ namespace Microsoft.Azure.Cosmos.Tests
         }
 
         [TestMethod]
-        public void OpenTcpConnectionTimeout_NegativeTimeSpan_Throws()
+        public void OpenTcpConnectionTimeout_NegativeTimeSpan_ResetsToDefault()
         {
             CosmosClientOptions options = new CosmosClientOptions
             {
                 ConnectionMode = ConnectionMode.Direct,
             };
 
-            Assert.ThrowsException<ArgumentOutOfRangeException>(
-                () => options.OpenTcpConnectionTimeout = TimeSpan.FromMilliseconds(-1));
-            Assert.ThrowsException<ArgumentOutOfRangeException>(
-                () => options.OpenTcpConnectionTimeout = TimeSpan.FromSeconds(-30));
+            // Negative values are reset to null (default) with a warning log.
+            options.OpenTcpConnectionTimeout = TimeSpan.FromMilliseconds(-1);
+            Assert.IsNull(options.OpenTcpConnectionTimeout);
+
+            options.OpenTcpConnectionTimeout = TimeSpan.FromSeconds(-30);
+            Assert.IsNull(options.OpenTcpConnectionTimeout);
         }
 
         [TestMethod]
@@ -991,15 +993,15 @@ namespace Microsoft.Azure.Cosmos.Tests
         }
 
         [TestMethod]
-        public void WithConnectionModeDirect_NegativeOpenTcpTimeout_Throws()
+        public void WithConnectionModeDirect_NegativeOpenTcpTimeout_DoesNotThrow()
         {
             CosmosClientBuilder builder = new CosmosClientBuilder(
                 accountEndpoint: AccountEndpoint,
                 authKeyOrResourceToken: MockCosmosUtil.RandomInvalidCorrectlyFormatedAuthKey);
 
-            Assert.ThrowsException<ArgumentOutOfRangeException>(
-                () => builder.WithConnectionModeDirect(
-                    openTcpConnectionTimeout: TimeSpan.FromSeconds(-1)));
+            // Negative values are accepted (no throw) but produce a warning log.
+            builder.WithConnectionModeDirect(
+                openTcpConnectionTimeout: TimeSpan.FromSeconds(-1));
         }
 
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
@@ -844,6 +844,48 @@ namespace Microsoft.Azure.Cosmos.Tests
         }
 
         [TestMethod]
+        public void MaxTcpConnectionsPerEndpoint_BelowMinimum_ResetsToDefault()
+        {
+            CosmosClientOptions options = new CosmosClientOptions
+            {
+                ConnectionMode = ConnectionMode.Direct,
+            };
+
+            // Value below minimum (15) is reset to null with a warning.
+            options.MaxTcpConnectionsPerEndpoint = 15;
+            Assert.IsNull(options.MaxTcpConnectionsPerEndpoint);
+
+            // Zero is reset to null with a warning.
+            options.MaxTcpConnectionsPerEndpoint = 0;
+            Assert.IsNull(options.MaxTcpConnectionsPerEndpoint);
+
+            // Negative value is reset to null with a warning.
+            options.MaxTcpConnectionsPerEndpoint = -1;
+            Assert.IsNull(options.MaxTcpConnectionsPerEndpoint);
+        }
+
+        [TestMethod]
+        public void MaxTcpConnectionsPerEndpoint_AtOrAboveMinimum_Succeeds()
+        {
+            CosmosClientOptions options = new CosmosClientOptions
+            {
+                ConnectionMode = ConnectionMode.Direct,
+            };
+
+            // Exact minimum is accepted.
+            options.MaxTcpConnectionsPerEndpoint = 16;
+            Assert.AreEqual(16, options.MaxTcpConnectionsPerEndpoint);
+
+            // Above minimum is accepted.
+            options.MaxTcpConnectionsPerEndpoint = 65535;
+            Assert.AreEqual(65535, options.MaxTcpConnectionsPerEndpoint);
+
+            // Null is accepted (means default).
+            options.MaxTcpConnectionsPerEndpoint = null;
+            Assert.IsNull(options.MaxTcpConnectionsPerEndpoint);
+        }
+
+        [TestMethod]
         public void OpenTcpConnectionTimeout_Zero_IsAllowed_AndRoundTripsThroughConnectionPolicy()
         {
             CosmosClientOptions options = new CosmosClientOptions

--- a/changelog.md
+++ b/changelog.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Bugs Fixed
 
-- [#4500](https://github.com/Azure/azure-cosmos-dotnet-v3/issues/4500) Direct: Fixes silent truncation of `OpenTcpConnectionTimeout`. Sub-second values normalize to `TimeSpan.Zero` (request-timeout fallback). Fractional values greater than or equal to 1 second round up to the nearest whole second at the transport boundary (for example, 2.5 seconds becomes 3 seconds). Negative values throw `ArgumentOutOfRangeException`.
+- [#4500](https://github.com/Azure/azure-cosmos-dotnet-v3/issues/4500) Direct: Fixes silent truncation of `OpenTcpConnectionTimeout`. Sub-second values normalize to `TimeSpan.Zero` (request-timeout fallback). Fractional values greater than or equal to 1 second round up to the nearest whole second at the transport boundary (for example, 2.3 seconds becomes 3 seconds). Negative values throw `ArgumentOutOfRangeException`.
 
 #### Other Changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Bugs Fixed
 
-- [#4500](https://github.com/Azure/azure-cosmos-dotnet-v3/issues/4500) Direct: Fixes silent truncation of `OpenTcpConnectionTimeout`. Sub-second values normalize to `TimeSpan.Zero` (request-timeout fallback). Fractional values greater than or equal to 1 second round up to the nearest whole second at the transport boundary (for example, 2.3 seconds becomes 3 seconds). Negative values throw `ArgumentOutOfRangeException`.
+- [#5873](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5873) Direct: Fixes silent truncation of `OpenTcpConnectionTimeout`. Sub-second values normalize to `TimeSpan.Zero` (request-timeout fallback). Fractional values greater than or equal to 1 second round up to the nearest whole second at the transport boundary (for example, 2.3 seconds becomes 3 seconds). Negative values are reset to the default with a warning log.
 
 #### Other Changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Bugs Fixed
 
+- [#5878](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5878) Direct: Fixes missing validation for `MaxTcpConnectionsPerEndpoint`. Values below the documented minimum (16) now emit a warning and reset to the default (null).
 - [#5873](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5873) Direct: Fixes silent truncation of `OpenTcpConnectionTimeout`. Sub-second values normalize to `TimeSpan.Zero` (request-timeout fallback). Fractional values greater than or equal to 1 second round up to the nearest whole second at the transport boundary (for example, 2.3 seconds becomes 3 seconds). Negative values are reset to the default with a warning log.
 
 #### Other Changes

--- a/changelog.md
+++ b/changelog.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Bugs Fixed
 
+- [#4500](https://github.com/Azure/azure-cosmos-dotnet-v3/issues/4500) Direct: Fixes silent truncation of `OpenTcpConnectionTimeout`. Sub-second values normalize to `TimeSpan.Zero` (request-timeout fallback). Fractional values greater than or equal to 1 second round up to the nearest whole second at the transport boundary (for example, 2.5 seconds becomes 3 seconds). Negative values throw `ArgumentOutOfRangeException`.
+
 #### Other Changes
 
 ### <a name="3.60.0-preview.0"/> [3.60.0-preview.0](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.60.0-preview.0) - 2026-4-24


### PR DESCRIPTION
## Description

Fixes #5878

`MaxTcpConnectionsPerEndpoint` documents that the value must be >= 16 (default 65,535), but the setter had no validation. This PR adds bound checking in `ValidateDirectTCPSettings()` following the same non-breaking pattern as `OpenTcpConnectionTimeout` (PR #5873):

- Values below 16 trigger a `DefaultTrace.TraceWarning` and reset to `null` (which falls through to the default of 65,535 in the transport layer)
- No exception is thrown — this is a non-breaking change

## Changes

- **`CosmosClientOptions.cs`** — Added validation in `ValidateDirectTCPSettings()` for `MaxTcpConnectionsPerEndpoint < 16`
- **`CosmosClientOptionsUnitTests.cs`** — Two new tests:
  - `MaxTcpConnectionsPerEndpoint_BelowMinimum_ResetsToDefault` (values 15, 0, -1 reset to null)
  - `MaxTcpConnectionsPerEndpoint_AtOrAboveMinimum_Succeeds` (values 16, 65535, null accepted)
- **`changelog.md`** — Added Bugs Fixed entry under Unreleased

## Testing

- Added unit tests covering boundary conditions
- Follows identical pattern to existing `OpenTcpConnectionTimeout` validation