### PR TITLE
Diagnostics: Adds gateway hedging suppression marker

### DIFF
--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -137,7 +137,7 @@ namespace Microsoft.Azure.Cosmos
 
         private readonly bool isThinClientFeatureFlagEnabled = ConfigurationManager.IsThinClientEnabled(defaultValue: false);
 
-        // Serializes the (disableCrossRegionalHedging, customerConfiguredAvailabilityStrategy,
+        // Serializes the (disableCrossRegionalHedgingGeneration, customerConfiguredAvailabilityStrategy,
         // ConnectionPolicy.AvailabilityStrategy) mutation sequence performed by the gateway-driven
         // hedging-override reconcile path.
         //
@@ -158,8 +158,9 @@ namespace Microsoft.Azure.Cosmos
         //      path, the stash/clear/restore sequence stays atomic instead of regressing silently.
         //
         // Per-request reads from RequestInvokerHandler intentionally do NOT take this lock:
-        //   • disableCrossRegionalHedging is declared volatile (acquire semantics on read, release on
-        //     write), which is sufficient for the per-request "is the gateway kill-switch on?" check.
+        //   • disableCrossRegionalHedgingGeneration is read/written with Volatile (acquire semantics on
+        //     read, release on write), which is sufficient for the per-request "is the gateway kill-switch
+        //     on?" check.
         //   • ConnectionPolicy.AvailabilityStrategy is a reference field; reference assignment is atomic
         //     on the CLR, so a request observes either the pre- or post-transition strategy, never a
         //     half-applied state.
@@ -206,21 +207,28 @@ namespace Microsoft.Azure.Cosmos
         private bool isDisposed;
 
         // Gateway-controlled override that disables all cross-regional hedging for PPAF accounts.
-        // Mirrors AccountProperties.DisableCrossRegionalHedging from the most recent account-properties refresh.
+        // Zero means AccountProperties.DisableCrossRegionalHedging is false. Positive values identify
+        // the true-cycle generation from the most recent account-properties refresh.
         //
-        // Declared volatile so per-request reads from RequestInvokerHandler (via IsHedgingDisabledByGateway)
-        // and the init-time read in InitializePartitionLevelFailoverWithDefaultHedging do not need to take
-        // hedgingStrategyLock — volatile gives acquire semantics on the read and release semantics on the
-        // write, which is exactly what the "atomic kill-switch" contract requires. The lock continues to
-        // serialize the multi-field (flag + stashed strategy + ConnectionPolicy.AvailabilityStrategy)
-        // mutation sequence on the refresh / init-stash paths.
-        private volatile bool disableCrossRegionalHedging;
+        // Read and written through Volatile so per-request reads from RequestInvokerHandler and the init-time
+        // read in InitializePartitionLevelFailoverWithDefaultHedging do not need to take hedgingStrategyLock.
+        // This gives acquire semantics on the read and release semantics on the write, which is exactly what
+        // the "atomic kill-switch" contract requires. The lock continues to serialize the multi-field
+        // (flag generation + stashed strategy + ConnectionPolicy.AvailabilityStrategy) mutation sequence on
+        // the refresh / init-stash paths.
+        private long disableCrossRegionalHedgingGeneration;
 
         // When the gateway disable flag is true, the customer's explicit AvailabilityStrategy
         // (if any) is stashed here so it can be restored verbatim if the flag is later toggled back to false.
         // Null when the customer never configured a strategy or when no stash is currently held.
         // Mutated only under hedgingStrategyLock.
         private AvailabilityStrategy customerConfiguredAvailabilityStrategy;
+
+        // One-shot marker consumed by RequestInvokerHandler to surface gateway-driven hedging suppression
+        // on the customer-visible CosmosDiagnostics surface. The emitted generation is monotonic, so a
+        // stale request from an older true-cycle cannot consume the marker for a newer true-cycle.
+        private long nextHedgingDisabledByGatewayDiagnosticGeneration;
+        private long emittedHedgingDisabledByGatewayDiagnosticGeneration;
 
         // creator of TransportClient is responsible for disposing it.
         private IStoreClientFactory storeClientFactory;
