### PR TITLE
[Internal] Distributed Transaction: Refactors APIs to accept Container reference

### DIFF
--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedReadTransaction.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedReadTransaction.cs
@@ -24,15 +24,13 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Adds a read operation to the distributed transaction.
         /// </summary>
-        /// <param name="database">The name of the database containing the container.</param>
-        /// <param name="collection">The name of the container where the item exists.</param>
+        /// <param name="container">The <see cref="Container"/> reference where the item exists.</param>
         /// <param name="partitionKey">The partition key for the item.</param>
         /// <param name="id">The unique identifier of the item to read.</param>
         /// <param name="requestOptions">Options for the read operation.</param>
         /// <returns>The current <see cref="DistributedReadTransaction"/> instance for method chaining.</returns>
         public abstract DistributedReadTransaction ReadItem(
-            string database,
-            string collection,
+            Container container,
             PartitionKey partitionKey,
             string id,
             DistributedTransactionRequestOptions requestOptions = null);

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedReadTransactionCore.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedReadTransactionCore.cs
@@ -27,15 +27,15 @@ namespace Microsoft.Azure.Cosmos
             string id,
             DistributedTransactionRequestOptions requestOptions = null)
         {
-            DistributedReadTransactionCore.ValidateContainerReference(container);
+            (string databaseId, string containerId) = DistributedTransactionConstants.ValidateAndUnpackContainer(container, this.clientContext.Client);
             DistributedReadTransactionCore.ValidateItemId(id);
 
             this.operations.Add(
                 new DistributedTransactionOperation(
                     operationType: OperationType.Read,
                     operationIndex: this.operations.Count,
-                    database: container.Database.Id,
-                    container: container.Id,
+                    database: databaseId,
+                    container: containerId,
                     partitionKey: partitionKey,
                     id: id,
                     requestOptions: requestOptions));
@@ -51,35 +51,6 @@ namespace Microsoft.Azure.Cosmos
                 clientContext: this.clientContext);
 
             return await committer.CommitTransactionAsync(cancellationToken);
-        }
-
-        private static void ValidateContainerReference(Container container)
-        {
-            if (container == null)
-            {
-                throw new ArgumentNullException(nameof(container));
-            }
-
-            if (string.IsNullOrWhiteSpace(container.Id))
-            {
-                throw new ArgumentException(
-                    "Container reference must have a non-empty Id.",
-                    nameof(container));
-            }
-
-            if (container.Database == null)
-            {
-                throw new ArgumentException(
-                    "Container reference must expose a non-null Database.",
-                    nameof(container));
-            }
-
-            if (string.IsNullOrWhiteSpace(container.Database.Id))
-            {
-                throw new ArgumentException(
-                    "Container reference must have a non-empty Database.Id.",
-                    nameof(container));
-            }
         }
 
         private static void ValidateItemId(string id)

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedReadTransactionCore.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedReadTransactionCore.cs
@@ -22,21 +22,20 @@ namespace Microsoft.Azure.Cosmos
         }
 
         public override DistributedReadTransaction ReadItem(
-            string database,
-            string collection,
+            Container container,
             PartitionKey partitionKey,
             string id,
             DistributedTransactionRequestOptions requestOptions = null)
         {
-            DistributedReadTransactionCore.ValidateContainerReference(database, collection);
+            DistributedReadTransactionCore.ValidateContainerReference(container);
             DistributedReadTransactionCore.ValidateItemId(id);
 
             this.operations.Add(
                 new DistributedTransactionOperation(
                     operationType: OperationType.Read,
                     operationIndex: this.operations.Count,
-                    database: database,
-                    container: collection,
+                    database: container.Database.Id,
+                    container: container.Id,
                     partitionKey: partitionKey,
                     id: id,
                     requestOptions: requestOptions));
@@ -54,16 +53,32 @@ namespace Microsoft.Azure.Cosmos
             return await committer.CommitTransactionAsync(cancellationToken);
         }
 
