### PR TITLE
[Internal] DTS: Fixes per-operation status code loss on error responses

### DIFF
--- a/Microsoft.Azure.Cosmos/src/GatewayStoreClient.cs
+++ b/Microsoft.Azure.Cosmos/src/GatewayStoreClient.cs
@@ -137,7 +137,6 @@ namespace Microsoft.Azure.Cosmos
                 {
                     // For DTC responses, preserve the response body (operationResponses JSON) so the caller can parse per-op statuses.
                     // If there is no response body, fall back to throwing to preserve detailed error context.
-                    if (responseMessage.Content == null
                     INameValueCollection headers = GatewayStoreClient.ExtractResponseHeaders(responseMessage);
                     Stream contentStream = await GatewayStoreClient.BufferContentIfAvailableAsync(responseMessage);
 
@@ -145,12 +144,7 @@ namespace Microsoft.Azure.Cosmos
                     {
                         throw await GatewayStoreClient.CreateDocumentClientExceptionAsync(responseMessage, requestStatistics);
                     }
-                    {
-                        throw await GatewayStoreClient.CreateDocumentClientExceptionAsync(responseMessage, requestStatistics);
-                    }
 
-                    INameValueCollection headers = GatewayStoreClient.ExtractResponseHeaders(responseMessage);
-                    Stream contentStream = await GatewayStoreClient.BufferContentIfAvailableAsync(responseMessage);
                     return new DocumentServiceResponse(
                         body: contentStream,
                         headers: headers,

--- a/Microsoft.Azure.Cosmos/src/GatewayStoreClient.cs
+++ b/Microsoft.Azure.Cosmos/src/GatewayStoreClient.cs
@@ -132,6 +132,26 @@ namespace Microsoft.Azure.Cosmos
                         clientSideRequestStatistics: requestStatistics,
                         serializerSettings: serializerSettings);
                 }
+                else if (request != null
+                    && request.ResourceType == ResourceType.DistributedTransactionBatch)
+                {
+                    // For DTC responses, preserve the response body (operationResponses JSON) so the caller can parse per-op statuses.
+                    // If there is no response body, fall back to throwing to preserve detailed error context.
+                    if (responseMessage.Content == null
+                        || responseMessage.Content.Headers.ContentLength.GetValueOrDefault() == 0)
+                    {
+                        throw await GatewayStoreClient.CreateDocumentClientExceptionAsync(responseMessage, requestStatistics);
+                    }
+
+                    INameValueCollection headers = GatewayStoreClient.ExtractResponseHeaders(responseMessage);
+                    Stream contentStream = await GatewayStoreClient.BufferContentIfAvailableAsync(responseMessage);
+                    return new DocumentServiceResponse(
+                        body: contentStream,
+                        headers: headers,
+                        statusCode: responseMessage.StatusCode,
+                        clientSideRequestStatistics: requestStatistics,
+                        serializerSettings: serializerSettings);
+                }
                 else
                 {
                     throw await GatewayStoreClient.CreateDocumentClientExceptionAsync(responseMessage, requestStatistics);

--- a/Microsoft.Azure.Cosmos/src/GatewayStoreClient.cs
+++ b/Microsoft.Azure.Cosmos/src/GatewayStoreClient.cs
@@ -138,7 +138,13 @@ namespace Microsoft.Azure.Cosmos
                     // For DTC responses, preserve the response body (operationResponses JSON) so the caller can parse per-op statuses.
                     // If there is no response body, fall back to throwing to preserve detailed error context.
                     if (responseMessage.Content == null
-                        || responseMessage.Content.Headers.ContentLength.GetValueOrDefault() == 0)
+                    INameValueCollection headers = GatewayStoreClient.ExtractResponseHeaders(responseMessage);
+                    Stream contentStream = await GatewayStoreClient.BufferContentIfAvailableAsync(responseMessage);
+
+                    if (contentStream == null || contentStream.Length == 0)
+                    {
+                        throw await GatewayStoreClient.CreateDocumentClientExceptionAsync(responseMessage, requestStatistics);
+                    }
                     {
                         throw await GatewayStoreClient.CreateDocumentClientExceptionAsync(responseMessage, requestStatistics);
                     }

--- a/Microsoft.Azure.Cosmos/src/Util/Extensions.cs
+++ b/Microsoft.Azure.Cosmos/src/Util/Extensions.cs
@@ -103,6 +103,33 @@ namespace Microsoft.Azure.Cosmos
             // If it's considered a failure create the corresponding CosmosException
             if (!documentServiceResponse.StatusCode.IsSuccess())
             {
+                // DTX responses carry per-operation results in the body that must be preserved
+                // for DistributedTransactionResponse.FromResponseMessageAsync to parse.
+                // Route through a lightweight CosmosException instead of CosmosExceptionFactory.Create
+                // which disposes the stream.
+                if (requestMessage?.ResourceType == ResourceType.DistributedTransactionBatch
+                    && documentServiceResponse.ResponseBody != null)
+                {
+                    CosmosException dtxCosmosException = new CosmosException(
+                        message: $"Distributed transaction batch failed with status code {(int)documentServiceResponse.StatusCode} ({documentServiceResponse.StatusCode}).",
+                        statusCode: documentServiceResponse.StatusCode,
+                        subStatusCode: (int)documentServiceResponse.SubStatusCode,
+                        activityId: headers.ActivityId,
+                        requestCharge: headers.RequestCharge);
+
+                    ResponseMessage dtcResponseMessage = new ResponseMessage(
+                        statusCode: documentServiceResponse.StatusCode,
+                        requestMessage: requestMessage,
+                        headers: headers,
+                        cosmosException: dtxCosmosException,
+                        trace: requestMessage.Trace ?? NoOpTrace.Singleton)
+                    {
+                        Content = documentServiceResponse.ResponseBody
+                    };
+
+                    return dtcResponseMessage;
+                }
+
                 CosmosException cosmosException = CosmosExceptionFactory.Create(
                     documentServiceResponse,
                     headers,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GatewayStoreClientTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GatewayStoreClientTests.cs
@@ -4,6 +4,7 @@
 namespace Microsoft.Azure.Cosmos
 {
     using System;
+    using System.IO;
     using System.Net;
     using System.Net.Http;
     using System.Text;
@@ -11,6 +12,7 @@ namespace Microsoft.Azure.Cosmos
     using Microsoft.Azure.Cosmos.Tracing;
     using Microsoft.Azure.Cosmos.Tracing.TraceData;
     using Microsoft.Azure.Documents;
+    using Microsoft.Azure.Documents.Collections;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Newtonsoft.Json;
 
@@ -276,6 +278,194 @@ namespace Microsoft.Azure.Cosmos
             Assert.IsNotNull(exception);
             Assert.AreEqual(HttpStatusCode.Forbidden, exception.StatusCode);
             Assert.IsTrue(exception.Message.Contains(invalidJson), "Exception message should contain the original invalid JSON content");
+        }
+
+        /// <summary>
+        /// Verifies that ParseResponseAsync preserves the response body for DTX requests
+        /// returning error status codes (e.g., 452), instead of throwing DocumentClientException
+        /// which would discard the per-operation results JSON.
+        /// </summary>
+        [TestMethod]
+        public async Task TestParseResponseAsync_DtxRequest_PreservesBodyOn452()
+        {
+            string dtxResponseBody = "{\"operationResponses\":[{\"statusCode\":412,\"subStatusCode\":0}],\"isRetriable\":false}";
+
+            HttpResponseMessage httpResponse = new HttpResponseMessage((HttpStatusCode)452)
+            {
+                RequestMessage = new HttpRequestMessage(HttpMethod.Post, "https://test.documents.azure.com/operations/dtc"),
+                Content = new StringContent(dtxResponseBody, Encoding.UTF8, "application/json")
+            };
+
+            using DocumentServiceRequest dsRequest = DocumentServiceRequest.Create(
+                OperationType.CommitDistributedTransaction,
+                ResourceType.DistributedTransactionBatch,
+                "operations/dtc",
+                new System.IO.MemoryStream(Encoding.UTF8.GetBytes("{}")),
+                AuthorizationTokenType.PrimaryMasterKey,
+                null);
+
+            DocumentServiceResponse response = await GatewayStoreClient.ParseResponseAsync(httpResponse, request: dsRequest);
+
+            Assert.IsNotNull(response);
+            Assert.AreEqual((HttpStatusCode)452, response.StatusCode);
+            Assert.IsNotNull(response.ResponseBody, "Response body must be preserved for DTX per-operation parsing.");
+
+            using System.IO.StreamReader reader = new System.IO.StreamReader(response.ResponseBody);
+            string body = await reader.ReadToEndAsync();
+            Assert.IsTrue(body.Contains("412"), "Per-operation status code should be present in the preserved body.");
+        }
+
+        /// <summary>
+        /// Verifies that ParseResponseAsync preserves the body for DTX requests returning
+        /// other error codes (e.g., 409 Conflict) that are not in the standard exceptionless set.
+        /// </summary>
+        [TestMethod]
+        [DataRow(409)]
+        [DataRow(500)]
+        [DataRow(449)]
+        public async Task TestParseResponseAsync_DtxRequest_PreservesBodyOnVariousErrorCodes(int statusCode)
+        {
+            string dtxResponseBody = "{\"operationResponses\":[{\"statusCode\":412,\"subStatusCode\":0}],\"isRetriable\":true}";
+
+            HttpResponseMessage httpResponse = new HttpResponseMessage((HttpStatusCode)statusCode)
+            {
+                RequestMessage = new HttpRequestMessage(HttpMethod.Post, "https://test.documents.azure.com/operations/dtc"),
+                Content = new StringContent(dtxResponseBody, Encoding.UTF8, "application/json")
+            };
+
+            using DocumentServiceRequest dsRequest = DocumentServiceRequest.Create(
+                OperationType.CommitDistributedTransaction,
+                ResourceType.DistributedTransactionBatch,
+                "operations/dtc",
+                new System.IO.MemoryStream(Encoding.UTF8.GetBytes("{}")),
+                AuthorizationTokenType.PrimaryMasterKey,
+                null);
+
+            DocumentServiceResponse response = await GatewayStoreClient.ParseResponseAsync(httpResponse, request: dsRequest);
+
+            Assert.IsNotNull(response);
+            Assert.AreEqual((HttpStatusCode)statusCode, response.StatusCode);
+            Assert.IsNotNull(response.ResponseBody, $"Response body must be preserved for DTX requests returning {statusCode}.");
+        }
+
+        /// <summary>
+        /// Verifies that ParseResponseAsync falls back to throwing DocumentClientException
+        /// for DTX requests when there is no content body (preserving detailed error context).
+        /// </summary>
+        [TestMethod]
+        public async Task TestParseResponseAsync_DtxRequest_NullContentThrowsForErrorContext()
+        {
+            HttpResponseMessage httpResponse = new HttpResponseMessage((HttpStatusCode)452)
+            {
+                RequestMessage = new HttpRequestMessage(HttpMethod.Post, "https://test.documents.azure.com/operations/dtc"),
+                Content = null
+            };
+
+            using DocumentServiceRequest dsRequest = DocumentServiceRequest.Create(
+                OperationType.CommitDistributedTransaction,
+                ResourceType.DistributedTransactionBatch,
+                "operations/dtc",
+                new System.IO.MemoryStream(Encoding.UTF8.GetBytes("{}")),
+                AuthorizationTokenType.PrimaryMasterKey,
+                null);
+
+            await Assert.ThrowsExceptionAsync<DocumentClientException>(
+                () => GatewayStoreClient.ParseResponseAsync(httpResponse, request: dsRequest));
+        }
+
+        /// <summary>
+        /// Verifies that Extensions.ToCosmosResponseMessage preserves the response body
+        /// for DTX error responses, so DistributedTransactionResponse can parse per-op results,
+        /// while also populating CosmosException for consumers that check it.
+        /// </summary>
+        [TestMethod]
+        public void TestToCosmosResponseMessage_DtxResponse_PreservesBodyOnError()
+        {
+            string dtxResponseBody = "{\"operationResponses\":[{\"statusCode\":412}]}";
+            byte[] bodyBytes = Encoding.UTF8.GetBytes(dtxResponseBody);
+            System.IO.MemoryStream bodyStream = new System.IO.MemoryStream(bodyBytes);
+
+            DocumentServiceResponse dsResponse = new DocumentServiceResponse(
+                body: bodyStream,
+                headers: new Documents.Collections.RequestNameValueCollection(),
+                statusCode: (HttpStatusCode)452);
+
+            RequestMessage requestMessage = new RequestMessage(
+                HttpMethod.Post,
+                new Uri("operations/dtc", UriKind.Relative))
+            {
+                ResourceType = ResourceType.DistributedTransactionBatch,
+                OperationType = OperationType.CommitDistributedTransaction
+            };
+
+            ResponseMessage responseMessage = dsResponse.ToCosmosResponseMessage(requestMessage, requestChargeTracker: null);
+
+            Assert.IsNotNull(responseMessage);
+            Assert.AreEqual((HttpStatusCode)452, responseMessage.StatusCode);
+            Assert.IsNotNull(responseMessage.Content, "DTX response body must be preserved through ToCosmosResponseMessage.");
+            Assert.IsNotNull(responseMessage.CosmosException, "CosmosException should be populated for error context.");
+            Assert.AreEqual((HttpStatusCode)452, responseMessage.CosmosException.StatusCode);
+
+            responseMessage.Content.Position = 0;
+            using System.IO.StreamReader reader = new System.IO.StreamReader(responseMessage.Content);
+            string body = reader.ReadToEnd();
+            Assert.IsTrue(body.Contains("412"), "Per-operation status code should be present in the preserved body.");
+        }
+
+        /// <summary>
+        /// Verifies that Extensions.ToCosmosResponseMessage still creates CosmosException
+        /// (without body) for non-DTX error responses — the existing behavior is unchanged.
+        /// </summary>
+        [TestMethod]
+        public void TestToCosmosResponseMessage_NonDtxResponse_DoesNotPreserveBodyOnError()
+        {
+            byte[] bodyBytes = Encoding.UTF8.GetBytes("{\"error\":\"test\"}");
+            System.IO.MemoryStream bodyStream = new System.IO.MemoryStream(bodyBytes);
+
+            DocumentServiceResponse dsResponse = new DocumentServiceResponse(
+                body: bodyStream,
+                headers: new Documents.Collections.RequestNameValueCollection(),
+                statusCode: HttpStatusCode.InternalServerError);
+
+            RequestMessage requestMessage = new RequestMessage(
+                HttpMethod.Post,
+                new Uri("dbs/db1/colls/coll1/docs", UriKind.Relative))
+            {
+                ResourceType = ResourceType.Document,
+                OperationType = OperationType.Create
+            };
+
+            ResponseMessage responseMessage = dsResponse.ToCosmosResponseMessage(requestMessage, requestChargeTracker: null);
+
+            Assert.IsNotNull(responseMessage);
+            Assert.AreEqual(HttpStatusCode.InternalServerError, responseMessage.StatusCode);
+            // Non-DTX error responses go through CosmosException path — Content is not the original body.
+            Assert.IsNull(responseMessage.Content, "Non-DTX error responses should not preserve raw body (goes through CosmosException path).");
+        }
+
+        /// <summary>
+        /// Verifies that ParseResponseAsync still throws DocumentClientException for non-DTX
+        /// requests that return error status codes not covered by exceptionless retry flags.
+        /// </summary>
+        [TestMethod]
+        public async Task TestParseResponseAsync_NonDtxRequest_StillThrowsOnError()
+        {
+            HttpResponseMessage httpResponse = new HttpResponseMessage((HttpStatusCode)452)
+            {
+                RequestMessage = new HttpRequestMessage(HttpMethod.Post, "https://test.documents.azure.com/dbs/db1/colls/coll1/docs"),
+                Content = new StringContent("{\"error\":\"test\"}", Encoding.UTF8, "application/json")
+            };
+
+            using DocumentServiceRequest dsRequest = DocumentServiceRequest.Create(
+                OperationType.Create,
+                ResourceType.Document,
+                new Uri("https://test.documents.azure.com/dbs/db1/colls/coll1/docs", UriKind.Absolute),
+                new System.IO.MemoryStream(Encoding.UTF8.GetBytes("{}")),
+                AuthorizationTokenType.PrimaryMasterKey,
+                null);
+
+            await Assert.ThrowsExceptionAsync<DocumentClientException>(
+                () => GatewayStoreClient.ParseResponseAsync(httpResponse, request: dsRequest));
         }
 
         private static IClientSideRequestStatistics CreateClientSideRequestStatistics()


### PR DESCRIPTION
# Pull Request Template

## Description

When the service returns a non-success status (e.g., 452) for a distributed transaction batch with a JSON body containing per-operation results, the response body was being discarded:

  - `GatewayStoreClient.ParseResponseAsync` threw `DocumentClientException` because 452 is not covered by `IsValidStatusCodeForExceptionlessRetry`, which disposed the response body.
  - `Extensions.ToCosmosResponseMessage` (`DocumentServiceResponse` overload) routed non-success responses through `CosmosExceptionFactory.Create`, whose `GetErrorFromStream` also disposes the body.

As a result, `DistributedTransactionResponse.FromResponseMessageAsync` saw null Content, skipped JSON parsing, and stamped every operation with the envelope status code (e.g., 452), losing the real per-op statuses (e.g., 412 PreconditionFailed).

Fix:
- `GatewayStoreClient.ParseResponseAsync`: for `DistributedTransactionBatch` requests, return a `DocumentServiceResponse `with the buffered body preserved when the body is non-empty. Falls back to the existing throw path when there is no body so detailed error context is retained.
- `Extensions.ToCosmosResponseMessage`: for `DistributedTransactionBatch` responses, bypass the `CosmosExceptionFactory` path and construct a `ResponseMessage` that keeps Content set. A lightweight `CosmosException` carrying status code, sub-status code, activity id, and request charge is still attached so consumers retain error context. Trace is propagated from `requestMessage.Trace` (with a `NoOpTrace` fallback to avoid NRE when no trace is set).

Tests:
- 6 new unit tests in `GatewayStoreClientTests` covering body preservation for 452/409/500/449, the null-body fallback, the Extensions DTX path (including `CosmosException` population), and a non-DTX regression check.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber

## Changelog

- [ ] I have added a changelog entry under `### Unreleased` in `changelog.md`
  for the user-facing impact of this change.
- [X] No changelog entry is required because this PR is one of:
  documentation-only, test-only, CI / build-only, or a pure internal refactor
  with no observable customer impact.

If the second box is checked, briefly justify here:

> Feature not public yet