@@ -6927,8 +6935,9 @@ namespace Microsoft.Azure.Cosmos
             {
                 lock (this.hedgingStrategyLock)
                 {
-                    this.disableCrossRegionalHedging = accountProperties.DisableCrossRegionalHedging ?? false;
-                    if (this.disableCrossRegionalHedging && this.ConnectionPolicy.AvailabilityStrategy != null)
+                    this.SetDisableCrossRegionalHedgingState(accountProperties.DisableCrossRegionalHedging ?? false);
+
+                    if (this.IsHedgingDisabledByGateway && this.ConnectionPolicy.AvailabilityStrategy != null)
                     {
                         this.customerConfiguredAvailabilityStrategy = this.ConnectionPolicy.AvailabilityStrategy;
                         this.ConnectionPolicy.AvailabilityStrategy = null;
@@ -6970,7 +6979,7 @@ namespace Microsoft.Azure.Cosmos
 
         internal void InitializePartitionLevelFailoverWithDefaultHedging()
         {
-            if (this.disableCrossRegionalHedging)
+            if (this.IsHedgingDisabledByGateway)
             {
                 DefaultTrace.TraceInformation(
                     "DocumentClient: Skipping default PPAF hedging because Gateway property disableCrossRegionalHedging=true");
@@ -7017,7 +7026,7 @@ namespace Microsoft.Azure.Cosmos
             lock (this.hedgingStrategyLock)
             {
                 bool ppafEnablementChanged = this.ConnectionPolicy.EnablePartitionLevelFailover != latestIsEnabled;
-                bool hedgingFlagChanged = this.disableCrossRegionalHedging != latestDisableCrossRegionalHedging;
+                bool hedgingFlagChanged = this.IsHedgingDisabledByGateway != latestDisableCrossRegionalHedging;
 
                 // No-op when nothing has actually changed.
                 //
@@ -7056,7 +7065,7 @@ namespace Microsoft.Azure.Cosmos
                     DefaultTrace.TraceInformation(
                         "DocumentClient: Gateway disableCrossRegionalHedging flag changed to {0}",
                         latestDisableCrossRegionalHedging);
-                    this.disableCrossRegionalHedging = latestDisableCrossRegionalHedging;
+                    this.SetDisableCrossRegionalHedgingState(latestDisableCrossRegionalHedging);
                 }
 
                 // Step 3: Reconcile the AvailabilityStrategy with the latest account state.
@@ -7092,7 +7101,7 @@ namespace Microsoft.Azure.Cosmos
 
         /// <summary>
         /// Reconciles <see cref="ConnectionPolicy.AvailabilityStrategy"/> with the current values of
-        /// <see cref="disableCrossRegionalHedging"/> and <see cref="ConnectionPolicy.EnablePartitionLevelFailover"/>.
+        /// <see cref="IsHedgingDisabledByGateway"/> and <see cref="ConnectionPolicy.EnablePartitionLevelFailover"/>.
         /// </summary>
         /// <remarks>
         /// Precedence (highest first):
@@ -7107,7 +7116,7 @@ namespace Microsoft.Azure.Cosmos
         {
             lock (this.hedgingStrategyLock)
             {
-                if (this.disableCrossRegionalHedging)
+                if (this.IsHedgingDisabledByGateway)
                 {
                     AvailabilityStrategy currentStrategy = this.ConnectionPolicy.AvailabilityStrategy;
                     if (currentStrategy != null)
@@ -7184,13 +7193,73 @@ namespace Microsoft.Azure.Cosmos
         /// regardless of where the strategy was configured.
         /// </summary>
         /// <remarks>
-        /// Safe to read without <see cref="hedgingStrategyLock"/> because the backing field is declared
-        /// <c>volatile</c> — the read has acquire semantics, so any write that completed on the refresh
-        /// path before its lock release is visible here. Taking a monitor on every request would impose
-        /// uncontended-but-non-zero cost on the SDK hot path (steady-state benchmarks would not surface
-        /// the regression).
+        /// Safe to read without <see cref="hedgingStrategyLock"/> because the backing generation is read
+        /// with acquire semantics and written with release semantics. Taking a monitor on every request
+        /// would impose uncontended-but-non-zero cost on the SDK hot path (steady-state benchmarks would
+        /// not surface the regression).
         /// </remarks>
-        internal bool IsHedgingDisabledByGateway => this.disableCrossRegionalHedging;
+        internal bool IsHedgingDisabledByGateway => Volatile.Read(ref this.disableCrossRegionalHedgingGeneration) != 0;
+
+        internal bool TryGetHedgingDisabledByGatewayDiagnosticGeneration(out long generation)
+        {
+            generation = Volatile.Read(ref this.disableCrossRegionalHedgingGeneration);
+            return generation != 0;
+        }
+
+        private void SetDisableCrossRegionalHedgingState(bool value)
+        {
+            if (value)
+            {
+                // Allocate the next true-cycle generation before publishing it so the first request that
+                // observes suppression also observes the matching diagnostics generation.
+                long generation = Interlocked.Increment(ref this.nextHedgingDisabledByGatewayDiagnosticGeneration);
+                Volatile.Write(ref this.disableCrossRegionalHedgingGeneration, generation);
+            }
+            else
+            {
+                // Unpublish suppression without changing the emitted generation. A racing request may already
+                // have observed a positive generation and can still legitimately suppress and emit for it.
+                Volatile.Write(ref this.disableCrossRegionalHedgingGeneration, 0);
+            }
+        }
+
+        internal AvailabilityStrategy CustomerConfiguredAvailabilityStrategyForGatewaySuppression
+        {
+            get
+            {
+                lock (this.hedgingStrategyLock)
+                {
+                    return this.customerConfiguredAvailabilityStrategy;
+                }
+            }
+        }
+
+        internal bool TryConsumeHedgingDisabledByGatewayDiagnosticForSuppressedRequest(long generation)
+        {
+            // The caller already observed this positive generation and is returning null to suppress
+            // an enabled availability strategy. Do not re-read the active generation here: a concurrent
+            // false or false -> true transition must not let this request consume another cycle's marker.
+            if (generation <= 0)
+            {
+                return false;
+            }
+
+            long emittedGeneration = Volatile.Read(ref this.emittedHedgingDisabledByGatewayDiagnosticGeneration);
+            while (emittedGeneration < generation)
+            {
+                if (Interlocked.CompareExchange(
+                    ref this.emittedHedgingDisabledByGatewayDiagnosticGeneration,
+                    generation,
+                    emittedGeneration) == emittedGeneration)
+                {
+                    return true;
+                }
+
+                emittedGeneration = Volatile.Read(ref this.emittedHedgingDisabledByGatewayDiagnosticGeneration);
+            }
+
+            return false;
+        }
 
         // Test-only accessors. Visible to the unit-test assembly via [InternalsVisibleTo] in
         // Microsoft.Azure.Cosmos.csproj.
@@ -7213,29 +7282,24 @@ namespace Microsoft.Azure.Cosmos
         // introduced these accessors should be removed in favor of mocking the account snapshot.
         internal bool DisableCrossRegionalHedgingForTests
         {
-            // Read is lock-free because disableCrossRegionalHedging is volatile (see field declaration).
+            // Read is lock-free because disableCrossRegionalHedgingGeneration is read with Volatile
+            // (see field declaration).
             // The setter retains the lock so a test write happens-before any subsequent observation on the
             // reconcile path that mutates the companion fields (customerConfiguredAvailabilityStrategy,
             // ConnectionPolicy.AvailabilityStrategy) under the same lock.
-            get => this.disableCrossRegionalHedging;
+            get => this.IsHedgingDisabledByGateway;
             set
             {
                 lock (this.hedgingStrategyLock)
                 {
-                    this.disableCrossRegionalHedging = value;
+                    this.SetDisableCrossRegionalHedgingState(value);
                 }
             }
         }
 
         internal AvailabilityStrategy CustomerConfiguredAvailabilityStrategyForTests
         {
-            get
-            {
-                lock (this.hedgingStrategyLock)
-                {
-                    return this.customerConfiguredAvailabilityStrategy;
-                }
-            }
+            get => this.CustomerConfiguredAvailabilityStrategyForGatewaySuppression;
         }
 
         internal void CaptureSessionToken(DocumentServiceRequest request, DocumentServiceResponse response)

--- a/Microsoft.Azure.Cosmos/src/Handler/RequestInvokerHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/RequestInvokerHandler.cs
@@ -15,6 +15,7 @@ namespace Microsoft.Azure.Cosmos.Handlers
     using Microsoft.Azure.Cosmos.Diagnostics;
     using Microsoft.Azure.Cosmos.Routing;
     using Microsoft.Azure.Cosmos.Tracing;
+    using Microsoft.Azure.Cosmos.Tracing.TraceData;
     using Microsoft.Azure.Documents;
     using Microsoft.Azure.Documents.Routing;
 
@@ -134,16 +135,24 @@ namespace Microsoft.Azure.Cosmos.Handlers
         /// <returns>whether the request should be a parallel hedging request.</returns>
         public AvailabilityStrategyInternal AvailabilityStrategy(RequestMessage request)
         {
+            AvailabilityStrategy requestAvailabilityStrategy = request.RequestOptions?.AvailabilityStrategy;
+            AvailabilityStrategy strategy = requestAvailabilityStrategy
+                    ?? this.client.DocumentClient.ConnectionPolicy.AvailabilityStrategy;
+
             // Gateway-driven operator override has absolute precedence over any request-level or
-            // client-level AvailabilityStrategy. See spec.md → "Gateway flag disables all hedging
-            // when true" and tasks.md item 4.1.
-            if (this.client.DocumentClient.IsHedgingDisabledByGateway)
+            // client-level AvailabilityStrategy while the gateway flag is active.
+            if (this.client.DocumentClient.TryGetHedgingDisabledByGatewayDiagnosticGeneration(out long diagnosticGeneration))
             {
+                if (this.ShouldEmitHedgingDisabledByGatewayDiagnostic(request, requestAvailabilityStrategy)
+                    && this.client.DocumentClient.TryConsumeHedgingDisabledByGatewayDiagnosticForSuppressedRequest(diagnosticGeneration))
+                {
+                    request.Trace.AddOrUpdateDatum(
+                        TraceDatumKeys.HedgingDisabledByGateway,
+                        new BooleanTraceDatum(true));
+                }
+
                 return null;
             }
-
-            AvailabilityStrategy strategy = request.RequestOptions?.AvailabilityStrategy
-                    ?? this.client.DocumentClient.ConnectionPolicy.AvailabilityStrategy;
 
             if (strategy == null)
             {
@@ -151,6 +160,51 @@ namespace Microsoft.Azure.Cosmos.Handlers
             }
 
             return strategy as AvailabilityStrategyInternal;
+        }
+
+        private bool ShouldEmitHedgingDisabledByGatewayDiagnostic(
+            RequestMessage request,
+            AvailabilityStrategy requestAvailabilityStrategy)
+        {
+            if (requestAvailabilityStrategy != null)
+            {
+                return this.ShouldAvailabilityStrategyHedgeRequest(requestAvailabilityStrategy, request);
+            }
+
+            AvailabilityStrategy clientAvailabilityStrategy = this.client.DocumentClient.ConnectionPolicy.AvailabilityStrategy;
+            if (clientAvailabilityStrategy != null)
+            {
+                return this.ShouldAvailabilityStrategyHedgeRequest(clientAvailabilityStrategy, request);
+            }
+
+            AvailabilityStrategy stashedAvailabilityStrategy =
+                this.client.DocumentClient.CustomerConfiguredAvailabilityStrategyForGatewaySuppression;
+            if (stashedAvailabilityStrategy != null)
+            {
+                return this.ShouldAvailabilityStrategyHedgeRequest(stashedAvailabilityStrategy, request);
+            }
+
+            return this.client.DocumentClient.ConnectionPolicy.EnablePartitionLevelFailover
+                && request.ResourceType == ResourceType.Document
+                && OperationTypeExtensions.IsReadOperation(request.OperationType);
+        }
+
+        private bool ShouldAvailabilityStrategyHedgeRequest(
+            AvailabilityStrategy availabilityStrategy,
+            RequestMessage request)
+        {
+            if (availabilityStrategy is not AvailabilityStrategyInternal availabilityStrategyInternal
+                || !availabilityStrategyInternal.Enabled())
+            {
+                return false;
+            }
+
+            if (availabilityStrategyInternal is CrossRegionHedgingAvailabilityStrategy crossRegionHedgingAvailabilityStrategy)
+            {
+                return crossRegionHedgingAvailabilityStrategy.ShouldHedge(request, this.client);
+            }
+
+            return true;
         }
 
         public virtual async Task<ResponseMessage> BaseSendAsync(

--- a/Microsoft.Azure.Cosmos/src/Tracing/ITraceDatumVisitor.cs
+++ b/Microsoft.Azure.Cosmos/src/Tracing/ITraceDatumVisitor.cs
@@ -17,5 +17,6 @@ namespace Microsoft.Azure.Cosmos.Tracing
         void Visit(CpuHistoryTraceDatum cpuHistoryTraceDatum);
         void Visit(ClientConfigurationTraceDatum clientConfigurationTraceDatum);
         void Visit(PartitionKeyRangeCacheTraceDatum partitionKeyRangeCacheTraceDatum);
+        void Visit(BooleanTraceDatum booleanTraceDatum);
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Tracing/TraceData/BooleanTraceDatum.cs
+++ b/Microsoft.Azure.Cosmos/src/Tracing/TraceData/BooleanTraceDatum.cs
@@ -1,0 +1,21 @@
+﻿// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Tracing.TraceData
+{
+    internal sealed class BooleanTraceDatum : TraceDatum
+    {
+        public BooleanTraceDatum(bool value)
+        {
+            this.Value = value;
+        }
+
+        public bool Value { get; }
+
+        internal override void Accept(ITraceDatumVisitor traceDatumVisitor)
+        {
+            traceDatumVisitor.Visit(this);
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Tracing/TraceData/TraceDatumKeys.cs
+++ b/Microsoft.Azure.Cosmos/src/Tracing/TraceData/TraceDatumKeys.cs
@@ -13,5 +13,6 @@ namespace Microsoft.Azure.Cosmos.Tracing.TraceData
         public const string QueryResponseSerialization = "Query Response Serialization";
         public const string FeedResponseSerialization = "Feed Response Serialization";
         public const string ChangeFeedResponseSerialization = "ChangeFeed Response Serialization";
+        public const string HedgingDisabledByGateway = "db.cosmosdb.hedging_disabled_by_gateway";
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Tracing/TraceWriter.TraceJsonWriter.cs
+++ b/Microsoft.Azure.Cosmos/src/Tracing/TraceWriter.TraceJsonWriter.cs
@@ -154,6 +154,11 @@ namespace Microsoft.Azure.Cosmos.Tracing
                 this.jsonWriter.WriteStringValue(queryMetricsTraceDatum.QueryMetrics.ToString());
             }
 
+            public void Visit(BooleanTraceDatum booleanTraceDatum)
+            {
+                this.jsonWriter.WriteBoolValue(booleanTraceDatum.Value);
+            }
+
             public void Visit(PointOperationStatisticsTraceDatum pointOperationStatisticsTraceDatum)
             {
                 this.jsonWriter.WriteObjectStart();

--- a/Microsoft.Azure.Cosmos/src/Tracing/TraceWriter.TraceTextWriter.cs
+++ b/Microsoft.Azure.Cosmos/src/Tracing/TraceWriter.TraceTextWriter.cs
@@ -314,6 +314,11 @@ namespace Microsoft.Azure.Cosmos.Tracing
                     this.toStringValue = queryMetricsTraceDatum.QueryMetrics.ToString();
                 }
 
+                public void Visit(BooleanTraceDatum booleanTraceDatum)
+                {
+                    this.toStringValue = booleanTraceDatum.Value.ToString();
+                }
+
                 public void Visit(PointOperationStatisticsTraceDatum pointOperationStatisticsTraceDatum)
                 {
                     StringBuilder stringBuilder = new StringBuilder();

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/GatewayHedgingDiagnosticsEmulatorTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/GatewayHedgingDiagnosticsEmulatorTests.cs
@@ -1,0 +1,104 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
+{
+    using System;
+    using System.Net;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Tracing.TraceData;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class GatewayHedgingDiagnosticsEmulatorTests
+    {
+        private CosmosClient cosmosClient;
+        private Database database;
+        private Container container;
+
+        [TestInitialize]
+        public async Task Initialize()
+        {
+            CosmosClientOptions clientOptions = new CosmosClientOptions
+            {
+                ConnectionMode = ConnectionMode.Gateway,
+                AvailabilityStrategy = AvailabilityStrategy.CrossRegionHedgingStrategy(
+                    threshold: TimeSpan.FromMilliseconds(1000),
+                    thresholdStep: TimeSpan.FromMilliseconds(500))
+            };
+
+            this.cosmosClient = TestCommon.CreateCosmosClient(clientOptions);
+            this.database = await this.cosmosClient.CreateDatabaseIfNotExistsAsync(Guid.NewGuid().ToString());
+            this.container = await this.database.CreateContainerAsync(Guid.NewGuid().ToString(), "/pk");
+        }
+
+        [TestCleanup]
+        public async Task Cleanup()
+        {
+            if (this.database != null)
+            {
+                await this.database.DeleteStreamAsync();
+            }
+
+            this.cosmosClient?.Dispose();
+        }
+
+        [TestMethod]
+        [TestCategory("GatewayHedgingDiagnostics")]
+        public async Task GatewayDrivenHedgingSuppressionDiagnostics_EmitsOnceAndReEmitsAfterFlagCycle()
+        {
+            ToDoActivity item = ToDoActivity.CreateRandomToDoActivity();
+            ItemResponse<ToDoActivity> createResponse = await this.container.CreateItemAsync(item);
+            Assert.AreEqual(HttpStatusCode.Created, createResponse.StatusCode);
+
+            ItemResponse<ToDoActivity> initialResponse = await this.ReadItemAsync(item);
+            GatewayHedgingDiagnosticsEmulatorTests.AssertNoHedgingDisabledByGatewayDiagnostic(initialResponse);
+
+            this.cosmosClient.DocumentClient.UpdatePartitionLevelFailoverConfigWithAccountRefresh(
+                latestIsEnabled: true,
+                latestDisableCrossRegionalHedging: true);
+
+            ItemResponse<ToDoActivity> firstSuppressedResponse = await this.ReadItemAsync(item);
+            GatewayHedgingDiagnosticsEmulatorTests.AssertHedgingDisabledByGatewayDiagnostic(firstSuppressedResponse);
+
+            ItemResponse<ToDoActivity> secondSuppressedResponse = await this.ReadItemAsync(item);
+            GatewayHedgingDiagnosticsEmulatorTests.AssertNoHedgingDisabledByGatewayDiagnostic(secondSuppressedResponse);
+
+            this.cosmosClient.DocumentClient.UpdatePartitionLevelFailoverConfigWithAccountRefresh(
+                latestIsEnabled: true,
+                latestDisableCrossRegionalHedging: false);
+
+            ItemResponse<ToDoActivity> falseFlagResponse = await this.ReadItemAsync(item);
+            GatewayHedgingDiagnosticsEmulatorTests.AssertNoHedgingDisabledByGatewayDiagnostic(falseFlagResponse);
+
+            this.cosmosClient.DocumentClient.UpdatePartitionLevelFailoverConfigWithAccountRefresh(
+                latestIsEnabled: true,
+                latestDisableCrossRegionalHedging: true);
+
+            ItemResponse<ToDoActivity> secondTrueResponse = await this.ReadItemAsync(item);
+            GatewayHedgingDiagnosticsEmulatorTests.AssertHedgingDisabledByGatewayDiagnostic(secondTrueResponse);
+        }
+
+        private Task<ItemResponse<ToDoActivity>> ReadItemAsync(ToDoActivity item)
+        {
+            return this.container.ReadItemAsync<ToDoActivity>(item.id, new PartitionKey(item.pk));
+        }
+
+        private static void AssertHedgingDisabledByGatewayDiagnostic(ItemResponse<ToDoActivity> response)
+        {
+            string diagnosticsText = response.Diagnostics.ToString();
+            StringAssert.Contains(
+                diagnosticsText,
+                $"\"{TraceDatumKeys.HedgingDisabledByGateway}\":true");
+        }
+
+        private static void AssertNoHedgingDisabledByGatewayDiagnostic(ItemResponse<ToDoActivity> response)
+        {
+            string diagnosticsText = response.Diagnostics.ToString();
+            Assert.IsFalse(
+                diagnosticsText.Contains(TraceDatumKeys.HedgingDisabledByGateway),
+                $"Did not expect serialized CosmosDiagnostics to contain {TraceDatumKeys.HedgingDisabledByGateway}: {diagnosticsText}");
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/QueryPerfTest/QueryStatisticsDatumVisitor.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/QueryPerfTest/QueryStatisticsDatumVisitor.cs
@@ -154,5 +154,10 @@
         {
             Debug.Fail("QueryStatisticsDatumVisitor Assert", "PartitionKeyRangeCacheTraceDatum is not supported");
         }
+
+        public void Visit(BooleanTraceDatum booleanTraceDatum)
+        {
+            Debug.Fail("QueryStatisticsDatumVisitor Assert", "BooleanTraceDatum is not supported");
+        }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BaselineTest/TestBaseline/TraceWriterBaselineTests.Serialization.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BaselineTest/TestBaseline/TraceWriterBaselineTests.Serialization.xml
@@ -443,4 +443,64 @@
 }]]></Json>
     </Output>
   </Result>
+  <Result>
+    <Input>
+      <Description>Typed Boolean Datum</Description>
+      <Setup><![CDATA[
+    TraceForBaselineTesting rootTrace;
+    using (rootTrace = TraceForBaselineTesting.GetRootTrace())
+    {
+        rootTrace.AddDatum(TraceDatumKeys.HedgingDisabledByGateway, new BooleanTraceDatum(true));
+    }
+]]></Setup>
+    </Input>
+    <Output>
+      <Text><![CDATA[.
+└── Trace For Baseline Testing(00000000-0000-0000-0000-000000000000)  Unknown-Component  00:00:00:000  0.00 milliseconds
+        (
+            [db.cosmosdb.hedging_disabled_by_gateway]
+            True
+        )
+]]></Text>
+      <Json><![CDATA[{
+  "Summary": {},
+  "name": "Trace For Baseline Testing",
+  "start datetime": "0544-01-01T00:00:00Z",
+  "duration in milliseconds": 0,
+  "data": {
+    "db.cosmosdb.hedging_disabled_by_gateway": true
+  }
+}]]></Json>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>Generic Boolean Datum</Description>
+      <Setup><![CDATA[
+    TraceForBaselineTesting rootTrace;
+    using (rootTrace = TraceForBaselineTesting.GetRootTrace())
+    {
+        rootTrace.AddDatum("Generic bool compatibility", true);
+    }
+]]></Setup>
+    </Input>
+    <Output>
+      <Text><![CDATA[.
+└── Trace For Baseline Testing(00000000-0000-0000-0000-000000000000)  Unknown-Component  00:00:00:000  0.00 milliseconds
+        (
+            [Generic bool compatibility]
+            True
+        )
+]]></Text>
+      <Json><![CDATA[{
+  "Summary": {},
+  "name": "Trace For Baseline Testing",
+  "start datetime": "0544-01-01T00:00:00Z",
+  "duration in milliseconds": 0,
+  "data": {
+    "Generic bool compatibility": "True"
+  }
+}]]></Json>
+    </Output>
+  </Result>
 </Results>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GatewayHedgingOverrideTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GatewayHedgingOverrideTests.cs
@@ -1,9 +1,16 @@
 namespace Microsoft.Azure.Cosmos.Tests
 {
     using System;
+    using System.Linq;
+    using System.Net;
     using System.Net.Http;
+    using System.Threading;
+    using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos;
+    using Microsoft.Azure.Cosmos.Diagnostics;
     using Microsoft.Azure.Cosmos.Handlers;
+    using Microsoft.Azure.Cosmos.Tracing;
+    using Microsoft.Azure.Cosmos.Tracing.TraceData;
     using Microsoft.Azure.Documents;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Newtonsoft.Json;
@@ -18,6 +25,7 @@ namespace Microsoft.Azure.Cosmos.Tests
     {
         private const string AccountEndpoint = "https://localhost:8081/";
         private const string AccountKey = "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
+        private const string HedgingDisabledByGatewayDiagnosticsKey = TraceDatumKeys.HedgingDisabledByGateway;
 
         [TestMethod]
         public void AccountProperties_DisableCrossRegionalHedging_True_Deserializes()
@@ -349,6 +357,261 @@ namespace Microsoft.Azure.Cosmos.Tests
                 "Per-request strategy must be returned verbatim when Gateway flag is false");
         }
 
+        [TestMethod]
+        public async Task RequestInvokerHandler_FlagTrue_FirstSuppressedRequest_EmitsDiagnosticsOnce()
+        {
+            using CosmosClient mockCosmosClient = MockCosmosUtil.CreateMockCosmosClient();
+            mockCosmosClient.DocumentClient.ConnectionPolicy.AvailabilityStrategy = CreateCustomerHedgingStrategy();
+            mockCosmosClient.DocumentClient.UpdatePartitionLevelFailoverConfigWithAccountRefresh(
+                latestIsEnabled: false,
+                latestDisableCrossRegionalHedging: true);
+
+            TestRequestInvokerHandler handler = new TestRequestInvokerHandler(mockCosmosClient);
+
+            using ResponseMessage firstResponse = await SendReadRequestAsync(handler);
+            AssertHedgingDisabledByGatewayDiagnostic(firstResponse);
+
+            using ResponseMessage secondResponse = await SendReadRequestAsync(handler);
+            AssertNoHedgingDisabledByGatewayDiagnostic(secondResponse);
+        }
+
+        [TestMethod]
+        public async Task RequestInvokerHandler_FlagFalse_DoesNotEmitDiagnostics()
+        {
+            using CosmosClient mockCosmosClient = MockCosmosUtil.CreateMockCosmosClient();
+            mockCosmosClient.DocumentClient.UpdatePartitionLevelFailoverConfigWithAccountRefresh(
+                latestIsEnabled: false,
+                latestDisableCrossRegionalHedging: false);
+
+            TestRequestInvokerHandler handler = new TestRequestInvokerHandler(mockCosmosClient);
+
+            using ResponseMessage response = await SendReadRequestAsync(handler);
+            AssertNoHedgingDisabledByGatewayDiagnostic(response);
+        }
+
+        [TestMethod]
+        public async Task RequestInvokerHandler_FlagTrue_NoEffectiveStrategy_DoesNotConsumeDiagnosticsMarker()
+        {
+            using CosmosClient mockCosmosClient = MockCosmosUtil.CreateMockCosmosClient();
+            mockCosmosClient.DocumentClient.UpdatePartitionLevelFailoverConfigWithAccountRefresh(
+                latestIsEnabled: false,
+                latestDisableCrossRegionalHedging: true);
+
+            TestRequestInvokerHandler handler = new TestRequestInvokerHandler(mockCosmosClient);
+
+            using ResponseMessage noStrategyResponse = await SendReadRequestAsync(handler);
+            AssertNoHedgingDisabledByGatewayDiagnostic(noStrategyResponse);
+
+            using ResponseMessage enabledStrategyResponse = await SendReadRequestAsync(
+                handler,
+                CreateCustomerHedgingStrategy());
+            AssertHedgingDisabledByGatewayDiagnostic(enabledStrategyResponse);
+        }
+
+        [TestMethod]
+        public async Task RequestInvokerHandler_FlagTrue_PerRequestDisabledStrategy_DoesNotConsumeDiagnosticsMarker()
+        {
+            using CosmosClient mockCosmosClient = MockCosmosUtil.CreateMockCosmosClient();
+            mockCosmosClient.DocumentClient.ConnectionPolicy.AvailabilityStrategy = CreateCustomerHedgingStrategy();
+            mockCosmosClient.DocumentClient.UpdatePartitionLevelFailoverConfigWithAccountRefresh(
+                latestIsEnabled: false,
+                latestDisableCrossRegionalHedging: true);
+
+            TestRequestInvokerHandler handler = new TestRequestInvokerHandler(mockCosmosClient);
+
+            using ResponseMessage disabledStrategyResponse = await SendReadRequestAsync(
+                handler,
+                AvailabilityStrategy.DisabledStrategy());
+            AssertNoHedgingDisabledByGatewayDiagnostic(disabledStrategyResponse);
+
+            using ResponseMessage enabledStrategyResponse = await SendReadRequestAsync(
+                handler,
+                CreateCustomerHedgingStrategy());
+            AssertHedgingDisabledByGatewayDiagnostic(enabledStrategyResponse);
+        }
+
+        [TestMethod]
+        public async Task RequestInvokerHandler_FlagTrue_DocumentCreate_DoesNotConsumeDiagnosticsMarker()
+        {
+            using CosmosClient mockCosmosClient = MockCosmosUtil.CreateMockCosmosClient();
+            mockCosmosClient.DocumentClient.ConnectionPolicy.AvailabilityStrategy = CreateCustomerHedgingStrategy();
+            mockCosmosClient.DocumentClient.UpdatePartitionLevelFailoverConfigWithAccountRefresh(
+                latestIsEnabled: false,
+                latestDisableCrossRegionalHedging: true);
+
+            TestRequestInvokerHandler handler = new TestRequestInvokerHandler(mockCosmosClient);
+
+            using ResponseMessage createResponse = await SendRequestAsync(
+                handler,
+                ResourceType.Document,
+                OperationType.Create);
+            AssertNoHedgingDisabledByGatewayDiagnostic(createResponse);
+
+            using ResponseMessage readResponse = await SendReadRequestAsync(handler);
+            AssertHedgingDisabledByGatewayDiagnostic(readResponse);
+        }
+
+        [TestMethod]
+        public async Task RequestInvokerHandler_FlagTrue_NonDocumentRead_DoesNotConsumeDiagnosticsMarker()
+        {
+            using CosmosClient mockCosmosClient = MockCosmosUtil.CreateMockCosmosClient();
+            mockCosmosClient.DocumentClient.ConnectionPolicy.AvailabilityStrategy = CreateCustomerHedgingStrategy();
+            mockCosmosClient.DocumentClient.UpdatePartitionLevelFailoverConfigWithAccountRefresh(
+                latestIsEnabled: false,
+                latestDisableCrossRegionalHedging: true);
+
+            TestRequestInvokerHandler handler = new TestRequestInvokerHandler(mockCosmosClient);
+
+            using ResponseMessage databaseReadResponse = await SendRequestAsync(
+                handler,
+                ResourceType.Database,
+                OperationType.Read);
+            AssertNoHedgingDisabledByGatewayDiagnostic(databaseReadResponse);
+
+            using ResponseMessage documentReadResponse = await SendReadRequestAsync(handler);
+            AssertHedgingDisabledByGatewayDiagnostic(documentReadResponse);
+        }
+
+        [TestMethod]
+        public async Task RequestInvokerHandler_FlagTrueFalseTrue_ReEmitsDiagnosticsAfterFlagCycle()
+        {
+            using CosmosClient mockCosmosClient = MockCosmosUtil.CreateMockCosmosClient();
+            mockCosmosClient.DocumentClient.ConnectionPolicy.AvailabilityStrategy = CreateCustomerHedgingStrategy();
+            TestRequestInvokerHandler handler = new TestRequestInvokerHandler(mockCosmosClient);
+
+            mockCosmosClient.DocumentClient.UpdatePartitionLevelFailoverConfigWithAccountRefresh(
+                latestIsEnabled: false,
+                latestDisableCrossRegionalHedging: true);
+
+            using ResponseMessage firstTrueResponse = await SendReadRequestAsync(handler);
+            AssertHedgingDisabledByGatewayDiagnostic(firstTrueResponse);
+
+            mockCosmosClient.DocumentClient.UpdatePartitionLevelFailoverConfigWithAccountRefresh(
+                latestIsEnabled: false,
+                latestDisableCrossRegionalHedging: false);
+
+            using ResponseMessage falseResponse = await SendReadRequestAsync(handler);
+            AssertNoHedgingDisabledByGatewayDiagnostic(falseResponse);
+
+            mockCosmosClient.DocumentClient.UpdatePartitionLevelFailoverConfigWithAccountRefresh(
+                latestIsEnabled: false,
+                latestDisableCrossRegionalHedging: true);
+
+            using ResponseMessage secondTrueResponse = await SendReadRequestAsync(handler);
+            AssertHedgingDisabledByGatewayDiagnostic(secondTrueResponse);
+        }
+
+        [TestMethod]
+        public async Task RequestInvokerHandler_FlagTrue_ConcurrentFirstSuppressedRequests_EmitsDiagnosticsOnce()
+        {
+            using CosmosClient mockCosmosClient = MockCosmosUtil.CreateMockCosmosClient();
+            mockCosmosClient.DocumentClient.ConnectionPolicy.AvailabilityStrategy = CreateCustomerHedgingStrategy();
+            mockCosmosClient.DocumentClient.UpdatePartitionLevelFailoverConfigWithAccountRefresh(
+                latestIsEnabled: false,
+                latestDisableCrossRegionalHedging: true);
+
+            TestRequestInvokerHandler handler = new TestRequestInvokerHandler(mockCosmosClient);
+            using ManualResetEventSlim startGate = new ManualResetEventSlim(false);
+            Task<bool>[] requests = Enumerable
+                .Range(0, 16)
+                .Select(_ => Task.Run(() =>
+                {
+                    startGate.Wait();
+
+                    using ITrace trace = Trace.GetRootTrace("Gateway hedging diagnostics concurrency test");
+                    using RequestMessage request = CreateReadRequest(trace);
+
+                    AvailabilityStrategyInternal resolved = handler.AvailabilityStrategy(request);
+                    Assert.IsNull(
+                        resolved,
+                        "Gateway operator override must suppress hedging for every concurrent first request");
+
+                    return TryGetBooleanTraceDatumValue(trace, HedgingDisabledByGatewayDiagnosticsKey, out bool value)
+                        && value;
+                }))
+                .ToArray();
+
+            startGate.Set();
+            bool[] emittedDiagnostics = await Task.WhenAll(requests);
+
+            Assert.AreEqual(
+                1,
+                emittedDiagnostics.Count(emitted => emitted),
+                "Exactly one concurrent first suppressed request should consume the one-shot diagnostics marker");
+        }
+
+        [TestMethod]
+        public void DocumentClient_ObservedSuppressionThenFlagFalse_DiagnosticMarkerStillConsumable()
+        {
+            using CosmosClient mockCosmosClient = MockCosmosUtil.CreateMockCosmosClient();
+            mockCosmosClient.DocumentClient.UpdatePartitionLevelFailoverConfigWithAccountRefresh(
+                latestIsEnabled: false,
+                latestDisableCrossRegionalHedging: true);
+
+            Assert.IsTrue(
+                mockCosmosClient.DocumentClient.IsHedgingDisabledByGateway,
+                "Pre-condition: request path observed gateway suppression as active");
+            Assert.IsTrue(
+                mockCosmosClient.DocumentClient.TryGetHedgingDisabledByGatewayDiagnosticGeneration(out long generation),
+                "Pre-condition: request path captured the active diagnostics generation");
+
+            mockCosmosClient.DocumentClient.UpdatePartitionLevelFailoverConfigWithAccountRefresh(
+                latestIsEnabled: false,
+                latestDisableCrossRegionalHedging: false);
+
+            Assert.IsFalse(
+                mockCosmosClient.DocumentClient.IsHedgingDisabledByGateway,
+                "False transition should unpublish suppression for later requests");
+
+            Assert.IsTrue(
+                mockCosmosClient.DocumentClient.TryConsumeHedgingDisabledByGatewayDiagnosticForSuppressedRequest(generation),
+                "A request that already observed suppression before the false transition should still emit diagnostics");
+
+            Assert.IsFalse(
+                mockCosmosClient.DocumentClient.TryConsumeHedgingDisabledByGatewayDiagnosticForSuppressedRequest(generation),
+                "The diagnostics marker must remain one-shot after the racing suppressed request consumes it");
+        }
+
+        [TestMethod]
+        public void DocumentClient_ObservedSuppressionThenFlagFalseTrue_DoesNotConsumeNewCycleMarker()
+        {
+            using CosmosClient mockCosmosClient = MockCosmosUtil.CreateMockCosmosClient();
+            mockCosmosClient.DocumentClient.UpdatePartitionLevelFailoverConfigWithAccountRefresh(
+                latestIsEnabled: false,
+                latestDisableCrossRegionalHedging: true);
+
+            Assert.IsTrue(
+                mockCosmosClient.DocumentClient.TryGetHedgingDisabledByGatewayDiagnosticGeneration(out long firstGeneration),
+                "Pre-condition: stale request captured the first active diagnostics generation");
+
+            mockCosmosClient.DocumentClient.UpdatePartitionLevelFailoverConfigWithAccountRefresh(
+                latestIsEnabled: false,
+                latestDisableCrossRegionalHedging: false);
+            mockCosmosClient.DocumentClient.UpdatePartitionLevelFailoverConfigWithAccountRefresh(
+                latestIsEnabled: false,
+                latestDisableCrossRegionalHedging: true);
+
+            Assert.IsTrue(
+                mockCosmosClient.DocumentClient.TryGetHedgingDisabledByGatewayDiagnosticGeneration(out long secondGeneration),
+                "Pre-condition: later request captured the second active diagnostics generation");
+            Assert.AreNotEqual(
+                firstGeneration,
+                secondGeneration,
+                "A false -> true cycle must publish a distinct diagnostics generation");
+
+            Assert.IsTrue(
+                mockCosmosClient.DocumentClient.TryConsumeHedgingDisabledByGatewayDiagnosticForSuppressedRequest(firstGeneration),
+                "A stale request can still consume the marker for the generation it observed");
+
+            Assert.IsTrue(
+                mockCosmosClient.DocumentClient.TryConsumeHedgingDisabledByGatewayDiagnosticForSuppressedRequest(secondGeneration),
+                "The stale request must not consume the marker for the later true cycle");
+
+            Assert.IsFalse(
+                mockCosmosClient.DocumentClient.TryConsumeHedgingDisabledByGatewayDiagnosticForSuppressedRequest(secondGeneration),
+                "The later true-cycle diagnostics marker must remain one-shot");
+        }
+
         private static DocumentClient CreateClient(ConnectionPolicy policy)
         {
             return new DocumentClient(new Uri(AccountEndpoint), AccountKey, policy);
@@ -362,6 +625,135 @@ namespace Microsoft.Azure.Cosmos.Tests
         private static AvailabilityStrategy GetCustomerStashedStrategy(DocumentClient client)
         {
             return client.CustomerConfiguredAvailabilityStrategyForTests;
+        }
+
+        private static CrossRegionHedgingAvailabilityStrategy CreateCustomerHedgingStrategy()
+        {
+            return new CrossRegionHedgingAvailabilityStrategy(
+                threshold: TimeSpan.FromMilliseconds(500),
+                thresholdStep: TimeSpan.FromMilliseconds(100));
+        }
+
+        private static async Task<ResponseMessage> SendReadRequestAsync(
+            RequestInvokerHandler handler,
+            AvailabilityStrategy availabilityStrategy = null)
+        {
+            return await SendRequestAsync(
+                handler,
+                ResourceType.Document,
+                OperationType.Read,
+                availabilityStrategy);
+        }
+
+        private static async Task<ResponseMessage> SendRequestAsync(
+            RequestInvokerHandler handler,
+            ResourceType resourceType,
+            OperationType operationType,
+            AvailabilityStrategy availabilityStrategy = null)
+        {
+            ITrace trace = Trace.GetRootTrace("Gateway hedging diagnostics test");
+            RequestMessage request = CreateRequest(trace, resourceType, operationType);
+            request.RequestOptions.AvailabilityStrategy = availabilityStrategy;
+            return await handler.SendAsync(request, CancellationToken.None);
+        }
+
+        private static RequestMessage CreateReadRequest(ITrace trace)
+        {
+            return CreateRequest(trace, ResourceType.Document, OperationType.Read);
+        }
+
+        private static RequestMessage CreateRequest(
+            ITrace trace,
+            ResourceType resourceType,
+            OperationType operationType)
+        {
+            RequestMessage request = new RequestMessage(
+                operationType == OperationType.Create ? HttpMethod.Post : HttpMethod.Get,
+                GetResourceLink(resourceType),
+                trace)
+            {
+                ResourceType = resourceType,
+                OperationType = operationType,
+                RequestOptions = new RequestOptions()
+            };
+
+            if (resourceType == ResourceType.Document)
+            {
+                request.Headers.PartitionKey = "[\"testPk\"]";
+            }
+
+            return request;
+        }
+
+        private static string GetResourceLink(ResourceType resourceType)
+        {
+            return resourceType == ResourceType.Database
+                ? "/dbs/testdb"
+                : "/dbs/testdb/colls/testcontainer/docs/testId";
+        }
+
+        private static void AssertHedgingDisabledByGatewayDiagnostic(ResponseMessage response)
+        {
+            Assert.IsTrue(
+                TryGetHedgingDisabledByGatewayDiagnostic(response, out object value),
+                $"Expected {HedgingDisabledByGatewayDiagnosticsKey} to be present in CosmosDiagnostics");
+            Assert.IsInstanceOfType(
+                value,
+                typeof(BooleanTraceDatum),
+                $"Expected {HedgingDisabledByGatewayDiagnosticsKey} to be represented as a typed boolean trace datum");
+            Assert.IsTrue(((BooleanTraceDatum)value).Value);
+            StringAssert.Contains(
+                response.Diagnostics.ToString(),
+                $"\"{HedgingDisabledByGatewayDiagnosticsKey}\":true");
+        }
+
+        private static void AssertNoHedgingDisabledByGatewayDiagnostic(ResponseMessage response)
+        {
+            Assert.IsFalse(
+                TryGetHedgingDisabledByGatewayDiagnostic(response, out _),
+                $"Did not expect {HedgingDisabledByGatewayDiagnosticsKey} to be present in CosmosDiagnostics");
+            Assert.IsFalse(
+                response.Diagnostics.ToString().Contains(HedgingDisabledByGatewayDiagnosticsKey),
+                $"Did not expect {HedgingDisabledByGatewayDiagnosticsKey} to be present in CosmosDiagnostics text");
+        }
+
+        private static bool TryGetHedgingDisabledByGatewayDiagnostic(ResponseMessage response, out object value)
+        {
+            CosmosTraceDiagnostics diagnostics = (CosmosTraceDiagnostics)response.Diagnostics;
+            return diagnostics.Value.TryGetDatum(HedgingDisabledByGatewayDiagnosticsKey, out value);
+        }
+
+        private static bool TryGetBooleanTraceDatumValue(ITrace trace, string key, out bool value)
+        {
+            value = false;
+            if (!trace.TryGetDatum(key, out object datum)
+                || datum is not BooleanTraceDatum booleanTraceDatum)
+            {
+                return false;
+            }
+
+            value = booleanTraceDatum.Value;
+            return true;
+        }
+
+        private sealed class TestRequestInvokerHandler : RequestInvokerHandler
+        {
+            public TestRequestInvokerHandler(CosmosClient client)
+                : base(
+                    client,
+                    requestedClientConsistencyLevel: null,
+                    requestedClientReadConsistencyStrategy: null,
+                    requestedClientPriorityLevel: null,
+                    requestedClientThroughputBucket: null)
+            {
+            }
+
+            public override Task<ResponseMessage> BaseSendAsync(
+                RequestMessage request,
+                CancellationToken cancellationToken)
+            {
+                return Task.FromResult(new ResponseMessage(HttpStatusCode.OK, request));
+            }
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Tracing/TraceWriterBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Tracing/TraceWriterBaselineTests.cs
@@ -239,6 +239,38 @@ namespace Microsoft.Azure.Cosmos.Tests.Tracing
             }
             //----------------------------------------------------------------
 
+            //----------------------------------------------------------------
+            //  Typed Boolean Datum
+            //----------------------------------------------------------------
+            {
+                startLineNumber = GetLineNumber();
+                TraceForBaselineTesting rootTrace;
+                using (rootTrace = TraceForBaselineTesting.GetRootTrace())
+                {
+                    rootTrace.AddDatum(TraceDatumKeys.HedgingDisabledByGateway, new BooleanTraceDatum(true));
+                }
+                endLineNumber = GetLineNumber();
+
+                inputs.Add(new Input("Typed Boolean Datum", rootTrace, startLineNumber, endLineNumber));
+            }
+            //----------------------------------------------------------------
+
+            //----------------------------------------------------------------
+            //  Generic Boolean Datum
+            //----------------------------------------------------------------
+            {
+                startLineNumber = GetLineNumber();
+                TraceForBaselineTesting rootTrace;
+                using (rootTrace = TraceForBaselineTesting.GetRootTrace())
+                {
+                    rootTrace.AddDatum("Generic bool compatibility", true);
+                }
+                endLineNumber = GetLineNumber();
+
+                inputs.Add(new Input("Generic Boolean Datum", rootTrace, startLineNumber, endLineNumber));
+            }
+            //----------------------------------------------------------------
+
             this.ExecuteTestSuite(inputs);
         }
 

--- a/changelog.md
+++ b/changelog.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Features Added
 
 - [5829](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5829) Routing: Adds Gateway Account Property Flag for Dynamic Hedging Control. Introduces a Gateway-controlled `disableCrossRegionalHedging` account property that lets operators dynamically disable PPAF cross-region hedging (and any customer-configured `AvailabilityStrategy`) without rolling back PPAF entirely. The SDK reconciles `ConnectionPolicy.AvailabilityStrategy` against the Gateway-supplied flag on each account-properties refresh; toggling the flag back to `false` restores the customer-configured strategy or rebuilds the SDK default.
+- [5894](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5894) Diagnostics: Adds a CosmosDiagnostics marker for gateway-driven hedging suppression so the first suppressed request reports `db.cosmosdb.hedging_disabled_by_gateway` as a JSON boolean.
 
 #### Breaking Changes
 


### PR DESCRIPTION
## Description

Fixes #5871.

Adds customer-visible diagnostics for gateway-driven hedging suppression. When the gateway disable flag first suppresses hedging for a client, `CosmosDiagnostics` now includes `db.cosmosdb.hedging_disabled_by_gateway = true`.

The marker is intentionally one-shot per gateway true-cycle: it is emitted on the first suppressed request for a client, remains quiet for later suppressed requests while the flag stays true, and is emitted again after the flag cycles back to false and then true.

The marker is emitted only when the gateway suppresses an availability strategy that would otherwise hedge that specific request. The diagnostics contract uses a typed internal boolean trace datum for this marker, so the new field serializes as a JSON boolean without changing the existing fallback behavior for generic `bool` trace data.

## Type of change

- [x] Bug fix / supportability improvement (non-breaking change)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Changes

- `DocumentClient`: tracks gateway suppression with a monotonic diagnostics generation instead of a shared bit, so stale requests from an older true-cycle cannot consume the marker for a newer true-cycle; exposes the gateway-suppressed stashed strategy through a small internal accessor.
- `RequestInvokerHandler`: emits the diagnostics marker only after gateway suppression is active and the effective availability strategy would hedge the specific request; non-hedgeable requests such as document creates or non-document reads do not consume the marker.
- `TraceWriter`: adds an internal `BooleanTraceDatum` path for JSON boolean diagnostics while preserving the existing generic `bool` fallback as string output.
- Tests and baselines: adds regression coverage for first emission, no emission when disabled, no marker consumption without an enabled strategy, no marker consumption for non-hedgeable requests, re-emission after a flag cycle, concurrent first suppressed requests, observed-true / transition-to-false races, stale true -> false -> true request races, customer-visible emulator diagnostics output, typed boolean trace serialization, and raw generic bool compatibility.

## Acceptance coverage

| Acceptance criterion | Coverage |
| --- | --- |
| First suppressed request emits `db.cosmosdb.hedging_disabled_by_gateway = true` | `RequestInvokerHandler_FlagTrue_FirstSuppressedRequest_EmitsDiagnosticsOnce`; emulator test `GatewayDrivenHedgingSuppressionDiagnostics_EmitsOnceAndReEmitsAfterFlagCycle` validates the customer-visible `CosmosDiagnostics.ToString()` output |
| Flag false does not emit the marker | `RequestInvokerHandler_FlagFalse_DoesNotEmitDiagnostics`; emulator test covers the initial false/inactive state and the explicit false state after a flag cycle |
| Requests with no effective strategy or per-request `DisabledStrategy()` do not consume the marker | `RequestInvokerHandler_FlagTrue_NoEffectiveStrategy_DoesNotConsumeDiagnosticsMarker`; `RequestInvokerHandler_FlagTrue_PerRequestDisabledStrategy_DoesNotConsumeDiagnosticsMarker` |
| Non-hedgeable requests do not consume the marker | `RequestInvokerHandler_FlagTrue_DocumentCreate_DoesNotConsumeDiagnosticsMarker`; `RequestInvokerHandler_FlagTrue_NonDocumentRead_DoesNotConsumeDiagnosticsMarker` |
| Later suppressed requests while the flag remains true do not re-emit | `RequestInvokerHandler_FlagTrue_FirstSuppressedRequest_EmitsDiagnosticsOnce`; emulator test verifies the second suppressed request has no marker |
| True -> false -> true emits again | `RequestInvokerHandler_FlagTrueFalseTrue_ReEmitsDiagnosticsAfterFlagCycle`; emulator test verifies the second true cycle emits again |
| Request observes true, then a false transition races before diagnostic consume | `DocumentClient_ObservedSuppressionThenFlagFalse_DiagnosticMarkerStillConsumable` |
| Stale request from an older true-cycle cannot consume the newer true-cycle marker | `DocumentClient_ObservedSuppressionThenFlagFalseTrue_DoesNotConsumeNewCycleMarker` |
| Concurrent first suppressed requests emit once | `RequestInvokerHandler_FlagTrue_ConcurrentFirstSuppressedRequests_EmitsDiagnosticsOnce` |
| Diagnostics baseline serializes the marker as a JSON boolean and keeps raw generic bool compatibility | `TraceWriterBaselineTests.Serialization` baseline includes typed `BooleanTraceDatum` as JSON boolean and raw generic bool as string `"True"` |

## Behavior

| State | Result |
| --- | --- |
| Gateway suppression inactive | No diagnostics marker is emitted |
| Gateway suppression active but no effective enabled availability strategy exists | No diagnostics marker is emitted and the marker is left available for the first real suppressed hedge |
| Gateway suppression active but the specific request would not hedge | No diagnostics marker is emitted and the marker is left available for the first real suppressed hedge |
| First suppressed hedgeable request after suppression becomes active | `db.cosmosdb.hedging_disabled_by_gateway = true` is emitted |
| Later suppressed requests while suppression remains active | Marker is not re-emitted |
| Suppression cycles inactive then active again | Marker is emitted again on the next suppressed hedgeable request for the new true-cycle |
| Request already observed suppression while the flag concurrently transitions false | The suppressed request can still consume and emit the one-shot marker for its observed generation |
| Request from an older true-cycle races with a newer true-cycle | The stale request cannot consume the newer true-cycle marker |
| Concurrent first suppressed requests | Exactly one request consumes and emits the one-shot marker for the observed generation |

## Validation

The validation focused on the runtime diagnostics path, emulator compile coverage, and the trace serialization contract.

- `GatewayHedgingOverrideTests`: 23/23 passed
- `Microsoft.Azure.Cosmos.EmulatorTests.csproj` build: passed
- `GatewayDrivenHedgingSuppressionDiagnostics_EmitsOnceAndReEmitsAfterFlagCycle`: passed in the fork emulator validation
- `git diff --check`: clean

## Changelog

- [x] Added an entry under `### Unreleased` / `#### Features Added` for the diagnostics/supportability change.
