### PR TITLE
[Internal] DTX: Use SubStatusCodes enum for sub-status code comparisons

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ClientRetryPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/ClientRetryPolicy.cs
@@ -692,14 +692,14 @@ namespace Microsoft.Azure.Cosmos
 
             bool isCoordinatorRetriable =
                 statusCodeValue == (int)HttpStatusCode.RequestTimeout
-                || (statusCodeValue == (int)StatusCodes.RetryWith && subStatusCodeValue == DistributedTransactionConstants.DtcCoordinatorRaceConflict)
-                || (statusCodeValue == (int)StatusCodes.TooManyRequests && subStatusCodeValue == DistributedTransactionConstants.DtcLedgerThrottled);
+                || (statusCodeValue == (int)StatusCodes.RetryWith && subStatusCode == SubStatusCodes.DtcCoordinatorRaceConflict)
+                || (statusCodeValue == (int)StatusCodes.TooManyRequests && subStatusCode == SubStatusCodes.RUBudgetExceeded);
 
             bool isInfraFailure =
                 statusCodeValue == (int)HttpStatusCode.InternalServerError
-                && (subStatusCodeValue == DistributedTransactionConstants.DtcLedgerFailure
-                    || subStatusCodeValue == DistributedTransactionConstants.DtcAccountConfigFailure
-                    || subStatusCodeValue == DistributedTransactionConstants.DtcDispatchFailure);
+                && (subStatusCode == SubStatusCodes.DtcLedgerFailure
+                    || subStatusCode == SubStatusCodes.DtcAccountConfigFailure
+                    || subStatusCode == SubStatusCodes.DtcDispatchFailure);
 
             // Body-bearing response carries per-op isRetriable in JSON. The outer DistributedTransactionCommitter
             // loop owns retry; defer to avoid inner×outer amplification.

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionConstants.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionConstants.cs
@@ -8,14 +8,6 @@ namespace Microsoft.Azure.Cosmos
 
     internal static class DistributedTransactionConstants
     {
-        // DTX envelope sub-status codes. The full status/body matrix and the inner-vs-outer retry ownership
-        // is documented at the call site in ClientRetryPolicy.ShouldRetryDtxRequest.
-        internal const int DtcCoordinatorRaceConflict = 5352; // 449 sub-status: coordinator ETag race
-        internal const int DtcLedgerThrottled = 3200;          // 429 sub-status: ledger backpressure
-        internal const int DtcLedgerFailure = 5411;            // 500 sub-status: ledger infra failure
-        internal const int DtcAccountConfigFailure = 5412;     // 500 sub-status: account-config infra failure
-        internal const int DtcDispatchFailure = 5413;          // 500 sub-status: dispatch infra failure
-
         internal static bool IsDistributedTransactionRequest(OperationType operationType, ResourceType resourceType)
         {
             return operationType == OperationType.CommitDistributedTransaction

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ClientRetryPolicyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ClientRetryPolicyTests.cs
@@ -1002,7 +1002,7 @@
             policy.OnBeforeSendRequest(request);
 
             ResponseMessage response = new ResponseMessage((HttpStatusCode)StatusCodes.RetryWith);
-            response.Headers.SubStatusCodeLiteral = DistributedTransactionConstants.DtcCoordinatorRaceConflict.ToString();
+            response.Headers.SubStatusCodeLiteral = ((int)SubStatusCodes.DtcCoordinatorRaceConflict).ToString();
 
             ShouldRetryResult result = await policy.ShouldRetryAsync(response, CancellationToken.None);
 
@@ -1027,7 +1027,7 @@
             policy.OnBeforeSendRequest(request);
 
             ResponseMessage response = new ResponseMessage((HttpStatusCode)StatusCodes.RetryWith);
-            response.Headers.SubStatusCodeLiteral = DistributedTransactionConstants.DtcCoordinatorRaceConflict.ToString();
+            response.Headers.SubStatusCodeLiteral = ((int)SubStatusCodes.DtcCoordinatorRaceConflict).ToString();
             response.Headers.RetryAfterLiteral = ((long)serverRetryAfter.TotalMilliseconds).ToString();
 
             ShouldRetryResult result = await policy.ShouldRetryAsync(response, CancellationToken.None);
@@ -1037,9 +1037,9 @@
         }
 
         [DataTestMethod]
-        [DataRow(DistributedTransactionConstants.DtcLedgerFailure, DisplayName = "500/5411 LedgerFailure")]
-        [DataRow(DistributedTransactionConstants.DtcAccountConfigFailure, DisplayName = "500/5412 AccountConfigFailure")]
-        [DataRow(DistributedTransactionConstants.DtcDispatchFailure, DisplayName = "500/5413 DispatchFailure")]
+        [DataRow((int)SubStatusCodes.DtcLedgerFailure, DisplayName = "500/5411 LedgerFailure")]
+        [DataRow((int)SubStatusCodes.DtcAccountConfigFailure, DisplayName = "500/5412 AccountConfigFailure")]
+        [DataRow((int)SubStatusCodes.DtcDispatchFailure, DisplayName = "500/5413 DispatchFailure")]
         public async Task DtxRequest_500_InfraFailure_ShouldRetry(int subStatusCode)
         {
             const bool enableEndpointDiscovery = true;
@@ -1083,9 +1083,9 @@
         }
 
         [DataTestMethod]
-        [DataRow(DistributedTransactionConstants.DtcLedgerFailure, DisplayName = "500/5411 LedgerFailure")]
-        [DataRow(DistributedTransactionConstants.DtcAccountConfigFailure, DisplayName = "500/5412 AccountConfigFailure")]
-        [DataRow(DistributedTransactionConstants.DtcDispatchFailure, DisplayName = "500/5413 DispatchFailure")]
+        [DataRow((int)SubStatusCodes.DtcLedgerFailure, DisplayName = "500/5411 LedgerFailure")]
+        [DataRow((int)SubStatusCodes.DtcAccountConfigFailure, DisplayName = "500/5412 AccountConfigFailure")]
+        [DataRow((int)SubStatusCodes.DtcDispatchFailure, DisplayName = "500/5413 DispatchFailure")]
         public async Task NonDtxWriteRequest_500_DtcSubStatus_ShouldNotRetry(int subStatusCode)
         {
             const bool enableEndpointDiscovery = true;
@@ -1141,7 +1141,7 @@
         [DataTestMethod]
         [Description("CRP must defer body-bearing envelope responses (408 and 449/5352) to the outer DistributedTransactionCommitter loop so the two retry budgets do not amplify each other.")]
         [DataRow((int)HttpStatusCode.RequestTimeout, 0, DisplayName = "408 with body deferred to outer loop")]
-        [DataRow((int)StatusCodes.RetryWith, DistributedTransactionConstants.DtcCoordinatorRaceConflict, DisplayName = "449/5352 with body deferred to outer loop")]
+        [DataRow((int)StatusCodes.RetryWith, (int)SubStatusCodes.DtcCoordinatorRaceConflict, DisplayName = "449/5352 with body deferred to outer loop")]
         public async Task DtxRequest_WithBody_DeferredToOuterLoop(int statusCode, int subStatusCode)
         {
             const bool enableEndpointDiscovery = true;


### PR DESCRIPTION
## Description

Replaces the local `DistributedTransactionConstants` int constants with the corresponding `SubStatusCodes` enum members from `Microsoft.Azure.Documents` in the DTX retry classifier and its tests.

| Removed local constant                                                | Replaced with                              |
| --------------------------------------------------------------------- | ------------------------------------------ |
| `DistributedTransactionConstants.DtcCoordinatorRaceConflict` (5352) | `SubStatusCodes.DtcCoordinatorRaceConflict` |
| `DistributedTransactionConstants.DtcLedgerThrottled` (3200)         | `SubStatusCodes.RUBudgetExceeded`           |
| `DistributedTransactionConstants.DtcLedgerFailure` (5411)           | `SubStatusCodes.DtcLedgerFailure`           |
| `DistributedTransactionConstants.DtcAccountConfigFailure` (5412)    | `SubStatusCodes.DtcAccountConfigFailure`    |
| `DistributedTransactionConstants.DtcDispatchFailure` (5413)         | `SubStatusCodes.DtcDispatchFailure`         |

Behavior is unchanged; this is an internal cleanup extracted from #5872 so the enum migration can land independently of the (now obsolete) `AbortDistributedTransaction` work that's being dropped after the coordinator team confirmed they won't expose an abort API.

Files touched:
- `Microsoft.Azure.Cosmos/src/ClientRetryPolicy.cs`  comparisons in `ShouldRetryDtxRequest`
- `Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionConstants.cs`  removes the 5 `Dtc*` int constants (keeps `IsDistributedTransactionRequest` and `GetCollectionFullName`)
- `Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ClientRetryPolicyTests.cs`  `[DataRow]` and `SubStatusCodeLiteral` updates

Verified locally: `Microsoft.Azure.Cosmos.csproj` and `Microsoft.Azure.Cosmos.Tests.csproj` build clean (0 warnings, 0 errors); all 44 `ClientRetryPolicyTests` pass.

## Type of change

- [x] New feature (non-breaking change which adds functionality)  <!-- internal cleanup; no customer-visible behavior change -->

## Closing issues

None.

## Changelog

- [x] No changelog entry is required because this PR is one of: documentation-only, test-only, CI / build-only, or a pure internal refactor with no observable customer impact.

> Pure internal refactor: replaces local int constants with equivalent enum members. No public API or behavior change.
