### PR TITLE
Add value-based equality for CosmosClientOptions and other option bags

### DIFF
--- a/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Azure.Cosmos
     /// ]]>
     /// </code>
     /// </example>
-    public class CosmosClientOptions
+    public class CosmosClientOptions : IEquatable<CosmosClientOptions>
     {
         /// <summary>
         /// Default connection mode
@@ -1114,12 +1114,139 @@ namespace Microsoft.Azure.Cosmos
 
         internal IChaosInterceptorFactory ChaosInterceptorFactory { get; set; }
 
+        /// <summary>
+        /// Compares this <see cref="CosmosClientOptions"/> instance with another for equality based on publicly settable properties.
+        /// </summary>
+        /// <remarks>
+        /// Only properties with a public setter (including properties whose setter is public in preview builds) are compared.
+        /// Internal state, derived state and properties without a public setter are excluded from the comparison.
+        /// Reference-type properties (delegates, factories, custom callbacks, etc.) are compared using reference equality.
+        /// </remarks>
+        /// <param name="other">The other <see cref="CosmosClientOptions"/> instance to compare against.</param>
+        /// <returns><c>true</c> if all publicly settable properties are equal; otherwise, <c>false</c>.</returns>
+        public bool Equals(CosmosClientOptions other)
+        {
+            if (other is null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return this.ApplicationName == other.ApplicationName
+                && this.ApplicationRegion == other.ApplicationRegion
+                && CosmosClientOptions.SequenceEqual(this.ApplicationPreferredRegions, other.ApplicationPreferredRegions)
+                && CosmosClientOptions.SequenceEqual(this.AccountInitializationCustomEndpoints, other.AccountInitializationCustomEndpoints)
+                && this.gatewayModeMaxConnectionLimit == other.gatewayModeMaxConnectionLimit
+                && this.RequestTimeout == other.RequestTimeout
+                && this.InferenceRequestTimeout == other.InferenceRequestTimeout
+                && this.TokenCredentialBackgroundRefreshInterval == other.TokenCredentialBackgroundRefreshInterval
+                && this.CustomHandlers.SequenceEqual(other.CustomHandlers)
+                && this.connectionMode == other.connectionMode
+                && this.ConsistencyLevel == other.ConsistencyLevel
+                && this.ReadConsistencyStrategy == other.ReadConsistencyStrategy
+                && this.EmbeddingGenerator == other.EmbeddingGenerator
+                && this.PriorityLevel == other.PriorityLevel
+                && this.MaxRetryAttemptsOnRateLimitedRequests == other.MaxRetryAttemptsOnRateLimitedRequests
+                && this.MaxRetryWaitTimeOnRateLimitedRequests == other.MaxRetryWaitTimeOnRateLimitedRequests
+                && this.EnableContentResponseOnWrite == other.EnableContentResponseOnWrite
+                && this.idleTcpConnectionTimeout == other.idleTcpConnectionTimeout
+                && this.openTcpConnectionTimeout == other.openTcpConnectionTimeout
+                && this.maxRequestsPerTcpConnection == other.maxRequestsPerTcpConnection
+                && this.maxTcpConnectionsPerEndpoint == other.maxTcpConnectionsPerEndpoint
+                && this.portReuseMode == other.portReuseMode
+                && this.webProxy == other.webProxy
+                && this.httpClientFactory == other.httpClientFactory
+                && Equals(this.serializerOptions, other.serializerOptions)
+                && this.serializerInternal == other.serializerInternal
+                && this.stjSerializerOptions == other.stjSerializerOptions
+                && this.LimitToEndpoint == other.LimitToEndpoint
+                && this.AllowBulkExecution == other.AllowBulkExecution
+                && this.EnableTcpConnectionEndpointRediscovery == other.EnableTcpConnectionEndpointRediscovery
+                && this.AvailabilityStrategy == other.AvailabilityStrategy
+                && Equals(this.SessionRetryOptions, other.SessionRetryOptions)
+                && this.ServerCertificateCustomValidationCallback == other.ServerCertificateCustomValidationCallback
+                && Equals(this.CosmosClientTelemetryOptions, other.CosmosClientTelemetryOptions)
+                && this.faultInjector == other.faultInjector
+                && this.ThroughputBucket == other.ThroughputBucket;
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object obj)
+        {
+            return this.Equals(obj as CosmosClientOptions);
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            HashCode hash = default;
+            hash.Add(this.ApplicationName);
+            hash.Add(this.ApplicationRegion);
+            hash.Add(this.gatewayModeMaxConnectionLimit);
+            hash.Add(this.RequestTimeout);
+            hash.Add(this.InferenceRequestTimeout);
+            hash.Add(this.TokenCredentialBackgroundRefreshInterval);
+            hash.Add(this.connectionMode);
+            hash.Add(this.ConsistencyLevel);
+            hash.Add(this.ReadConsistencyStrategy);
+            hash.Add(this.PriorityLevel);
+            hash.Add(this.MaxRetryAttemptsOnRateLimitedRequests);
+            hash.Add(this.MaxRetryWaitTimeOnRateLimitedRequests);
+            hash.Add(this.EnableContentResponseOnWrite);
+            hash.Add(this.idleTcpConnectionTimeout);
+            hash.Add(this.openTcpConnectionTimeout);
+            hash.Add(this.maxRequestsPerTcpConnection);
+            hash.Add(this.maxTcpConnectionsPerEndpoint);
+            hash.Add(this.portReuseMode);
+            hash.Add(this.LimitToEndpoint);
+            hash.Add(this.AllowBulkExecution);
+            hash.Add(this.EnableTcpConnectionEndpointRediscovery);
+            hash.Add(this.ThroughputBucket);
+            hash.Add(this.SessionRetryOptions);
+            hash.Add(this.serializerOptions);
+            hash.Add(this.CosmosClientTelemetryOptions);
+            CosmosClientOptions.AddSequenceHashCode(ref hash, this.ApplicationPreferredRegions);
+            CosmosClientOptions.AddSequenceHashCode(ref hash, this.AccountInitializationCustomEndpoints);
+            CosmosClientOptions.AddSequenceHashCode(ref hash, this.CustomHandlers);
+            return hash.ToHashCode();
+        }
+
+        private static bool SequenceEqual<T>(IEnumerable<T> first, IEnumerable<T> second)
+        {
+            if (ReferenceEquals(first, second))
+            {
+                return true;
+            }
+
+            if (first is null || second is null)
+            {
+                return false;
+            }
+
+            return first.SequenceEqual(second);
+        }
+
+        private static void AddSequenceHashCode<T>(ref HashCode hash, IEnumerable<T> sequence)
+        {
+            if (sequence is null)
+            {
+                hash.Add(0);
+                return;
+            }
+
+            foreach (T item in sequence)
+            {
+                hash.Add(item);
+            }
+        }
+
         internal void SetSerializerIfNotConfigured(CosmosSerializer serializer)
         {
-            if (this.serializerInternal == null)
-            {
-                this.serializerInternal = serializer ?? throw new ArgumentNullException(nameof(serializer));
-            }
+            this.serializerInternal ??= serializer ?? throw new ArgumentNullException(nameof(serializer));
         }
 
         internal CosmosClientOptions Clone()

--- a/Microsoft.Azure.Cosmos/src/CosmosClientTelemetryOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClientTelemetryOptions.cs
@@ -4,10 +4,12 @@
 
 namespace Microsoft.Azure.Cosmos
 {
+    using System;
+
     /// <summary>
     /// Telemetry Options for Cosmos Client to enable/disable telemetry and distributed tracing along with corresponding threshold values.
     /// </summary>
-    public class CosmosClientTelemetryOptions
+    public class CosmosClientTelemetryOptions : IEquatable<CosmosClientTelemetryOptions>
     {
         /// <summary>
         /// Disable sending telemetry data to Microsoft, <see cref="Microsoft.Azure.Cosmos.CosmosThresholdOptions"/> is not applicable for this. 
@@ -86,5 +88,46 @@ namespace Microsoft.Azure.Cosmos
         internal
 #endif
         NetworkMetricsOptions NetworkMetricsOptions { get; set; }
+
+        /// <inheritdoc />
+        public bool Equals(CosmosClientTelemetryOptions other)
+        {
+            if (other is null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return this.DisableSendingMetricsToService == other.DisableSendingMetricsToService
+                && this.DisableDistributedTracing == other.DisableDistributedTracing
+                && Equals(this.CosmosThresholdOptions, other.CosmosThresholdOptions)
+                && this.QueryTextMode == other.QueryTextMode
+                && this.IsClientMetricsEnabled == other.IsClientMetricsEnabled
+                && this.OperationMetricsOptions == other.OperationMetricsOptions
+                && this.NetworkMetricsOptions == other.NetworkMetricsOptions;
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object obj)
+        {
+            return this.Equals(obj as CosmosClientTelemetryOptions);
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(
+                this.DisableSendingMetricsToService,
+                this.DisableDistributedTracing,
+                this.CosmosThresholdOptions,
+                this.QueryTextMode,
+                this.IsClientMetricsEnabled,
+                this.OperationMetricsOptions,
+                this.NetworkMetricsOptions);
+        }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/CosmosThresholdOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosThresholdOptions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Azure.Cosmos
     /// This class describes the thresholds when more details diagnostics events are emitted, if subscribed, for an operation due to high latency,
     /// high RU consumption or high payload sizes.
     /// </summary>
-    public class CosmosThresholdOptions
+    public class CosmosThresholdOptions : IEquatable<CosmosThresholdOptions>
     {
         /// <summary>
         /// Can be used to define custom latency thresholds. When the latency threshold is exceeded more detailed
@@ -50,5 +50,40 @@ namespace Microsoft.Azure.Cosmos
         /// is significantly higher than expected.
         /// </summary>
         public int? PayloadSizeThresholdInBytes { get; set; } = null;
+
+        /// <inheritdoc />
+        public bool Equals(CosmosThresholdOptions other)
+        {
+            if (other is null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return this.NonPointOperationLatencyThreshold == other.NonPointOperationLatencyThreshold
+                && this.PointOperationLatencyThreshold == other.PointOperationLatencyThreshold
+                && this.RequestChargeThreshold == other.RequestChargeThreshold
+                && this.PayloadSizeThresholdInBytes == other.PayloadSizeThresholdInBytes;
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object obj)
+        {
+            return this.Equals(obj as CosmosThresholdOptions);
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(
+                this.NonPointOperationLatencyThreshold,
+                this.PointOperationLatencyThreshold,
+                this.RequestChargeThreshold,
+                this.PayloadSizeThresholdInBytes);
+        }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Serializer/CosmosSerializationOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/Serializer/CosmosSerializationOptions.cs
@@ -4,11 +4,13 @@
 
 namespace Microsoft.Azure.Cosmos
 {
+    using System;
+
     /// <summary>
     /// This class provides a way to configure basic
     /// serializer settings.
     /// </summary>
-    public sealed class CosmosSerializationOptions
+    public sealed class CosmosSerializationOptions : IEquatable<CosmosSerializationOptions>
     {
         /// <summary>
         /// Create an instance of CosmosSerializationOptions
@@ -45,5 +47,35 @@ namespace Microsoft.Azure.Cosmos
         /// The default value is CosmosPropertyNamingPolicy.Default
         /// </remarks>
         public CosmosPropertyNamingPolicy PropertyNamingPolicy { get; set; }
+
+        /// <inheritdoc />
+        public bool Equals(CosmosSerializationOptions other)
+        {
+            if (other is null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return this.IgnoreNullValues == other.IgnoreNullValues
+                && this.Indented == other.Indented
+                && this.PropertyNamingPolicy == other.PropertyNamingPolicy;
+        }
+
+        /// <inheritdoc />
+        public override bool Equals(object obj)
+        {
+            return this.Equals(obj as CosmosSerializationOptions);
+        }
+
+        /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(this.IgnoreNullValues, this.Indented, this.PropertyNamingPolicy);
+        }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/SessionRetryOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/SessionRetryOptions.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Azure.Cosmos
     /// <summary>
     /// Implementation of ISessionRetryOptions interface, do not want clients to subclass.
     /// </summary>
-    internal sealed class SessionRetryOptions : ISessionRetryOptions
+    internal sealed class SessionRetryOptions : ISessionRetryOptions, IEquatable<SessionRetryOptions>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="SessionRetryOptions"/> class.
@@ -39,5 +39,31 @@ namespace Microsoft.Azure.Cosmos
         /// </summary>
         public bool RemoteRegionPreferred { get; set; } = false;
 
+        public bool Equals(SessionRetryOptions other)
+        {
+            if (other is null)
+            {
+                return false;
+            }
+
+            if (ReferenceEquals(this, other))
+            {
+                return true;
+            }
+
+            return this.MinInRegionRetryTime == other.MinInRegionRetryTime
+                && this.MaxInRegionRetryCount == other.MaxInRegionRetryCount
+                && this.RemoteRegionPreferred == other.RemoteRegionPreferred;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return this.Equals(obj as SessionRetryOptions);
+        }
+
+        public override int GetHashCode()
+        {
+            return HashCode.Combine(this.MinInRegionRetryTime, this.MaxInRegionRetryCount, this.RemoteRegionPreferred);
+        }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
@@ -1442,5 +1442,325 @@ namespace Microsoft.Azure.Cosmos.Tests
                 throw new NotImplementedException();
             }
         }
+
+        [TestMethod]
+        public void Equality_DefaultInstances_AreEqual()
+        {
+            CosmosClientOptions options1 = new CosmosClientOptions();
+            CosmosClientOptions options2 = new CosmosClientOptions();
+
+            Assert.AreEqual(options1, options2);
+            Assert.AreEqual(options1.GetHashCode(), options2.GetHashCode());
+        }
+
+        [TestMethod]
+        public void Equality_SameInstance_IsEqual()
+        {
+            CosmosClientOptions options = new CosmosClientOptions();
+
+            Assert.IsTrue(options.Equals(options));
+            Assert.AreEqual(options, options);
+        }
+
+        [TestMethod]
+        public void Equality_NullInstance_IsNotEqual()
+        {
+            CosmosClientOptions options = new CosmosClientOptions();
+
+            Assert.IsFalse(options.Equals((CosmosClientOptions)null));
+            Assert.IsFalse(options.Equals((object)null));
+        }
+
+        [TestMethod]
+        public void Equality_DifferentType_IsNotEqual()
+        {
+            CosmosClientOptions options = new CosmosClientOptions();
+
+            Assert.IsFalse(options.Equals("not an options object"));
+        }
+
+        [TestMethod]
+        public void Equality_ApplicationName_AffectsEquality()
+        {
+            CosmosClientOptions options1 = new CosmosClientOptions { ApplicationName = "App1" };
+            CosmosClientOptions options2 = new CosmosClientOptions { ApplicationName = "App1" };
+            CosmosClientOptions options3 = new CosmosClientOptions { ApplicationName = "App2" };
+
+            Assert.AreEqual(options1, options2);
+            Assert.AreEqual(options1.GetHashCode(), options2.GetHashCode());
+            Assert.AreNotEqual(options1, options3);
+        }
+
+        [TestMethod]
+        public void Equality_ApplicationRegion_AffectsEquality()
+        {
+            CosmosClientOptions options1 = new CosmosClientOptions { ApplicationRegion = Regions.EastUS };
+            CosmosClientOptions options2 = new CosmosClientOptions { ApplicationRegion = Regions.EastUS };
+            CosmosClientOptions options3 = new CosmosClientOptions { ApplicationRegion = Regions.WestUS };
+
+            Assert.AreEqual(options1, options2);
+            Assert.AreEqual(options1.GetHashCode(), options2.GetHashCode());
+            Assert.AreNotEqual(options1, options3);
+        }
+
+        [TestMethod]
+        public void Equality_ApplicationPreferredRegions_SequenceEquality()
+        {
+            CosmosClientOptions options1 = new CosmosClientOptions
+            {
+                ApplicationPreferredRegions = new List<string> { Regions.EastUS, Regions.WestUS }
+            };
+            CosmosClientOptions options2 = new CosmosClientOptions
+            {
+                ApplicationPreferredRegions = new List<string> { Regions.EastUS, Regions.WestUS }
+            };
+            CosmosClientOptions options3 = new CosmosClientOptions
+            {
+                ApplicationPreferredRegions = new List<string> { Regions.WestUS, Regions.EastUS }
+            };
+            CosmosClientOptions options4 = new CosmosClientOptions
+            {
+                ApplicationPreferredRegions = null
+            };
+
+            Assert.AreEqual(options1, options2);
+            Assert.AreEqual(options1.GetHashCode(), options2.GetHashCode());
+            Assert.AreNotEqual(options1, options3, "Different order should not be equal");
+            Assert.AreNotEqual(options1, options4, "Non-null vs null should not be equal");
+        }
+
+        [TestMethod]
+        public void Equality_AccountInitializationCustomEndpoints_SequenceEquality()
+        {
+            Uri uri1 = new Uri("https://endpoint1.documents.azure.com");
+            Uri uri2 = new Uri("https://endpoint2.documents.azure.com");
+
+            CosmosClientOptions options1 = new CosmosClientOptions
+            {
+                AccountInitializationCustomEndpoints = new HashSet<Uri> { uri1, uri2 }
+            };
+            CosmosClientOptions options2 = new CosmosClientOptions
+            {
+                AccountInitializationCustomEndpoints = new HashSet<Uri> { uri1, uri2 }
+            };
+
+            Assert.AreEqual(options1, options2);
+            Assert.AreEqual(options1.GetHashCode(), options2.GetHashCode());
+        }
+
+        [TestMethod]
+        public void Equality_ConnectionMode_AffectsEquality()
+        {
+            CosmosClientOptions options1 = new CosmosClientOptions { ConnectionMode = ConnectionMode.Direct };
+            CosmosClientOptions options2 = new CosmosClientOptions { ConnectionMode = ConnectionMode.Direct };
+            CosmosClientOptions options3 = new CosmosClientOptions { ConnectionMode = ConnectionMode.Gateway };
+
+            Assert.AreEqual(options1, options2);
+            Assert.AreEqual(options1.GetHashCode(), options2.GetHashCode());
+            Assert.AreNotEqual(options1, options3);
+        }
+
+        [TestMethod]
+        public void Equality_ValueTypeProperties_AffectEquality()
+        {
+            CosmosClientOptions options1 = new CosmosClientOptions
+            {
+                RequestTimeout = TimeSpan.FromSeconds(30),
+                MaxRetryAttemptsOnRateLimitedRequests = 5,
+                MaxRetryWaitTimeOnRateLimitedRequests = TimeSpan.FromMinutes(1),
+                EnableContentResponseOnWrite = true,
+                LimitToEndpoint = true,
+                AllowBulkExecution = true,
+                ConsistencyLevel = Cosmos.ConsistencyLevel.Session,
+            };
+            CosmosClientOptions options2 = new CosmosClientOptions
+            {
+                RequestTimeout = TimeSpan.FromSeconds(30),
+                MaxRetryAttemptsOnRateLimitedRequests = 5,
+                MaxRetryWaitTimeOnRateLimitedRequests = TimeSpan.FromMinutes(1),
+                EnableContentResponseOnWrite = true,
+                LimitToEndpoint = true,
+                AllowBulkExecution = true,
+                ConsistencyLevel = Cosmos.ConsistencyLevel.Session,
+            };
+            CosmosClientOptions options3 = new CosmosClientOptions
+            {
+                RequestTimeout = TimeSpan.FromSeconds(60),
+                MaxRetryAttemptsOnRateLimitedRequests = 5,
+                MaxRetryWaitTimeOnRateLimitedRequests = TimeSpan.FromMinutes(1),
+                EnableContentResponseOnWrite = true,
+                LimitToEndpoint = true,
+                AllowBulkExecution = true,
+                ConsistencyLevel = Cosmos.ConsistencyLevel.Session,
+            };
+
+            Assert.AreEqual(options1, options2);
+            Assert.AreEqual(options1.GetHashCode(), options2.GetHashCode());
+            Assert.AreNotEqual(options1, options3, "Different RequestTimeout should not be equal");
+        }
+
+        [TestMethod]
+        public void Equality_SerializerOptions_AffectsEquality()
+        {
+            CosmosClientOptions options1 = new CosmosClientOptions
+            {
+                SerializerOptions = new CosmosSerializationOptions
+                {
+                    IgnoreNullValues = true,
+                    PropertyNamingPolicy = CosmosPropertyNamingPolicy.CamelCase
+                }
+            };
+            CosmosClientOptions options2 = new CosmosClientOptions
+            {
+                SerializerOptions = new CosmosSerializationOptions
+                {
+                    IgnoreNullValues = true,
+                    PropertyNamingPolicy = CosmosPropertyNamingPolicy.CamelCase
+                }
+            };
+            CosmosClientOptions options3 = new CosmosClientOptions
+            {
+                SerializerOptions = new CosmosSerializationOptions
+                {
+                    IgnoreNullValues = false,
+                    PropertyNamingPolicy = CosmosPropertyNamingPolicy.CamelCase
+                }
+            };
+
+            Assert.AreEqual(options1, options2);
+            Assert.AreEqual(options1.GetHashCode(), options2.GetHashCode());
+            Assert.AreNotEqual(options1, options3);
+        }
+
+        [TestMethod]
+        public void Equality_TelemetryOptions_AffectsEquality()
+        {
+            CosmosClientOptions options1 = new CosmosClientOptions();
+            options1.CosmosClientTelemetryOptions.DisableSendingMetricsToService = false;
+
+            CosmosClientOptions options2 = new CosmosClientOptions();
+            options2.CosmosClientTelemetryOptions.DisableSendingMetricsToService = false;
+
+            CosmosClientOptions options3 = new CosmosClientOptions();
+            options3.CosmosClientTelemetryOptions.DisableSendingMetricsToService = true;
+
+            Assert.AreEqual(options1, options2);
+            Assert.AreEqual(options1.GetHashCode(), options2.GetHashCode());
+            Assert.AreNotEqual(options1, options3);
+        }
+
+        [TestMethod]
+        public void Equality_ReferenceTypeProperties_UseReferenceEquality()
+        {
+            Func<HttpClient> factory1 = () => new HttpClient();
+            Func<HttpClient> factory2 = () => new HttpClient();
+
+            CosmosClientOptions options1 = new CosmosClientOptions { HttpClientFactory = factory1 };
+            CosmosClientOptions options2 = new CosmosClientOptions { HttpClientFactory = factory1 };
+            CosmosClientOptions options3 = new CosmosClientOptions { HttpClientFactory = factory2 };
+
+            Assert.AreEqual(options1, options2, "Same delegate reference should be equal");
+            Assert.AreNotEqual(options1, options3, "Different delegate references should not be equal");
+        }
+
+        [TestMethod]
+        public void Equality_InternalState_DoesNotAffectEquality()
+        {
+            // Internal/non-publicly-settable state changes must not affect equality of CosmosClientOptions.
+            CosmosClientOptions options1 = new CosmosClientOptions();
+            CosmosClientOptions options2 = new CosmosClientOptions
+            {
+                ApiType = ApiType.Sql,
+                EnableCpuMonitor = false,
+                DisableServerCertificateValidation = true,
+                InitialRetryForRetryWithMilliseconds = 100,
+                MaximumRetryForRetryWithMilliseconds = 200,
+                RandomSaltForRetryWithMilliseconds = 5,
+                TotalWaitTimeForRetryWithMilliseconds = 1000,
+                EnableAdvancedReplicaSelectionForTcp = true,
+                EnableStreamPassThrough = true,
+            };
+
+            Assert.AreEqual(options1, options2);
+            Assert.AreEqual(options1.GetHashCode(), options2.GetHashCode());
+        }
+
+        [TestMethod]
+        public void Equality_CosmosSerializationOptions_ValueSemantics()
+        {
+            CosmosSerializationOptions so1 = new CosmosSerializationOptions
+            {
+                IgnoreNullValues = true,
+                Indented = true,
+                PropertyNamingPolicy = CosmosPropertyNamingPolicy.CamelCase,
+            };
+            CosmosSerializationOptions so2 = new CosmosSerializationOptions
+            {
+                IgnoreNullValues = true,
+                Indented = true,
+                PropertyNamingPolicy = CosmosPropertyNamingPolicy.CamelCase,
+            };
+            CosmosSerializationOptions so3 = new CosmosSerializationOptions
+            {
+                IgnoreNullValues = false,
+                Indented = true,
+                PropertyNamingPolicy = CosmosPropertyNamingPolicy.CamelCase,
+            };
+
+            Assert.AreEqual(so1, so2);
+            Assert.AreEqual(so1.GetHashCode(), so2.GetHashCode());
+            Assert.AreNotEqual(so1, so3);
+        }
+
+        [TestMethod]
+        public void Equality_CosmosThresholdOptions_ValueSemantics()
+        {
+            CosmosThresholdOptions to1 = new CosmosThresholdOptions
+            {
+                PointOperationLatencyThreshold = TimeSpan.FromSeconds(2),
+                NonPointOperationLatencyThreshold = TimeSpan.FromSeconds(5),
+                RequestChargeThreshold = 100.0,
+                PayloadSizeThresholdInBytes = 1024,
+            };
+            CosmosThresholdOptions to2 = new CosmosThresholdOptions
+            {
+                PointOperationLatencyThreshold = TimeSpan.FromSeconds(2),
+                NonPointOperationLatencyThreshold = TimeSpan.FromSeconds(5),
+                RequestChargeThreshold = 100.0,
+                PayloadSizeThresholdInBytes = 1024,
+            };
+            CosmosThresholdOptions to3 = new CosmosThresholdOptions
+            {
+                PointOperationLatencyThreshold = TimeSpan.FromSeconds(3),
+            };
+
+            Assert.AreEqual(to1, to2);
+            Assert.AreEqual(to1.GetHashCode(), to2.GetHashCode());
+            Assert.AreNotEqual(to1, to3);
+        }
+
+        [TestMethod]
+        public void Equality_CosmosClientTelemetryOptions_ValueSemantics()
+        {
+            CosmosClientTelemetryOptions cto1 = new CosmosClientTelemetryOptions
+            {
+                DisableSendingMetricsToService = false,
+                QueryTextMode = QueryTextMode.All,
+            };
+            CosmosClientTelemetryOptions cto2 = new CosmosClientTelemetryOptions
+            {
+                DisableSendingMetricsToService = false,
+                QueryTextMode = QueryTextMode.All,
+            };
+            CosmosClientTelemetryOptions cto3 = new CosmosClientTelemetryOptions
+            {
+                DisableSendingMetricsToService = false,
+                QueryTextMode = QueryTextMode.None,
+            };
+
+            Assert.AreEqual(cto1, cto2);
+            Assert.AreEqual(cto1.GetHashCode(), cto2.GetHashCode());
+            Assert.AreNotEqual(cto1, cto3);
+        }
     }
 }


### PR DESCRIPTION
Implements IEquatable<T> on CosmosClientOptions, CosmosClientTelemetryOptions, CosmosThresholdOptions, and CosmosSerializationOptions. Equality compares only publicly settable properties (including PREVIEW-gated public setters); internal-only state and properties without a public setter are excluded. Reference-type properties (delegates, factories, custom callbacks) use reference equality, matching the rest of the SDK conventions.

Closes #4965.