-        private static void ValidateContainerReference(string database, string collection)
+        private static void ValidateContainerReference(Container container)
         {
-            if (string.IsNullOrWhiteSpace(database))
+            if (container == null)
             {
-                throw new ArgumentNullException(nameof(database));
+                throw new ArgumentNullException(nameof(container));
             }
 
-            if (string.IsNullOrWhiteSpace(collection))
+            if (string.IsNullOrWhiteSpace(container.Id))
             {
-                throw new ArgumentNullException(nameof(collection));
+                throw new ArgumentException(
+                    "Container reference must have a non-empty Id.",
+                    nameof(container));
+            }
+
+            if (container.Database == null)
+            {
+                throw new ArgumentException(
+                    "Container reference must expose a non-null Database.",
+                    nameof(container));
+            }
+
+            if (string.IsNullOrWhiteSpace(container.Database.Id))
+            {
+                throw new ArgumentException(
+                    "Container reference must have a non-empty Database.Id.",
+                    nameof(container));
             }
         }
 

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionConstants.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionConstants.cs
@@ -4,6 +4,7 @@
 
 namespace Microsoft.Azure.Cosmos
 {
+    using System;
     using Microsoft.Azure.Documents;
 
     internal static class DistributedTransactionConstants
@@ -25,6 +26,44 @@ namespace Microsoft.Azure.Cosmos
         internal static string GetCollectionFullName(string database, string container)
         {
             return $"dbs/{database}/colls/{container}";
+        }
+
+        internal static (string databaseId, string containerId) ValidateAndUnpackContainer(
+            Container container,
+            CosmosClient expectedClient)
+        {
+            if (container == null)
+            {
+                throw new ArgumentNullException(nameof(container));
+            }
+            Database database = container.Database;
+            if (database == null)
+            {
+                throw new ArgumentException("Container reference must expose a non-null Database.", nameof(container));
+            }
+
+            string containerId = container.Id;
+            string databaseId = database.Id;
+
+            if (string.IsNullOrWhiteSpace(containerId))
+            {
+                throw new ArgumentException("Container reference must have a non-empty Id.", nameof(container));
+            }
+
+            if (string.IsNullOrWhiteSpace(databaseId))
+            {
+                throw new ArgumentException("Container reference must have a non-empty Database.Id.", nameof(container));
+            }
+
+            CosmosClient owner = database.Client;
+            if (!object.ReferenceEquals(owner, expectedClient))
+            {
+                throw new ArgumentException(
+                    "Container must belong to the same CosmosClient instance that created this distributed transaction.",
+                    nameof(container));
+            }
+
+            return (databaseId, containerId);
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedWriteTransaction.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedWriteTransaction.cs
@@ -21,16 +21,14 @@ namespace Microsoft.Azure.Cosmos
         /// Adds a create operation to the distributed transaction.
         /// </summary>
         /// <typeparam name="T">The type of the resource to create.</typeparam>
-        /// <param name="database">The name of the database containing the container.</param>
-        /// <param name="collection">The name of the container where the item will be created.</param>
+        /// <param name="container">The <see cref="Container"/> reference where the item will be created.</param>
         /// <param name="partitionKey">The partition key for the item.</param>
         /// <param name="id">The unique identifier of the item to create.</param>
         /// <param name="resource">The resource to create.</param>
         /// <param name="requestOptions">Options for the create operation.</param>
         /// <returns>The current <see cref="DistributedWriteTransaction"/> instance for method chaining.</returns>
         public abstract DistributedWriteTransaction CreateItem<T>(
-            string database,
-            string collection,
+            Container container,
             PartitionKey partitionKey,
             string id,
             T resource,
@@ -39,16 +37,14 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Adds a create operation to the distributed transaction using a pre-serialized JSON stream.
         /// </summary>
-        /// <param name="database">The name of the database containing the container.</param>
-        /// <param name="collection">The name of the container where the item will be created.</param>
+        /// <param name="container">The <see cref="Container"/> reference where the item will be created.</param>
         /// <param name="partitionKey">The partition key for the item.</param>
         /// <param name="id">The unique identifier of the item to create.</param>
         /// <param name="streamPayload">A <see cref="Stream"/> containing the JSON serialization of the item.</param>
         /// <param name="requestOptions">Options for the create operation.</param>
         /// <returns>The current <see cref="DistributedWriteTransaction"/> instance for method chaining.</returns>
         public abstract DistributedWriteTransaction CreateItemStream(
-            string database,
-            string collection,
+            Container container,
             PartitionKey partitionKey,
             string id,
             Stream streamPayload,
@@ -58,16 +54,14 @@ namespace Microsoft.Azure.Cosmos
         /// Adds a replace operation to the distributed transaction.
         /// </summary>
         /// <typeparam name="T">The type of the resource to replace.</typeparam>
-        /// <param name="database">The name of the database containing the container.</param>
-        /// <param name="collection">The name of the container where the item exists.</param>
+        /// <param name="container">The <see cref="Container"/> reference where the item exists.</param>
         /// <param name="partitionKey">The partition key for the item.</param>
         /// <param name="id">The unique identifier of the item to replace.</param>
         /// <param name="resource">The resource with updated values.</param>
         /// <param name="requestOptions">Options for the replace operation.</param>
         /// <returns>The current <see cref="DistributedWriteTransaction"/> instance for method chaining.</returns>
         public abstract DistributedWriteTransaction ReplaceItem<T>(
-            string database,
-            string collection,
+            Container container,
             PartitionKey partitionKey,
             string id,
             T resource,
@@ -76,16 +70,14 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Adds a replace operation to the distributed transaction using a pre-serialized JSON stream.
         /// </summary>
-        /// <param name="database">The name of the database containing the container.</param>
-        /// <param name="collection">The name of the container where the item exists.</param>
+        /// <param name="container">The <see cref="Container"/> reference where the item exists.</param>
         /// <param name="partitionKey">The partition key for the item.</param>
         /// <param name="id">The unique identifier of the item to replace.</param>
         /// <param name="streamPayload">A <see cref="Stream"/> containing the JSON serialization of the replacement item.</param>
         /// <param name="requestOptions">Options for the replace operation.</param>
         /// <returns>The current <see cref="DistributedWriteTransaction"/> instance for method chaining.</returns>
         public abstract DistributedWriteTransaction ReplaceItemStream(
-            string database,
-            string collection,
+            Container container,
             PartitionKey partitionKey,
             string id,
             Stream streamPayload,
@@ -94,15 +86,13 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Adds a delete operation to the distributed transaction.
         /// </summary>
-        /// <param name="database">The name of the database containing the container.</param>
-        /// <param name="collection">The name of the container where the item exists.</param>
+        /// <param name="container">The <see cref="Container"/> reference where the item exists.</param>
         /// <param name="partitionKey">The partition key for the item.</param>
         /// <param name="id">The unique identifier of the item to delete.</param>
         /// <param name="requestOptions">Options for the delete operation.</param>
         /// <returns>The current <see cref="DistributedWriteTransaction"/> instance for method chaining.</returns>
         public abstract DistributedWriteTransaction DeleteItem(
-            string database,
-            string collection,
+            Container container,
             PartitionKey partitionKey,
             string id,
             DistributedTransactionRequestOptions requestOptions = null);
@@ -110,16 +100,14 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Adds a patch operation to the distributed transaction.
         /// </summary>
-        /// <param name="database">The name of the database containing the container.</param>
-        /// <param name="collection">The name of the container where the item exists.</param>
+        /// <param name="container">The <see cref="Container"/> reference where the item exists.</param>
         /// <param name="partitionKey">The partition key for the item.</param>
         /// <param name="id">The unique identifier of the item to patch.</param>
         /// <param name="patchOperations">The list of <see cref="PatchOperation"/> to apply to the item.</param>
         /// <param name="requestOptions">Options for the patch operation</param>
         /// <returns>The current <see cref="DistributedWriteTransaction"/> instance for method chaining.</returns>
         public abstract DistributedWriteTransaction PatchItem(
-            string database,
-            string collection,
+            Container container,
             PartitionKey partitionKey,
             string id,
             IReadOnlyList<PatchOperation> patchOperations,
@@ -128,16 +116,14 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Adds a patch operation to the distributed transaction using a pre-serialized JSON patch stream.
         /// </summary>
-        /// <param name="database">The name of the database containing the container.</param>
-        /// <param name="collection">The name of the container where the item exists.</param>
+        /// <param name="container">The <see cref="Container"/> reference where the item exists.</param>
         /// <param name="partitionKey">The partition key for the item.</param>
         /// <param name="id">The unique identifier of the item to patch.</param>
         /// <param name="streamPayload">A <see cref="Stream"/> containing the JSON serialization of the patch operations.</param>
         /// <param name="requestOptions">Options for the patch operation.</param>
         /// <returns>The current <see cref="DistributedWriteTransaction"/> instance for method chaining.</returns>
         public abstract DistributedWriteTransaction PatchItemStream(
-            string database,
-            string collection,
+            Container container,
             PartitionKey partitionKey,
             string id,
             Stream streamPayload,
@@ -148,16 +134,14 @@ namespace Microsoft.Azure.Cosmos
         /// If the item exists, it will be replaced; otherwise, it will be created.
         /// </summary>
         /// <typeparam name="T">The type of the resource to upsert.</typeparam>
-        /// <param name="database">The name of the database containing the container.</param>
-        /// <param name="collection">The name of the container where the item will be upserted.</param>
+        /// <param name="container">The <see cref="Container"/> reference where the item will be upserted.</param>
         /// <param name="partitionKey">The partition key for the item.</param>
         /// <param name="id">The unique identifier of the item to upsert.</param>
         /// <param name="resource">The resource to upsert.</param>
         /// <param name="requestOptions">Options for the upsert operation.</param>
         /// <returns>The current <see cref="DistributedWriteTransaction"/> instance for method chaining.</returns>
         public abstract DistributedWriteTransaction UpsertItem<T>(
-            string database,
-            string collection,
+            Container container,
             PartitionKey partitionKey,
             string id,
             T resource,
@@ -167,16 +151,14 @@ namespace Microsoft.Azure.Cosmos
         /// Adds an upsert operation to the distributed transaction using a pre-serialized JSON stream.
         /// If the item exists, it will be replaced; otherwise, it will be created.
         /// </summary>
-        /// <param name="database">The name of the database containing the container.</param>
-        /// <param name="collection">The name of the container where the item will be upserted.</param>
+        /// <param name="container">The <see cref="Container"/> reference where the item will be upserted.</param>
         /// <param name="partitionKey">The partition key for the item.</param>
         /// <param name="id">The unique identifier of the item to upsert.</param>
         /// <param name="streamPayload">A <see cref="Stream"/> containing the JSON serialization of the item.</param>
         /// <param name="requestOptions">Options for the upsert operation.</param>
         /// <returns>The current <see cref="DistributedWriteTransaction"/> instance for method chaining.</returns>
         public abstract DistributedWriteTransaction UpsertItemStream(
-            string database,
-            string collection,
+            Container container,
             PartitionKey partitionKey,
             string id,
             Stream streamPayload,

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedWriteTransactionCore.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedWriteTransactionCore.cs
@@ -24,14 +24,13 @@ namespace Microsoft.Azure.Cosmos
         }
 
         public override DistributedWriteTransaction CreateItem<T>(
-            string database,
-            string collection,
+            Container container,
             PartitionKey partitionKey,
             string id,
             T resource,
             DistributedTransactionRequestOptions requestOptions = null)
         {
-            DistributedWriteTransactionCore.ValidateContainerReference(database, collection);
+            DistributedWriteTransactionCore.ValidateContainerReference(container);
             DistributedWriteTransactionCore.ValidateItemId(id);
             DistributedWriteTransactionCore.ValidateResource(resource);
 
@@ -39,8 +38,8 @@ namespace Microsoft.Azure.Cosmos
                 new DistributedTransactionOperation<T>(
                     operationType: OperationType.Create,
                     operationIndex: this.operations.Count,
-                    database,
-                    collection,
+                    container.Database.Id,
+                    container.Id,
                     partitionKey,
                     id,
                     resource,
@@ -49,14 +48,13 @@ namespace Microsoft.Azure.Cosmos
         }
 
         public override DistributedWriteTransaction CreateItemStream(
-            string database,
-            string collection,
+            Container container,
             PartitionKey partitionKey,
             string id,
             Stream streamPayload,
             DistributedTransactionRequestOptions requestOptions = null)
         {
-            DistributedWriteTransactionCore.ValidateContainerReference(database, collection);
+            DistributedWriteTransactionCore.ValidateContainerReference(container);
             DistributedWriteTransactionCore.ValidateItemId(id);
             if (streamPayload == null)
             {
@@ -67,8 +65,8 @@ namespace Microsoft.Azure.Cosmos
                 new DistributedTransactionOperation(
                     operationType: OperationType.Create,
                     operationIndex: this.operations.Count,
-                    database: database,
-                    container: collection,
+                    database: container.Database.Id,
+                    container: container.Id,
                     partitionKey: partitionKey,
                     id: id,
                     requestOptions: requestOptions)
@@ -79,14 +77,13 @@ namespace Microsoft.Azure.Cosmos
         }
 
         public override DistributedWriteTransaction ReplaceItem<T>(
-            string database,
-            string collection,
+            Container container,
             PartitionKey partitionKey,
             string id,
             T resource,
             DistributedTransactionRequestOptions requestOptions = null)
         {
-            DistributedWriteTransactionCore.ValidateContainerReference(database, collection);
+            DistributedWriteTransactionCore.ValidateContainerReference(container);
             DistributedWriteTransactionCore.ValidateItemId(id);
             DistributedWriteTransactionCore.ValidateResource(resource);
 
@@ -94,8 +91,8 @@ namespace Microsoft.Azure.Cosmos
                 new DistributedTransactionOperation<T>(
                     operationType: OperationType.Replace,
                     operationIndex: this.operations.Count,
-                    database,
-                    collection,
+                    container.Database.Id,
+                    container.Id,
                     partitionKey,
                     id,
                     resource,
@@ -104,14 +101,13 @@ namespace Microsoft.Azure.Cosmos
         }
 
         public override DistributedWriteTransaction ReplaceItemStream(
-            string database,
-            string collection,
+            Container container,
             PartitionKey partitionKey,
             string id,
             Stream streamPayload,
             DistributedTransactionRequestOptions requestOptions = null)
         {
-            DistributedWriteTransactionCore.ValidateContainerReference(database, collection);
+            DistributedWriteTransactionCore.ValidateContainerReference(container);
             DistributedWriteTransactionCore.ValidateItemId(id);
             if (streamPayload == null)
             {
@@ -122,8 +118,8 @@ namespace Microsoft.Azure.Cosmos
                 new DistributedTransactionOperation(
                     operationType: OperationType.Replace,
                     operationIndex: this.operations.Count,
-                    database: database,
-                    container: collection,
+                    database: container.Database.Id,
+                    container: container.Id,
                     partitionKey: partitionKey,
                     id: id,
                     requestOptions: requestOptions)
@@ -134,21 +130,20 @@ namespace Microsoft.Azure.Cosmos
         }
 
         public override DistributedWriteTransaction DeleteItem(
-            string database,
-            string collection,
+            Container container,
             PartitionKey partitionKey,
             string id,
             DistributedTransactionRequestOptions requestOptions = null)
         {
-            DistributedWriteTransactionCore.ValidateContainerReference(database, collection);
+            DistributedWriteTransactionCore.ValidateContainerReference(container);
             DistributedWriteTransactionCore.ValidateItemId(id);
 
             this.operations.Add(
                 new DistributedTransactionOperation(
                     operationType: OperationType.Delete,
                     operationIndex: this.operations.Count,
-                    database,
-                    collection,
+                    container.Database.Id,
+                    container.Id,
                     partitionKey,
                     id: id,
                     requestOptions));
@@ -156,14 +151,13 @@ namespace Microsoft.Azure.Cosmos
         }
 
         public override DistributedWriteTransaction PatchItem(
-            string database,
-            string collection,
+            Container container,
             PartitionKey partitionKey,
             string id,
             IReadOnlyList<PatchOperation> patchOperations,
             DistributedTransactionRequestOptions requestOptions = null)
         {
-            DistributedWriteTransactionCore.ValidateContainerReference(database, collection);
+            DistributedWriteTransactionCore.ValidateContainerReference(container);
             DistributedWriteTransactionCore.ValidateItemId(id);
 
             if (patchOperations == null || !patchOperations.Any())
@@ -177,8 +171,8 @@ namespace Microsoft.Azure.Cosmos
                 new DistributedTransactionOperation<PatchSpec>(
                     operationType: OperationType.Patch,
                     operationIndex: this.operations.Count,
-                    database,
-                    collection,
+                    container.Database.Id,
+                    container.Id,
                     partitionKey,
                     id,
                     resource: patchSpec,
@@ -187,14 +181,13 @@ namespace Microsoft.Azure.Cosmos
         }
 
         public override DistributedWriteTransaction PatchItemStream(
-            string database,
-            string collection,
+            Container container,
             PartitionKey partitionKey,
             string id,
             Stream streamPayload,
             DistributedTransactionRequestOptions requestOptions = null)
         {
-            DistributedWriteTransactionCore.ValidateContainerReference(database, collection);
+            DistributedWriteTransactionCore.ValidateContainerReference(container);
             DistributedWriteTransactionCore.ValidateItemId(id);
             if (streamPayload == null)
             {
@@ -205,8 +198,8 @@ namespace Microsoft.Azure.Cosmos
                 new DistributedTransactionOperation(
                     operationType: OperationType.Patch,
                     operationIndex: this.operations.Count,
-                    database: database,
-                    container: collection,
+                    database: container.Database.Id,
+                    container: container.Id,
                     partitionKey: partitionKey,
                     id: id,
                     requestOptions: requestOptions)
@@ -217,14 +210,13 @@ namespace Microsoft.Azure.Cosmos
         }
 
         public override DistributedWriteTransaction UpsertItem<T>(
-            string database,
-            string collection,
+            Container container,
             PartitionKey partitionKey,
             string id,
             T resource,
             DistributedTransactionRequestOptions requestOptions = null)
         {
-            DistributedWriteTransactionCore.ValidateContainerReference(database, collection);
+            DistributedWriteTransactionCore.ValidateContainerReference(container);
             DistributedWriteTransactionCore.ValidateItemId(id);
             DistributedWriteTransactionCore.ValidateResource(resource);
 
@@ -232,8 +224,8 @@ namespace Microsoft.Azure.Cosmos
                 new DistributedTransactionOperation<T>(
                     operationType: OperationType.Upsert,
                     operationIndex: this.operations.Count,
-                    database,
-                    collection,
+                    container.Database.Id,
+                    container.Id,
                     partitionKey,
                     id,
                     resource,
@@ -242,14 +234,13 @@ namespace Microsoft.Azure.Cosmos
         }
 
         public override DistributedWriteTransaction UpsertItemStream(
-            string database,
-            string collection,
+            Container container,
             PartitionKey partitionKey,
             string id,
             Stream streamPayload,
             DistributedTransactionRequestOptions requestOptions = null)
         {
-            DistributedWriteTransactionCore.ValidateContainerReference(database, collection);
+            DistributedWriteTransactionCore.ValidateContainerReference(container);
             DistributedWriteTransactionCore.ValidateItemId(id);
             if (streamPayload == null)
             {
@@ -260,8 +251,8 @@ namespace Microsoft.Azure.Cosmos
                 new DistributedTransactionOperation(
                     operationType: OperationType.Upsert,
                     operationIndex: this.operations.Count,
-                    database: database,
-                    container: collection,
+                    database: container.Database.Id,
+                    container: container.Id,
                     partitionKey: partitionKey,
                     id: id,
                     requestOptions: requestOptions)
@@ -280,16 +271,32 @@ namespace Microsoft.Azure.Cosmos
             return await committer.CommitTransactionAsync(cancellationToken);
         }
 
-        private static void ValidateContainerReference(string database, string collection)
+        private static void ValidateContainerReference(Container container)
         {
-            if (string.IsNullOrWhiteSpace(database))
+            if (container == null)
             {
-                throw new ArgumentNullException(nameof(database));
+                throw new ArgumentNullException(nameof(container));
             }
 
-            if (string.IsNullOrWhiteSpace(collection))
+            if (string.IsNullOrWhiteSpace(container.Id))
             {
-                throw new ArgumentNullException(nameof(collection));
+                throw new ArgumentException(
+                    "Container reference must have a non-empty Id.",
+                    nameof(container));
+            }
+
+            if (container.Database == null)
+            {
+                throw new ArgumentException(
+                    "Container reference must expose a non-null Database.",
+                    nameof(container));
+            }
+
+            if (string.IsNullOrWhiteSpace(container.Database.Id))
+            {
+                throw new ArgumentException(
+                    "Container reference must have a non-empty Database.Id.",
+                    nameof(container));
             }
         }
 

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedWriteTransactionCore.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedWriteTransactionCore.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Azure.Cosmos
             T resource,
             DistributedTransactionRequestOptions requestOptions = null)
         {
-            DistributedWriteTransactionCore.ValidateContainerReference(container);
+            (string databaseId, string containerId) = DistributedTransactionConstants.ValidateAndUnpackContainer(container, this.clientContext.Client);
             DistributedWriteTransactionCore.ValidateItemId(id);
             DistributedWriteTransactionCore.ValidateResource(resource);
 
@@ -38,8 +38,8 @@ namespace Microsoft.Azure.Cosmos
                 new DistributedTransactionOperation<T>(
                     operationType: OperationType.Create,
                     operationIndex: this.operations.Count,
-                    container.Database.Id,
-                    container.Id,
+                    databaseId,
+                    containerId,
                     partitionKey,
                     id,
                     resource,
@@ -54,7 +54,7 @@ namespace Microsoft.Azure.Cosmos
             Stream streamPayload,
             DistributedTransactionRequestOptions requestOptions = null)
         {
-            DistributedWriteTransactionCore.ValidateContainerReference(container);
+            (string databaseId, string containerId) = DistributedTransactionConstants.ValidateAndUnpackContainer(container, this.clientContext.Client);
             DistributedWriteTransactionCore.ValidateItemId(id);
             if (streamPayload == null)
             {
@@ -65,8 +65,8 @@ namespace Microsoft.Azure.Cosmos
                 new DistributedTransactionOperation(
                     operationType: OperationType.Create,
                     operationIndex: this.operations.Count,
-                    database: container.Database.Id,
-                    container: container.Id,
+                    database: databaseId,
+                    container: containerId,
                     partitionKey: partitionKey,
                     id: id,
                     requestOptions: requestOptions)
@@ -83,7 +83,7 @@ namespace Microsoft.Azure.Cosmos
             T resource,
             DistributedTransactionRequestOptions requestOptions = null)
         {
-            DistributedWriteTransactionCore.ValidateContainerReference(container);
+            (string databaseId, string containerId) = DistributedTransactionConstants.ValidateAndUnpackContainer(container, this.clientContext.Client);
             DistributedWriteTransactionCore.ValidateItemId(id);
             DistributedWriteTransactionCore.ValidateResource(resource);
 
@@ -91,8 +91,8 @@ namespace Microsoft.Azure.Cosmos
                 new DistributedTransactionOperation<T>(
                     operationType: OperationType.Replace,
                     operationIndex: this.operations.Count,
-                    container.Database.Id,
-                    container.Id,
+                    databaseId,
+                    containerId,
                     partitionKey,
                     id,
                     resource,
@@ -107,7 +107,7 @@ namespace Microsoft.Azure.Cosmos
             Stream streamPayload,
             DistributedTransactionRequestOptions requestOptions = null)
         {
-            DistributedWriteTransactionCore.ValidateContainerReference(container);
+            (string databaseId, string containerId) = DistributedTransactionConstants.ValidateAndUnpackContainer(container, this.clientContext.Client);
             DistributedWriteTransactionCore.ValidateItemId(id);
             if (streamPayload == null)
             {
@@ -118,8 +118,8 @@ namespace Microsoft.Azure.Cosmos
                 new DistributedTransactionOperation(
                     operationType: OperationType.Replace,
                     operationIndex: this.operations.Count,
-                    database: container.Database.Id,
-                    container: container.Id,
+                    database: databaseId,
+                    container: containerId,
                     partitionKey: partitionKey,
                     id: id,
                     requestOptions: requestOptions)
@@ -135,15 +135,15 @@ namespace Microsoft.Azure.Cosmos
             string id,
             DistributedTransactionRequestOptions requestOptions = null)
         {
-            DistributedWriteTransactionCore.ValidateContainerReference(container);
+            (string databaseId, string containerId) = DistributedTransactionConstants.ValidateAndUnpackContainer(container, this.clientContext.Client);
             DistributedWriteTransactionCore.ValidateItemId(id);
 
             this.operations.Add(
                 new DistributedTransactionOperation(
                     operationType: OperationType.Delete,
                     operationIndex: this.operations.Count,
-                    container.Database.Id,
-                    container.Id,
+                    databaseId,
+                    containerId,
                     partitionKey,
                     id: id,
                     requestOptions));
@@ -157,7 +157,7 @@ namespace Microsoft.Azure.Cosmos
             IReadOnlyList<PatchOperation> patchOperations,
             DistributedTransactionRequestOptions requestOptions = null)
         {
-            DistributedWriteTransactionCore.ValidateContainerReference(container);
+            (string databaseId, string containerId) = DistributedTransactionConstants.ValidateAndUnpackContainer(container, this.clientContext.Client);
             DistributedWriteTransactionCore.ValidateItemId(id);
 
             if (patchOperations == null || !patchOperations.Any())
@@ -171,8 +171,8 @@ namespace Microsoft.Azure.Cosmos
                 new DistributedTransactionOperation<PatchSpec>(
                     operationType: OperationType.Patch,
                     operationIndex: this.operations.Count,
-                    container.Database.Id,
-                    container.Id,
+                    databaseId,
+                    containerId,
                     partitionKey,
                     id,
                     resource: patchSpec,
@@ -187,7 +187,7 @@ namespace Microsoft.Azure.Cosmos
             Stream streamPayload,
             DistributedTransactionRequestOptions requestOptions = null)
         {
-            DistributedWriteTransactionCore.ValidateContainerReference(container);
+            (string databaseId, string containerId) = DistributedTransactionConstants.ValidateAndUnpackContainer(container, this.clientContext.Client);
             DistributedWriteTransactionCore.ValidateItemId(id);
             if (streamPayload == null)
             {
@@ -198,8 +198,8 @@ namespace Microsoft.Azure.Cosmos
                 new DistributedTransactionOperation(
                     operationType: OperationType.Patch,
                     operationIndex: this.operations.Count,
-                    database: container.Database.Id,
-                    container: container.Id,
+                    database: databaseId,
+                    container: containerId,
                     partitionKey: partitionKey,
                     id: id,
                     requestOptions: requestOptions)
@@ -216,7 +216,7 @@ namespace Microsoft.Azure.Cosmos
             T resource,
             DistributedTransactionRequestOptions requestOptions = null)
         {
-            DistributedWriteTransactionCore.ValidateContainerReference(container);
+            (string databaseId, string containerId) = DistributedTransactionConstants.ValidateAndUnpackContainer(container, this.clientContext.Client);
             DistributedWriteTransactionCore.ValidateItemId(id);
             DistributedWriteTransactionCore.ValidateResource(resource);
 
@@ -224,8 +224,8 @@ namespace Microsoft.Azure.Cosmos
                 new DistributedTransactionOperation<T>(
                     operationType: OperationType.Upsert,
                     operationIndex: this.operations.Count,
-                    container.Database.Id,
-                    container.Id,
+                    databaseId,
+                    containerId,
                     partitionKey,
                     id,
                     resource,
@@ -240,7 +240,7 @@ namespace Microsoft.Azure.Cosmos
             Stream streamPayload,
             DistributedTransactionRequestOptions requestOptions = null)
         {
-            DistributedWriteTransactionCore.ValidateContainerReference(container);
+            (string databaseId, string containerId) = DistributedTransactionConstants.ValidateAndUnpackContainer(container, this.clientContext.Client);
             DistributedWriteTransactionCore.ValidateItemId(id);
             if (streamPayload == null)
             {
@@ -251,8 +251,8 @@ namespace Microsoft.Azure.Cosmos
                 new DistributedTransactionOperation(
                     operationType: OperationType.Upsert,
                     operationIndex: this.operations.Count,
-                    database: container.Database.Id,
-                    container: container.Id,
+                    database: databaseId,
+                    container: containerId,
                     partitionKey: partitionKey,
                     id: id,
                     requestOptions: requestOptions)
@@ -269,35 +269,6 @@ namespace Microsoft.Azure.Cosmos
                 clientContext: this.clientContext);
 
             return await committer.CommitTransactionAsync(cancellationToken);
-        }
-
-        private static void ValidateContainerReference(Container container)
-        {
-            if (container == null)
-            {
-                throw new ArgumentNullException(nameof(container));
-            }
-
-            if (string.IsNullOrWhiteSpace(container.Id))
-            {
-                throw new ArgumentException(
-                    "Container reference must have a non-empty Id.",
-                    nameof(container));
-            }
-
-            if (container.Database == null)
-            {
-                throw new ArgumentException(
-                    "Container reference must expose a non-null Database.",
-                    nameof(container));
-            }
-
-            if (string.IsNullOrWhiteSpace(container.Database.Id))
-            {
-                throw new ArgumentException(
-                    "Container reference must have a non-empty Database.Id.",
-                    nameof(container));
-            }
         }
 
         private static void ValidateItemId(string id)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/DistributedTransaction/DistributedTransactionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/DistributedTransaction/DistributedTransactionTests.cs
@@ -69,8 +69,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             using CosmosClient client = this.CreateMockClient(handler);
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .CreateItem(this.container, new PartitionKey(doc1.pk), doc1.id, doc1)
-                .CreateItem(this.container, new PartitionKey(doc2.pk), doc2.id, doc2)
+                .CreateItem(this.GetContainerForClient(client, this.container), new PartitionKey(doc1.pk), doc1.id, doc1)
+                .CreateItem(this.GetContainerForClient(client, this.container), new PartitionKey(doc2.pk), doc2.id, doc2)
                 .CommitTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
@@ -95,9 +95,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             using CosmosClient client = this.CreateMockClient(handler);
 
             await client.CreateDistributedWriteTransaction()
-                .CreateItem(this.container, new PartitionKey(createDoc.pk), createDoc.id, createDoc)
-                .ReplaceItem(this.container, new PartitionKey(replaceDoc.pk), replaceDoc.id, replaceDoc)
-                .DeleteItem(this.container, new PartitionKey("delete-pk"), "delete-id")
+                .CreateItem(this.GetContainerForClient(client, this.container), new PartitionKey(createDoc.pk), createDoc.id, createDoc)
+                .ReplaceItem(this.GetContainerForClient(client, this.container), new PartitionKey(replaceDoc.pk), replaceDoc.id, replaceDoc)
+                .DeleteItem(this.GetContainerForClient(client, this.container), new PartitionKey("delete-pk"), "delete-id")
                 .CommitTransactionAsync(CancellationToken.None);
 
             using JsonDocument requestJson = JsonDocument.Parse(handler.CapturedRequestBody);
@@ -122,8 +122,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             using CosmosClient client = this.CreateMockClient(handler);
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .CreateItem(this.container, new PartitionKey(createDoc.pk), createDoc.id, createDoc)
-                .UpsertItem(this.container, new PartitionKey(upsertDoc.pk), upsertDoc.id, upsertDoc)
+                .CreateItem(this.GetContainerForClient(client, this.container), new PartitionKey(createDoc.pk), createDoc.id, createDoc)
+                .UpsertItem(this.GetContainerForClient(client, this.container), new PartitionKey(upsertDoc.pk), upsertDoc.id, upsertDoc)
                 .CommitTransactionAsync(CancellationToken.None);
 
             using JsonDocument requestJson = JsonDocument.Parse(handler.CapturedRequestBody);
@@ -149,8 +149,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             using CosmosClient client = this.CreateMockClient(handler);
 
             await client.CreateDistributedWriteTransaction()
-                .CreateItem(this.container, new PartitionKey(createDoc.pk), createDoc.id, createDoc)
-                .PatchItem(this.container, new PartitionKey("patch-pk"), "item-to-patch", patchOps)
+                .CreateItem(this.GetContainerForClient(client, this.container), new PartitionKey(createDoc.pk), createDoc.id, createDoc)
+                .PatchItem(this.GetContainerForClient(client, this.container), new PartitionKey("patch-pk"), "item-to-patch", patchOps)
                 .CommitTransactionAsync(CancellationToken.None);
 
             using JsonDocument requestJson = JsonDocument.Parse(handler.CapturedRequestBody);
@@ -179,8 +179,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             using CosmosClient client = this.CreateMockClient(handler);
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .CreateItem(this.container, new PartitionKey(doc1.pk), doc1.id, doc1)
-                .CreateItem(secondContainer, new PartitionKey(doc2.pk), doc2.id, doc2)
+                .CreateItem(this.GetContainerForClient(client, this.container), new PartitionKey(doc1.pk), doc1.id, doc1)
+                .CreateItem(this.GetContainerForClient(client, secondContainer), new PartitionKey(doc2.pk), doc2.id, doc2)
                 .CommitTransactionAsync(CancellationToken.None);
 
             using JsonDocument requestJson = JsonDocument.Parse(handler.CapturedRequestBody);
@@ -214,7 +214,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             ToDoActivity doc = ToDoActivity.CreateRandomToDoActivity();
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .CreateItem(this.container, new PartitionKey(doc.pk), doc.id, doc)
+                .CreateItem(this.GetContainerForClient(client, this.container), new PartitionKey(doc.pk), doc.id, doc)
                 .CommitTransactionAsync(CancellationToken.None);
 
             Assert.AreNotEqual(Guid.Empty, response.IdempotencyToken, "Response must carry the idempotency token.");
@@ -236,9 +236,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             using CosmosClient client = this.CreateMockClient(handler);
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .CreateItem(this.container, new PartitionKey(doc1.pk), doc1.id, doc1)
-                .CreateItem(this.container, new PartitionKey(doc2.pk), doc2.id, doc2)
-                .CreateItem(this.container, new PartitionKey(doc3.pk), doc3.id, doc3)
+                .CreateItem(this.GetContainerForClient(client, this.container), new PartitionKey(doc1.pk), doc1.id, doc1)
+                .CreateItem(this.GetContainerForClient(client, this.container), new PartitionKey(doc2.pk), doc2.id, doc2)
+                .CreateItem(this.GetContainerForClient(client, this.container), new PartitionKey(doc3.pk), doc3.id, doc3)
                 .CommitTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(3, response.Count);
@@ -272,7 +272,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             using CosmosClient client = this.CreateMockClient(handler);
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .CreateItem(this.container, new PartitionKey(expectedDoc.pk), expectedDoc.id, expectedDoc)
+                .CreateItem(this.GetContainerForClient(client, this.container), new PartitionKey(expectedDoc.pk), expectedDoc.id, expectedDoc)
                 .CommitTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(HttpStatusCode.Created, response[0].StatusCode);
@@ -309,7 +309,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             ToDoActivity doc = ToDoActivity.CreateRandomToDoActivity();
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .CreateItem(this.container, new PartitionKey(doc.pk), doc.id, doc)
+                .CreateItem(this.GetContainerForClient(client, this.container), new PartitionKey(doc.pk), doc.id, doc)
                 .CommitTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(HttpStatusCode.Conflict, response.StatusCode);
@@ -339,7 +339,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             ToDoActivity doc = ToDoActivity.CreateRandomToDoActivity();
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .ReplaceItem(this.container, new PartitionKey(doc.pk), doc.id, doc)
+                .ReplaceItem(this.GetContainerForClient(client, this.container), new PartitionKey(doc.pk), doc.id, doc)
                 .CommitTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
@@ -369,8 +369,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             ToDoActivity doc2 = ToDoActivity.CreateRandomToDoActivity();
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .CreateItem(this.container, new PartitionKey(doc1.pk), doc1.id, doc1)
-                .CreateItem(this.container, new PartitionKey(doc2.pk), doc2.id, doc2)
+                .CreateItem(this.GetContainerForClient(client, this.container), new PartitionKey(doc1.pk), doc1.id, doc1)
+                .CreateItem(this.GetContainerForClient(client, this.container), new PartitionKey(doc2.pk), doc2.id, doc2)
                 .CommitTransactionAsync(CancellationToken.None);
 
             // All results must be present regardless of partial failure
@@ -395,9 +395,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             using CosmosClient client = this.CreateMockClient(handler);
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .CreateItem(this.container, new PartitionKey(createDoc.pk), createDoc.id, createDoc)
-                .ReplaceItem(this.container, new PartitionKey(replaceDoc.pk), replaceDoc.id, replaceDoc)
-                .DeleteItem(this.container, new PartitionKey("delete-pk"), "delete-id")
+                .CreateItem(this.GetContainerForClient(client, this.container), new PartitionKey(createDoc.pk), createDoc.id, createDoc)
+                .ReplaceItem(this.GetContainerForClient(client, this.container), new PartitionKey(replaceDoc.pk), replaceDoc.id, replaceDoc)
+                .DeleteItem(this.GetContainerForClient(client, this.container), new PartitionKey("delete-pk"), "delete-id")
                 .CommitTransactionAsync(CancellationToken.None);
 
             using JsonDocument requestJson = JsonDocument.Parse(handler.CapturedRequestBody);
@@ -464,7 +464,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
                 .ReplaceItem(
-                    this.container,
+                    this.GetContainerForClient(client, this.container),
                     new PartitionKey(doc.pk),
                     doc.id,
                     doc,
@@ -495,7 +495,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
                 .DeleteItem(
-                    this.container,
+                    this.GetContainerForClient(client, this.container),
                     new PartitionKey("delete-pk"),
                     "delete-id",
                     new DistributedTransactionRequestOptions { IfMatchEtag = expectedEtag })
@@ -526,7 +526,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
                 .PatchItem(
-                    this.container,
+                    this.GetContainerForClient(client, this.container),
                     new PartitionKey("patch-pk"),
                     "patch-id",
                     patchOps,
@@ -564,7 +564,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
                 .ReplaceItem(
-                    this.container,
+                    this.GetContainerForClient(client, this.container),
                     new PartitionKey(doc.pk),
                     doc.id,
                     doc,
@@ -592,8 +592,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             using CosmosClient client = this.CreateMockClient(handler);
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .CreateItem(this.container, new PartitionKey(createDoc.pk), createDoc.id, createDoc)
-                .ReplaceItem(this.container, new PartitionKey(replaceDoc.pk), replaceDoc.id, replaceDoc)
+                .CreateItem(this.GetContainerForClient(client, this.container), new PartitionKey(createDoc.pk), createDoc.id, createDoc)
+                .ReplaceItem(this.GetContainerForClient(client, this.container), new PartitionKey(replaceDoc.pk), replaceDoc.id, replaceDoc)
                 .CommitTransactionAsync(CancellationToken.None);
 
             using JsonDocument requestJson = JsonDocument.Parse(handler.CapturedRequestBody);
@@ -622,7 +622,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             using MemoryStream stream = new MemoryStream(docBytes);
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .CreateItemStream(this.container, new PartitionKey(doc.pk), doc.id, stream)
+                .CreateItemStream(this.GetContainerForClient(client, this.container), new PartitionKey(doc.pk), doc.id, stream)
                 .CommitTransactionAsync(CancellationToken.None);
 
             Assert.IsTrue(response.IsSuccessStatusCode);
@@ -652,7 +652,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             using MemoryStream stream = new MemoryStream(docBytes);
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .ReplaceItemStream(this.container, new PartitionKey(doc.pk), doc.id, stream)
+                .ReplaceItemStream(this.GetContainerForClient(client, this.container), new PartitionKey(doc.pk), doc.id, stream)
                 .CommitTransactionAsync(CancellationToken.None);
 
             Assert.IsTrue(response.IsSuccessStatusCode);
@@ -683,7 +683,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             using MemoryStream stream = new MemoryStream(patchBytes);
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .PatchItemStream(this.container, new PartitionKey("patch-pk"), "patch-id", stream)
+                .PatchItemStream(this.GetContainerForClient(client, this.container), new PartitionKey("patch-pk"), "patch-id", stream)
                 .CommitTransactionAsync(CancellationToken.None);
 
             Assert.IsTrue(response.IsSuccessStatusCode);
@@ -709,7 +709,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             using MemoryStream stream = new MemoryStream(docBytes);
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .UpsertItemStream(this.container, new PartitionKey(doc.pk), doc.id, stream)
+                .UpsertItemStream(this.GetContainerForClient(client, this.container), new PartitionKey(doc.pk), doc.id, stream)
                 .CommitTransactionAsync(CancellationToken.None);
 
             Assert.IsTrue(response.IsSuccessStatusCode);
@@ -765,7 +765,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             ToDoActivity newDoc = ToDoActivity.CreateRandomToDoActivity(pk: seedDoc.pk);
             DistributedTransactionResponse dtcResponse = await dtcClient
                 .CreateDistributedWriteTransaction()
-                .CreateItem(this.container, new PartitionKey(newDoc.pk), newDoc.id, newDoc)
+                .CreateItem(this.GetContainerForClient(dtcClient, this.container), new PartitionKey(newDoc.pk), newDoc.id, newDoc)
                 .CommitTransactionAsync(this.cancellationToken);
 
             Assert.IsTrue(dtcResponse.IsSuccessStatusCode, "The simulated DTC commit should appear successful to the client.");
@@ -828,7 +828,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             ToDoActivity newDoc = ToDoActivity.CreateRandomToDoActivity(pk: seedDoc.pk);
             DistributedTransactionResponse dtcResponse = await dtcClient
                 .CreateDistributedWriteTransaction()
-                .CreateItem(this.container, new PartitionKey(newDoc.pk), newDoc.id, newDoc)
+                .CreateItem(this.GetContainerForClient(dtcClient, this.container), new PartitionKey(newDoc.pk), newDoc.id, newDoc)
                 .CommitTransactionAsync(this.cancellationToken);
 
             // Commit must succeed — this was the crash point before the fix (IndexOutOfRangeException
@@ -860,8 +860,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             // Act
             DistributedTransactionResponse response = await client
                 .CreateDistributedReadTransaction()
-                .ReadItem(this.container, new PartitionKey(doc1.pk), doc1.id)
-                .ReadItem(this.container, new PartitionKey(doc2.pk), doc2.id)
+                .ReadItem(this.GetContainerForClient(client, this.container), new PartitionKey(doc1.pk), doc1.id)
+                .ReadItem(this.GetContainerForClient(client, this.container), new PartitionKey(doc2.pk), doc2.id)
                 .CommitTransactionAsync(CancellationToken.None);
 
             // Assert
@@ -889,7 +889,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             // Act
             DistributedTransactionResponse response = await client
                 .CreateDistributedReadTransaction()
-                .ReadItem(this.container, new PartitionKey(doc.pk), doc.id)
+                .ReadItem(this.GetContainerForClient(client, this.container), new PartitionKey(doc.pk), doc.id)
                 .CommitTransactionAsync(CancellationToken.None);
 
             // Assert – request structure
@@ -923,7 +923,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             // Act
             DistributedTransactionResponse response = await client
                 .CreateDistributedReadTransaction()
-                .ReadItem(this.container, new PartitionKey(expectedDoc.pk), expectedDoc.id)
+                .ReadItem(this.GetContainerForClient(client, this.container), new PartitionKey(expectedDoc.pk), expectedDoc.id)
                 .CommitTransactionAsync(CancellationToken.None);
 
             // Assert
@@ -953,7 +953,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             // Act
             DistributedTransactionResponse response = await client
                 .CreateDistributedReadTransaction()
-                .ReadItem(this.container, new PartitionKey(expectedDoc.pk), expectedDoc.id)
+                .ReadItem(this.GetContainerForClient(client, this.container), new PartitionKey(expectedDoc.pk), expectedDoc.id)
                 .CommitTransactionAsync(CancellationToken.None);
 
             // Assert – raw stream access
@@ -974,7 +974,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             Assert.ThrowsException<ArgumentNullException>(() =>
                 client.CreateDistributedReadTransaction()
-                    .ReadItem(this.container, new PartitionKey("pk"), id: null));
+                    .ReadItem(this.GetContainerForClient(client, this.container), new PartitionKey("pk"), id: null));
         }
 
         [TestMethod]
@@ -989,6 +989,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         // Helpers
+
+        private Container GetContainerForClient(CosmosClient client, Container sourceContainer)
+        {
+            return client.GetContainer(sourceContainer.Database.Id, sourceContainer.Id);
+        }
 
         private void ValidateValueKind(JsonElement operation, string property, JsonValueKind expectedValueKind, int operationIndex, bool isRequired)
         {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/DistributedTransaction/DistributedTransactionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/DistributedTransaction/DistributedTransactionTests.cs
@@ -1,4 +1,4 @@
-﻿// ------------------------------------------------------------
+// ------------------------------------------------------------
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 // ------------------------------------------------------------
 
@@ -69,8 +69,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             using CosmosClient client = this.CreateMockClient(handler);
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(doc1.pk), doc1.id, doc1)
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(doc2.pk), doc2.id, doc2)
+                .CreateItem(this.container, new PartitionKey(doc1.pk), doc1.id, doc1)
+                .CreateItem(this.container, new PartitionKey(doc2.pk), doc2.id, doc2)
                 .CommitTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
@@ -95,9 +95,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             using CosmosClient client = this.CreateMockClient(handler);
 
             await client.CreateDistributedWriteTransaction()
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(createDoc.pk), createDoc.id, createDoc)
-                .ReplaceItem(this.database.Id, this.container.Id, new PartitionKey(replaceDoc.pk), replaceDoc.id, replaceDoc)
-                .DeleteItem(this.database.Id, this.container.Id, new PartitionKey("delete-pk"), "delete-id")
+                .CreateItem(this.container, new PartitionKey(createDoc.pk), createDoc.id, createDoc)
+                .ReplaceItem(this.container, new PartitionKey(replaceDoc.pk), replaceDoc.id, replaceDoc)
+                .DeleteItem(this.container, new PartitionKey("delete-pk"), "delete-id")
                 .CommitTransactionAsync(CancellationToken.None);
 
             using JsonDocument requestJson = JsonDocument.Parse(handler.CapturedRequestBody);
@@ -122,8 +122,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             using CosmosClient client = this.CreateMockClient(handler);
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(createDoc.pk), createDoc.id, createDoc)
-                .UpsertItem(this.database.Id, this.container.Id, new PartitionKey(upsertDoc.pk), upsertDoc.id, upsertDoc)
+                .CreateItem(this.container, new PartitionKey(createDoc.pk), createDoc.id, createDoc)
+                .UpsertItem(this.container, new PartitionKey(upsertDoc.pk), upsertDoc.id, upsertDoc)
                 .CommitTransactionAsync(CancellationToken.None);
 
             using JsonDocument requestJson = JsonDocument.Parse(handler.CapturedRequestBody);
@@ -149,8 +149,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             using CosmosClient client = this.CreateMockClient(handler);
 
             await client.CreateDistributedWriteTransaction()
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(createDoc.pk), createDoc.id, createDoc)
-                .PatchItem(this.database.Id, this.container.Id, new PartitionKey("patch-pk"), "item-to-patch", patchOps)
+                .CreateItem(this.container, new PartitionKey(createDoc.pk), createDoc.id, createDoc)
+                .PatchItem(this.container, new PartitionKey("patch-pk"), "item-to-patch", patchOps)
                 .CommitTransactionAsync(CancellationToken.None);
 
             using JsonDocument requestJson = JsonDocument.Parse(handler.CapturedRequestBody);
@@ -179,8 +179,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             using CosmosClient client = this.CreateMockClient(handler);
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(doc1.pk), doc1.id, doc1)
-                .CreateItem(this.database.Id, secondContainer.Id, new PartitionKey(doc2.pk), doc2.id, doc2)
+                .CreateItem(this.container, new PartitionKey(doc1.pk), doc1.id, doc1)
+                .CreateItem(secondContainer, new PartitionKey(doc2.pk), doc2.id, doc2)
                 .CommitTransactionAsync(CancellationToken.None);
 
             using JsonDocument requestJson = JsonDocument.Parse(handler.CapturedRequestBody);
@@ -214,7 +214,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             ToDoActivity doc = ToDoActivity.CreateRandomToDoActivity();
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(doc.pk), doc.id, doc)
+                .CreateItem(this.container, new PartitionKey(doc.pk), doc.id, doc)
                 .CommitTransactionAsync(CancellationToken.None);
 
             Assert.AreNotEqual(Guid.Empty, response.IdempotencyToken, "Response must carry the idempotency token.");
@@ -236,9 +236,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             using CosmosClient client = this.CreateMockClient(handler);
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(doc1.pk), doc1.id, doc1)
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(doc2.pk), doc2.id, doc2)
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(doc3.pk), doc3.id, doc3)
+                .CreateItem(this.container, new PartitionKey(doc1.pk), doc1.id, doc1)
+                .CreateItem(this.container, new PartitionKey(doc2.pk), doc2.id, doc2)
+                .CreateItem(this.container, new PartitionKey(doc3.pk), doc3.id, doc3)
                 .CommitTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(3, response.Count);
@@ -272,7 +272,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             using CosmosClient client = this.CreateMockClient(handler);
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(expectedDoc.pk), expectedDoc.id, expectedDoc)
+                .CreateItem(this.container, new PartitionKey(expectedDoc.pk), expectedDoc.id, expectedDoc)
                 .CommitTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(HttpStatusCode.Created, response[0].StatusCode);
@@ -309,7 +309,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             ToDoActivity doc = ToDoActivity.CreateRandomToDoActivity();
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(doc.pk), doc.id, doc)
+                .CreateItem(this.container, new PartitionKey(doc.pk), doc.id, doc)
                 .CommitTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(HttpStatusCode.Conflict, response.StatusCode);
@@ -339,7 +339,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             ToDoActivity doc = ToDoActivity.CreateRandomToDoActivity();
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .ReplaceItem(this.database.Id, this.container.Id, new PartitionKey(doc.pk), doc.id, doc)
+                .ReplaceItem(this.container, new PartitionKey(doc.pk), doc.id, doc)
                 .CommitTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
@@ -369,8 +369,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             ToDoActivity doc2 = ToDoActivity.CreateRandomToDoActivity();
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(doc1.pk), doc1.id, doc1)
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(doc2.pk), doc2.id, doc2)
+                .CreateItem(this.container, new PartitionKey(doc1.pk), doc1.id, doc1)
+                .CreateItem(this.container, new PartitionKey(doc2.pk), doc2.id, doc2)
                 .CommitTransactionAsync(CancellationToken.None);
 
             // All results must be present regardless of partial failure
@@ -395,9 +395,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             using CosmosClient client = this.CreateMockClient(handler);
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(createDoc.pk), createDoc.id, createDoc)
-                .ReplaceItem(this.database.Id, this.container.Id, new PartitionKey(replaceDoc.pk), replaceDoc.id, replaceDoc)
-                .DeleteItem(this.database.Id, this.container.Id, new PartitionKey("delete-pk"), "delete-id")
+                .CreateItem(this.container, new PartitionKey(createDoc.pk), createDoc.id, createDoc)
+                .ReplaceItem(this.container, new PartitionKey(replaceDoc.pk), replaceDoc.id, replaceDoc)
+                .DeleteItem(this.container, new PartitionKey("delete-pk"), "delete-id")
                 .CommitTransactionAsync(CancellationToken.None);
 
             using JsonDocument requestJson = JsonDocument.Parse(handler.CapturedRequestBody);
@@ -464,8 +464,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
                 .ReplaceItem(
-                    this.database.Id,
-                    this.container.Id,
+                    this.container,
                     new PartitionKey(doc.pk),
                     doc.id,
                     doc,
@@ -496,8 +495,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
                 .DeleteItem(
-                    this.database.Id,
-                    this.container.Id,
+                    this.container,
                     new PartitionKey("delete-pk"),
                     "delete-id",
                     new DistributedTransactionRequestOptions { IfMatchEtag = expectedEtag })
@@ -528,8 +526,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
                 .PatchItem(
-                    this.database.Id,
-                    this.container.Id,
+                    this.container,
                     new PartitionKey("patch-pk"),
                     "patch-id",
                     patchOps,
@@ -567,8 +564,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
                 .ReplaceItem(
-                    this.database.Id,
-                    this.container.Id,
+                    this.container,
                     new PartitionKey(doc.pk),
                     doc.id,
                     doc,
@@ -596,8 +592,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             using CosmosClient client = this.CreateMockClient(handler);
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(createDoc.pk), createDoc.id, createDoc)
-                .ReplaceItem(this.database.Id, this.container.Id, new PartitionKey(replaceDoc.pk), replaceDoc.id, replaceDoc)
+                .CreateItem(this.container, new PartitionKey(createDoc.pk), createDoc.id, createDoc)
+                .ReplaceItem(this.container, new PartitionKey(replaceDoc.pk), replaceDoc.id, replaceDoc)
                 .CommitTransactionAsync(CancellationToken.None);
 
             using JsonDocument requestJson = JsonDocument.Parse(handler.CapturedRequestBody);
@@ -626,7 +622,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             using MemoryStream stream = new MemoryStream(docBytes);
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .CreateItemStream(this.database.Id, this.container.Id, new PartitionKey(doc.pk), doc.id, stream)
+                .CreateItemStream(this.container, new PartitionKey(doc.pk), doc.id, stream)
                 .CommitTransactionAsync(CancellationToken.None);
 
             Assert.IsTrue(response.IsSuccessStatusCode);
@@ -656,7 +652,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             using MemoryStream stream = new MemoryStream(docBytes);
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .ReplaceItemStream(this.database.Id, this.container.Id, new PartitionKey(doc.pk), doc.id, stream)
+                .ReplaceItemStream(this.container, new PartitionKey(doc.pk), doc.id, stream)
                 .CommitTransactionAsync(CancellationToken.None);
 
             Assert.IsTrue(response.IsSuccessStatusCode);
@@ -687,7 +683,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             using MemoryStream stream = new MemoryStream(patchBytes);
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .PatchItemStream(this.database.Id, this.container.Id, new PartitionKey("patch-pk"), "patch-id", stream)
+                .PatchItemStream(this.container, new PartitionKey("patch-pk"), "patch-id", stream)
                 .CommitTransactionAsync(CancellationToken.None);
 
             Assert.IsTrue(response.IsSuccessStatusCode);
@@ -713,7 +709,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             using MemoryStream stream = new MemoryStream(docBytes);
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
-                .UpsertItemStream(this.database.Id, this.container.Id, new PartitionKey(doc.pk), doc.id, stream)
+                .UpsertItemStream(this.container, new PartitionKey(doc.pk), doc.id, stream)
                 .CommitTransactionAsync(CancellationToken.None);
 
             Assert.IsTrue(response.IsSuccessStatusCode);
@@ -769,7 +765,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             ToDoActivity newDoc = ToDoActivity.CreateRandomToDoActivity(pk: seedDoc.pk);
             DistributedTransactionResponse dtcResponse = await dtcClient
                 .CreateDistributedWriteTransaction()
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(newDoc.pk), newDoc.id, newDoc)
+                .CreateItem(this.container, new PartitionKey(newDoc.pk), newDoc.id, newDoc)
                 .CommitTransactionAsync(this.cancellationToken);
 
             Assert.IsTrue(dtcResponse.IsSuccessStatusCode, "The simulated DTC commit should appear successful to the client.");
@@ -832,7 +828,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             ToDoActivity newDoc = ToDoActivity.CreateRandomToDoActivity(pk: seedDoc.pk);
             DistributedTransactionResponse dtcResponse = await dtcClient
                 .CreateDistributedWriteTransaction()
-                .CreateItem(this.database.Id, this.container.Id, new PartitionKey(newDoc.pk), newDoc.id, newDoc)
+                .CreateItem(this.container, new PartitionKey(newDoc.pk), newDoc.id, newDoc)
                 .CommitTransactionAsync(this.cancellationToken);
 
             // Commit must succeed — this was the crash point before the fix (IndexOutOfRangeException
@@ -864,8 +860,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             // Act
             DistributedTransactionResponse response = await client
                 .CreateDistributedReadTransaction()
-                .ReadItem(this.database.Id, this.container.Id, new PartitionKey(doc1.pk), doc1.id)
-                .ReadItem(this.database.Id, this.container.Id, new PartitionKey(doc2.pk), doc2.id)
+                .ReadItem(this.container, new PartitionKey(doc1.pk), doc1.id)
+                .ReadItem(this.container, new PartitionKey(doc2.pk), doc2.id)
                 .CommitTransactionAsync(CancellationToken.None);
 
             // Assert
@@ -893,7 +889,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             // Act
             DistributedTransactionResponse response = await client
                 .CreateDistributedReadTransaction()
-                .ReadItem(this.database.Id, this.container.Id, new PartitionKey(doc.pk), doc.id)
+                .ReadItem(this.container, new PartitionKey(doc.pk), doc.id)
                 .CommitTransactionAsync(CancellationToken.None);
 
             // Assert – request structure
@@ -927,7 +923,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             // Act
             DistributedTransactionResponse response = await client
                 .CreateDistributedReadTransaction()
-                .ReadItem(this.database.Id, this.container.Id, new PartitionKey(expectedDoc.pk), expectedDoc.id)
+                .ReadItem(this.container, new PartitionKey(expectedDoc.pk), expectedDoc.id)
                 .CommitTransactionAsync(CancellationToken.None);
 
             // Assert
@@ -957,7 +953,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             // Act
             DistributedTransactionResponse response = await client
                 .CreateDistributedReadTransaction()
-                .ReadItem(this.database.Id, this.container.Id, new PartitionKey(expectedDoc.pk), expectedDoc.id)
+                .ReadItem(this.container, new PartitionKey(expectedDoc.pk), expectedDoc.id)
                 .CommitTransactionAsync(CancellationToken.None);
 
             // Assert – raw stream access
@@ -978,18 +974,18 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             Assert.ThrowsException<ArgumentNullException>(() =>
                 client.CreateDistributedReadTransaction()
-                    .ReadItem(this.database.Id, this.container.Id, new PartitionKey("pk"), id: null));
+                    .ReadItem(this.container, new PartitionKey("pk"), id: null));
         }
 
         [TestMethod]
-        public void ValidateReadTransactionMissingDatabaseThrows()
+        public void ValidateReadTransactionMissingContainerThrows()
         {
             using CosmosClient client = this.CreateMockClient(new DistributedTransactionMockHandler(
                 request => Task.FromResult(this.BuildMockResponse(HttpStatusCode.OK, BuildSuccessResponseJson(1)))));
 
             Assert.ThrowsException<ArgumentNullException>(() =>
                 client.CreateDistributedReadTransaction()
-                    .ReadItem(null, this.container.Id, new PartitionKey("pk"), "item-id"));
+                    .ReadItem(null, new PartitionKey("pk"), "item-id"));
         }
 
         // Helpers

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedReadTransactionCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedReadTransactionCoreTests.cs
@@ -14,8 +14,8 @@ namespace Microsoft.Azure.Cosmos.Tests
     [TestClass]
     public class DistributedReadTransactionCoreTests
     {
-        private static readonly string Database = "testDb";
-        private static readonly string Collection = "testColl";
+        private const string DatabaseName = "testDb";
+        private const string ContainerName = "testColl";
         private static readonly CosmosPK TestPartitionKey = new CosmosPK("pk1");
         private static readonly string ItemId = "item-1";
 
@@ -23,6 +23,20 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             Mock<CosmosClientContext> mockContext = new Mock<CosmosClientContext>();
             return new DistributedReadTransactionCore(mockContext.Object);
+        }
+
+        private static Cosmos.Container BuildMockContainer(
+            string databaseId = DatabaseName,
+            string containerId = ContainerName)
+        {
+            Mock<Cosmos.Database> databaseMock = new Mock<Cosmos.Database>();
+            databaseMock.Setup(d => d.Id).Returns(databaseId);
+
+            Mock<Cosmos.Container> containerMock = new Mock<Cosmos.Container>();
+            containerMock.Setup(c => c.Id).Returns(containerId);
+            containerMock.Setup(c => c.Database).Returns(databaseMock.Object);
+
+            return containerMock.Object;
         }
 
         #region Constructor validation
@@ -38,43 +52,71 @@ namespace Microsoft.Azure.Cosmos.Tests
         #region ReadItem argument validation
 
         [TestMethod]
-        public void ReadItem_NullDatabase_ThrowsArgumentNullException()
+        public void ReadItem_NullContainer_ThrowsArgumentNullException()
         {
             DistributedReadTransactionCore txn = this.CreateTransaction();
             Assert.ThrowsException<ArgumentNullException>(() =>
-                txn.ReadItem(null, Collection, TestPartitionKey, ItemId));
+                txn.ReadItem(null, TestPartitionKey, ItemId));
         }
 
         [TestMethod]
-        public void ReadItem_EmptyDatabase_ThrowsArgumentNullException()
+        public void ReadItem_NullContainerId_ThrowsArgumentException()
         {
             DistributedReadTransactionCore txn = this.CreateTransaction();
-            Assert.ThrowsException<ArgumentNullException>(() =>
-                txn.ReadItem(string.Empty, Collection, TestPartitionKey, ItemId));
+            Assert.ThrowsException<ArgumentException>(() =>
+                txn.ReadItem(BuildMockContainer(containerId: null), TestPartitionKey, ItemId));
         }
 
         [TestMethod]
-        public void ReadItem_WhitespaceDatabase_ThrowsArgumentNullException()
+        public void ReadItem_EmptyContainerId_ThrowsArgumentException()
         {
             DistributedReadTransactionCore txn = this.CreateTransaction();
-            Assert.ThrowsException<ArgumentNullException>(() =>
-                txn.ReadItem("   ", Collection, TestPartitionKey, ItemId));
+            Assert.ThrowsException<ArgumentException>(() =>
+                txn.ReadItem(BuildMockContainer(containerId: string.Empty), TestPartitionKey, ItemId));
         }
 
         [TestMethod]
-        public void ReadItem_NullCollection_ThrowsArgumentNullException()
+        public void ReadItem_WhitespaceContainerId_ThrowsArgumentException()
         {
             DistributedReadTransactionCore txn = this.CreateTransaction();
-            Assert.ThrowsException<ArgumentNullException>(() =>
-                txn.ReadItem(Database, null, TestPartitionKey, ItemId));
+            Assert.ThrowsException<ArgumentException>(() =>
+                txn.ReadItem(BuildMockContainer(containerId: "   "), TestPartitionKey, ItemId));
         }
 
         [TestMethod]
-        public void ReadItem_EmptyCollection_ThrowsArgumentNullException()
+        public void ReadItem_NullDatabase_ThrowsArgumentException()
         {
             DistributedReadTransactionCore txn = this.CreateTransaction();
-            Assert.ThrowsException<ArgumentNullException>(() =>
-                txn.ReadItem(Database, string.Empty, TestPartitionKey, ItemId));
+            Mock<Cosmos.Container> containerMock = new Mock<Cosmos.Container>();
+            containerMock.Setup(c => c.Id).Returns(ContainerName);
+            containerMock.Setup(c => c.Database).Returns((Cosmos.Database)null);
+
+            Assert.ThrowsException<ArgumentException>(() =>
+                txn.ReadItem(containerMock.Object, TestPartitionKey, ItemId));
+        }
+
+        [TestMethod]
+        public void ReadItem_NullDatabaseId_ThrowsArgumentException()
+        {
+            DistributedReadTransactionCore txn = this.CreateTransaction();
+            Assert.ThrowsException<ArgumentException>(() =>
+                txn.ReadItem(BuildMockContainer(databaseId: null), TestPartitionKey, ItemId));
+        }
+
+        [TestMethod]
+        public void ReadItem_EmptyDatabaseId_ThrowsArgumentException()
+        {
+            DistributedReadTransactionCore txn = this.CreateTransaction();
+            Assert.ThrowsException<ArgumentException>(() =>
+                txn.ReadItem(BuildMockContainer(databaseId: string.Empty), TestPartitionKey, ItemId));
+        }
+
+        [TestMethod]
+        public void ReadItem_WhitespaceDatabaseId_ThrowsArgumentException()
+        {
+            DistributedReadTransactionCore txn = this.CreateTransaction();
+            Assert.ThrowsException<ArgumentException>(() =>
+                txn.ReadItem(BuildMockContainer(databaseId: "   "), TestPartitionKey, ItemId));
         }
 
         [TestMethod]
@@ -82,7 +124,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             DistributedReadTransactionCore txn = this.CreateTransaction();
             Assert.ThrowsException<ArgumentNullException>(() =>
-                txn.ReadItem(Database, Collection, TestPartitionKey, null));
+                txn.ReadItem(BuildMockContainer(), TestPartitionKey, null));
         }
 
         [TestMethod]
@@ -90,7 +132,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             DistributedReadTransactionCore txn = this.CreateTransaction();
             Assert.ThrowsException<ArgumentNullException>(() =>
-                txn.ReadItem(Database, Collection, TestPartitionKey, string.Empty));
+                txn.ReadItem(BuildMockContainer(), TestPartitionKey, string.Empty));
         }
 
         [TestMethod]
@@ -98,7 +140,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             DistributedReadTransactionCore txn = this.CreateTransaction();
             Assert.ThrowsException<ArgumentNullException>(() =>
-                txn.ReadItem(Database, Collection, TestPartitionKey, "   "));
+                txn.ReadItem(BuildMockContainer(), TestPartitionKey, "   "));
         }
 
         #endregion
@@ -109,7 +151,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         public void ReadItem_ValidArgs_ReturnsThisForChaining()
         {
             DistributedReadTransactionCore txn = this.CreateTransaction();
-            DistributedReadTransaction result = txn.ReadItem(Database, Collection, TestPartitionKey, ItemId);
+            DistributedReadTransaction result = txn.ReadItem(BuildMockContainer(), TestPartitionKey, ItemId);
             Assert.AreSame(txn, result);
         }
 
@@ -117,7 +159,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         public void ReadItem_BuildsOperationWithReadType()
         {
             DistributedReadTransactionCore txn = this.CreateTransaction();
-            txn.ReadItem(Database, Collection, TestPartitionKey, ItemId);
+            txn.ReadItem(BuildMockContainer(), TestPartitionKey, ItemId);
 
             IReadOnlyList<DistributedTransactionOperation> ops = GetOperations(txn);
             Assert.AreEqual(1, ops.Count);
@@ -128,11 +170,11 @@ namespace Microsoft.Azure.Cosmos.Tests
         public void ReadItem_BuildsOperationWithCorrectFields()
         {
             DistributedReadTransactionCore txn = this.CreateTransaction();
-            txn.ReadItem(Database, Collection, TestPartitionKey, ItemId);
+            txn.ReadItem(BuildMockContainer(), TestPartitionKey, ItemId);
 
             DistributedTransactionOperation op = GetOperations(txn)[0];
-            Assert.AreEqual(Database, op.Database);
-            Assert.AreEqual(Collection, op.Container);
+            Assert.AreEqual(DatabaseName, op.Database);
+            Assert.AreEqual(ContainerName, op.Container);
             Assert.AreEqual(ItemId, op.Id);
             Assert.AreEqual(0, op.OperationIndex);
         }
@@ -141,7 +183,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         public void ReadItem_HasNoResourceBody()
         {
             DistributedReadTransactionCore txn = this.CreateTransaction();
-            txn.ReadItem(Database, Collection, TestPartitionKey, ItemId);
+            txn.ReadItem(BuildMockContainer(), TestPartitionKey, ItemId);
 
             DistributedTransactionOperation op = GetOperations(txn)[0];
             Assert.IsTrue(op.ResourceBody.IsEmpty);
@@ -152,9 +194,9 @@ namespace Microsoft.Azure.Cosmos.Tests
         public void MultipleReadItems_CorrectOperationIndices()
         {
             DistributedReadTransactionCore txn = this.CreateTransaction();
-            txn.ReadItem(Database, Collection, TestPartitionKey, "id-0")
-                .ReadItem(Database, Collection, TestPartitionKey, "id-1")
-                .ReadItem(Database, Collection, TestPartitionKey, "id-2");
+            txn.ReadItem(BuildMockContainer(), TestPartitionKey, "id-0")
+                .ReadItem(BuildMockContainer(), TestPartitionKey, "id-1")
+                .ReadItem(BuildMockContainer(), TestPartitionKey, "id-2");
 
             IReadOnlyList<DistributedTransactionOperation> ops = GetOperations(txn);
             Assert.AreEqual(3, ops.Count);
@@ -168,7 +210,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             DistributedReadTransactionCore txn = this.CreateTransaction();
             DistributedTransactionRequestOptions options = new DistributedTransactionRequestOptions();
-            txn.ReadItem(Database, Collection, TestPartitionKey, ItemId, options);
+            txn.ReadItem(BuildMockContainer(), TestPartitionKey, ItemId, options);
 
             DistributedTransactionOperation op = GetOperations(txn)[0];
             Assert.AreSame(options, op.RequestOptions);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedReadTransactionCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedReadTransactionCoreTests.cs
@@ -256,6 +256,9 @@ namespace Microsoft.Azure.Cosmos.Tests
 
             Mock<CosmosClientContext> contextMock = new Mock<CosmosClientContext>();
             contextMock
+                .Setup(c => c.Client)
+                .Returns(DistributedReadTransactionCoreTests.SharedMockClient);
+            contextMock
                 .Setup(c => c.OperationHelperAsync<DistributedTransactionResponse>(
                     It.IsAny<string>(),
                     It.IsAny<string>(),
@@ -278,7 +281,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                     });
 
             DistributedReadTransactionCore txn = new DistributedReadTransactionCore(contextMock.Object);
-            txn.ReadItem(Database, Collection, TestPartitionKey, ItemId);
+            txn.ReadItem(BuildMockContainer(), TestPartitionKey, ItemId);
 
             await txn.CommitTransactionAsync(CancellationToken.None);
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedReadTransactionCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedReadTransactionCoreTests.cs
@@ -18,19 +18,23 @@ namespace Microsoft.Azure.Cosmos.Tests
         private const string ContainerName = "testColl";
         private static readonly CosmosPK TestPartitionKey = new CosmosPK("pk1");
         private static readonly string ItemId = "item-1";
+        private static readonly CosmosClient SharedMockClient = new Mock<CosmosClient>().Object;
 
         private DistributedReadTransactionCore CreateTransaction()
         {
             Mock<CosmosClientContext> mockContext = new Mock<CosmosClientContext>();
+            mockContext.Setup(c => c.Client).Returns(DistributedReadTransactionCoreTests.SharedMockClient);
             return new DistributedReadTransactionCore(mockContext.Object);
         }
 
         private static Cosmos.Container BuildMockContainer(
             string databaseId = DatabaseName,
-            string containerId = ContainerName)
+            string containerId = ContainerName,
+            CosmosClient client = null)
         {
             Mock<Cosmos.Database> databaseMock = new Mock<Cosmos.Database>();
             databaseMock.Setup(d => d.Id).Returns(databaseId);
+            databaseMock.Setup(d => d.Client).Returns(client ?? DistributedReadTransactionCoreTests.SharedMockClient);
 
             Mock<Cosmos.Container> containerMock = new Mock<Cosmos.Container>();
             containerMock.Setup(c => c.Id).Returns(containerId);
@@ -117,6 +121,22 @@ namespace Microsoft.Azure.Cosmos.Tests
             DistributedReadTransactionCore txn = this.CreateTransaction();
             Assert.ThrowsException<ArgumentException>(() =>
                 txn.ReadItem(BuildMockContainer(databaseId: "   "), TestPartitionKey, ItemId));
+        }
+
+        [TestMethod]
+        public void ReadItem_DifferentCosmosClient_ThrowsArgumentException()
+        {
+            DistributedReadTransactionCore txn = this.CreateTransaction();
+            CosmosClient differentClient = new Mock<CosmosClient>().Object;
+            Assert.ThrowsException<ArgumentException>(() =>
+                txn.ReadItem(BuildMockContainer(client: differentClient), TestPartitionKey, ItemId));
+        }
+
+        [TestMethod]
+        public void ReadItem_SameCosmosClient_Succeeds()
+        {
+            DistributedReadTransactionCore txn = this.CreateTransaction();
+            txn.ReadItem(BuildMockContainer(), TestPartitionKey, ItemId);
         }
 
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionSerializerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionSerializerTests.cs
@@ -30,8 +30,8 @@ namespace Microsoft.Azure.Cosmos.Tests
     [TestClass]
     public class DistributedTransactionSerializerTests
     {
-        private const string Database = "testDb";
-        private const string Container = "testContainer";
+        private const string DatabaseName = "testDb";
+        private const string ContainerName = "testContainer";
 
         // id field presence per operation type
 
@@ -41,7 +41,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             const string itemId = "create-item";
             string capturedJson = await this.CaptureCommitBodyAsync(tx =>
-                tx.CreateItem(Database, Container, new PartitionKey("pk"), itemId, new TestItem(itemId)));
+                tx.CreateItem(BuildMockContainer(), new PartitionKey("pk"), itemId, new TestItem(itemId)));
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
             JsonElement op = doc.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
@@ -61,7 +61,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             const string itemId = "replace-item-id";
 
             string capturedJson = await this.CaptureCommitBodyAsync(tx =>
-                tx.ReplaceItem(Database, Container, new PartitionKey("pk"), itemId, new TestItem(itemId)));
+                tx.ReplaceItem(BuildMockContainer(), new PartitionKey("pk"), itemId, new TestItem(itemId)));
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
             JsonElement op = doc.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
@@ -79,7 +79,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             const string itemId = "delete-item-id";
 
             string capturedJson = await this.CaptureCommitBodyAsync(tx =>
-                tx.DeleteItem(Database, Container, new PartitionKey("pk"), itemId));
+                tx.DeleteItem(BuildMockContainer(), new PartitionKey("pk"), itemId));
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
             JsonElement op = doc.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
@@ -96,7 +96,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             const string itemId = "upsert-item";
             string capturedJson = await this.CaptureCommitBodyAsync(tx =>
-                tx.UpsertItem(Database, Container, new PartitionKey("pk"), itemId, new TestItem(itemId)));
+                tx.UpsertItem(BuildMockContainer(), new PartitionKey("pk"), itemId, new TestItem(itemId)));
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
             JsonElement op = doc.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
