### PR TITLE
[Internal] PRLint: Refactors regex failure comment format in prlint.yml

### DIFF
--- a/.github/workflows/prlint.yml
+++ b/.github/workflows/prlint.yml
@@ -18,11 +18,13 @@ jobs:
         on-failed-regex-fail-action: true
         on-failed-regex-request-changes: false
         on-failed-regex-create-review: true
-        on-failed-regex-comment: >
-         Please follow the required format: \"[Internal] Category: (Adds|Fixes|Refactors|Removes) Description\"<br /><br />
+        on-failed-regex-comment: |
+         Please follow the required format: \"[Internal] Category: (Adds|Fixes|Refactors|Removes) Description\"
+         Regex: '(\[Internal\]|\[v4\] )?.{3}.+: (Adds|Fixes|Refactors|Removes) .{3}.+'
+         
          The `[Internal]` prefix is a review hint indicating no customer-observable impact (test pipelines, CI, doc-only changes, pure internal refactors). It does **not** affect changelog generation — the changelog is maintained per-PR in `### Unreleased` of `changelog.md`. See CONTRIBUTING.md for the full `[Internal]` definition and the preview-feature carve-out.
-         Examples:<br />
-         Diagnostics: Adds GetElapsedClientLatency to CosmosDiagnostics<br/>
-         PartitionKey: Fixes null reference when using default(PartitionKey)<br/>
-         [v4] Client Encryption: Refactors code to external project<br/>
-         [Internal] Query: Adds code generator for CosmosNumbers for easy additions in the future.<br/>
+         Examples:
+         - Diagnostics: Adds GetElapsedClientLatency to CosmosDiagnostics
+         - PartitionKey: Fixes null reference when using default(PartitionKey)
+         - [v4] Client Encryption: Refactors code to external project
+         - [Internal] Query: Adds code generator for CosmosNumbers for easy additions in the future

--- a/.github/workflows/prlint.yml
+++ b/.github/workflows/prlint.yml
@@ -19,9 +19,9 @@ jobs:
         on-failed-regex-request-changes: false
         on-failed-regex-create-review: true
         on-failed-regex-comment: |
-         Please follow the required format: \"[Internal] Category: (Adds|Fixes|Refactors|Removes) Description\"
-         Regex: '(\[Internal\]|\[v4\] )?.{3}.+: (Adds|Fixes|Refactors|Removes) .{3}.+'
-         
+         Please follow the required format: "[Internal] Category: (Adds|Fixes|Refactors|Removes) Description"
+         Regex: `(\[Internal\]|\[v4\] )?.{3}.+: (Adds|Fixes|Refactors|Removes) .{3}.+`
+
          The `[Internal]` prefix is a review hint indicating no customer-observable impact (test pipelines, CI, doc-only changes, pure internal refactors). It does **not** affect changelog generation — the changelog is maintained per-PR in `### Unreleased` of `changelog.md`. See CONTRIBUTING.md for the full `[Internal]` definition and the preview-feature carve-out.
          Examples:
          - Diagnostics: Adds GetElapsedClientLatency to CosmosDiagnostics


### PR DESCRIPTION
## Description

Updated the comment format for regex failure messages and examples in the PR lint workflow.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Closing issues



## Changelog

- [ ] I have added a changelog entry under `### Unreleased` in `changelog.md`
  for the user-facing impact of this change.
- [x] No changelog entry is required because this PR is one of:
  documentation-only, test-only, CI / build-only, or a pure internal refactor
  with no observable customer impact.

If the second box is checked, briefly justify here:

> Internal CI comment changes for build error clarity
