### PR TITLE
[Internal] DTS: Removes dead code and refactors to manual JSON deserialization

### DIFF
--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperationResult.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperationResult.cs
@@ -75,44 +75,49 @@ namespace Microsoft.Azure.Cosmos
         /// <returns>The deserialized operation result with a canonical session token.</returns>
         internal static DistributedTransactionOperationResult FromJson(JsonElement json)
         {
+            if (json.ValueKind != JsonValueKind.Object)
+            {
+                throw new JsonException($"DTC operation result must be a JSON object, but was '{json.ValueKind}'.");
+            }
+
             DistributedTransactionOperationResult result = new DistributedTransactionOperationResult();
 
-            if (TryGetProperty(json, "index", out JsonElement indexEl) && indexEl.TryGetInt32(out int index))
+            if (TryGetInt32Property(json, DistributedTransactionSerializer.Index, out int index))
             {
                 result.Index = index;
             }
 
-            if (TryGetProperty(json, "statusCode", out JsonElement statusCodeEl) && statusCodeEl.TryGetInt32(out int statusCode))
+            if (TryGetInt32Property(json, DistributedTransactionSerializer.StatusCode, out int statusCode))
             {
                 result.StatusCode = (HttpStatusCode)statusCode;
             }
 
-            if (TryGetProperty(json, "subStatusCode", out JsonElement subStatusEl) && subStatusEl.TryGetUInt32(out uint subStatus))
+            if (TryGetUInt32Property(json, DistributedTransactionSerializer.SubStatusCode, out uint subStatus))
             {
                 result.SubStatusCode = (SubStatusCodes)subStatus;
             }
 
-            if (TryGetProperty(json, "etag", out JsonElement etagEl) && etagEl.ValueKind == JsonValueKind.String)
+            if (TryGetProperty(json, DistributedTransactionSerializer.ResponseETag, out JsonElement etagEl) && etagEl.ValueKind == JsonValueKind.String)
             {
                 result.ETag = etagEl.GetString();
             }
 
-            if (TryGetProperty(json, "sessionToken", out JsonElement sessionTokenEl) && sessionTokenEl.ValueKind == JsonValueKind.String)
+            if (TryGetProperty(json, DistributedTransactionSerializer.SessionToken, out JsonElement sessionTokenEl) && sessionTokenEl.ValueKind == JsonValueKind.String)
             {
                 result.SessionToken = sessionTokenEl.GetString();
             }
 
-            if (TryGetProperty(json, "partitionKeyRangeId", out JsonElement pkRangeIdEl) && pkRangeIdEl.ValueKind == JsonValueKind.String)
+            if (TryGetProperty(json, DistributedTransactionSerializer.PartitionKeyRangeId, out JsonElement pkRangeIdEl) && pkRangeIdEl.ValueKind == JsonValueKind.String)
             {
                 result.PartitionKeyRangeId = pkRangeIdEl.GetString();
             }
 
-            if (TryGetProperty(json, "requestCharge", out JsonElement requestChargeEl) && requestChargeEl.TryGetDouble(out double requestCharge))
+            if (TryGetDoubleProperty(json, DistributedTransactionSerializer.RequestCharge, out double requestCharge))
             {
                 result.RequestCharge = requestCharge;
             }
 
-            if (TryGetProperty(json, DistributedTransactionSerializer.ResourceBody, out JsonElement resourceBody)
+            if (TryGetPropertyOrdinal(json, DistributedTransactionSerializer.ResourceBody, out JsonElement resourceBody)
                 && resourceBody.ValueKind != JsonValueKind.Undefined
                 && resourceBody.ValueKind != JsonValueKind.Null)
             {
@@ -157,6 +162,12 @@ namespace Microsoft.Azure.Cosmos
 
         internal static bool TryGetProperty(JsonElement element, string propertyName, out JsonElement value)
         {
+            if (element.ValueKind != JsonValueKind.Object)
+            {
+                value = default;
+                return false;
+            }
+
             foreach (JsonProperty prop in element.EnumerateObject())
             {
                 if (string.Equals(prop.Name, propertyName, StringComparison.OrdinalIgnoreCase))
@@ -164,6 +175,80 @@ namespace Microsoft.Azure.Cosmos
                     value = prop.Value;
                     return true;
                 }
+            }
+
+            value = default;
+            return false;
+        }
+
+        internal static bool TryGetPropertyOrdinal(JsonElement element, string propertyName, out JsonElement value)
+        {
+            if (element.ValueKind != JsonValueKind.Object)
+            {
+                value = default;
+                return false;
+            }
+
+            return element.TryGetProperty(propertyName, out value);
+        }
+
+        private static bool TryGetInt32Property(JsonElement element, string propertyName, out int value)
+        {
+            if (TryGetProperty(element, propertyName, out JsonElement propertyElement))
+            {
+                if (propertyElement.ValueKind != JsonValueKind.Number)
+                {
+                    throw new JsonException($"'{propertyName}' must be a JSON number, but was '{propertyElement.ValueKind}'.");
+                }
+
+                if (!propertyElement.TryGetInt32(out value))
+                {
+                    throw new JsonException($"'{propertyName}' must be a 32-bit integer JSON number.");
+                }
+
+                return true;
+            }
+
+            value = default;
+            return false;
+        }
+
+        private static bool TryGetUInt32Property(JsonElement element, string propertyName, out uint value)
+        {
+            if (TryGetProperty(element, propertyName, out JsonElement propertyElement))
+            {
+                if (propertyElement.ValueKind != JsonValueKind.Number)
+                {
+                    throw new JsonException($"'{propertyName}' must be a JSON number, but was '{propertyElement.ValueKind}'.");
+                }
+
+                if (!propertyElement.TryGetUInt32(out value))
+                {
+                    throw new JsonException($"'{propertyName}' must be a 32-bit unsigned integer JSON number.");
+                }
+
+                return true;
+            }
+
+            value = default;
+            return false;
+        }
+
+        private static bool TryGetDoubleProperty(JsonElement element, string propertyName, out double value)
+        {
+            if (TryGetProperty(element, propertyName, out JsonElement propertyElement))
+            {
+                if (propertyElement.ValueKind != JsonValueKind.Number)
+                {
+                    throw new JsonException($"'{propertyName}' must be a JSON number, but was '{propertyElement.ValueKind}'.");
+                }
+
+                if (!propertyElement.TryGetDouble(out value))
+                {
+                    throw new JsonException($"'{propertyName}' must be a double-precision JSON number.");
+                }
+
+                return true;
             }
 
             value = default;

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperationResult.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperationResult.cs
@@ -8,7 +8,6 @@ namespace Microsoft.Azure.Cosmos
     using System.IO;
     using System.Net;
     using System.Text.Json;
-    using System.Text.Json.Serialization;
     using Microsoft.Azure.Cosmos.Core.Trace;
     using Microsoft.Azure.Cosmos.Tracing;
     using Microsoft.Azure.Documents;
@@ -46,14 +45,7 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// Initializes a new instance of the <see cref="DistributedTransactionOperationResult"/> class.
         /// </summary>
-        /// <remarks>
-        /// Must be <c>public</c> for System.Text.Json reflection-based deserialization.
-        /// System.Text.Json 6.x only scans <c>BindingFlags.Public</c> constructors when resolving
-        /// <see cref="JsonConstructorAttribute"/>; non-public constructors are not found.
-        /// Support for non-public constructors was added in System.Text.Json 7.0.
-        /// </remarks>
-        [JsonConstructor]
-        public DistributedTransactionOperationResult()
+        internal DistributedTransactionOperationResult()
         {
         }
 
@@ -88,7 +80,6 @@ namespace Microsoft.Azure.Cosmos
         /// Do not dispose it directly. To deserialize to a typed object, use
         /// <see cref="DistributedTransactionResponse.GetOperationResultAtIndex{T}"/>.
         /// </remarks>
-        [JsonIgnore]
         public virtual Stream ResourceStream { get; internal set; }
 
         /// <summary>
@@ -105,13 +96,10 @@ namespace Microsoft.Azure.Cosmos
         /// <summary>
         /// ActivityId related to the operation.
         /// </summary>
-        [JsonIgnore]
         internal virtual string ActivityId { get; set; }
 
-        [JsonIgnore]
         internal ITrace Trace { get; set; }
 
-        [JsonIgnore]
         internal CosmosSerializerCore SerializerCore { get; set; }
 
         /// <summary>
@@ -203,7 +191,7 @@ namespace Microsoft.Azure.Cosmos
                 result.RequestCharge = requestCharge;
             }
 
-            if (TryGetPropertyOrdinal(json, DistributedTransactionSerializer.ResourceBody, out JsonElement resourceBody)
+            if (TryGetProperty(json, DistributedTransactionSerializer.ResourceBody, out JsonElement resourceBody)
                 && resourceBody.ValueKind != JsonValueKind.Undefined
                 && resourceBody.ValueKind != JsonValueKind.Null)
             {
@@ -265,17 +253,6 @@ namespace Microsoft.Azure.Cosmos
 
             value = default;
             return false;
-        }
-
-        internal static bool TryGetPropertyOrdinal(JsonElement element, string propertyName, out JsonElement value)
-        {
-            if (element.ValueKind != JsonValueKind.Object)
-            {
-                value = default;
-                return false;
-            }
-
-            return element.TryGetProperty(propertyName, out value);
         }
 
         private static bool TryGetInt32Property(JsonElement element, string propertyName, out int value)

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperationResult.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperationResult.cs
@@ -8,9 +8,7 @@ namespace Microsoft.Azure.Cosmos
     using System.IO;
     using System.Net;
     using System.Text.Json;
-    using System.Text.Json.Serialization;
     using Microsoft.Azure.Cosmos.Core.Trace;
-    using Microsoft.Azure.Cosmos.Tracing;
     using Microsoft.Azure.Documents;
 
     /// <summary>
@@ -28,117 +26,47 @@ namespace Microsoft.Azure.Cosmos
             this.StatusCode = statusCode;
         }
 
-        internal DistributedTransactionOperationResult(DistributedTransactionOperationResult other)
-        {
-            this.Index = other.Index;
-            this.StatusCode = other.StatusCode;
-            this.SubStatusCode = other.SubStatusCode;
-            this.ETag = other.ETag;
-            this.ResourceStream = other.ResourceStream;
-            this.SessionToken = other.SessionToken;
-            this.PartitionKeyRangeId = other.PartitionKeyRangeId;
-            this.RequestCharge = other.RequestCharge;
-            this.ActivityId = other.ActivityId;
-            this.Trace = other.Trace;
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="DistributedTransactionOperationResult"/> class.
-        /// </summary>
-        /// <remarks>
-        /// Must be <c>public</c> for System.Text.Json reflection-based deserialization.
-        /// System.Text.Json 6.x only scans <c>BindingFlags.Public</c> constructors when resolving
-        /// <see cref="JsonConstructorAttribute"/>; non-public constructors are not found.
-        /// Support for non-public constructors was added in System.Text.Json 7.0.
-        /// </remarks>
-        [JsonConstructor]
-        public DistributedTransactionOperationResult()
+        internal DistributedTransactionOperationResult()
         {
         }
 
         /// <summary>
         /// Gets the index of this operation within the distributed transaction.
         /// </summary>
-        [JsonInclude]
-        [JsonPropertyName("index")]
         public virtual int Index { get; internal set; }
 
         /// <summary>
         /// Gets the HTTP status code returned by the operation.
         /// </summary>
-        [JsonInclude]
-        [JsonPropertyName("statusCode")]
         public virtual HttpStatusCode StatusCode { get; internal set; }
 
         /// <summary>
         /// Gets a value indicating whether the HTTP status code returned by the operation indicates success.
         /// </summary>
-        [JsonIgnore]
         public virtual bool IsSuccessStatusCode => (int)this.StatusCode >= 200 && (int)this.StatusCode <= 299;
 
         /// <summary>
         /// Gets the entity tag (ETag) associated with the operation result.
         /// The ETag is used for concurrency control and represents the version of the resource.
         /// </summary>
-        [JsonInclude]
-        [JsonPropertyName("etag")]
         public virtual string ETag { get; internal set; }
-
-        /// <summary>
-        /// Gets the session token associated with the operation result.
-        /// </summary>
-        [JsonInclude]
-        [JsonPropertyName("sessionToken")]
-        public virtual string SessionToken { get; internal set; }
-
-        /// <summary>
-        /// Gets the raw partition key range ID emitted by the server.
-        /// </summary>
-        [JsonInclude]
-        [JsonPropertyName("partitionKeyRangeId")]
-        public virtual string PartitionKeyRangeId { get; internal set; }
 
         /// <summary>
         /// Gets the resource stream associated with the operation result.
         /// The stream contains the raw response payload returned by the operation.
         /// </summary>
-        [JsonIgnore]
         public virtual Stream ResourceStream { get; internal set; }
 
         /// <summary>
         /// Request charge in request units for the operation.
         /// </summary>
-        [JsonInclude]
-        [JsonPropertyName("requestCharge")]
         public virtual double RequestCharge { get; internal set; }
 
-        [JsonIgnore]
         internal virtual SubStatusCodes SubStatusCode { get; set; }
 
-        /// <summary>
-        /// Gets the sub-status code value as an unsigned integer.
-        /// </summary>
-        [JsonInclude]
-        [JsonPropertyName("subStatusCode")]
-        public virtual uint SubStatusCodeValue
-        {
-            get => (uint)this.SubStatusCode;
-            internal set => this.SubStatusCode = (SubStatusCodes)value;
-        }
+        internal virtual string SessionToken { get; set; }
 
-        /// <summary>
-        /// ActivityId related to the operation.
-        /// </summary>
-        [JsonIgnore]
-        internal virtual string ActivityId { get; set; }
-
-        [JsonIgnore]
-        internal ITrace Trace { get; set; }
-
-        private static readonly JsonSerializerOptions CaseInsensitiveOptions = new JsonSerializerOptions
-        {
-            PropertyNameCaseInsensitive = true,
-        };
+        internal virtual string PartitionKeyRangeId { get; set; }
 
         /// <summary>
         /// Creates a <see cref="DistributedTransactionOperationResult"/> from a JSON element.
@@ -147,10 +75,44 @@ namespace Microsoft.Azure.Cosmos
         /// <returns>The deserialized operation result with a canonical session token.</returns>
         internal static DistributedTransactionOperationResult FromJson(JsonElement json)
         {
-            DistributedTransactionOperationResult result = JsonSerializer.Deserialize<DistributedTransactionOperationResult>(json, DistributedTransactionOperationResult.CaseInsensitiveOptions)
-                ?? throw new JsonException($"Failed to deserialize DTC operation result: Deserialize returned null. JSON element kind: '{json.ValueKind}'.");
+            DistributedTransactionOperationResult result = new DistributedTransactionOperationResult();
 
-            if (json.TryGetProperty(DistributedTransactionSerializer.ResourceBody, out JsonElement resourceBody)
+            if (TryGetProperty(json, "index", out JsonElement indexEl) && indexEl.TryGetInt32(out int index))
+            {
+                result.Index = index;
+            }
+
+            if (TryGetProperty(json, "statusCode", out JsonElement statusCodeEl) && statusCodeEl.TryGetInt32(out int statusCode))
+            {
+                result.StatusCode = (HttpStatusCode)statusCode;
+            }
+
+            if (TryGetProperty(json, "subStatusCode", out JsonElement subStatusEl) && subStatusEl.TryGetUInt32(out uint subStatus))
+            {
+                result.SubStatusCode = (SubStatusCodes)subStatus;
+            }
+
+            if (TryGetProperty(json, "etag", out JsonElement etagEl) && etagEl.ValueKind == JsonValueKind.String)
+            {
+                result.ETag = etagEl.GetString();
+            }
+
+            if (TryGetProperty(json, "sessionToken", out JsonElement sessionTokenEl) && sessionTokenEl.ValueKind == JsonValueKind.String)
+            {
+                result.SessionToken = sessionTokenEl.GetString();
+            }
+
+            if (TryGetProperty(json, "partitionKeyRangeId", out JsonElement pkRangeIdEl) && pkRangeIdEl.ValueKind == JsonValueKind.String)
+            {
+                result.PartitionKeyRangeId = pkRangeIdEl.GetString();
+            }
+
+            if (TryGetProperty(json, "requestCharge", out JsonElement requestChargeEl) && requestChargeEl.TryGetDouble(out double requestCharge))
+            {
+                result.RequestCharge = requestCharge;
+            }
+
+            if (TryGetProperty(json, DistributedTransactionSerializer.ResourceBody, out JsonElement resourceBody)
                 && resourceBody.ValueKind != JsonValueKind.Undefined
                 && resourceBody.ValueKind != JsonValueKind.Null)
             {
@@ -191,6 +153,21 @@ namespace Microsoft.Azure.Cosmos
             }
 
             return result;
+        }
+
+        internal static bool TryGetProperty(JsonElement element, string propertyName, out JsonElement value)
+        {
+            foreach (JsonProperty prop in element.EnumerateObject())
+            {
+                if (string.Equals(prop.Name, propertyName, StringComparison.OrdinalIgnoreCase))
+                {
+                    value = prop.Value;
+                    return true;
+                }
+            }
+
+            value = default;
+            return false;
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionResponse.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionResponse.cs
@@ -375,20 +375,20 @@ namespace Microsoft.Azure.Cosmos
             {
                 JsonElement root = responseJson.RootElement;
 
-                if (DistributedTransactionOperationResult.TryGetPropertyOrdinal(root, DistributedTransactionSerializer.IsRetriable, out JsonElement isRetriableElement) &&
+                if (DistributedTransactionOperationResult.TryGetProperty(root, DistributedTransactionSerializer.IsRetriable, out JsonElement isRetriableElement) &&
                     isRetriableElement.ValueKind == JsonValueKind.True)
                 {
                     isRetriable = true;
                 }
 
-                if (root.TryGetProperty(DistributedTransactionSerializer.DiagnosticString, out JsonElement diagnosticStringElement) &&
+                if (DistributedTransactionOperationResult.TryGetProperty(root, DistributedTransactionSerializer.DiagnosticString, out JsonElement diagnosticStringElement) &&
                     diagnosticStringElement.ValueKind == JsonValueKind.String)
                 {
                     diagnosticString = diagnosticStringElement.GetString();
                 }
 
                 // Parse operation results from "operationResponses" array.
-                if (DistributedTransactionOperationResult.TryGetPropertyOrdinal(root, DistributedTransactionSerializer.OperationResponses, out JsonElement operationResponses) &&
+                if (DistributedTransactionOperationResult.TryGetProperty(root, DistributedTransactionSerializer.OperationResponses, out JsonElement operationResponses) &&
                     operationResponses.ValueKind == JsonValueKind.Array)
                 {
                     try

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionResponse.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionResponse.cs
@@ -32,21 +32,17 @@ namespace Microsoft.Azure.Cosmos
         private DistributedTransactionResponse(
             HttpStatusCode statusCode,
             SubStatusCodes subStatusCode,
-            string errorMessage,
             Headers headers,
             IReadOnlyList<DistributedTransactionOperation> operations,
             CosmosSerializerCore serializer,
-            ITrace trace,
             Guid idempotencyToken,
             bool isRetriable = false)
         {
             this.Headers = headers;
             this.StatusCode = statusCode;
             this.SubStatusCode = subStatusCode;
-            this.ErrorMessage = errorMessage;
             this.Operations = operations;
             this.SerializerCore = serializer;
-            this.Trace = trace;
             this.IdempotencyToken = idempotencyToken;
             this.IsRetriable = isRetriable;
         }
@@ -104,11 +100,6 @@ namespace Microsoft.Azure.Cosmos
         public virtual bool IsSuccessStatusCode => (int)this.StatusCode >= 200 && (int)this.StatusCode <= 299;
 
         /// <summary>
-        /// Gets the error message associated with the distributed transaction response, if any.
-        /// </summary>
-        public virtual string ErrorMessage { get; }
-
-        /// <summary>
         /// Gets the number of operation results in the distributed transaction response.
         /// </summary>
         public virtual int Count => this.results?.Count ?? 0;
@@ -128,8 +119,6 @@ namespace Microsoft.Azure.Cosmos
         internal virtual CosmosSerializerCore SerializerCore { get; }
 
         internal IReadOnlyList<DistributedTransactionOperation> Operations { get; }
-
-        internal ITrace Trace { get; }
 
         /// <summary>
         /// Returns an enumerator that iterates through the operation results.
@@ -169,7 +158,7 @@ namespace Microsoft.Azure.Cosmos
             ITrace trace,
             CancellationToken cancellationToken)
         {
-            using (ITrace createResponseTrace = trace.StartChild("Create Distributed Transaction Response", TraceComponent.Batch, TraceLevel.Info))
+            using (trace.StartChild("Create Distributed Transaction Response", TraceComponent.Batch, TraceLevel.Info))
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
@@ -200,7 +189,6 @@ namespace Microsoft.Azure.Cosmos
                             serverRequest,
                             serializer,
                             idempotencyToken,
-                            createResponseTrace,
                             cancellationToken);
                     }
 
@@ -208,11 +196,9 @@ namespace Microsoft.Azure.Cosmos
                     response ??= new DistributedTransactionResponse(
                         responseMessage.StatusCode,
                         responseMessage.Headers.SubStatusCode,
-                        responseMessage.ErrorMessage,
                         responseMessage.Headers,
                         serverRequest.Operations,
                         serializer,
-                        createResponseTrace,
                         idempotencyToken);
 
                     // Validate results count matches operations count
@@ -229,15 +215,13 @@ namespace Microsoft.Azure.Cosmos
                             return new DistributedTransactionResponse(
                                 HttpStatusCode.InternalServerError,
                                 SubStatusCodes.Unknown,
-                                ClientResources.InvalidServerResponse,
                                 responseMessage.Headers,
                                 serverRequest.Operations,
                                 serializer,
-                                createResponseTrace,
                                 idempotencyToken);
                         }
 
-                        response.CreateAndPopulateResults(serverRequest.Operations, createResponseTrace);
+                        response.CreateAndPopulateResults(serverRequest.Operations);
                     }
 
                     return response;
@@ -298,7 +282,6 @@ namespace Microsoft.Azure.Cosmos
             DistributedTransactionServerRequest serverRequest,
             CosmosSerializerCore serializer,
             Guid idempotencyToken,
-            ITrace trace,
             CancellationToken cancellationToken)
         {
             List<DistributedTransactionOperationResult> results = new List<DistributedTransactionOperationResult>();
@@ -321,14 +304,14 @@ namespace Microsoft.Azure.Cosmos
             {
                 JsonElement root = responseJson.RootElement;
 
-                if (root.TryGetProperty("isRetriable", out JsonElement isRetriableElement) &&
+                if (DistributedTransactionOperationResult.TryGetProperty(root, "isRetriable", out JsonElement isRetriableElement) &&
                     isRetriableElement.ValueKind == JsonValueKind.True)
                 {
                     isRetriable = true;
                 }
 
                 // Parse operation results from "operationResponses" array.
-                if (root.TryGetProperty("operationResponses", out JsonElement operationResponses) &&
+                if (DistributedTransactionOperationResult.TryGetProperty(root, "operationResponses", out JsonElement operationResponses) &&
                     operationResponses.ValueKind == JsonValueKind.Array)
                 {
                     try
@@ -338,8 +321,6 @@ namespace Microsoft.Azure.Cosmos
                             cancellationToken.ThrowIfCancellationRequested();
 
                             DistributedTransactionOperationResult operationResult = DistributedTransactionOperationResult.FromJson(operationElement);
-                            operationResult.Trace = trace;
-                            operationResult.ActivityId = responseMessage.Headers.ActivityId;
                             results.Add(operationResult);
                         }
                     }
@@ -375,11 +356,9 @@ namespace Microsoft.Azure.Cosmos
             return new DistributedTransactionResponse(
                 finalStatusCode,
                 finalSubStatusCode,
-                responseMessage.ErrorMessage,
                 responseMessage.Headers,
                 serverRequest.Operations,
                 serializer,
-                trace,
                 idempotencyToken,
                 isRetriable)
             {
@@ -388,8 +367,7 @@ namespace Microsoft.Azure.Cosmos
         }
 
         private void CreateAndPopulateResults(
-            IReadOnlyList<DistributedTransactionOperation> operations,
-            ITrace trace)
+            IReadOnlyList<DistributedTransactionOperation> operations)
         {
             this.results = new List<DistributedTransactionOperationResult>(operations.Count);
 
@@ -398,8 +376,6 @@ namespace Microsoft.Azure.Cosmos
                 this.results.Add(new DistributedTransactionOperationResult(this.StatusCode)
                 {
                     SubStatusCode = this.SubStatusCode,
-                    ActivityId = this.ActivityId,
-                    Trace = trace
                 });
             }
         }

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionResponse.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionResponse.cs
@@ -32,6 +32,7 @@ namespace Microsoft.Azure.Cosmos
         private DistributedTransactionResponse(
             HttpStatusCode statusCode,
             SubStatusCodes subStatusCode,
+            string errorMessage,
             Headers headers,
             IReadOnlyList<DistributedTransactionOperation> operations,
             CosmosSerializerCore serializer,
@@ -41,6 +42,7 @@ namespace Microsoft.Azure.Cosmos
             this.Headers = headers;
             this.StatusCode = statusCode;
             this.SubStatusCode = subStatusCode;
+            this.ErrorMessage = errorMessage;
             this.Operations = operations;
             this.SerializerCore = serializer;
             this.IdempotencyToken = idempotencyToken;
@@ -98,6 +100,11 @@ namespace Microsoft.Azure.Cosmos
         /// Gets a value indicating whether the transaction was processed successfully.
         /// </summary>
         public virtual bool IsSuccessStatusCode => (int)this.StatusCode >= 200 && (int)this.StatusCode <= 299;
+
+        /// <summary>
+        /// Gets the error message associated with the distributed transaction response.
+        /// </summary>
+        public virtual string ErrorMessage { get; }
 
         /// <summary>
         /// Gets the number of operation results in the distributed transaction response.
@@ -196,6 +203,7 @@ namespace Microsoft.Azure.Cosmos
                     response ??= new DistributedTransactionResponse(
                         responseMessage.StatusCode,
                         responseMessage.Headers.SubStatusCode,
+                        responseMessage.ErrorMessage,
                         responseMessage.Headers,
                         serverRequest.Operations,
                         serializer,
@@ -215,6 +223,7 @@ namespace Microsoft.Azure.Cosmos
                             return new DistributedTransactionResponse(
                                 HttpStatusCode.InternalServerError,
                                 SubStatusCodes.Unknown,
+                                ClientResources.InvalidServerResponse,
                                 responseMessage.Headers,
                                 serverRequest.Operations,
                                 serializer,
@@ -297,6 +306,12 @@ namespace Microsoft.Azure.Cosmos
                 DefaultTrace.TraceWarning(
                     "DistributedTransactionResponse: failed to parse response body: {0}",
                     jsonEx.Message);
+
+                if (responseMessage.IsSuccessStatusCode)
+                {
+                    return CreateDeserializationFailureResponse(responseMessage, serverRequest, serializer, idempotencyToken);
+                }
+
                 return null;
             }
 
@@ -304,14 +319,14 @@ namespace Microsoft.Azure.Cosmos
             {
                 JsonElement root = responseJson.RootElement;
 
-                if (DistributedTransactionOperationResult.TryGetProperty(root, "isRetriable", out JsonElement isRetriableElement) &&
+                if (DistributedTransactionOperationResult.TryGetPropertyOrdinal(root, DistributedTransactionSerializer.IsRetriable, out JsonElement isRetriableElement) &&
                     isRetriableElement.ValueKind == JsonValueKind.True)
                 {
                     isRetriable = true;
                 }
 
                 // Parse operation results from "operationResponses" array.
-                if (DistributedTransactionOperationResult.TryGetProperty(root, "operationResponses", out JsonElement operationResponses) &&
+                if (DistributedTransactionOperationResult.TryGetPropertyOrdinal(root, DistributedTransactionSerializer.OperationResponses, out JsonElement operationResponses) &&
                     operationResponses.ValueKind == JsonValueKind.Array)
                 {
                     try
@@ -329,8 +344,21 @@ namespace Microsoft.Azure.Cosmos
                         DefaultTrace.TraceWarning(
                             "DistributedTransactionResponse: per-operation parse failed; forcing isRetriable=false. {0}",
                             jsonEx.Message);
+
+                        // Dispose any resource streams allocated for the partially-parsed operations
+                        // before discarding them.
+                        foreach (DistributedTransactionOperationResult partial in results)
+                        {
+                            partial.ResourceStream?.Dispose();
+                        }
+
                         results.Clear();
                         isRetriable = false;
+
+                        if (responseMessage.IsSuccessStatusCode)
+                        {
+                            return CreateDeserializationFailureResponse(responseMessage, serverRequest, serializer, idempotencyToken);
+                        }
                     }
                 }
             }
@@ -356,6 +384,7 @@ namespace Microsoft.Azure.Cosmos
             return new DistributedTransactionResponse(
                 finalStatusCode,
                 finalSubStatusCode,
+                responseMessage.ErrorMessage,
                 responseMessage.Headers,
                 serverRequest.Operations,
                 serializer,
@@ -378,6 +407,29 @@ namespace Microsoft.Azure.Cosmos
                     SubStatusCode = this.SubStatusCode,
                 });
             }
+        }
+
+        /// <summary>
+        /// Builds an InternalServerError response indicating the server replied with success but
+        /// the SDK could not deserialize the response payload. Mirrors TransactionalBatch behavior.
+        /// </summary>
+        private static DistributedTransactionResponse CreateDeserializationFailureResponse(
+            ResponseMessage responseMessage,
+            DistributedTransactionServerRequest serverRequest,
+            CosmosSerializerCore serializer,
+            Guid idempotencyToken)
+        {
+            DistributedTransactionResponse failedResponse = new DistributedTransactionResponse(
+                HttpStatusCode.InternalServerError,
+                SubStatusCodes.Unknown,
+                ClientResources.ServerResponseDeserializationFailure,
+                responseMessage.Headers,
+                serverRequest.Operations,
+                serializer,
+                idempotencyToken);
+
+            failedResponse.CreateAndPopulateResults(serverRequest.Operations);
+            return failedResponse;
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionSerializer.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionSerializer.cs
@@ -24,10 +24,16 @@ namespace Microsoft.Azure.Cosmos
         internal const string DatabaseResourceId = "databaseResourceId";
         internal const string PartitionKey = "partitionKey";
         internal const string Index = "index";
+        internal const string StatusCode = "statusCode";
+        internal const string SubStatusCode = "subStatusCode";
         internal const string ResourceBody = "resourceBody";
+        internal const string RequestCharge = "requestCharge";
+        internal const string IsRetriable = "isRetriable";
+        internal const string OperationResponses = "operationResponses";
         internal const string SessionToken = "sessionToken";
         internal const string PartitionKeyRangeId = "partitionKeyRangeId";
         internal const string ETag = "ifMatch";
+        internal const string ResponseETag = "Etag";
         internal const string OperationType = "operationType";
         internal const string ResourceType = "resourceType";
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionResponseTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionResponseTests.cs
@@ -492,7 +492,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         // Operation result property deserialization
 
         [TestMethod]
-        [Description("SubStatusCodeValue deserializes from the 'subStatusCode' JSON property and is accessible as both uint and SubStatusCodes enum.")]
+        [Description("SubStatusCode deserializes from the 'subStatusCode' JSON property.")]
         public async Task FromResponseMessage_OperationResult_SubStatusCode_DeserializesCorrectly()
         {
             const uint expectedSubStatusCode = 449; // RetryWith
@@ -508,10 +508,8 @@ namespace Microsoft.Azure.Cosmos.Tests
                 NoOpTrace.Singleton,
                 CancellationToken.None);
 
-            Assert.AreEqual(expectedSubStatusCode, response[0].SubStatusCodeValue,
-                "SubStatusCodeValue must equal the uint value from the JSON 'subStatusCode' field.");
             Assert.AreEqual((SubStatusCodes)expectedSubStatusCode, response[0].SubStatusCode,
-                "SubStatusCode enum must be the cast of the uint value.");
+                "SubStatusCode must equal the cast of the uint value from the JSON 'subStatusCode' field.");
         }
 
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionResponseTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionResponseTests.cs
@@ -144,12 +144,13 @@ namespace Microsoft.Azure.Cosmos.Tests
         }
 
         [DataTestMethod]
-        [Description("When numeric operation fields are present but not numeric, per-operation parsing fails and a success response is converted to InternalServerError with a deserialization-failure message.")]
+        [Description("When per-operation fields have wrong types or non-object entries, parsing fails and a success response is converted to InternalServerError with a deserialization-failure message.")]
         [DataRow(@"{""operationResponses"":[{""index"":0,""statusCode"":""abc""}]}", DisplayName = "statusCode wrong type")]
         [DataRow(@"{""operationResponses"":[{""index"":0,""statusCode"":449,""subStatusCode"":""abc""}]}", DisplayName = "subStatusCode wrong type")]
         [DataRow(@"{""operationResponses"":[{""index"":0,""statusCode"":201,""requestCharge"":""abc""}]}", DisplayName = "requestCharge wrong type")]
         [DataRow(@"{""operationResponses"":[{""index"":""abc"",""statusCode"":201}]}", DisplayName = "index wrong type")]
-        public async Task FromResponseMessage_OperationResult_NumericTypeMismatch_SuccessStatus_ReturnsInternalServerError(string json)
+        [DataRow(@"{""operationResponses"":[null]}", DisplayName = "non-object element (null)")]
+        public async Task FromResponseMessage_OperationResult_InvalidElement_SuccessStatus_ReturnsInternalServerError(string json)
         {
             DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
             ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.OK, json);
@@ -167,28 +168,8 @@ namespace Microsoft.Azure.Cosmos.Tests
         }
 
         [TestMethod]
-        [Description("When operationResponses contains a non-object entry, the parser fails safely and a success response is converted to InternalServerError with a deserialization-failure message.")]
-        public async Task FromResponseMessage_OperationResult_NonObjectElement_SuccessStatus_ReturnsInternalServerError()
-        {
-            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
-            string json = @"{""operationResponses"":[null]}";
-            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.OK, json);
-
-            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
-                responseMessage,
-                serverRequest,
-                MockCosmosUtil.Serializer,
-                NoOpTrace.Singleton,
-                CancellationToken.None);
-
-            Assert.AreEqual(HttpStatusCode.InternalServerError, response.StatusCode);
-            Assert.IsFalse(response.IsSuccessStatusCode);
-            Assert.AreEqual(ClientResources.ServerResponseDeserializationFailure, response.ErrorMessage);
-        }
-
-        [TestMethod]
-        [Description("Top-level lookups are case-sensitive; PascalCase 'OperationResponses' is ignored and success responses become InternalServerError due to count mismatch.")]
-        public async Task FromResponseMessage_OperationResponses_PascalCaseKey_SuccessStatus_ReturnsInternalServerError()
+        [Description("Top-level lookups are case-insensitive; PascalCase 'OperationResponses' is accepted.")]
+        public async Task FromResponseMessage_OperationResponses_PascalCaseKey_SuccessStatus_ParsesSuccessfully()
         {
             DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
             string json = @"{""OperationResponses"":[{""index"":0,""statusCode"":201}]}";
@@ -201,8 +182,10 @@ namespace Microsoft.Azure.Cosmos.Tests
                 NoOpTrace.Singleton,
                 CancellationToken.None);
 
-            Assert.AreEqual(HttpStatusCode.InternalServerError, response.StatusCode);
-            Assert.IsFalse(response.IsSuccessStatusCode);
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            Assert.IsTrue(response.IsSuccessStatusCode);
+            Assert.AreEqual(1, response.Count);
+            Assert.AreEqual(HttpStatusCode.Created, response[0].StatusCode);
         }
 
         // Count mismatch