@@ -118,7 +118,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             const string expectedId = "exact-replace-id";
 
             string capturedJson = await this.CaptureCommitBodyAsync(tx =>
-                tx.ReplaceItem(Database, Container, new PartitionKey("pk"), expectedId, new TestItem(expectedId)));
+                tx.ReplaceItem(BuildMockContainer(), new PartitionKey("pk"), expectedId, new TestItem(expectedId)));
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
             JsonElement op = doc.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
@@ -135,7 +135,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             const string expectedId = "exact-delete-id";
 
             string capturedJson = await this.CaptureCommitBodyAsync(tx =>
-                tx.DeleteItem(Database, Container, new PartitionKey("pk"), expectedId));
+                tx.DeleteItem(BuildMockContainer(), new PartitionKey("pk"), expectedId));
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
             JsonElement op = doc.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
@@ -152,7 +152,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         public async Task CreateItem_SerializedBody_ResourceBodyIsValidJson()
         {
             string capturedJson = await this.CaptureCommitBodyAsync(tx =>
-                tx.CreateItem(Database, Container, new PartitionKey("pk"), "json-check", new TestItem("json-check")));
+                tx.CreateItem(BuildMockContainer(), new PartitionKey("pk"), "json-check", new TestItem("json-check")));
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
             JsonElement op = doc.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
