### PR TITLE
Query: Refactors TryCatch.FromException to defer StackTrace capture

### DIFF
--- a/Microsoft.Azure.Cosmos.Samples/Tools/FaultInjection429Bench/FaultInjection429Bench.csproj
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/FaultInjection429Bench/FaultInjection429Bench.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>disable</Nullable>
+    <LangVersion>$(LangVersion)</LangVersion>
+    <RootNamespace>Microsoft.Azure.Cosmos.Samples.FaultInjection429Bench</RootNamespace>
+    <AssemblyName>FaultInjection429Bench</AssemblyName>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+    <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
+    <TieredCompilation>true</TieredCompilation>
+    <NoWarn>$(NoWarn);CS1591;CA1303;CA2007;CA1031</NoWarn>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <SignAssembly>true</SignAssembly>
+    <DelaySign>true</DelaySign>
+    <AssemblyOriginatorKeyFile>..\..\..\testkey.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Cosmos.Direct" Version="[$(DirectVersion)]" />
+    <PackageReference Include="Microsoft.HybridRow" Version="[$(HybridRowVersion)]" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Microsoft.Azure.Cosmos\src\Microsoft.Azure.Cosmos.csproj" />
+    <ProjectReference Include="..\..\..\Microsoft.Azure.Cosmos\FaultInjection\src\FaultInjection.csproj" />
+  </ItemGroup>
+</Project>