@@ -347,15 +330,21 @@ namespace Microsoft.Azure.Cosmos.Tests
 
         // Idempotency token resolution
 
-        [TestMethod]
-        [Description("When the IdempotencyToken header is absent from the response, the request token is used as the fallback.")]
-        public async Task FromResponseMessage_IdempotencyToken_MissingFromHeader_FallsBackToRequestToken()
+        [DataTestMethod]
+        [Description("When the IdempotencyToken response header is absent or unparseable, the SDK falls back to the request token.")]
+        [DataRow(null, DisplayName = "Header absent")]
+        [DataRow("not-a-valid-guid", DisplayName = "Invalid GUID in header")]
+        public async Task FromResponseMessage_IdempotencyToken_FallsBackToRequestToken(string headerValue)
         {
             DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
 
             string json = @"{""operationResponses"":[{""index"":0,""statusCode"":201}]}";
             ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.OK, json);
-            // No IdempotencyToken header added
+
+            if (headerValue != null)
+            {
+                responseMessage.Headers.Add(HttpConstants.HttpHeaders.IdempotencyToken, headerValue);
+            }
 
             DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
                 responseMessage,
@@ -365,54 +354,10 @@ namespace Microsoft.Azure.Cosmos.Tests
                 CancellationToken.None);
 
             Assert.AreEqual(serverRequest.IdempotencyToken, response.IdempotencyToken,
-                "The request token must be used when the response header is absent.");
-        }
-
-        [TestMethod]
-        [Description("When the IdempotencyToken response header contains a non-GUID value, the SDK falls back to the request token.")]
-        public async Task FromResponseMessage_IdempotencyToken_InvalidGuidInHeader_FallsBackToRequestToken()
-        {
-            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
-
-            string json = @"{""operationResponses"":[{""index"":0,""statusCode"":201}]}";
-            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.OK, json);
-            responseMessage.Headers.Add(HttpConstants.HttpHeaders.IdempotencyToken, "not-a-valid-guid");
-
-            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
-                responseMessage,
-                serverRequest,
-                MockCosmosUtil.Serializer,
-                NoOpTrace.Singleton,
-                CancellationToken.None);
-
-            Assert.AreEqual(serverRequest.IdempotencyToken, response.IdempotencyToken,
-                "An unparseable header value must fall back to the request token.");
+                "The request token must be used when the response header is absent or unparseable.");
         }
 
         // IDisposable and ObjectDisposed