@@ -172,11 +172,11 @@ namespace Microsoft.Azure.Cosmos.Tests
             IReadOnlyList<PatchOperation> patchOps = new[] { PatchOperation.Add("/value", "v") };
 
             string capturedJson = await this.CaptureCommitBodyAsync(tx =>
-                tx.CreateItem(Database, Container, new PartitionKey("pk"), "c", new TestItem("c"))
-                  .ReplaceItem(Database, Container, new PartitionKey("pk"), "r", new TestItem("r"))
-                  .DeleteItem(Database, Container, new PartitionKey("pk"), "d")
-                  .UpsertItem(Database, Container, new PartitionKey("pk"), "u", new TestItem("u"))
-                  .PatchItem(Database, Container, new PartitionKey("pk"), "p", patchOps),
+                tx.CreateItem(BuildMockContainer(), new PartitionKey("pk"), "c", new TestItem("c"))
+                  .ReplaceItem(BuildMockContainer(), new PartitionKey("pk"), "r", new TestItem("r"))
+                  .DeleteItem(BuildMockContainer(), new PartitionKey("pk"), "d")
+                  .UpsertItem(BuildMockContainer(), new PartitionKey("pk"), "u", new TestItem("u"))
+                  .PatchItem(BuildMockContainer(), new PartitionKey("pk"), "p", patchOps),
                 expectedResultCount: 5);
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
@@ -197,11 +197,11 @@ namespace Microsoft.Azure.Cosmos.Tests
             IReadOnlyList<PatchOperation> patchOps = new[] { PatchOperation.Add("/value", "v") };
 
             string capturedJson = await this.CaptureCommitBodyAsync(tx =>
-                tx.CreateItem(Database, Container, new PartitionKey("pk"), "c", new TestItem("c"))
-                  .ReplaceItem(Database, Container, new PartitionKey("pk"), "r", new TestItem("r"))
-                  .DeleteItem(Database, Container, new PartitionKey("pk"), "d")
-                  .UpsertItem(Database, Container, new PartitionKey("pk"), "u", new TestItem("u"))
-                  .PatchItem(Database, Container, new PartitionKey("pk"), "p", patchOps),
+                tx.CreateItem(BuildMockContainer(), new PartitionKey("pk"), "c", new TestItem("c"))
+                  .ReplaceItem(BuildMockContainer(), new PartitionKey("pk"), "r", new TestItem("r"))
+                  .DeleteItem(BuildMockContainer(), new PartitionKey("pk"), "d")
+                  .UpsertItem(BuildMockContainer(), new PartitionKey("pk"), "u", new TestItem("u"))
+                  .PatchItem(BuildMockContainer(), new PartitionKey("pk"), "p", patchOps),
                 expectedResultCount: 5);
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
@@ -225,7 +225,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             const string itemId = "type-check-id";
 
             string capturedJson = await this.CaptureCommitBodyAsync(tx =>
-                tx.ReplaceItem(Database, Container, new PartitionKey("pk"), itemId, new TestItem(itemId)));
+                tx.ReplaceItem(BuildMockContainer(), new PartitionKey("pk"), itemId, new TestItem(itemId)));
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
             JsonElement op = doc.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