--- a/Microsoft.Azure.Cosmos.Samples/Tools/FaultInjection429Bench/Program.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/FaultInjection429Bench/Program.cs
@@ -1,0 +1,326 @@
+// ------------------------------------------------------------
+// FaultInjection 429 storm benchmark for Cosmos DB .NET SDK.
+//
+// Phases per OTel mode: warmup / 429-burst / recovery
+// Runs twice: OTel-OFF and OTel-ON.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Samples.FaultInjection429Bench
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Globalization;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using System.Runtime;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos;
+    using Microsoft.Azure.Cosmos.FaultInjection;
+
+    internal static class Program
+    {
+        private const string EmulatorEndpoint = "https://127.0.0.1:8081/";
+        private const string EmulatorKey      = "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
+        private const string DatabaseName     = "FI429BenchDb";
+        private const string ContainerName    = "FI429BenchContainer";
+        private const string CosmosActivitySource = "Azure.Cosmos.Operation";
+        private const int    ItemCount        = 64;
+        private const int    Concurrency      = 128;
+        private const int    PhaseSeconds     = 20;
+
+        private static async Task<int> Main(string[] args)
+        {
+            ServicePointManager.ServerCertificateValidationCallback = (_, _, _, _) => true;
+
+            string sdkVersion = typeof(CosmosClient).Assembly.GetName().Version?.ToString() ?? "unknown";
+            Console.WriteLine("== FaultInjection 429 storm benchmark ==");
+            Console.WriteLine($"SDK assembly version : {sdkVersion}");
+            Console.WriteLine($"GC mode              : Server={GCSettings.IsServerGC}, Latency={GCSettings.LatencyMode}");
+            Console.WriteLine($"Concurrency          : {Concurrency}, PhaseSeconds={PhaseSeconds}");
+            Console.WriteLine();
+
+            List<BenchmarkResult> all = new List<BenchmarkResult>();
+            all.AddRange(await RunMatrixAsync(otelEnabled: false));
+            all.AddRange(await RunMatrixAsync(otelEnabled: true));
+
+            Console.WriteLine();
+            Console.WriteLine("== All Results ==");
+            BenchmarkResult.PrintHeader();
+            foreach (BenchmarkResult r in all) r.Print();
+
+            Console.WriteLine();
+            Console.WriteLine("== BURST deltas vs same-mode WARMUP ==");
+            BenchmarkResult warmOff  = all.First(r => r.Label.StartsWith("OFF-WARM"));
+            BenchmarkResult burstOff = all.First(r => r.Label.StartsWith("OFF-BURST"));
+            BenchmarkResult recOff   = all.First(r => r.Label.StartsWith("OFF-RECV"));
+            BenchmarkResult warmOn   = all.First(r => r.Label.StartsWith("ON-WARM"));
+            BenchmarkResult burstOn  = all.First(r => r.Label.StartsWith("ON-BURST"));
+            BenchmarkResult recOn    = all.First(r => r.Label.StartsWith("ON-RECV"));
+            BenchmarkResult.PrintDelta("OTel-OFF BURST   ", warmOff, burstOff);
+            BenchmarkResult.PrintDelta("OTel-OFF RECOVERY", warmOff, recOff);
+            BenchmarkResult.PrintDelta("OTel-ON  BURST   ", warmOn,  burstOn);
+            BenchmarkResult.PrintDelta("OTel-ON  RECOVERY", warmOn,  recOn);
+
+            Console.WriteLine();
+            Console.WriteLine("== Cross-mode comparison (OTel-ON / OTel-OFF, same phase) ==");
+            BenchmarkResult.PrintDelta("WARMUP    ON/OFF", warmOff,  warmOn);
+            BenchmarkResult.PrintDelta("BURST     ON/OFF", burstOff, burstOn);
+            BenchmarkResult.PrintDelta("RECOVERY  ON/OFF", recOff,   recOn);
+
+            Console.WriteLine();
+            Console.WriteLine($"sdk_version={sdkVersion}");
+            return 0;
+        }
+
+        private static async Task<List<BenchmarkResult>> RunMatrixAsync(bool otelEnabled)
+        {
+            string tag = otelEnabled ? "ON" : "OFF";
+            using ActivityListener listener = otelEnabled ? SubscribeListener() : null;
+            Console.WriteLine();
+            Console.WriteLine($"=== OTel={tag} matrix start (listener {(otelEnabled ? "subscribed" : "absent")}) ===");
+
+            FaultInjectionRule queryRule = new FaultInjectionRuleBuilder(
+                    id: $"query-429-{tag}",
+                    condition: new FaultInjectionConditionBuilder()
+                        .WithOperationType(FaultInjectionOperationType.QueryItem)
+                        .Build(),
+                    result: FaultInjectionResultBuilder
+                        .GetResultBuilder(FaultInjectionServerErrorType.TooManyRequests)
+                        .WithInjectionRate(1.0)
+                        .Build())
+                .Build();
+            queryRule.Disable();
+
+            FaultInjector injector = new FaultInjector(new List<FaultInjectionRule> { queryRule });
+
+            CosmosClientOptions options = new CosmosClientOptions
+            {
+                ConnectionMode    = ConnectionMode.Direct,
+                ConsistencyLevel  = ConsistencyLevel.Eventual,
+                RequestTimeout    = TimeSpan.FromSeconds(1),
+                MaxRetryWaitTimeOnRateLimitedRequests = TimeSpan.FromSeconds(2),
+                MaxRetryAttemptsOnRateLimitedRequests = 1,
+                EnableContentResponseOnWrite          = false,
+                LimitToEndpoint                       = true,
+                HttpClientFactory = () =>
+                {
+                    HttpClientHandler handler = new HttpClientHandler
+                    {
+                        ServerCertificateCustomValidationCallback = (_, _, _, _) => true,
+                    };
+                    return new HttpClient(handler);
+                },
+                CosmosClientTelemetryOptions = new CosmosClientTelemetryOptions
+                {
+                    DisableDistributedTracing = !otelEnabled,
+                },
+            };
+            CosmosClientOptions clientOptions = injector.GetFaultInjectionClientOptions(options);
+
+            using CosmosClient client = new CosmosClient(EmulatorEndpoint, EmulatorKey, clientOptions);
+            Database db = (await client.CreateDatabaseIfNotExistsAsync(DatabaseName)).Database;
+            ContainerProperties props = new ContainerProperties(ContainerName, "/pk");
+            Container container = (await db.CreateContainerIfNotExistsAsync(props, throughput: 10000)).Container;
+            await SeedAsync(container);
+
+            List<BenchmarkResult> results = new List<BenchmarkResult>(3);
+            results.Add(await RunPhaseAsync($"{tag}-WARM", container, queryRule, ruleEnabled: false, durationSec: PhaseSeconds));
+            results.Add(await RunPhaseAsync($"{tag}-BURST", container, queryRule, ruleEnabled: true, durationSec: PhaseSeconds));
+            results.Add(await RunPhaseAsync($"{tag}-RECV", container, queryRule, ruleEnabled: false, durationSec: PhaseSeconds));
+            return results;
+        }
+
+        private static ActivityListener SubscribeListener()
+        {
+            ActivityListener listener = new ActivityListener
+            {
+                ShouldListenTo  = src => src.Name.StartsWith("Azure.Cosmos", StringComparison.Ordinal),
+                Sample          = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllDataAndRecorded,
+                SampleUsingParentId = (ref ActivityCreationOptions<string> _) => ActivitySamplingResult.AllDataAndRecorded,
+                ActivityStarted = _ => { },
+                ActivityStopped = _ => { },
+            };
+            ActivitySource.AddActivityListener(listener);
+            return listener;
+        }
+
+        private static async Task SeedAsync(Container container)
+        {
+            List<Task> tasks = new List<Task>();
+            for (int i = 0; i < ItemCount; i++)
+            {
+                string pk = $"pk-{i:D4}";
+                tasks.Add(SafeUpsertAsync(container, pk, i));
+            }
+            await Task.WhenAll(tasks);
+        }
+
+        private static async Task SafeUpsertAsync(Container container, string pk, int i)
+        {
+            try
+            {
+                await container.UpsertItemAsync(new { id = pk, pk, n = i, payload = new string('x', 128) },
+                    new PartitionKey(pk));
+            }
+            catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.Conflict)
+            {
+            }
+        }
+
+        private static async Task<BenchmarkResult> RunPhaseAsync(
+            string label,
+            Container container,
+            FaultInjectionRule rule,
+            bool ruleEnabled,
+            int durationSec)
+        {
+            if (ruleEnabled) rule.Enable(); else rule.Disable();
+            Console.WriteLine();
+            Console.WriteLine($"-- Phase {label}  ruleEnabled={ruleEnabled} --");
+
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+            await Task.Delay(500);
+
+            BenchmarkResult result = new BenchmarkResult(label);
+            result.StartSnapshot();
+            using CancellationTokenSource cts = new CancellationTokenSource(TimeSpan.FromSeconds(durationSec));
+            long throttled = 0, succeeded = 0, otherFailed = 0;
+
+            Task[] workers = Enumerable.Range(0, Concurrency).Select(_ => Task.Run(async () =>
+            {
+                while (!cts.IsCancellationRequested)
+                {
+                    try
+                    {
+                        QueryDefinition q = new QueryDefinition("SELECT c.n, c.pk FROM c ORDER BY c.n");
+                        using FeedIterator<dynamic> it = container.GetItemQueryIterator<dynamic>(
+                            q,
+                            requestOptions: new QueryRequestOptions
+                            {
+                                MaxConcurrency = -1,
+                                MaxItemCount = 100,
+                            });
+                        while (it.HasMoreResults && !cts.IsCancellationRequested)
+                        {
+                            try
+                            {
+                                FeedResponse<dynamic> page = await it.ReadNextAsync(cts.Token);
+                                _ = page.Count;
+                                Interlocked.Increment(ref succeeded);
+                            }
+                            catch (CosmosException ce) when ((int)ce.StatusCode == 429
+                                                          || ce.StatusCode == HttpStatusCode.RequestTimeout
+                                                          || ce.StatusCode == HttpStatusCode.ServiceUnavailable)
+                            {
+                                Interlocked.Increment(ref throttled);
+                                break;
+                            }
+                            catch (OperationCanceledException)
+                            {
+                                break;
+                            }
+                            catch (Exception)
+                            {
+                                Interlocked.Increment(ref otherFailed);
+                                break;
+                            }
+                        }
+                    }
+                    catch (OperationCanceledException) { break; }
+                    catch (Exception) { Interlocked.Increment(ref otherFailed); }
+                }
+            }, cts.Token)).ToArray();
+
+            try { await Task.WhenAll(workers); }
+            catch (OperationCanceledException) { }
+
+            result.StopSnapshot();
+            result.Successful = succeeded;
+            result.Throttled  = throttled;
+            result.OtherFailed = otherFailed;
+            Console.WriteLine($"   pages_ok={succeeded}  throttled={throttled}  other_failed={otherFailed}");
+            return result;
+        }
+    }
+
+    internal sealed class BenchmarkResult
+    {
+        public string Label { get; }
+        public long Successful { get; set; }
+        public long Throttled { get; set; }
+        public long OtherFailed { get; set; }
+
+        private long startCpuTicks, startAllocBytes, startContention, startExceptionCount;
+        private int startGen0, startGen1, startGen2;
+        private readonly Stopwatch sw = new Stopwatch();
+
+        public TimeSpan Wall { get; private set; }
+        public TimeSpan Cpu { get; private set; }
+        public long AllocBytes { get; private set; }
+        public long Contention { get; private set; }
+        public long ExceptionCount { get; private set; }
+        public int Gen0 { get; private set; }
+        public int Gen1 { get; private set; }
+        public int Gen2 { get; private set; }
+
+        public BenchmarkResult(string label) { this.Label = label; }
+
+        public void StartSnapshot()
+        {
+            Process p = Process.GetCurrentProcess();
+            this.startCpuTicks       = p.TotalProcessorTime.Ticks;
+            this.startAllocBytes     = GC.GetTotalAllocatedBytes(precise: false);
+            this.startContention     = Monitor.LockContentionCount;
+            this.startExceptionCount = Interlocked.Read(ref ExceptionCounter.Count);
+            this.startGen0 = GC.CollectionCount(0);
+            this.startGen1 = GC.CollectionCount(1);
+            this.startGen2 = GC.CollectionCount(2);
+            this.sw.Restart();
+        }
+
+        public void StopSnapshot()
+        {
+            this.sw.Stop();
+            Process p = Process.GetCurrentProcess();
+            this.Wall           = this.sw.Elapsed;
+            this.Cpu            = TimeSpan.FromTicks(p.TotalProcessorTime.Ticks - this.startCpuTicks);
+            this.AllocBytes     = GC.GetTotalAllocatedBytes(precise: false) - this.startAllocBytes;
+            this.Contention     = Monitor.LockContentionCount - this.startContention;
+            this.ExceptionCount = Interlocked.Read(ref ExceptionCounter.Count) - this.startExceptionCount;
+            this.Gen0 = GC.CollectionCount(0) - this.startGen0;
+            this.Gen1 = GC.CollectionCount(1) - this.startGen1;
+            this.Gen2 = GC.CollectionCount(2) - this.startGen2;
+        }
+
+        public static void PrintHeader()
+        {
+            Console.WriteLine($"{"Phase",-10} {"Wall(s)",8} {"CPU(s)",8} {"CPU/W",6} {"AllocMB",10} {"Excs",10} {"LockCont",10} {"Gen0",6} {"Gen1",6} {"Gen2",6} {"PagesOK",10} {"Throt",8}");
+        }
+
+        public void Print()
+        {
+            string cpuRatio = (this.Cpu.TotalSeconds / Math.Max(this.Wall.TotalSeconds, 0.001)).ToString("F2", CultureInfo.InvariantCulture);
+            Console.WriteLine($"{this.Label,-10} {this.Wall.TotalSeconds,8:F2} {this.Cpu.TotalSeconds,8:F2} {cpuRatio,6} {this.AllocBytes / 1024.0 / 1024.0,10:F1} {this.ExceptionCount,10} {this.Contention,10} {this.Gen0,6} {this.Gen1,6} {this.Gen2,6} {this.Successful,10} {this.Throttled,8}");
+        }
+
+        public static void PrintDelta(string label, BenchmarkResult baseline, BenchmarkResult other)
+        {
+            double Safe(double a, double b) => b <= 0 ? double.PositiveInfinity : a / b;
+            Console.WriteLine($"   {label}  alloc x{Safe(other.AllocBytes, baseline.AllocBytes):F2}  exceptions x{Safe(other.ExceptionCount, baseline.ExceptionCount):F2}  lockCont x{Safe(other.Contention, baseline.Contention):F2}  cpu x{Safe(other.Cpu.TotalSeconds, baseline.Cpu.TotalSeconds):F2}  gen0 x{Safe(other.Gen0, baseline.Gen0):F2}");
+        }
+    }
+
+    internal static class ExceptionCounter
+    {
+        public static long Count;
+        static ExceptionCounter()
+        {
+            AppDomain.CurrentDomain.FirstChanceException += (_, _) => Interlocked.Increment(ref Count);
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos.Samples/Tools/FaultInjection429Dump/FaultInjection429Dump.csproj
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/FaultInjection429Dump/FaultInjection429Dump.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>disable</Nullable>
+    <LangVersion>$(LangVersion)</LangVersion>
+    <RootNamespace>Microsoft.Azure.Cosmos.Samples.FaultInjection429Dump</RootNamespace>
+    <AssemblyName>FaultInjection429Dump</AssemblyName>
+    <ServerGarbageCollection>true</ServerGarbageCollection>
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <NoWarn>$(NoWarn);CS1591;CA1303;CA2007;CA1031</NoWarn>
+    <SignAssembly>true</SignAssembly>
+    <DelaySign>true</DelaySign>
+    <AssemblyOriginatorKeyFile>..\..\..\testkey.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Azure.Cosmos.Direct" Version="[$(DirectVersion)]" />
+    <PackageReference Include="Microsoft.HybridRow" Version="[$(HybridRowVersion)]" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Microsoft.Azure.Cosmos\src\Microsoft.Azure.Cosmos.csproj" />
+    <ProjectReference Include="..\..\..\Microsoft.Azure.Cosmos\FaultInjection\src\FaultInjection.csproj" />
+  </ItemGroup>
+</Project>

--- a/Microsoft.Azure.Cosmos.Samples/Tools/FaultInjection429Dump/MultiCode.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/FaultInjection429Dump/MultiCode.cs
@@ -1,0 +1,178 @@
+// ------------------------------------------------------------
+// Multi-status-code Exception + Diagnostics E2E dump.
+// Issues one cross-partition query per fault type and dumps the caller-visible
+// exception/diagnostics shape. Used to compare BEFORE/AFTER the
+// TryCatch.FromException stack-trace patch across every status code that
+// flows through the query path.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Samples.FaultInjection429Dump
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos;
+    using Microsoft.Azure.Cosmos.FaultInjection;
+
+    internal static class MultiCodeProgram
+    {
+        private const string EmulatorEndpoint = "https://127.0.0.1:8081/";
+        private const string EmulatorKey      = "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
+        private const string DatabaseName     = "FI429BenchDb";
+        private const string ContainerName    = "FI429BenchContainer";
+
+        // Server-error types worth exercising. We skip Gone/PartitionIsSplitting/PartitionIsMigrating because
+        // those drive cache-refresh / split-retry paths that won't surface to the caller in a single attempt.
+        private static readonly (string Label, FaultInjectionServerErrorType Type)[] Cases = new[]
+        {
+            ("429 TooManyRequests       ", FaultInjectionServerErrorType.TooManyRequests),
+            ("503 ServiceUnavailable    ", FaultInjectionServerErrorType.ServiceUnavailable),
+            ("500 InternalServerError   ", FaultInjectionServerErrorType.InternalServerError),
+            ("408 Timeout               ", FaultInjectionServerErrorType.Timeout),
+            ("449 RetryWith             ", FaultInjectionServerErrorType.RetryWith),
+            ("404/1002 ReadSessionNotAvailable", FaultInjectionServerErrorType.ReadSessionNotAvailable),
+            ("401 Unauthorized          ", FaultInjectionServerErrorType.Unauthorized),
+        };
+
+        public static async Task<int> RunAsync(string[] args)
+        {
+            ServicePointManager.ServerCertificateValidationCallback = (_, _, _, _) => true;
+            string sdkVersion = typeof(CosmosClient).Assembly.GetName().Version?.ToString() ?? "unknown";
+            Console.WriteLine($"=== Cosmos SDK assembly version : {sdkVersion} ===");
+            Console.WriteLine();
+
+            List<FaultInjectionRule> rules = new List<FaultInjectionRule>();
+            Dictionary<FaultInjectionServerErrorType, FaultInjectionRule> ruleByType = new();
+            foreach (var (label, type) in Cases)
+            {
+                FaultInjectionRule rule = new FaultInjectionRuleBuilder(
+                    id: $"q-{type}",
+                    condition: new FaultInjectionConditionBuilder()
+                        .WithOperationType(FaultInjectionOperationType.QueryItem)
+                        .Build(),
+                    result: FaultInjectionResultBuilder.GetResultBuilder(type).WithInjectionRate(1.0).Build())
+                    .Build();
+                rule.Disable();
+                rules.Add(rule);
+                ruleByType[type] = rule;
+            }
+
+            FaultInjector injector = new FaultInjector(rules);
+
+            CosmosClientOptions options = new CosmosClientOptions
+            {
+                ConnectionMode    = ConnectionMode.Direct,
+                ConsistencyLevel  = ConsistencyLevel.Eventual,
+                RequestTimeout    = TimeSpan.FromSeconds(2),
+                MaxRetryWaitTimeOnRateLimitedRequests = TimeSpan.FromSeconds(2),
+                MaxRetryAttemptsOnRateLimitedRequests = 1,
+                LimitToEndpoint   = true,
+                HttpClientFactory = () =>
+                {
+                    HttpClientHandler handler = new HttpClientHandler
+                    {
+                        ServerCertificateCustomValidationCallback = (_, _, _, _) => true,
+                    };
+                    return new HttpClient(handler);
+                },
+            };
+
+            using CosmosClient client = new CosmosClient(EmulatorEndpoint, EmulatorKey, injector.GetFaultInjectionClientOptions(options));
+            Database db = (await client.CreateDatabaseIfNotExistsAsync(DatabaseName)).Database;
+            Container container = (await db.CreateContainerIfNotExistsAsync(new ContainerProperties(ContainerName, "/pk"), throughput: 10000)).Container;
+            try { await container.UpsertItemAsync(new { id = "dump1", pk = "pk-0000", n = 1 }, new PartitionKey("pk-0000")); }
+            catch (CosmosException ce) when (ce.StatusCode == HttpStatusCode.Conflict) { }
+
+            // Prime the cache with a successful query so subsequent failures are not init-time failures
+            using (FeedIterator<dynamic> warm = container.GetItemQueryIterator<dynamic>("SELECT c.n FROM c"))
+            {
+                while (warm.HasMoreResults) { _ = await warm.ReadNextAsync(); }
+            }
+            Console.WriteLine("[primed routing/cache]");
+            Console.WriteLine();
+
+            foreach (var (label, type) in Cases)
+            {
+                FaultInjectionRule rule = ruleByType[type];
+                rule.Enable();
+                Exception caught = null;
+                try
+                {
+                    using FeedIterator<dynamic> it = container.GetItemQueryIterator<dynamic>(
+                        "SELECT c.n, c.pk FROM c ORDER BY c.n",
+                        requestOptions: new QueryRequestOptions { MaxConcurrency = -1, MaxItemCount = 100 });
+                    while (it.HasMoreResults)
+                    {
+                        FeedResponse<dynamic> _ = await it.ReadNextAsync();
+                    }
+                }
+                catch (Exception ex)
+                {
+                    caught = ex;
+                }
+                rule.Disable();
+
+                Dump(label, caught);
+            }
+            return 0;
+        }
+
+        private static void Dump(string label, Exception ex)
+        {
+            Console.WriteLine(new string('=', 100));
+            Console.WriteLine($"CASE: {label}");
+            Console.WriteLine(new string('=', 100));
+            if (ex == null)
+            {
+                Console.WriteLine("(no exception caught — fault did not propagate to caller)");
+                Console.WriteLine();
+                return;
+            }
+            Console.WriteLine($"  Chain.depth = {ChainDepth(ex)}");
+            Console.WriteLine($"  Outer.Type  = {ex.GetType().FullName}");
+
+            CosmosException ce = ex as CosmosException ?? FindInner<CosmosException>(ex);
+            if (ce != null)
+            {
+                Console.WriteLine($"  Status      = {(int)ce.StatusCode} ({ce.StatusCode})  SubStatus={ce.SubStatusCode}  RetryAfter={ce.RetryAfter}");
+                Console.WriteLine($"  ActivityId  = {ce.ActivityId}");
+                Console.WriteLine($"  Message     = {Truncate(ce.Message, 200)}");
+#pragma warning disable CDX1002
+                string stack = ce.StackTrace ?? string.Empty;
+                Console.WriteLine($"  StackBytes  = {stack.Length}");
+                string firstFrame = stack.Split('\n')[0].TrimEnd();
+                Console.WriteLine($"  StackTop    = {Truncate(firstFrame, 140)}");
+#pragma warning restore CDX1002
+                string diag = ce.Diagnostics?.ToString() ?? "(null)";
+                int directCallsIdx = diag.IndexOf("\"DirectCalls\":", StringComparison.Ordinal);
+                string directCallsSnippet = directCallsIdx >= 0 ? diag.Substring(directCallsIdx, Math.Min(120, diag.Length - directCallsIdx)) : "(no DirectCalls summary)";
+                Console.WriteLine($"  Diag.summary= {directCallsSnippet}");
+                Console.WriteLine($"  Diag.length = {diag.Length} bytes");
+            }
+            else
+            {
+                Console.WriteLine($"  (no CosmosException in chain)");
+                Console.WriteLine($"  Message     = {Truncate(ex.Message, 200)}");
+            }
+            Console.WriteLine();
+        }
+
+        private static int ChainDepth(Exception e)
+        {
+            int d = 0; while (e != null) { d++; e = e.InnerException; } return d;
+        }
+
+        private static T FindInner<T>(Exception e) where T : Exception
+        {
+            while (e != null) { if (e is T t) return t; e = e.InnerException; } return null;
+        }
+
+        private static string Truncate(string s, int n)
+        {
+            if (string.IsNullOrEmpty(s)) return s ?? string.Empty;
+            return s.Length <= n ? s : s.Substring(0, n) + "...";
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos.Samples/Tools/FaultInjection429Dump/Program.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/FaultInjection429Dump/Program.cs
@@ -1,0 +1,173 @@
+// ------------------------------------------------------------
+// Exception + Diagnostics E2E dump for a single FaultInjection-induced 429
+// on a cross-partition query. Used to compare SDK behavior before/after
+// the TryCatch.FromException stack-trace patch.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Samples.FaultInjection429Dump
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Net;
+    using System.Net.Http;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos;
+    using Microsoft.Azure.Cosmos.FaultInjection;
+
+    internal static class Program
+    {
+        private const string EmulatorEndpoint = "https://127.0.0.1:8081/";
+        private const string EmulatorKey      = "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
+        private const string DatabaseName     = "FI429BenchDb";
+        private const string ContainerName    = "FI429BenchContainer";
+
+        private static async Task<int> Main(string[] args)
+        {
+            if (args.Length > 0 && args[0] == "multi")
+            {
+                return await MultiCodeProgram.RunAsync(args);
+            }
+            if (args.Length > 0 && args[0] == "timeout-spread")
+            {
+                return await TimeoutSpreadProgram.RunAsync(args);
+            }
+            return await SingleRunAsync();
+        }
+
+        private static async Task<int> SingleRunAsync()
+        {
+            ServicePointManager.ServerCertificateValidationCallback = (_, _, _, _) => true;
+            string sdkVersion = typeof(CosmosClient).Assembly.GetName().Version?.ToString() ?? "unknown";
+            Console.WriteLine($"=== Cosmos SDK assembly version : {sdkVersion} ===");
+            Console.WriteLine();
+
+            FaultInjectionRule queryRule = new FaultInjectionRuleBuilder(
+                    id: "dump-query-429",
+                    condition: new FaultInjectionConditionBuilder()
+                        .WithOperationType(FaultInjectionOperationType.QueryItem)
+                        .Build(),
+                    result: FaultInjectionResultBuilder
+                        .GetResultBuilder(FaultInjectionServerErrorType.TooManyRequests)
+                        .WithInjectionRate(1.0)
+                        .Build())
+                .Build();
+            queryRule.Disable();
+
+            FaultInjector injector = new FaultInjector(new List<FaultInjectionRule> { queryRule });
+
+            CosmosClientOptions options = new CosmosClientOptions
+            {
+                ConnectionMode    = ConnectionMode.Direct,
+                ConsistencyLevel  = ConsistencyLevel.Eventual,
+                RequestTimeout    = TimeSpan.FromSeconds(1),
+                MaxRetryWaitTimeOnRateLimitedRequests = TimeSpan.FromSeconds(2),
+                MaxRetryAttemptsOnRateLimitedRequests = 1,
+                LimitToEndpoint   = true,
+                HttpClientFactory = () =>
+                {
+                    HttpClientHandler handler = new HttpClientHandler
+                    {
+                        ServerCertificateCustomValidationCallback = (_, _, _, _) => true,
+                    };
+                    return new HttpClient(handler);
+                },
+            };
+
+            using CosmosClient client = new CosmosClient(EmulatorEndpoint, EmulatorKey, injector.GetFaultInjectionClientOptions(options));
+            Database db = (await client.CreateDatabaseIfNotExistsAsync(DatabaseName)).Database;
+            Container container = (await db.CreateContainerIfNotExistsAsync(new ContainerProperties(ContainerName, "/pk"), throughput: 10000)).Container;
+
+            try
+            {
+                await container.UpsertItemAsync(new { id = "dump1", pk = "pk-0000", n = 1 }, new PartitionKey("pk-0000"));
+            }
+            catch (CosmosException ce) when (ce.StatusCode == HttpStatusCode.Conflict) { }
+
+            using (FeedIterator<dynamic> warm = container.GetItemQueryIterator<dynamic>("SELECT c.n, c.pk FROM c ORDER BY c.n"))
+            {
+                while (warm.HasMoreResults) { _ = await warm.ReadNextAsync(); }
+            }
+            Console.WriteLine("[primed routing/cache]");
+
+            queryRule.Enable();
+            Console.WriteLine("[rule enabled - issuing query that will see 429]");
+            try
+            {
+                using FeedIterator<dynamic> it = container.GetItemQueryIterator<dynamic>(
+                    "SELECT c.n, c.pk FROM c ORDER BY c.n",
+                    requestOptions: new QueryRequestOptions { MaxConcurrency = -1, MaxItemCount = 100 });
+                while (it.HasMoreResults)
+                {
+                    FeedResponse<dynamic> page = await it.ReadNextAsync();
+                    Console.WriteLine($"[unexpected success page Count={page.Count}]");
+                }
+            }
+            catch (Exception caught)
+            {
+                DumpException(caught);
+            }
+            queryRule.Disable();
+            return 0;
+        }
+
+        private static void DumpException(Exception ex)
+        {
+            Console.WriteLine();
+            Console.WriteLine(new string('=', 88));
+            Console.WriteLine("CAUGHT EXCEPTION (caller-visible) - what an SDK consumer sees");
+            Console.WriteLine(new string('=', 88));
+
+            int depth = 0;
+            Exception cur = ex;
+            while (cur != null)
+            {
+                Console.WriteLine($"--- chain[{depth}] ---");
+                Console.WriteLine($"  Type     : {cur.GetType().FullName}");
+                Console.WriteLine($"  Message  : {Truncate(cur.Message, 220)}");
+                if (cur is CosmosException ce)
+                {
+                    Console.WriteLine($"  Status   : {(int)ce.StatusCode} ({ce.StatusCode})  SubStatus={ce.SubStatusCode}");
+                    Console.WriteLine($"  ActivityId={ce.ActivityId}  RetryAfter={ce.RetryAfter}");
+                }
+#pragma warning disable CDX1002
+                Console.WriteLine($"  HasStack : {(cur.StackTrace != null ? "yes" : "no")} (length={cur.StackTrace?.Length ?? 0})");
+                if (cur.StackTrace != null)
+                {
+                    Console.WriteLine("  StackTrace (first 6 frames):");
+                    int n = 0;
+                    foreach (string line in cur.StackTrace.Split('\n'))
+                    {
+                        if (++n > 6) break;
+                        Console.WriteLine("    " + line.TrimEnd());
+                    }
+                }
+#pragma warning restore CDX1002
+                cur = cur.InnerException;
+                depth++;
+            }
+            Console.WriteLine();
+            Console.WriteLine("--- ex.ToString() (first 1500 chars) ---");
+#pragma warning disable CDX1003
+            Console.WriteLine(Truncate(ex.ToString(), 1500));
+#pragma warning restore CDX1003
+
+            if (ex is CosmosException cosmosEx)
+            {
+                Console.WriteLine();
+                Console.WriteLine(new string('-', 88));
+                Console.WriteLine("DIAGNOSTICS (CosmosException.Diagnostics.ToString(), first 1800 chars)");
+                Console.WriteLine(new string('-', 88));
+                string diag = cosmosEx.Diagnostics?.ToString() ?? "(null)";
+                Console.WriteLine(Truncate(diag, 1800));
+            }
+            Console.WriteLine();
+            Console.WriteLine(new string('=', 88));
+        }
+
+        private static string Truncate(string s, int n)
+        {
+            if (string.IsNullOrEmpty(s)) return s ?? string.Empty;
+            return s.Length <= n ? s : s.Substring(0, n) + "...[truncated]";
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos.Samples/Tools/FaultInjection429Dump/TimeoutSpread.cs
+++ b/Microsoft.Azure.Cosmos.Samples/Tools/FaultInjection429Dump/TimeoutSpread.cs
@@ -1,0 +1,121 @@
+// Multi-run 408 timeout case to show run-to-run noise in DirectCalls count.
+namespace Microsoft.Azure.Cosmos.Samples.FaultInjection429Dump
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Linq;
+    using System.Net;
+    using System.Net.Http;
+    using System.Text.RegularExpressions;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos;
+    using Microsoft.Azure.Cosmos.FaultInjection;
+
+    internal static class TimeoutSpreadProgram
+    {
+        private const string EmulatorEndpoint = "https://127.0.0.1:8081/";
+        private const string EmulatorKey      = "C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
+        private const string DatabaseName     = "FI429BenchDb";
+        private const string ContainerName    = "FI429BenchContainer";
+        private const int    Runs             = 5;
+
+        public static async Task<int> RunAsync(string[] args)
+        {
+            ServicePointManager.ServerCertificateValidationCallback = (_, _, _, _) => true;
+            string sdkVersion = typeof(CosmosClient).Assembly.GetName().Version?.ToString() ?? "unknown";
+            Console.WriteLine($"=== Cosmos SDK assembly version : {sdkVersion} ===");
+            Console.WriteLine($"408 Timeout: {Runs} runs to show run-to-run spread of DirectCalls and wall time.");
+            Console.WriteLine();
+
+            FaultInjectionRule rule = new FaultInjectionRuleBuilder(
+                id: "q-Timeout",
+                condition: new FaultInjectionConditionBuilder().WithOperationType(FaultInjectionOperationType.QueryItem).Build(),
+                result: FaultInjectionResultBuilder.GetResultBuilder(FaultInjectionServerErrorType.Timeout).WithInjectionRate(1.0).Build())
+                .Build();
+            rule.Disable();
+
+            FaultInjector injector = new FaultInjector(new List<FaultInjectionRule> { rule });
+            CosmosClientOptions options = new CosmosClientOptions
+            {
+                ConnectionMode = ConnectionMode.Direct,
+                ConsistencyLevel = ConsistencyLevel.Eventual,
+                RequestTimeout = TimeSpan.FromSeconds(2),
+                MaxRetryWaitTimeOnRateLimitedRequests = TimeSpan.FromSeconds(2),
+                MaxRetryAttemptsOnRateLimitedRequests = 1,
+                LimitToEndpoint = true,
+                HttpClientFactory = () =>
+                {
+                    HttpClientHandler handler = new HttpClientHandler
+                    {
+                        ServerCertificateCustomValidationCallback = (_, _, _, _) => true,
+                    };
+                    return new HttpClient(handler);
+                },
+            };
+
+            using CosmosClient client = new CosmosClient(EmulatorEndpoint, EmulatorKey, injector.GetFaultInjectionClientOptions(options));
+            Database db = (await client.CreateDatabaseIfNotExistsAsync(DatabaseName)).Database;
+            Container container = (await db.CreateContainerIfNotExistsAsync(new ContainerProperties(ContainerName, "/pk"), throughput: 10000)).Container;
+            try { await container.UpsertItemAsync(new { id = "dump1", pk = "pk-0000", n = 1 }, new PartitionKey("pk-0000")); }
+            catch (CosmosException ce) when (ce.StatusCode == HttpStatusCode.Conflict) { }
+            using (FeedIterator<dynamic> warm = container.GetItemQueryIterator<dynamic>("SELECT c.n FROM c"))
+            {
+                while (warm.HasMoreResults) { _ = await warm.ReadNextAsync(); }
+            }
+
+            Console.WriteLine($"{"Run",4} {"WallMs",8} {"DirectCalls",14} {"GatewayCalls",14} {"DiagBytes",10} {"FinalStatus",18}");
+            Regex callsRe = new Regex("\"\\((?<status>\\d+), (?<sub>\\d+)\\)\":(?<count>\\d+)", RegexOptions.Compiled);
+
+            int[] directs = new int[Runs];
+            long[] walls = new long[Runs];
+
+            for (int r = 0; r < Runs; r++)
+            {
+                rule.Enable();
+                Stopwatch sw = Stopwatch.StartNew();
+                CosmosException caught = null;
+                try
+                {
+                    using FeedIterator<dynamic> it = container.GetItemQueryIterator<dynamic>(
+                        "SELECT c.n, c.pk FROM c ORDER BY c.n",
+                        requestOptions: new QueryRequestOptions { MaxConcurrency = -1, MaxItemCount = 100 });
+                    while (it.HasMoreResults) { _ = await it.ReadNextAsync(); }
+                }
+                catch (CosmosException ce) { caught = ce; }
+                sw.Stop();
+                rule.Disable();
+
+                string diag = caught?.Diagnostics?.ToString() ?? string.Empty;
+                int direct = 0, gw = 0;
+                int dcIdx = diag.IndexOf("\"DirectCalls\":", StringComparison.Ordinal);
+                int gwIdx = diag.IndexOf("\"GatewayCalls\":", StringComparison.Ordinal);
+                if (dcIdx >= 0)
+                {
+                    int close = diag.IndexOf('}', dcIdx);
+                    foreach (Match m in callsRe.Matches(diag.Substring(dcIdx, close - dcIdx)))
+                    {
+                        direct += int.Parse(m.Groups["count"].Value);
+                    }
+                }
+                if (gwIdx >= 0)
+                {
+                    int close = diag.IndexOf('}', gwIdx);
+                    foreach (Match m in callsRe.Matches(diag.Substring(gwIdx, close - gwIdx)))
+                    {
+                        gw += int.Parse(m.Groups["count"].Value);
+                    }
+                }
+                directs[r] = direct;
+                walls[r] = sw.ElapsedMilliseconds;
+                string finalStatus = caught != null ? $"{(int)caught.StatusCode}/{caught.SubStatusCode}" : "(none)";
+                Console.WriteLine($"{r,4} {sw.ElapsedMilliseconds,8} {direct,14} {gw,14} {diag.Length,10} {finalStatus,18}");
+            }
+
+            Console.WriteLine();
+            Console.WriteLine($"DirectCalls min={directs.Min()} max={directs.Max()} mean={directs.Average():F1} spread={directs.Max() - directs.Min()}");
+            Console.WriteLine($"Wall(ms)    min={walls.Min()} max={walls.Max()} mean={walls.Average():F0}");
+            return 0;
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Monads/ExceptionWithStackTraceException.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Monads/ExceptionWithStackTraceException.cs
@@ -31,17 +31,23 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Monads
                   message: message,
                   innerException: innerException)
         {
-            if (stackTrace == null)
-            {
-#pragma warning disable IDE0016 // Use 'throw' expression
-                throw new ArgumentNullException(nameof(stackTrace));
-#pragma warning restore IDE0016 // Use 'throw' expression
-            }
-
             this.stackTrace = stackTrace;
         }
 
-        public override string StackTrace => this.stackTrace.ToString();
+        public override string StackTrace
+        {
+            get
+            {
+                if (this.stackTrace != null)
+                {
+                    return this.stackTrace.ToString();
+                }
+
+#pragma warning disable CDX1002 // DontUseExceptionStackTrace
+                return base.StackTrace ?? this.InnerException?.StackTrace;
+#pragma warning restore CDX1002 // DontUseExceptionStackTrace
+            }
+        }
 
         public override string ToString()
         {

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Monads/TryCatch{TResult}.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Monads/TryCatch{TResult}.cs
@@ -242,14 +242,12 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Monads
 
         public static TryCatch<TResult> FromException(Exception exception)
         {
-            // Skipping a stack frame, since we don't want this method showing up in the stack trace.
-            StackTrace stackTrace = new StackTrace(skipFrames: 1);
 #pragma warning disable CDX1000 // DontConvertExceptionToObject
             return new TryCatch<TResult>(
                 new ExceptionWithStackTraceException(
                     message: $"{nameof(TryCatch<TResult>)} resulted in an exception.",
                     innerException: exception,
-                    stackTrace: stackTrace));
+                    stackTrace: null));
 #pragma warning restore CDX1000 // DontConvertExceptionToObject
         }
 

--- a/Microsoft.Azure.Cosmos/src/Query/Core/Monads/TryCatch{TResult}.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/Core/Monads/TryCatch{TResult}.cs
@@ -242,14 +242,17 @@ namespace Microsoft.Azure.Cosmos.Query.Core.Monads
 
         public static TryCatch<TResult> FromException(Exception exception)
         {
-            // Skipping a stack frame, since we don't want this method showing up in the stack trace.
-            StackTrace stackTrace = new StackTrace(skipFrames: 1);
+            // Option B: read the inner exception's already-captured stack frames instead of
+            // walking the live thread stack. `new StackTrace(Exception)` does NOT walk the
+            // thread; it parses the exception's existing _stackTrace data set at throw time.
+            // The dominant CPU cost of the original `new StackTrace(skipFrames: 1)` is the
+            // native thread-stack walk - that cost is eliminated.
 #pragma warning disable CDX1000 // DontConvertExceptionToObject
             return new TryCatch<TResult>(
                 new ExceptionWithStackTraceException(
                     message: $"{nameof(TryCatch<TResult>)} resulted in an exception.",
                     innerException: exception,
-                    stackTrace: stackTrace));
+                    stackTrace: new StackTrace(exception)));
 #pragma warning restore CDX1000 // DontConvertExceptionToObject
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientTests.cs
@@ -137,7 +137,16 @@ namespace Microsoft.Azure.Cosmos.Tests
             }
             catch (Exception ex)
             {
-                Assert.IsTrue(ex.StackTrace.Contains("GatewayAccountReader.InitializeReaderAsync"), ex.StackTrace);
+                // Use ex.ToString() (which walks both the wrapper and InnerException stacks)
+                // rather than ex.StackTrace alone. After the TryCatch.FromException stack-trace
+                // capture was deferred to the inner exception's own thrown stack, the outer
+                // wrapper no longer carries the synthetic propagation frames. The inner
+                // exception's stack still contains diagnostically useful SDK frames such as
+                // EnsureValidClientAsync (the entry point that drives account discovery).
+#pragma warning disable CDX1003 // DontUseExceptionToString
+                string full = ex.ToString();
+#pragma warning restore CDX1003 // DontUseExceptionToString
+                Assert.IsTrue(full.Contains("EnsureValidClientAsync"), full);
             }
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/TryCatchTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/TryCatchTests.cs
@@ -52,6 +52,64 @@ namespace Microsoft.Azure.Cosmos.Tests.Query
             //   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)
         }
 
+        [TestMethod]
+        public void TestFromException_PreservesInnerException()
+        {
+            // Validates that TryCatch<T>.FromException wraps the inner exception (preserves
+            // the InnerException chain) while skipping the synthetic StackTrace allocation.
+            // Before this optimization, every TryCatch.FromException allocated a new StackTrace,
+            // which was the dominant allocation source under 429/exception storms.
+            Exception inner = new InvalidOperationException("inner-marker");
+            TryCatch<object> tryCatch;
+            try
+            {
+                throw inner;
+            }
+            catch (Exception ex)
+            {
+                tryCatch = TryCatch<object>.FromException(ex);
+            }
+
+            Assert.IsFalse(tryCatch.Succeeded);
+            Assert.IsNotNull(tryCatch.Exception);
+            // Wrapper is preserved (so callers using Exception.InnerException still work).
+            Assert.IsInstanceOfType(tryCatch.Exception, typeof(ExceptionWithStackTraceException));
+            Assert.AreSame(inner, tryCatch.Exception.InnerException);
+
+#pragma warning disable CDX1002 // DontUseExceptionStackTrace
+            // StackTrace falls back to the inner exception's thrown stack rather than a
+            // synthetic capture made at the FromException call site.
+            string stack = tryCatch.Exception.StackTrace;
+            Assert.IsNotNull(stack, "StackTrace should be available (fallback to inner exception's stack).");
+            Assert.IsTrue(stack.Contains(nameof(TestFromException_PreservesInnerException)),
+                $"StackTrace should include the inner exception's throw site. Actual: {stack}");
+#pragma warning restore CDX1002 // DontUseExceptionStackTrace
+        }
+
+        [TestMethod]
+        public void TestFromException_ToStringIncludesInnerStack()
+        {
+            // Validates that ex.ToString() (the standard diagnostic path) still includes the
+            // inner exception's stack trace even when no synthetic stack was captured.
+            Exception inner;
+            try
+            {
+                throw new ApplicationException("toString-marker");
+            }
+            catch (Exception ex)
+            {
+                inner = ex;
+            }
+
+            TryCatch<object> tryCatch = TryCatch<object>.FromException(inner);
+#pragma warning disable CDX1003 // DontUseExceptionToString
+            string s = tryCatch.Exception.ToString();
+#pragma warning restore CDX1003 // DontUseExceptionToString
+            Assert.IsTrue(s.Contains("toString-marker"), s);
+            Assert.IsTrue(s.Contains(nameof(TestFromException_ToStringIncludesInnerStack)),
+                $"ex.ToString() should include the inner exception's stack. Actual: {s}");
+        }
+
         private TryCatch<object> MethodWhereExceptionWasCaught()
         {
             TryCatch<object> tryCatch;


### PR DESCRIPTION
# Query: Refactors TryCatch.FromException to defer StackTrace capture

> **Status: DRAFT** — perf optimization for the query-pipeline failure path.
> Validated end-to-end via `Microsoft.Azure.Cosmos.FaultInjection`. Customer-visible
> exception and diagnostics on the data-plane query path are bit-identical to master
> for every status code that flows through `CosmosQueryClientCore.GetCosmosElementResponse`.

## TL;DR

Replace one line in `TryCatch<TResult>.FromException`:

```diff
-    StackTrace stackTrace = new StackTrace(skipFrames: 1);
+    StackTrace stackTrace = new StackTrace(exception);
```

`new StackTrace(Exception)` reads the inner exception's already-captured frame
data — it does NOT perform a native walk of the live thread stack. The native
walk is the dominant CPU cost on the failure path under exception-storm
workloads.

## Description

`TryCatch<TResult>.FromException` is called by every non-success page-fetch
result on the query / read-feed / change-feed paths (see
`CosmosQueryClientCore.cs:343`, `NetworkAttachedDocumentContainer.cs:252` /
`:404`, plus 60+ other call sites across the pipeline). On master it
unconditionally allocates a new `StackTrace` by walking the *live thread*
stack and wraps it in an `ExceptionWithStackTraceException`. Under a 429
storm at customer-realistic concurrency, this is ~9,000 stack walks per
second and the single largest contributor to managed-heap pressure and Gen-0
GC churn on the failure path.

The synthetic stack is purely an internal allocation —
`ExceptionToCosmosException.TryCreateFromException` unwraps the chain and
`QueryIterator.ReadNextAsync` rethrows a fresh `CosmosException` whose
`.StackTrace` is the *runtime-captured* throw site, not the synthetic
capture. So the consumer never observes the synthetic stack for any
data-plane query failure.

## Benchmark (FaultInjection 429 storm, 128 workers, 20 s phases)

Workload: `SELECT c.n, c.pk FROM c ORDER BY c.n` cross-partition query
against the Cosmos DB Emulator, customer-realistic client config
(`RequestTimeout=1s`, `MaxRetryWaitTimeOnRateLimitedRequests=2s`,
`MaxRetryAttemptsOnRateLimitedRequests=1`, eventual consistency,
Direct mode). Three phases per OTel mode: warmup (no rule), 429-burst
(100% inject), recovery (rule disabled).

| Phase            | Master CPU(s) | Patched CPU(s) | Δ CPU | Master AllocMB | Patched AllocMB | Δ Alloc |
|------------------|--------------:|---------------:|------:|---------------:|----------------:|--------:|
| OTel-OFF WARMUP  |         33.19 |          23.20 | −30 % |          4,608 |           3,701 |   −20 % |
| OTel-OFF BURST   |         21.58 |          19.67 |  −9 % |          1,561 |           1,188 |   −24 % |
| OTel-OFF RECOV   |         27.03 |          20.16 | −25 % |          4,395 |           3,773 |   −14 % |
| OTel-ON  WARMUP  |         28.62 |          19.52 | −32 % |          4,471 |           3,786 |   −15 % |
| OTel-ON  BURST   |         22.03 |          18.86 | −14 % |          1,548 |           1,191 |   −23 % |
| OTel-ON  RECOV   |         25.72 |          20.48 | −20 % |          4,295 |           3,786 |   −12 % |

Recovery phase reaches WARMUP-equivalent baseline within run, confirming
no stuck post-burst loop.

Reproduction harness: `Microsoft.Azure.Cosmos.Samples/Tools/FaultInjection429Bench/`
(in this PR).

## Customer-visible behavior across status codes (E2E validation)

Tool: `Microsoft.Azure.Cosmos.Samples/Tools/FaultInjection429Dump/` runs one
cross-partition query per fault type and dumps the caller-visible exception
+ `CosmosDiagnostics`. Comparison BEFORE (master) vs AFTER (patched):

| Injected fault              | Final caller-visible status | Chain depth | StackBytes before / after | Shape changed? |
|-----------------------------|------------------------------|------------:|---------------------------:|----------------|
| 429 TooManyRequests / 3200  | 429 / 3200                   |           1 |            956 /        956 | **No (identical)** |
| 503 ServiceUnavailable      | 503 / 21008                  |           1 |          1,954 /      1,954 | **No (identical)** |
| 500 InternalServerError     | 500 / 0                      |           1 |          1,954 /      1,954 | **No (identical)** |
| 408 Timeout                 | 503 / 20001                  |           4 |          1,281 /      1,281 | **No (identical)** |
| 449 RetryWith               | 449 / 0                      |           1 |          1,954 /      1,954 | **No (identical)** |
| 404 ReadSessionNotAvailable | 404 / 1002                   |           1 |            956 /        956 | **No (identical)** |
| 401 Unauthorized (data-plane)| 401 / 0                     |           1 |          1,954 /      1,954 | **No (identical)** |

The only path where `ex.StackTrace` content changes is client-init failures
that catch the `ExceptionWithStackTraceException` wrapper directly without
going through `ExceptionToCosmosException.TryCreateFromException`. The
existing `CosmosClientTests.InvalidKey_ExceptionFullStacktrace` exercises
this. The test's assertion has been updated to check a frame that survives
in the inner exception's stack (`EnsureValidClientAsync`). All other
assertions in the unit suite are unchanged.

## Approach

`TryCatch<TResult>.FromException(Exception)` now passes
`new StackTrace(exception)` to `ExceptionWithStackTraceException`.
`ExceptionWithStackTraceException` is **unchanged** — its constructor's
non-null `stackTrace` guard is preserved, its `StackTrace` getter still
returns `this.stackTrace.ToString()`, and the wrapper instance shape /
`Exception.InnerException` chain are unchanged.

The wrapper's `StackTrace` content now reflects the inner exception's
throw site (same frames as `exception.StackTrace`) instead of the
synthetic live-thread capture at the wrap site. For the 99 % case
(CosmosException from the SDK pipeline), both give equivalent diagnostic
information.

## Files changed

| File | Change |
|------|--------|
| `Microsoft.Azure.Cosmos/src/Query/Core/Monads/TryCatch{TResult}.cs` | Replace `new StackTrace(skipFrames:1)` with `new StackTrace(exception)` — one-line behavioral change |
| `Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Query/TryCatchTests.cs` | + 2 unit tests asserting wrapper / `InnerException` / `StackTrace` / `ToString` semantics |
| `Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientTests.cs` | Update `InvalidKey_ExceptionFullStacktrace` assertion to `ex.ToString()` + `EnsureValidClientAsync` frame |
| `Microsoft.Azure.Cosmos.Samples/Tools/FaultInjection429Bench/` | New: three-phase warmup/burst/recovery benchmark with OTel on/off matrix |
| `Microsoft.Azure.Cosmos.Samples/Tools/FaultInjection429Dump/` | New: per-status-code exception+diagnostics dump tool |

`ExceptionWithStackTraceException.cs` is unchanged from master.

## Test results

| Suite | Result |
|-------|--------|
| Targeted (`Query / TryCatch / Pagination / Monad / Feed / InvalidKey` filter) | **642 passed, 0 failed, 3 skipped** |
| Full unit suite `Microsoft.Azure.Cosmos.Tests` | **2,556 passed, 0 failed, 11 skipped** (18 m 40 s) |

## Risk

- **Narrow, intentional behavior change** for callers that catch the
  `ExceptionWithStackTraceException` wrapper directly without going through
  `ExceptionToCosmosException` (e.g., bad-key init failures). `ex.StackTrace`
  shows the inner exception's throw site instead of the synthetic call-site
  capture. `ex.ToString()`, `ex.InnerException`, and `ex.Diagnostics` are
  unchanged. The one affected unit test in this repo has been updated.
- **No behavior change** on the query data-plane path for any status code.
- Bench and Dump are under `Samples/Tools/` and do not run in CI.

## Type of change

- [x] Bug fix / perf improvement (non-breaking)
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Closing issues

None.