-
-        [TestMethod]
-        [Description("Dispose() must set result ResourceStreams to null so callers cannot accidentally use a closed stream.")]
-        public async Task Dispose_ReleasesResultResourceStreams()
-        {
-            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
-
-            string json = @"{""operationResponses"":[{""index"":0,""statusCode"":201,""resourceBody"":{""id"":""item1""}}]}";
-            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.OK, json);
-
-            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
-                responseMessage,
-                serverRequest,
-                MockCosmosUtil.Serializer,
-                NoOpTrace.Singleton,
-                CancellationToken.None);
-
-            Assert.IsNotNull(response[0].ResourceStream, "ResourceStream should be populated from resourcebody before Dispose.");
-
-            response.Dispose();
-
-            // Indexer-after-dispose behavior is covered by Indexer_AfterDispose_ThrowsObjectDisposedException.
-        }
 
         [TestMethod]
         [Description("Calling Dispose() a second time must be a safe no-op.")]
@@ -491,9 +436,11 @@ namespace Microsoft.Azure.Cosmos.Tests
             Assert.AreEqual(1, response[1].Index);
         }
 
-        [TestMethod]
-        [Description("Accessing a negative index must throw ArgumentOutOfRangeException.")]
-        public async Task Indexer_NegativeIndex_ThrowsArgumentOutOfRangeException()
+        [DataTestMethod]
+        [Description("Accessing an out-of-range index must throw ArgumentOutOfRangeException.")]
+        [DataRow(-1, DisplayName = "Negative index")]
+        [DataRow(1, DisplayName = "Index equals count")]
+        public async Task Indexer_OutOfRange_ThrowsArgumentOutOfRangeException(int index)
         {
             DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
             string json = @"{""operationResponses"":[{""index"":0,""statusCode"":201}]}";
@@ -506,25 +453,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 NoOpTrace.Singleton,
                 CancellationToken.None);
 