@@ -252,7 +252,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             byte[] docBytes = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(new TestItem(itemId)));
             using MemoryStream stream = new MemoryStream(docBytes);
             string capturedJson = await this.CaptureCommitBodyAsync(
-                tx => tx.CreateItemStream(Database, Container, new PartitionKey("pk"), itemId, stream));
+                tx => tx.CreateItemStream(BuildMockContainer(), new PartitionKey("pk"), itemId, stream));
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
             JsonElement op = doc.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
@@ -273,7 +273,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             byte[] docBytes = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(new TestItem(itemId)));
             using MemoryStream stream = new MemoryStream(docBytes);
             string capturedJson = await this.CaptureCommitBodyAsync(
-                tx => tx.ReplaceItemStream(Database, Container, new PartitionKey("pk"), itemId, stream));
+                tx => tx.ReplaceItemStream(BuildMockContainer(), new PartitionKey("pk"), itemId, stream));
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
             JsonElement op = doc.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
@@ -292,7 +292,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             byte[] patchBytes = Encoding.UTF8.GetBytes(@"{""operations"":[{""op"":""add"",""path"":""/description"",""value"":""patched""}]}");
             using MemoryStream stream = new MemoryStream(patchBytes);
             string capturedJson = await this.CaptureCommitBodyAsync(
-                tx => tx.PatchItemStream(Database, Container, new PartitionKey("pk"), itemId, stream));
+                tx => tx.PatchItemStream(BuildMockContainer(), new PartitionKey("pk"), itemId, stream));
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
             JsonElement op = doc.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