-            Assert.ThrowsException<ArgumentOutOfRangeException>(() => _ = response[-1]);
-        }
-
-        [TestMethod]
-        [Description("Accessing index equal to Count must throw ArgumentOutOfRangeException.")]
-        public async Task Indexer_IndexEqualsCount_ThrowsArgumentOutOfRangeException()
-        {
-            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
-            string json = @"{""operationResponses"":[{""index"":0,""statusCode"":201}]}";
-            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.OK, json);
-
-            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
-                responseMessage,
-                serverRequest,
-                MockCosmosUtil.Serializer,
-                NoOpTrace.Singleton,
-                CancellationToken.None);
-
-            Assert.ThrowsException<ArgumentOutOfRangeException>(() => _ = response[response.Count]);
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => _ = response[index]);
         }
 
         [TestMethod]
@@ -641,8 +570,8 @@ namespace Microsoft.Azure.Cosmos.Tests
         }
 
         [TestMethod]
-        [Description("resourceBody lookup remains case-sensitive; PascalCase 'ResourceBody' must not populate ResourceStream.")]
-        public async Task FromResponseMessage_OperationResult_ResourceBody_PascalCaseKey_DoesNotDeserialize()
+        [Description("resourceBody lookup is case-insensitive; PascalCase 'ResourceBody' populates ResourceStream.")]
+        public async Task FromResponseMessage_OperationResult_ResourceBody_PascalCaseKey_Deserializes()
         {
             DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
 
@@ -656,7 +585,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 NoOpTrace.Singleton,
                 CancellationToken.None);
 