@@ -311,7 +311,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             byte[] docBytes = Encoding.UTF8.GetBytes(JsonSerializer.Serialize(new TestItem(itemId)));
             using MemoryStream stream = new MemoryStream(docBytes);
             string capturedJson = await this.CaptureCommitBodyAsync(
-                tx => tx.UpsertItemStream(Database, Container, new PartitionKey("pk"), itemId, stream));
+                tx => tx.UpsertItemStream(BuildMockContainer(), new PartitionKey("pk"), itemId, stream));
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
             JsonElement op = doc.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
@@ -334,7 +334,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             const string itemId = "etag-read-id";
 
             string capturedJson = await this.CaptureReadCommitBodyAsync(tx =>
-                tx.ReadItem(Database, Container, new PartitionKey("pk"), itemId,
+                tx.ReadItem(BuildMockContainer(), new PartitionKey("pk"), itemId,
                     new DistributedTransactionRequestOptions { IfNoneMatchEtag = etag }));
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
@@ -350,7 +350,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         public async Task ReadItem_WithoutEtag_DoesNotIncludeEtagField()
         {
             string capturedJson = await this.CaptureReadCommitBodyAsync(tx =>
-                tx.ReadItem(Database, Container, new PartitionKey("pk"), "read-no-etag"));
+                tx.ReadItem(BuildMockContainer(), new PartitionKey("pk"), "read-no-etag"));
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
             JsonElement op = doc.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
@@ -367,7 +367,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             const string itemId = "read-ifmatch-id";
 
             string capturedJson = await this.CaptureReadCommitBodyAsync(tx =>
-                tx.ReadItem(Database, Container, new PartitionKey("pk"), itemId,
+                tx.ReadItem(BuildMockContainer(), new PartitionKey("pk"), itemId,
                     new DistributedTransactionRequestOptions { IfMatchEtag = etag }));
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
@@ -387,7 +387,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             const string itemId = "etag-replace-id";
 
             string capturedJson = await this.CaptureCommitBodyAsync(tx =>
-                tx.ReplaceItem(Database, Container, new PartitionKey("pk"), itemId, new TestItem(itemId),
+                tx.ReplaceItem(BuildMockContainer(), new PartitionKey("pk"), itemId, new TestItem(itemId),
                     new DistributedTransactionRequestOptions { IfMatchEtag = etag }));
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
@@ -406,7 +406,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             const string itemId = "etag-delete-id";
 
             string capturedJson = await this.CaptureCommitBodyAsync(tx =>
-                tx.DeleteItem(Database, Container, new PartitionKey("pk"), itemId,
+                tx.DeleteItem(BuildMockContainer(), new PartitionKey("pk"), itemId,
                     new DistributedTransactionRequestOptions { IfMatchEtag = etag }));
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
@@ -425,7 +425,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             const string itemId = "etag-patch-id";
 
             string capturedJson = await this.CaptureCommitBodyAsync(tx =>
-                tx.PatchItem(Database, Container, new PartitionKey("pk"), itemId,
+                tx.PatchItem(BuildMockContainer(), new PartitionKey("pk"), itemId,
                     new[] { PatchOperation.Add("/value", "v") },
                     new DistributedTransactionRequestOptions { IfMatchEtag = etag }));
 
@@ -442,8 +442,8 @@ namespace Microsoft.Azure.Cosmos.Tests
         public async Task Operations_WithoutIfMatchEtag_DoNotIncludeEtagField()
         {
             string capturedJson = await this.CaptureCommitBodyAsync(tx =>
-                tx.CreateItem(Database, Container, new PartitionKey("pk"), "create-no-etag", new TestItem("create-no-etag"))
-                  .ReplaceItem(Database, Container, new PartitionKey("pk"), "replace-no-etag", new TestItem("replace-no-etag")),
+                tx.CreateItem(BuildMockContainer(), new PartitionKey("pk"), "create-no-etag", new TestItem("create-no-etag"))
+                  .ReplaceItem(BuildMockContainer(), new PartitionKey("pk"), "replace-no-etag", new TestItem("replace-no-etag")),
                 expectedResultCount: 2);
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
@@ -462,7 +462,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             DistributedWriteTransaction tx = new DistributedWriteTransactionCore(this.BuildContextSetup().Object);
             Assert.ThrowsException<ArgumentNullException>(() =>
-                tx.CreateItem(Database, Container, new PartitionKey("pk"), id: null, new TestItem("body-id")));
+                tx.CreateItem(BuildMockContainer(), new PartitionKey("pk"), id: null, new TestItem("body-id")));
         }
 
         [TestMethod]
@@ -471,7 +471,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             DistributedWriteTransaction tx = new DistributedWriteTransactionCore(this.BuildContextSetup().Object);
             Assert.ThrowsException<ArgumentNullException>(() =>
-                tx.UpsertItem(Database, Container, new PartitionKey("pk"), id: string.Empty, new TestItem("body-id")));
+                tx.UpsertItem(BuildMockContainer(), new PartitionKey("pk"), id: string.Empty, new TestItem("body-id")));
         }
 
         [TestMethod]
@@ -481,7 +481,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             DistributedWriteTransaction tx = new DistributedWriteTransactionCore(this.BuildContextSetup().Object);
             using MemoryStream stream = new MemoryStream(Encoding.UTF8.GetBytes(@"{""value"":1}"));
             Assert.ThrowsException<ArgumentNullException>(() =>
-                tx.CreateItemStream(Database, Container, new PartitionKey("pk"), id: null, stream));
+                tx.CreateItemStream(BuildMockContainer(), new PartitionKey("pk"), id: null, stream));
         }
 
         [TestMethod]