-            Assert.IsNull(response[0].ResourceStream, "ResourceStream must remain null when the property name is not exact 'resourceBody'.");
+            Assert.IsNotNull(response[0].ResourceStream, "ResourceStream should be populated because property name lookup is case-insensitive.");
         }
 
         [TestMethod]
@@ -827,7 +756,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         [DataRow(@"{""isRetriable"":false,""operationResponses"":[{""index"":0,""statusCode"":503}]}", false, DisplayName = "JSON boolean false → IsRetriable=false")]
         [DataRow(@"{""operationResponses"":[{""index"":0,""statusCode"":503}]}", false, DisplayName = "isRetriable absent → IsRetriable=false")]
         [DataRow(@"{""isRetriable"":""true"",""operationResponses"":[{""index"":0,""statusCode"":503}]}", false, DisplayName = "string 'true' (not a JSON boolean) → IsRetriable=false")]
-        [DataRow(@"{""IsRetriable"":true,""operationResponses"":[{""index"":0,""statusCode"":503}]}", false, DisplayName = "PascalCase 'IsRetriable' is ignored")]
+        [DataRow(@"{""IsRetriable"":true,""operationResponses"":[{""index"":0,""statusCode"":503}]}", true, DisplayName = "PascalCase 'IsRetriable' is accepted")]
         public async Task FromResponseMessage_IsRetriable_Parsing(string json, bool expected)
         {
             DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
@@ -845,14 +774,16 @@ namespace Microsoft.Azure.Cosmos.Tests
 
         // DiagnosticString parsing
 
-        [TestMethod]
-        [Description("DiagnosticString deserializes from the 'diagnosticString' JSON property.")]
-        public async Task FromResponseMessage_DiagnosticString_DeserializesCorrectly()
+        [DataTestMethod]
+        [Description("DiagnosticString deserializes from the top-level JSON property case-insensitively.")]
+        [DataRow("diagnosticString", DisplayName = "camelCase key")]
+        [DataRow("DiagnosticString", DisplayName = "PascalCase key")]
+        public async Task FromResponseMessage_DiagnosticString_DeserializesCorrectly(string diagnosticStringPropertyName)
         {
             const string expectedDiagnosticString = "TransactionCommitted";
             DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
 
-            string json = $@"{{""diagnosticString"":""{expectedDiagnosticString}"",""operationResponses"":[{{""index"":0,""statusCode"":200}}]}}";
+            string json = $@"{{""{diagnosticStringPropertyName}"":""{expectedDiagnosticString}"",""operationResponses"":[{{""index"":0,""statusCode"":200}}]}}";
             ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.OK, json);
 
             DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
@@ -1275,31 +1206,6 @@ namespace Microsoft.Azure.Cosmos.Tests
             using StreamReader reader = new StreamReader(response[0].ResourceStream);
             string raw = reader.ReadToEnd();
             StringAssert.Contains(raw, "\"id\":\"dup\"", "Underlying ResourceStream must remain readable after GetOperationResultAtIndex<T>.");
-        }
-
-        [TestMethod]
-        [Description("Reading response[index].ResourceStream directly after GetOperationResultAtIndex<T> must still return the original bytes.")]
-        public async Task GetOperationResultAtIndex_FollowedByDirectStreamRead_StreamIsIntact()
-        {
-            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
-            string json = @"{""operationResponses"":[{""index"":0,""statusCode"":200,""resourceBody"":{""id"":""x"",""value"":99}}]}";
-            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.OK, json);
-
-            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
-                responseMessage,
-                serverRequest,
-                MockCosmosUtil.Serializer,
-                NoOpTrace.Singleton,
-                CancellationToken.None);
-
-            _ = response.GetOperationResultAtIndex<TestDocument>(0);
-
-            Stream stream = response[0].ResourceStream;
-            Assert.IsNotNull(stream);
-            stream.Position = 0;
-            using StreamReader reader = new StreamReader(stream);
-            string raw = reader.ReadToEnd();
-            Assert.AreEqual(@"{""id"":""x"",""value"":99}", raw);
         }
 
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionResponseTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionResponseTests.cs
@@ -100,7 +100,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         }
 
         [TestMethod]