@@ -491,10 +491,29 @@ namespace Microsoft.Azure.Cosmos.Tests
             DistributedWriteTransaction tx = new DistributedWriteTransactionCore(this.BuildContextSetup().Object);
             using MemoryStream stream = new MemoryStream(Encoding.UTF8.GetBytes(@"{""value"":1}"));
             Assert.ThrowsException<ArgumentNullException>(() =>
-                tx.UpsertItemStream(Database, Container, new PartitionKey("pk"), id: "   ", stream));
+                tx.UpsertItemStream(BuildMockContainer(), new PartitionKey("pk"), id: "   ", stream));
         }
 
         // Helpers
+
+        /// <summary>
+        /// Builds a mock <see cref="Cosmos.Container"/> that returns <see cref="DatabaseName"/>
+        /// and <see cref="ContainerName"/> from its <see cref="Cosmos.Container.Database"/>/<see cref="Cosmos.Container.Id"/>
+        /// accessors.
+        /// </summary>
+        private static Cosmos.Container BuildMockContainer(
+            string databaseId = DatabaseName,
+            string containerId = ContainerName)
+        {
+            Mock<Cosmos.Database> databaseMock = new Mock<Cosmos.Database>();
+            databaseMock.Setup(d => d.Id).Returns(databaseId);
+
+            Mock<Cosmos.Container> containerMock = new Mock<Cosmos.Container>();
+            containerMock.Setup(c => c.Id).Returns(containerId);
+            containerMock.Setup(c => c.Database).Returns(databaseMock.Object);
+
+            return containerMock.Object;
+        }
 
         /// <summary>
         /// Builds a transaction using <paramref name="buildTransaction"/>, intercepts the HTTP

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedWriteTransactionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedWriteTransactionTests.cs
@@ -467,6 +467,9 @@ namespace Microsoft.Azure.Cosmos.Tests
 
             Mock<CosmosClientContext> contextMock = new Mock<CosmosClientContext>();
             contextMock
+                .Setup(c => c.Client)
+                .Returns(DistributedWriteTransactionTests.SharedMockClient);
+            contextMock
                 .Setup(c => c.OperationHelperAsync<DistributedTransactionResponse>(
                     It.IsAny<string>(),
                     It.IsAny<string>(),
@@ -489,7 +492,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                     });
 
             await new DistributedWriteTransactionCore(contextMock.Object)
-                .CreateItem(Database, Container, new PartitionKey("pk"), "id", new TestItem())
+                .CreateItem(BuildMockContainer(), new PartitionKey("pk"), "id", new TestItem())
                 .CommitTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual($"{nameof(DistributedWriteTransaction)}.{nameof(DistributedWriteTransaction.CommitTransactionAsync)}", capturedOperationName);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedWriteTransactionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedWriteTransactionTests.cs
@@ -101,6 +101,22 @@ namespace Microsoft.Azure.Cosmos.Tests
         }
 
         [TestMethod]
+        public void CreateItem_DifferentCosmosClient_ThrowsArgumentException()
+        {
+            DistributedWriteTransaction tx = this.NewTransaction();
+            CosmosClient differentClient = new Mock<CosmosClient>().Object;
+            Assert.ThrowsException<ArgumentException>(
+                () => tx.CreateItem(BuildMockContainer(client: differentClient), new PartitionKey("pk"), "item-id", new TestItem()));
+        }
+
+        [TestMethod]
+        public void CreateItem_SameCosmosClient_Succeeds()
+        {
+            DistributedWriteTransaction tx = this.NewTransaction();
+            tx.CreateItem(BuildMockContainer(), new PartitionKey("pk"), "item-id", new TestItem());
+        }
+
+        [TestMethod]
         public void CreateItem_NullResource_ThrowsArgumentException()
         {
             DistributedWriteTransaction tx = this.NewTransaction();
@@ -467,6 +483,10 @@ namespace Microsoft.Azure.Cosmos.Tests
             Mock<CosmosClientContext> contextMock = new Mock<CosmosClientContext>();
 
             contextMock
+                .Setup(c => c.Client)
+                .Returns(DistributedWriteTransactionTests.SharedMockClient);
+
+            contextMock
                 .Setup(c => c.DocumentClient)
                 .Returns(documentClient);
 
@@ -484,6 +504,8 @@ namespace Microsoft.Azure.Cosmos.Tests
             return contextMock;
         }
 
+        private static readonly CosmosClient SharedMockClient = new Mock<CosmosClient>().Object;
+
         /// <summary>
         /// Builds a mock <see cref="Cosmos.Container"/> that returns <see cref="DatabaseName"/>
         /// and <see cref="ContainerName"/> from its <see cref="Cosmos.Container.Database"/>/<see cref="Cosmos.Container.Id"/>