-        [Description("When the response body contains malformed JSON and the HTTP status is success, the SDK must return 500.")]
+        [Description("When the response body contains malformed JSON and the HTTP status is success, the SDK must return 500 with a deserialization-failure error message.")]
         public async Task FromResponseMessage_MalformedJson_SuccessStatus_ReturnsInternalServerError()
         {
             DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
@@ -116,6 +116,7 @@ namespace Microsoft.Azure.Cosmos.Tests
 
             Assert.AreEqual(HttpStatusCode.InternalServerError, response.StatusCode);
             Assert.IsFalse(response.IsSuccessStatusCode);
+            Assert.AreEqual(ClientResources.ServerResponseDeserializationFailure, response.ErrorMessage);
         }
 
         [TestMethod]
@@ -140,6 +141,68 @@ namespace Microsoft.Azure.Cosmos.Tests
             {
                 Assert.AreEqual(HttpStatusCode.Conflict, response[i].StatusCode);
             }
+        }
+
+        [DataTestMethod]
+        [Description("When numeric operation fields are present but not numeric, per-operation parsing fails and a success response is converted to InternalServerError with a deserialization-failure message.")]
+        [DataRow(@"{""operationResponses"":[{""index"":0,""statusCode"":""abc""}]}", DisplayName = "statusCode wrong type")]
+        [DataRow(@"{""operationResponses"":[{""index"":0,""statusCode"":449,""subStatusCode"":""abc""}]}", DisplayName = "subStatusCode wrong type")]
+        [DataRow(@"{""operationResponses"":[{""index"":0,""statusCode"":201,""requestCharge"":""abc""}]}", DisplayName = "requestCharge wrong type")]
+        [DataRow(@"{""operationResponses"":[{""index"":""abc"",""statusCode"":201}]}", DisplayName = "index wrong type")]
+        public async Task FromResponseMessage_OperationResult_NumericTypeMismatch_SuccessStatus_ReturnsInternalServerError(string json)
+        {
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
+            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.OK, json);
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            Assert.AreEqual(HttpStatusCode.InternalServerError, response.StatusCode);
+            Assert.IsFalse(response.IsSuccessStatusCode);
+            Assert.AreEqual(ClientResources.ServerResponseDeserializationFailure, response.ErrorMessage);
+        }
+
+        [TestMethod]
+        [Description("When operationResponses contains a non-object entry, the parser fails safely and a success response is converted to InternalServerError with a deserialization-failure message.")]
+        public async Task FromResponseMessage_OperationResult_NonObjectElement_SuccessStatus_ReturnsInternalServerError()
+        {
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
+            string json = @"{""operationResponses"":[null]}";
+            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.OK, json);
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            Assert.AreEqual(HttpStatusCode.InternalServerError, response.StatusCode);
+            Assert.IsFalse(response.IsSuccessStatusCode);
+            Assert.AreEqual(ClientResources.ServerResponseDeserializationFailure, response.ErrorMessage);
+        }
+
+        [TestMethod]
+        [Description("Top-level lookups are case-sensitive; PascalCase 'OperationResponses' is ignored and success responses become InternalServerError due to count mismatch.")]
+        public async Task FromResponseMessage_OperationResponses_PascalCaseKey_SuccessStatus_ReturnsInternalServerError()
+        {
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
+            string json = @"{""OperationResponses"":[{""index"":0,""statusCode"":201}]}";
+            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.OK, json);
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            Assert.AreEqual(HttpStatusCode.InternalServerError, response.StatusCode);
+            Assert.IsFalse(response.IsSuccessStatusCode);
         }
 
         // Count mismatch
@@ -555,6 +618,25 @@ namespace Microsoft.Azure.Cosmos.Tests
         }
 
         [TestMethod]
+        [Description("resourceBody lookup remains case-sensitive; PascalCase 'ResourceBody' must not populate ResourceStream.")]
+        public async Task FromResponseMessage_OperationResult_ResourceBody_PascalCaseKey_DoesNotDeserialize()
+        {
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
+
+            string json = @"{""operationResponses"":[{""index"":0,""statusCode"":201,""ResourceBody"":{""id"":""item1""}}]}";
+            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.OK, json);
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            Assert.IsNull(response[0].ResourceStream, "ResourceStream must remain null when the property name is not exact 'resourceBody'.");
+        }
+
+        [TestMethod]
         [Description("SessionToken is assembled as {pkRangeId}:{lsn} from the separate 'sessionToken' (LSN-only) and 'partitionKeyRangeId' JSON fields.")]
         public async Task FromResponseMessage_OperationResult_SessionToken_DeserializesCorrectly()
         {
@@ -722,6 +804,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         [DataRow(@"{""isRetriable"":false,""operationResponses"":[{""index"":0,""statusCode"":503}]}", false, DisplayName = "JSON boolean false → IsRetriable=false")]
         [DataRow(@"{""operationResponses"":[{""index"":0,""statusCode"":503}]}", false, DisplayName = "isRetriable absent → IsRetriable=false")]
         [DataRow(@"{""isRetriable"":""true"",""operationResponses"":[{""index"":0,""statusCode"":503}]}", false, DisplayName = "string 'true' (not a JSON boolean) → IsRetriable=false")]
+        [DataRow(@"{""IsRetriable"":true,""operationResponses"":[{""index"":0,""statusCode"":503}]}", false, DisplayName = "PascalCase 'IsRetriable' is ignored")]
         public async Task FromResponseMessage_IsRetriable_Parsing(string json, bool expected)
         {
             DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);


### PR DESCRIPTION
# Pull Request Template

## Description

This pull request refactors the distributed transaction response and operation result handling in the Cosmos DB SDK. The main focus is on removing dependencies on `System.Text.Json.Serialization` attributes and reflection-based deserialization, instead implementing explicit JSON parsing logic. Additionally, error message and tracing fields are removed from the public API surface and internal data flow, simplifying the object model.

### Serialization and Deserialization Refactoring

* Removed all `System.Text.Json.Serialization` attributes (such as `[JsonInclude]`, `[JsonPropertyName]`, `[JsonIgnore]`, and `[JsonConstructor]`) from `DistributedTransactionOperationResult` and replaced reflection-based deserialization with a manual, case-insensitive property lookup and assignment in the new `FromJson` method. (`DistributedTransactionOperationResult.cs`)
* Added a new helper method `TryGetProperty` for case-insensitive property lookup when parsing JSON elements. (`DistributedTransactionOperationResult.cs`)
* Updated the deserialization logic in `DistributedTransactionResponse` to use the new explicit parsing methods instead of relying on `System.Text.Json` attributes. (`DistributedTransactionResponse.cs`) [[1]](diffhunk://#diff-2115107c88c6a1f6a4b4bce64e055f821eb64b82ba0813f4e55ad60a015aae87L324-R314) [[2]](diffhunk://#diff-2115107c88c6a1f6a4b4bce64e055f821eb64b82ba0813f4e55ad60a015aae87L341-L342)

### Error Message and Tracing Cleanup

* Removed the `ErrorMessage` property and associated logic from `DistributedTransactionResponse` and related constructors, as well as the corresponding test assertions. (`DistributedTransactionResponse.cs`, `DistributedTransactionResponseTests.cs`) [[1]](diffhunk://#diff-2115107c88c6a1f6a4b4bce64e055f821eb64b82ba0813f4e55ad60a015aae87L35-L49) [[2]](diffhunk://#diff-2115107c88c6a1f6a4b4bce64e055f821eb64b82ba0813f4e55ad60a015aae87L106-L110) [[3]](diffhunk://#diff-2115107c88c6a1f6a4b4bce64e055f821eb64b82ba0813f4e55ad60a015aae87L203-L215) [[4]](diffhunk://#diff-2115107c88c6a1f6a4b4bce64e055f821eb64b82ba0813f4e55ad60a015aae87L232-R224) [[5]](diffhunk://#diff-2115107c88c6a1f6a4b4bce64e055f821eb64b82ba0813f4e55ad60a015aae87L378-L382)
* Removed the `Trace` and `ActivityId` fields from both `DistributedTransactionResponse` and `DistributedTransactionOperationResult`, and eliminated their propagation through constructors and methods. (`DistributedTransactionResponse.cs`, `DistributedTransactionOperationResult.cs`) [[1]](diffhunk://#diff-2115107c88c6a1f6a4b4bce64e055f821eb64b82ba0813f4e55ad60a015aae87L35-L49) [[2]](diffhunk://#diff-2115107c88c6a1f6a4b4bce64e055f821eb64b82ba0813f4e55ad60a015aae87L132-L133) [[3]](diffhunk://#diff-2115107c88c6a1f6a4b4bce64e055f821eb64b82ba0813f4e55ad60a015aae87L341-L342) [[4]](diffhunk://#diff-2115107c88c6a1f6a4b4bce64e055f821eb64b82ba0813f4e55ad60a015aae87L391-R370) [[5]](diffhunk://#diff-2115107c88c6a1f6a4b4bce64e055f821eb64b82ba0813f4e55ad60a015aae87L401-L402)

### Public API Simplification

* Changed several properties in `DistributedTransactionOperationResult` (such as `SessionToken`, `PartitionKeyRangeId`, and `SubStatusCode`) from public to internal, further restricting their visibility and clarifying the public API. (`DistributedTransactionOperationResult.cs`)

### Test Adjustments

* Updated tests to match the new deserialization logic and removed checks for properties that no longer exist (such as `SubStatusCodeValue`). (`DistributedTransactionResponseTests.cs`) [[1]](diffhunk://#diff-60339e9720594260887240840c9612ed875596345fa3fb21714827d34511a59aL495-R495) [[2]](diffhunk://#diff-60339e9720594260887240840c9612ed875596345fa3fb21714827d34511a59aL511-R512)

These changes collectively improve maintainability, reduce reliance on reflection and serialization attributes, and clarify the SDK's public and internal APIs.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber

## Changelog

- [ ] I have added a changelog entry under `### Unreleased` in `changelog.md`
  for the user-facing impact of this change.
- [x] No changelog entry is required because this PR is one of:
  documentation-only, test-only, CI / build-only, or a pure internal refactor
  with no observable customer impact.

If the second box is checked, briefly justify here:

> Feature isn't public yet.