@@ -491,10 +513,12 @@ namespace Microsoft.Azure.Cosmos.Tests
         /// </summary>
         private static Cosmos.Container BuildMockContainer(
             string databaseId = DatabaseName,
-            string containerId = ContainerName)
+            string containerId = ContainerName,
+            CosmosClient client = null)
         {
             Mock<Cosmos.Database> databaseMock = new Mock<Cosmos.Database>();
             databaseMock.Setup(d => d.Id).Returns(databaseId);
+            databaseMock.Setup(d => d.Client).Returns(client ?? DistributedWriteTransactionTests.SharedMockClient);
 
             Mock<Cosmos.Container> containerMock = new Mock<Cosmos.Container>();
             containerMock.Setup(c => c.Id).Returns(containerId);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedWriteTransactionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedWriteTransactionTests.cs
@@ -27,25 +27,77 @@ namespace Microsoft.Azure.Cosmos.Tests
     [TestClass]
     public class DistributedWriteTransactionTests
     {
-        private const string Database = "testDb";
-        private const string Container = "testContainer";
+        private const string DatabaseName = "testDb";
+        private const string ContainerName = "testContainer";
 
         // Argument validation
+
+        [TestMethod]
+        public void CreateItem_NullContainer_ThrowsArgumentException()
+        {
+            DistributedWriteTransaction tx = this.NewTransaction();
+            Assert.ThrowsException<ArgumentNullException>(
+                () => tx.CreateItem(null, new PartitionKey("pk"), "item-id", new TestItem()));
+        }
+
+        [TestMethod]
+        public void CreateItem_NullContainerId_ThrowsArgumentException()
+        {
+            DistributedWriteTransaction tx = this.NewTransaction();
+            Assert.ThrowsException<ArgumentException>(
+                () => tx.CreateItem(BuildMockContainer(containerId: null), new PartitionKey("pk"), "item-id", new TestItem()));
+        }
+
+        [TestMethod]
+        public void CreateItem_EmptyContainerId_ThrowsArgumentException()
+        {
+            DistributedWriteTransaction tx = this.NewTransaction();
+            Assert.ThrowsException<ArgumentException>(
+                () => tx.CreateItem(BuildMockContainer(containerId: string.Empty), new PartitionKey("pk"), "item-id", new TestItem()));
+        }
+
+        [TestMethod]
+        public void CreateItem_WhitespaceContainerId_ThrowsArgumentException()
+        {
+            DistributedWriteTransaction tx = this.NewTransaction();
+            Assert.ThrowsException<ArgumentException>(
+                () => tx.CreateItem(BuildMockContainer(containerId: "   "), new PartitionKey("pk"), "item-id", new TestItem()));
+        }
 
         [TestMethod]
         public void CreateItem_NullDatabase_ThrowsArgumentException()
         {
             DistributedWriteTransaction tx = this.NewTransaction();
-            Assert.ThrowsException<ArgumentNullException>(
-                () => tx.CreateItem(null, Container, new PartitionKey("pk"), "item-id", new TestItem()));
+            Mock<Cosmos.Container> containerMock = new Mock<Cosmos.Container>();
+            containerMock.Setup(c => c.Id).Returns(ContainerName);
+            containerMock.Setup(c => c.Database).Returns((Cosmos.Database)null);
+
+            Assert.ThrowsException<ArgumentException>(
+                () => tx.CreateItem(containerMock.Object, new PartitionKey("pk"), "item-id", new TestItem()));
         }
 
         [TestMethod]
-        public void CreateItem_NullCollection_ThrowsArgumentException()
+        public void CreateItem_NullDatabaseId_ThrowsArgumentException()
         {
             DistributedWriteTransaction tx = this.NewTransaction();
-            Assert.ThrowsException<ArgumentNullException>(
-                () => tx.CreateItem(Database, null, new PartitionKey("pk"), "item-id", new TestItem()));
+            Assert.ThrowsException<ArgumentException>(
+                () => tx.CreateItem(BuildMockContainer(databaseId: null), new PartitionKey("pk"), "item-id", new TestItem()));
+        }
+
+        [TestMethod]
+        public void CreateItem_EmptyDatabaseId_ThrowsArgumentException()
+        {
+            DistributedWriteTransaction tx = this.NewTransaction();
+            Assert.ThrowsException<ArgumentException>(
+                () => tx.CreateItem(BuildMockContainer(databaseId: string.Empty), new PartitionKey("pk"), "item-id", new TestItem()));
+        }
+
+        [TestMethod]
+        public void CreateItem_WhitespaceDatabaseId_ThrowsArgumentException()
+        {
+            DistributedWriteTransaction tx = this.NewTransaction();
+            Assert.ThrowsException<ArgumentException>(
+                () => tx.CreateItem(BuildMockContainer(databaseId: "   "), new PartitionKey("pk"), "item-id", new TestItem()));
         }
 
         [TestMethod]
@@ -53,7 +105,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             DistributedWriteTransaction tx = this.NewTransaction();
             Assert.ThrowsException<ArgumentNullException>(
-                () => tx.CreateItem<TestItem>(Database, Container, new PartitionKey("pk"), "item-id", null));
+                () => tx.CreateItem<TestItem>(BuildMockContainer(), new PartitionKey("pk"), "item-id", null));
         }
 
         [TestMethod]
@@ -61,7 +113,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             DistributedWriteTransaction tx = this.NewTransaction();
             Assert.ThrowsException<ArgumentNullException>(
-                () => tx.ReplaceItem(Database, Container, new PartitionKey("pk"), null, new TestItem()));
+                () => tx.ReplaceItem(BuildMockContainer(), new PartitionKey("pk"), null, new TestItem()));
         }
 
         [TestMethod]
@@ -69,7 +121,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             DistributedWriteTransaction tx = this.NewTransaction();
             Assert.ThrowsException<ArgumentNullException>(
-                () => tx.DeleteItem(Database, Container, new PartitionKey("pk"), string.Empty));
+                () => tx.DeleteItem(BuildMockContainer(), new PartitionKey("pk"), string.Empty));
         }
 
         [TestMethod]
@@ -77,7 +129,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             DistributedWriteTransaction tx = this.NewTransaction();
             Assert.ThrowsException<ArgumentNullException>(
-                () => tx.PatchItem(Database, Container, new PartitionKey("pk"), "item-id", null));
+                () => tx.PatchItem(BuildMockContainer(), new PartitionKey("pk"), "item-id", null));
         }
 
         [TestMethod]
@@ -85,7 +137,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             DistributedWriteTransaction tx = this.NewTransaction();
             Assert.ThrowsException<ArgumentNullException>(
-                () => tx.PatchItem(Database, Container, new PartitionKey("pk"), "item-id", new List<PatchOperation>()));
+                () => tx.PatchItem(BuildMockContainer(), new PartitionKey("pk"), "item-id", new List<PatchOperation>()));
         }
 
         [TestMethod]
@@ -93,7 +145,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             DistributedWriteTransaction tx = this.NewTransaction();
             Assert.ThrowsException<ArgumentNullException>(
-                () => tx.CreateItemStream(Database, Container, new PartitionKey("pk"), "item-id", null));
+                () => tx.CreateItemStream(BuildMockContainer(), new PartitionKey("pk"), "item-id", null));
         }
 
         [TestMethod]
@@ -101,7 +153,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             DistributedWriteTransaction tx = this.NewTransaction();
             Assert.ThrowsException<ArgumentNullException>(
-                () => tx.ReplaceItemStream(Database, Container, new PartitionKey("pk"), "item-id", null));
+                () => tx.ReplaceItemStream(BuildMockContainer(), new PartitionKey("pk"), "item-id", null));
         }
 
         [TestMethod]
@@ -109,7 +161,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             DistributedWriteTransaction tx = this.NewTransaction();
             Assert.ThrowsException<ArgumentNullException>(
-                () => tx.PatchItemStream(Database, Container, new PartitionKey("pk"), "item-id", null));
+                () => tx.PatchItemStream(BuildMockContainer(), new PartitionKey("pk"), "item-id", null));
         }
 
         [TestMethod]
@@ -117,7 +169,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         {
             DistributedWriteTransaction tx = this.NewTransaction();
             Assert.ThrowsException<ArgumentNullException>(
-                () => tx.UpsertItemStream(Database, Container, new PartitionKey("pk"), "item-id", null));
+                () => tx.UpsertItemStream(BuildMockContainer(), new PartitionKey("pk"), "item-id", null));
         }
 
         // Request structure
@@ -151,7 +203,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                     });
 
             await new DistributedWriteTransactionCore(contextMock.Object)
-                .CreateItem(Database, Container, new PartitionKey("pk"), "item-id", new TestItem())
+                .CreateItem(BuildMockContainer(), new PartitionKey("pk"), "item-id", new TestItem())
                 .CommitTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(ResourceType.DistributedTransactionBatch, capturedResourceType);
@@ -187,7 +239,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                     });
 
             await new DistributedWriteTransactionCore(contextMock.Object)
-                .CreateItem(Database, Container, new PartitionKey("pk"), "item-id", new TestItem())
+                .CreateItem(BuildMockContainer(), new PartitionKey("pk"), "item-id", new TestItem())
                 .CommitTransactionAsync(CancellationToken.None);
 
             Assert.IsNotNull(capturedToken, "Idempotency token header must be set.");
@@ -227,7 +279,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                     });
 
             DistributedTransactionResponse response = await new DistributedWriteTransactionCore(contextMock.Object)
-                .CreateItem(Database, Container, new PartitionKey("pk"), "item-id", new TestItem())
+                .CreateItem(BuildMockContainer(), new PartitionKey("pk"), "item-id", new TestItem())
                 .CommitTransactionAsync(CancellationToken.None);
 
             Assert.AreNotEqual(Guid.Empty, response.IdempotencyToken, "Response must carry the idempotency token.");
@@ -262,9 +314,9 @@ namespace Microsoft.Azure.Cosmos.Tests
                     });
 
             await new DistributedWriteTransactionCore(contextMock.Object)
-                .CreateItem(Database, Container, new PartitionKey("pk1"), "id1", new TestItem("id1"))
-                .ReplaceItem(Database, Container, new PartitionKey("pk2"), "id2", new TestItem("id2"))
-                .DeleteItem(Database, Container, new PartitionKey("pk3"), "id3")
+                .CreateItem(BuildMockContainer(), new PartitionKey("pk1"), "id1", new TestItem("id1"))
+                .ReplaceItem(BuildMockContainer(), new PartitionKey("pk2"), "id2", new TestItem("id2"))
+                .DeleteItem(BuildMockContainer(), new PartitionKey("pk3"), "id3")
                 .CommitTransactionAsync(CancellationToken.None);
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
@@ -306,11 +358,11 @@ namespace Microsoft.Azure.Cosmos.Tests
                     });
 
             await new DistributedWriteTransactionCore(contextMock.Object)
-                .CreateItem(Database, Container, new PartitionKey("pk"), "create", new TestItem("create"))
-                .ReplaceItem(Database, Container, new PartitionKey("pk"), "replace", new TestItem("replace"))
-                .DeleteItem(Database, Container, new PartitionKey("pk"), "delete")
-                .PatchItem(Database, Container, new PartitionKey("pk"), "patch", new[] { PatchOperation.Add("/value", "v") })
-                .UpsertItem(Database, Container, new PartitionKey("pk"), "upsert", new TestItem("upsert"))
+                .CreateItem(BuildMockContainer(), new PartitionKey("pk"), "create", new TestItem("create"))
+                .ReplaceItem(BuildMockContainer(), new PartitionKey("pk"), "replace", new TestItem("replace"))
+                .DeleteItem(BuildMockContainer(), new PartitionKey("pk"), "delete")
+                .PatchItem(BuildMockContainer(), new PartitionKey("pk"), "patch", new[] { PatchOperation.Add("/value", "v") })
+                .UpsertItem(BuildMockContainer(), new PartitionKey("pk"), "upsert", new TestItem("upsert"))
                 .CommitTransactionAsync(CancellationToken.None);
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
@@ -351,8 +403,8 @@ namespace Microsoft.Azure.Cosmos.Tests
                 .ReturnsAsync(BuildSuccessResponse(2));
 
             DistributedTransactionResponse response = await new DistributedWriteTransactionCore(contextMock.Object)
-                .CreateItem(Database, Container, new PartitionKey("pk1"), "id1", new TestItem("id1"))
-                .CreateItem(Database, Container, new PartitionKey("pk2"), "id2", new TestItem("id2"))
+                .CreateItem(BuildMockContainer(), new PartitionKey("pk1"), "id1", new TestItem("id1"))
+                .CreateItem(BuildMockContainer(), new PartitionKey("pk2"), "id2", new TestItem("id2"))
                 .CommitTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
@@ -380,7 +432,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 .ReturnsAsync(BuildErrorResponse(HttpStatusCode.Conflict));
 
             DistributedTransactionResponse response = await new DistributedWriteTransactionCore(contextMock.Object)
-                .CreateItem(Database, Container, new PartitionKey("pk"), "item-id", new TestItem())
+                .CreateItem(BuildMockContainer(), new PartitionKey("pk"), "item-id", new TestItem())
                 .CommitTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(HttpStatusCode.Conflict, response.StatusCode);
@@ -430,6 +482,25 @@ namespace Microsoft.Azure.Cosmos.Tests
                 .ReturnsAsync(containerProps);
 
             return contextMock;
+        }
+
+        /// <summary>
+        /// Builds a mock <see cref="Cosmos.Container"/> that returns <see cref="DatabaseName"/>
+        /// and <see cref="ContainerName"/> from its <see cref="Cosmos.Container.Database"/>/<see cref="Cosmos.Container.Id"/>
+        /// accessors. The Container proxy makes no network calls, so a minimal mock is sufficient.
+        /// </summary>
+        private static Cosmos.Container BuildMockContainer(
+            string databaseId = DatabaseName,
+            string containerId = ContainerName)
+        {
+            Mock<Cosmos.Database> databaseMock = new Mock<Cosmos.Database>();
+            databaseMock.Setup(d => d.Id).Returns(databaseId);
+
+            Mock<Cosmos.Container> containerMock = new Mock<Cosmos.Container>();
+            containerMock.Setup(c => c.Id).Returns(containerId);
+            containerMock.Setup(c => c.Database).Returns(databaseMock.Object);
+
+            return containerMock.Object;
         }
 
         private static ResponseMessage BuildSuccessResponse(int operationCount)


### PR DESCRIPTION
## Description

Replaces the `(string database, string collection)` parameter pair on every `DistributedWriteTransaction` / `DistributedReadTransaction` abstract method with a single `Container` reference  consistent with the rest of the v3 SDK where operations target a `Container` instance.

This is a hard signature swap (no overloads). Safe because all DTC APIs are gated behind `#if INTERNAL` and have no shipped customer surface.

## Changes

**Source (4 files):**
- `DistributedWriteTransaction`: 8 abstract methods updated
- `DistributedReadTransaction`: `ReadItem` updated
- `*Core` overrides extract `container.Database.Id` / `container.Id` at the entry point; downstream pipeline (`DistributedTransactionOperation`, committer, serializer, wire format) intentionally untouched
- `ValidateContainerReference(Container)` checks: `container != null`, `container.Id` non-empty, `container.Database != null`, `container.Database.Id` non-empty

**Tests (4 files):**
- `DistributedWriteTransactionTests`, `DistributedReadTransactionCoreTests`: rebuilt with `BuildMockContainer()` Moq helper; 14 new null/empty/whitespace validation test cases added
- `DistributedTransactionSerializerTests`, emulator `DistributedTransactionTests`: call sites updated to pass `Container` directly

## Validation
- Full solution build: 0 errors
- Unit tests: 148/148 DTC tests pass (was 134 before validation additions)
- Emulator tests: compile clean; not run locally (require Windows Cosmos Emulator)

## Changelog

No changelog entry required  the affected APIs are `#if INTERNAL` and are not part of the customer-visible public surface in any released SDK build.