### PR TITLE
Serializer: Fixes excessive allocations in CosmosSystemTextJsonSerializer read path

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Json/IJsonWriter.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/IJsonWriter.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.Cosmos.Json
 #else
     internal
 #endif
-    interface IJsonWriter
+    interface IJsonWriter : IDisposable
     {
         /// <summary>
         /// Gets the SerializationFormat of the JsonWriter.

--- a/Microsoft.Azure.Cosmos/src/Json/JsonMemoryWriter.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/JsonMemoryWriter.cs
@@ -5,14 +5,20 @@
 namespace Microsoft.Azure.Cosmos.Json
 {
     using System;
+    using System.Buffers;
 
-    internal abstract class JsonMemoryWriter
+    internal abstract class JsonMemoryWriter : IDisposable
     {
         protected byte[] buffer;
 
-        protected JsonMemoryWriter(int initialCapacity = 256)
+        private readonly bool pooled;
+
+        protected JsonMemoryWriter(int initialCapacity = 256, bool pooled = false)
         {
-            this.buffer = new byte[initialCapacity];
+            this.pooled = pooled;
+            this.buffer = pooled
+                ? ArrayPool<byte>.Shared.Rent(initialCapacity)
+                : new byte[initialCapacity];
         }
 
         public int Position
@@ -53,7 +59,27 @@ namespace Microsoft.Azure.Cosmos.Json
 
             long newLength = minNewSize * 2;
             newLength = Math.Min(newLength, int.MaxValue);
-            Array.Resize(ref this.buffer, (int)newLength);
+
+            if (this.pooled)
+            {
+                byte[] newBuffer = ArrayPool<byte>.Shared.Rent((int)newLength);
+                Array.Copy(this.buffer, newBuffer, this.Position);
+                ArrayPool<byte>.Shared.Return(this.buffer);
+                this.buffer = newBuffer;
+            }
+            else
+            {
+                Array.Resize(ref this.buffer, (int)newLength);
+            }
+        }
+
+        public void Dispose()
+        {
+            if (this.pooled && this.buffer != null)
+            {
+                ArrayPool<byte>.Shared.Return(this.buffer);
+                this.buffer = null;
+            }
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Json/JsonWriter.JsonBinaryWriter.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/JsonWriter.JsonBinaryWriter.cs
@@ -269,6 +269,12 @@ namespace Microsoft.Azure.Cosmos.Json
             /// </summary>
             private readonly JsonBinaryMemoryWriter binaryWriter;
 
+            /// <inheritdoc />
+            public override void Dispose()
+            {
+                this.binaryWriter.Dispose();
+            }
+
             /// <summary>
             /// With binary encoding all the JSON elements are length prefixed,
             /// unfortunately the caller of this class only provides what tokens to write.

--- a/Microsoft.Azure.Cosmos/src/Json/JsonWriter.JsonBinaryWriter.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/JsonWriter.JsonBinaryWriter.cs
@@ -269,12 +269,6 @@ namespace Microsoft.Azure.Cosmos.Json
             /// </summary>
             private readonly JsonBinaryMemoryWriter binaryWriter;
 
-            /// <inheritdoc />
-            public override void Dispose()
-            {
-                this.binaryWriter.Dispose();
-            }
-
             /// <summary>
             /// With binary encoding all the JSON elements are length prefixed,
             /// unfortunately the caller of this class only provides what tokens to write.

--- a/Microsoft.Azure.Cosmos/src/Json/JsonWriter.JsonTextWriter.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/JsonWriter.JsonTextWriter.cs
@@ -94,10 +94,16 @@ namespace Microsoft.Azure.Cosmos.Json
             /// <summary>
             /// Initializes a new instance of the JsonTextWriter class.
             /// </summary>
-            public JsonTextWriter(int initialCapacity = 256)
+            public JsonTextWriter(int initialCapacity = 256, bool pooled = false)
             {
                 this.firstValue = true;
-                this.jsonTextMemoryWriter = new JsonTextMemoryWriter(initialCapacity);
+                this.jsonTextMemoryWriter = new JsonTextMemoryWriter(initialCapacity, pooled);
+            }
+
+            /// <inheritdoc />
+            public override void Dispose()
+            {
+                this.jsonTextMemoryWriter.Dispose();
             }
 
             /// <inheritdoc />
@@ -543,8 +549,8 @@ namespace Microsoft.Azure.Cosmos.Json
                 private static readonly StandardFormat doubleFormat = new StandardFormat(
                     symbol: 'R');
 
-                public JsonTextMemoryWriter(int initialCapacity = 256)
-                    : base(initialCapacity)
+                public JsonTextMemoryWriter(int initialCapacity = 256, bool pooled = false)
+                    : base(initialCapacity, pooled)
                 {
                 }
 

--- a/Microsoft.Azure.Cosmos/src/Json/JsonWriter.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/JsonWriter.cs
@@ -256,7 +256,7 @@ namespace Microsoft.Azure.Cosmos.Json
         public abstract ReadOnlyMemory<byte> GetResult();
 
         /// <summary>
-        /// Releases any pooled buffers held by this writer. Writers created with
+        /// Releases any pooled buffer held by this writer. Writers created with
         /// <c>pooled: true</c> return their rented buffer to the shared
         /// <see cref="System.Buffers.ArrayPool{T}"/>; otherwise this is a no-op.
         /// The result of <see cref="GetResult"/> must not be used after disposal.

--- a/Microsoft.Azure.Cosmos/src/Json/JsonWriter.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/JsonWriter.cs
@@ -256,7 +256,7 @@ namespace Microsoft.Azure.Cosmos.Json
         public abstract ReadOnlyMemory<byte> GetResult();
 
         /// <summary>
-        /// Returns any pooled buffer to the shared <see cref="System.Buffers.ArrayPool{T}"/>; otherwise a no-op.
+        /// Releases the rented buffer back to the shared <see cref="System.Buffers.ArrayPool{T}"/>. Does nothing when not pooled.
         /// </summary>
         public virtual void Dispose()
         {

--- a/Microsoft.Azure.Cosmos/src/Json/JsonWriter.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/JsonWriter.cs
@@ -5,6 +5,7 @@ namespace Microsoft.Azure.Cosmos.Json
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics;
     using System.Globalization;
     using System.Text;
     using Microsoft.Azure.Cosmos.Core.Utf8;
@@ -58,6 +59,10 @@ namespace Microsoft.Azure.Cosmos.Json
             IJsonStringDictionary jsonStringDictionary = null,
             bool pooled = false)
         {
+            Debug.Assert(
+                !pooled || jsonSerializationFormat == JsonSerializationFormat.Text,
+                "Buffer pooling is only supported for the Text format.");
+
             return jsonSerializationFormat switch
             {
                 JsonSerializationFormat.Text => new JsonTextWriter(initialCapacity, pooled),

--- a/Microsoft.Azure.Cosmos/src/Json/JsonWriter.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/JsonWriter.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.Cosmos.Json
 #else
     internal
 #endif
-    abstract partial class JsonWriter : IJsonWriter
+    abstract partial class JsonWriter : IJsonWriter, IDisposable
     {
         private const int MaxStackAlloc = 4 * 1024;
 
@@ -49,16 +49,18 @@ namespace Microsoft.Azure.Cosmos.Json
         /// <param name="writeOptions">The write options the control the write behavior.</param>
         /// <param name="initialCapacity">Initial capacity to help avoid intermediary allocations.</param>
         /// <param name="jsonStringDictionary">The dictionary to use for user string encoding.</param>
+        /// <param name="pooled">Whether the writer should rent its internal buffer from the shared <see cref="System.Buffers.ArrayPool{T}"/>. When true, the writer must be disposed and the result of GetResult must not be used after disposal. Only honored for the text format.</param>
         /// <returns>A JsonWriter that can write in a particular JsonSerializationFormat</returns>
         public static IJsonWriter Create(
             JsonSerializationFormat jsonSerializationFormat,
             JsonWriteOptions writeOptions = JsonWriteOptions.None,
             int initialCapacity = 256,
-            IJsonStringDictionary jsonStringDictionary = null)
+            IJsonStringDictionary jsonStringDictionary = null,
+            bool pooled = false)
         {
             return jsonSerializationFormat switch
             {
-                JsonSerializationFormat.Text => new JsonTextWriter(initialCapacity),
+                JsonSerializationFormat.Text => new JsonTextWriter(initialCapacity, pooled),
                 JsonSerializationFormat.Binary => new JsonBinaryWriter(
                     enableNumberArrays: writeOptions.HasFlag(JsonWriteOptions.EnableNumberArrays),
                     enableUint64Values: writeOptions.HasFlag(JsonWriteOptions.EnableUInt64Values),
@@ -252,5 +254,15 @@ namespace Microsoft.Azure.Cosmos.Json
 
         /// <inheritdoc />
         public abstract ReadOnlyMemory<byte> GetResult();
+
+        /// <summary>
+        /// Releases any pooled buffers held by this writer. Writers created with
+        /// <c>pooled: true</c> return their rented buffer to the shared
+        /// <see cref="System.Buffers.ArrayPool{T}"/>; otherwise this is a no-op.
+        /// The result of <see cref="GetResult"/> must not be used after disposal.
+        /// </summary>
+        public virtual void Dispose()
+        {
+        }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Json/JsonWriter.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/JsonWriter.cs
@@ -50,7 +50,7 @@ namespace Microsoft.Azure.Cosmos.Json
         /// <param name="writeOptions">The write options the control the write behavior.</param>
         /// <param name="initialCapacity">Initial capacity to help avoid intermediary allocations.</param>
         /// <param name="jsonStringDictionary">The dictionary to use for user string encoding.</param>
-        /// <param name="pooled">Whether to rent the internal buffer from the shared <see cref="System.Buffers.ArrayPool{T}"/>. When true, the writer must be disposed and the GetResult span is invalid after disposal. Text format only.</param>
+        /// <param name="pooled">Whether to rent the internal buffer from the shared <see cref="System.Buffers.ArrayPool{T}"/>. When true, the writer must be disposed and the GetResult span is invalid after the next write or disposal. Text format only.</param>
         /// <returns>A JsonWriter that can write in a particular JsonSerializationFormat</returns>
         public static IJsonWriter Create(
             JsonSerializationFormat jsonSerializationFormat,

--- a/Microsoft.Azure.Cosmos/src/Json/JsonWriter.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/JsonWriter.cs
@@ -19,7 +19,7 @@ namespace Microsoft.Azure.Cosmos.Json
 #else
     internal
 #endif
-    abstract partial class JsonWriter : IJsonWriter, IDisposable
+    abstract partial class JsonWriter : IJsonWriter
     {
         private const int MaxStackAlloc = 4 * 1024;
 

--- a/Microsoft.Azure.Cosmos/src/Json/JsonWriter.cs
+++ b/Microsoft.Azure.Cosmos/src/Json/JsonWriter.cs
@@ -49,7 +49,7 @@ namespace Microsoft.Azure.Cosmos.Json
         /// <param name="writeOptions">The write options the control the write behavior.</param>
         /// <param name="initialCapacity">Initial capacity to help avoid intermediary allocations.</param>
         /// <param name="jsonStringDictionary">The dictionary to use for user string encoding.</param>
-        /// <param name="pooled">Whether the writer should rent its internal buffer from the shared <see cref="System.Buffers.ArrayPool{T}"/>. When true, the writer must be disposed and the result of GetResult must not be used after disposal. Only honored for the text format.</param>
+        /// <param name="pooled">Whether to rent the internal buffer from the shared <see cref="System.Buffers.ArrayPool{T}"/>. When true, the writer must be disposed and the GetResult span is invalid after disposal. Text format only.</param>
         /// <returns>A JsonWriter that can write in a particular JsonSerializationFormat</returns>
         public static IJsonWriter Create(
             JsonSerializationFormat jsonSerializationFormat,
@@ -256,10 +256,7 @@ namespace Microsoft.Azure.Cosmos.Json
         public abstract ReadOnlyMemory<byte> GetResult();
 
         /// <summary>
-        /// Releases any pooled buffer held by this writer. Writers created with
-        /// <c>pooled: true</c> return their rented buffer to the shared
-        /// <see cref="System.Buffers.ArrayPool{T}"/>; otherwise this is a no-op.
-        /// The result of <see cref="GetResult"/> must not be used after disposal.
+        /// Returns any pooled buffer to the shared <see cref="System.Buffers.ArrayPool{T}"/>; otherwise a no-op.
         /// </summary>
         public virtual void Dispose()
         {

--- a/Microsoft.Azure.Cosmos/src/Serializer/CosmosSystemTextJsonSerializer.cs
+++ b/Microsoft.Azure.Cosmos/src/Serializer/CosmosSystemTextJsonSerializer.cs
@@ -62,7 +62,9 @@ namespace Microsoft.Azure.Cosmos
 
                             if (CosmosObject.TryCreateFromBuffer(content, out CosmosObject cosmosObject))
                             {
-                                return System.Text.Json.JsonSerializer.Deserialize<T>(cosmosObject.ToString(), this.jsonSerializerOptions);
+                                IJsonWriter jsonWriter = JsonWriter.Create(JsonSerializationFormat.Text);
+                                cosmosObject.WriteTo(jsonWriter);
+                                return System.Text.Json.JsonSerializer.Deserialize<T>(jsonWriter.GetResult().Span, this.jsonSerializerOptions);
                             }
                             else
                             {
@@ -133,8 +135,7 @@ namespace Microsoft.Azure.Cosmos
         private T DeserializeStream<T>(
             Stream stream)
         {
-            using StreamReader reader = new (stream);
-            return System.Text.Json.JsonSerializer.Deserialize<T>(reader.ReadToEnd(), this.jsonSerializerOptions);
+            return System.Text.Json.JsonSerializer.Deserialize<T>(stream, this.jsonSerializerOptions);
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Serializer/CosmosSystemTextJsonSerializer.cs
+++ b/Microsoft.Azure.Cosmos/src/Serializer/CosmosSystemTextJsonSerializer.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.Cosmos
 
                             if (CosmosObject.TryCreateFromBuffer(content, out CosmosObject cosmosObject))
                             {
-                                using JsonWriter jsonWriter = (JsonWriter)JsonWriter.Create(JsonSerializationFormat.Text, pooled: true);
+                                using IJsonWriter jsonWriter = JsonWriter.Create(JsonSerializationFormat.Text, pooled: true);
                                 cosmosObject.WriteTo(jsonWriter);
                                 return System.Text.Json.JsonSerializer.Deserialize<T>(jsonWriter.GetResult().Span, this.jsonSerializerOptions);
                             }

--- a/Microsoft.Azure.Cosmos/src/Serializer/CosmosSystemTextJsonSerializer.cs
+++ b/Microsoft.Azure.Cosmos/src/Serializer/CosmosSystemTextJsonSerializer.cs
@@ -62,7 +62,7 @@ namespace Microsoft.Azure.Cosmos
 
                             if (CosmosObject.TryCreateFromBuffer(content, out CosmosObject cosmosObject))
                             {
-                                IJsonWriter jsonWriter = JsonWriter.Create(JsonSerializationFormat.Text);
+                                using JsonWriter jsonWriter = (JsonWriter)JsonWriter.Create(JsonSerializationFormat.Text, pooled: true);
                                 cosmosObject.WriteTo(jsonWriter);
                                 return System.Text.Json.JsonSerializer.Deserialize<T>(jsonWriter.GetResult().Span, this.jsonSerializerOptions);
                             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Json/StjBinaryPooledBenchmark.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Json/StjBinaryPooledBenchmark.cs
@@ -1,3 +1,7 @@
+// ----------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ----------------------------------------------------------------
+
 namespace Microsoft.Azure.Cosmos.Performance.Tests.Json
 {
     using System.IO;
@@ -72,7 +76,7 @@ namespace Microsoft.Azure.Cosmos.Performance.Tests.Json
         [Benchmark(Description = "STJ + Binary after")]
         public object Binary_Pooled()
         {
-            using JsonWriter jsonWriter = (JsonWriter)JsonWriter.Create(JsonSerializationFormat.Text, pooled: true);
+            using IJsonWriter jsonWriter = JsonWriter.Create(JsonSerializationFormat.Text, pooled: true);
             this.cosmosObject.WriteTo(jsonWriter);
             return System.Text.Json.JsonSerializer.Deserialize<FamilyRoot>(jsonWriter.GetResult().Span, Options);
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Json/StjBinaryPooledBenchmark.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Json/StjBinaryPooledBenchmark.cs
@@ -1,7 +1,3 @@
-// ----------------------------------------------------------------
-// Copyright (c) Microsoft Corporation.  All rights reserved.
-// ----------------------------------------------------------------
-
 namespace Microsoft.Azure.Cosmos.Performance.Tests.Json
 {
     using System.IO;
@@ -15,21 +11,7 @@ namespace Microsoft.Azure.Cosmos.Performance.Tests.Json
     using Microsoft.Azure.Cosmos.Json;
     using Microsoft.Azure.Cosmos.Tests.Json;
 
-    /// <summary>
-    /// Before/after micro-benchmark for both read paths of
-    /// <c>CosmosSystemTextJsonSerializer.FromStream</c>. MediumRun +
-    /// MemoryDiagnoser, with an Op/s column (throughput; higher = less CPU
-    /// per operation).
-    ///
-    /// Each method mirrors the SDK branch exactly:
-    ///   Binary_Old = JsonSerializer.Deserialize&lt;T&gt;(cosmosObject.ToString())                       // UTF-16 string
-    ///   Binary_New = WriteTo(JsonWriter Text, pooled) + Deserialize&lt;T&gt;(ReadOnlySpan&lt;byte&gt;) + Dispose // span + ArrayPool
-    ///   Text_Old   = new StreamReader(stream).ReadToEnd() + Deserialize&lt;T&gt;(string)                  // UTF-16 string
-    ///   Text_New   = Deserialize&lt;T&gt;(stream)                                                          // streamed, no buffer
-    ///
-    /// Note: the text path has no transcode buffer, so there is nothing to pool;
-    /// its "New" is the stream optimization only.
-    /// </summary>
+    // Before/after benchmark for both read paths
     [Config(typeof(MediumRunConfig))]
     [MemoryDiagnoser]
     public class StjBinaryPooledBenchmark
@@ -80,14 +62,14 @@ namespace Microsoft.Azure.Cosmos.Performance.Tests.Json
             this.cosmosObject = CosmosObject.CreateFromBuffer(binaryBuffer);
         }
 
-        [Benchmark(Description = "Binary Before")]
+        [Benchmark(Description = "STJ + Binary before")]
         public object Binary_Old()
         {
             string text = this.cosmosObject.ToString();
             return System.Text.Json.JsonSerializer.Deserialize<FamilyRoot>(text, Options);
         }
 
-        [Benchmark(Description = "Binary After")]
+        [Benchmark(Description = "STJ + Binary after")]
         public object Binary_Pooled()
         {
             using JsonWriter jsonWriter = (JsonWriter)JsonWriter.Create(JsonSerializationFormat.Text, pooled: true);
@@ -95,7 +77,7 @@ namespace Microsoft.Azure.Cosmos.Performance.Tests.Json
             return System.Text.Json.JsonSerializer.Deserialize<FamilyRoot>(jsonWriter.GetResult().Span, Options);
         }
 
-        [Benchmark(Description = "Text Before")]
+        [Benchmark(Description = "STJ before")]
         public object Text_Old()
         {
             using MemoryStream stream = new (this.textUtf8, writable: false);
@@ -103,7 +85,7 @@ namespace Microsoft.Azure.Cosmos.Performance.Tests.Json
             return System.Text.Json.JsonSerializer.Deserialize<FamilyRoot>(reader.ReadToEnd(), Options);
         }
 
-        [Benchmark(Description = "Text After")]
+        [Benchmark(Description = "STJ after")]
         public object Text_New()
         {
             using MemoryStream stream = new (this.textUtf8, writable: false);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Json/StjBinaryPooledBenchmark.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Json/StjBinaryPooledBenchmark.cs
@@ -8,24 +8,37 @@ namespace Microsoft.Azure.Cosmos.Performance.Tests.Json
     using System.Text;
     using System.Text.Json;
     using BenchmarkDotNet.Attributes;
+    using BenchmarkDotNet.Columns;
+    using BenchmarkDotNet.Configs;
+    using BenchmarkDotNet.Jobs;
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Json;
     using Microsoft.Azure.Cosmos.Tests.Json;
 
     /// <summary>
-    /// A/B/C micro-benchmark for the binary read path of
+    /// Before/after micro-benchmark for the binary read path of
     /// <c>CosmosSystemTextJsonSerializer.FromStream</c>, isolating the
-    /// transcode-buffer allocation. Uses the team's <see cref="SdkBenchmarkConfiguration"/>
-    /// (Op/s throughput, percentiles, MemoryDiagnoser + ThreadingDiagnoser).
+    /// transcode-buffer allocation. MediumRun + MemoryDiagnoser, with an
+    /// Op/s column (throughput; higher = less CPU per operation).
     ///
     /// Each method mirrors the SDK binary branch exactly
     /// (ReadAll -&gt; TryCreateFromBuffer -&gt; transcode -&gt; deserialize):
     ///   Before = JsonSerializer.Deserialize&lt;T&gt;(cosmosObject.ToString())                       // UTF-16 string
     ///   After  = WriteTo(JsonWriter Text, pooled) + Deserialize&lt;T&gt;(ReadOnlySpan&lt;byte&gt;) + Dispose
     /// </summary>
-    [Config(typeof(SdkBenchmarkConfiguration))]
+    [Config(typeof(MediumRunConfig))]
+    [MemoryDiagnoser]
     public class StjBinaryPooledBenchmark
     {
+        private class MediumRunConfig : ManualConfig
+        {
+            public MediumRunConfig()
+            {
+                this.AddJob(Job.MediumRun);
+                this.AddColumn(StatisticColumn.OperationsPerSecond);
+            }
+        }
+
         private static readonly JsonSerializerOptions Options = new ()
         {
             PropertyNameCaseInsensitive = true,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Json/StjBinaryPooledBenchmark.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Json/StjBinaryPooledBenchmark.cs
@@ -20,9 +20,8 @@ namespace Microsoft.Azure.Cosmos.Performance.Tests.Json
     ///
     /// Each method mirrors the SDK binary branch exactly
     /// (ReadAll -&gt; TryCreateFromBuffer -&gt; transcode -&gt; deserialize):
-    ///   Old    = JsonSerializer.Deserialize&lt;T&gt;(cosmosObject.ToString())          // UTF-16 string
-    ///   New    = WriteTo(JsonWriter Text) + Deserialize&lt;T&gt;(ReadOnlySpan&lt;byte&gt;)   // PR #5908
-    ///   Pooled = WriteTo(JsonWriter Text, pooled) + Deserialize + Dispose         // this prototype
+    ///   Before = JsonSerializer.Deserialize&lt;T&gt;(cosmosObject.ToString())                       // UTF-16 string
+    ///   After  = WriteTo(JsonWriter Text, pooled) + Deserialize&lt;T&gt;(ReadOnlySpan&lt;byte&gt;) + Dispose
     /// </summary>
     [Config(typeof(SdkBenchmarkConfiguration))]
     public class StjBinaryPooledBenchmark
@@ -60,22 +59,14 @@ namespace Microsoft.Azure.Cosmos.Performance.Tests.Json
             this.cosmosObject = CosmosObject.CreateFromBuffer(binaryBuffer);
         }
 
-        [Benchmark(Description = "Binary_Old (ToString -> Deserialize<string>)", Baseline = true)]
+        [Benchmark(Description = "Before (ToString -> Deserialize<string>)", Baseline = true)]
         public object Binary_Old()
         {
             string text = this.cosmosObject.ToString();
             return System.Text.Json.JsonSerializer.Deserialize<FamilyRoot>(text, Options);
         }
 
-        [Benchmark(Description = "Binary_New (WriteTo -> Deserialize<ReadOnlySpan<byte>>)")]
-        public object Binary_New()
-        {
-            IJsonWriter jsonWriter = JsonWriter.Create(JsonSerializationFormat.Text);
-            this.cosmosObject.WriteTo(jsonWriter);
-            return System.Text.Json.JsonSerializer.Deserialize<FamilyRoot>(jsonWriter.GetResult().Span, Options);
-        }
-
-        [Benchmark(Description = "Binary_Pooled (WriteTo pooled -> Deserialize -> Dispose)")]
+        [Benchmark(Description = "After (WriteTo pooled -> Deserialize<ReadOnlySpan<byte>> -> Dispose)")]
         public object Binary_Pooled()
         {
             using JsonWriter jsonWriter = (JsonWriter)JsonWriter.Create(JsonSerializationFormat.Text, pooled: true);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Json/StjBinaryPooledBenchmark.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Json/StjBinaryPooledBenchmark.cs
@@ -10,7 +10,6 @@ namespace Microsoft.Azure.Cosmos.Performance.Tests.Json
     using BenchmarkDotNet.Attributes;
     using BenchmarkDotNet.Columns;
     using BenchmarkDotNet.Configs;
-    using BenchmarkDotNet.Diagnosers;
     using BenchmarkDotNet.Jobs;
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Json;
@@ -22,12 +21,6 @@ namespace Microsoft.Azure.Cosmos.Performance.Tests.Json
     /// transcode-buffer allocation. MediumRun + MemoryDiagnoser, with an
     /// Op/s column (throughput; higher = less CPU per operation).
     ///
-    /// CPU hardware counters (cycles, cache misses, branch mispredictions) are
-    /// also collected. These require an ELEVATED (Administrator) console on
-    /// Windows; run from an admin shell, otherwise the counter columns are
-    /// silently omitted. (Hardware counters are x86/x64 only - they are not
-    /// available on Arm64 hosts.)
-    ///
     /// Each method mirrors the SDK binary branch exactly
     /// (ReadAll -&gt; TryCreateFromBuffer -&gt; transcode -&gt; deserialize):
     ///   Before = JsonSerializer.Deserialize&lt;T&gt;(cosmosObject.ToString())                       // UTF-16 string
@@ -35,11 +28,6 @@ namespace Microsoft.Azure.Cosmos.Performance.Tests.Json
     /// </summary>
     [Config(typeof(MediumRunConfig))]
     [MemoryDiagnoser]
-    [HardwareCounters(
-        HardwareCounter.TotalCycles,
-        HardwareCounter.CacheMisses,
-        HardwareCounter.BranchInstructions,
-        HardwareCounter.BranchMispredictions)]
     public class StjBinaryPooledBenchmark
     {
         private class MediumRunConfig : ManualConfig

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Json/StjBinaryPooledBenchmark.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Json/StjBinaryPooledBenchmark.cs
@@ -16,15 +16,19 @@ namespace Microsoft.Azure.Cosmos.Performance.Tests.Json
     using Microsoft.Azure.Cosmos.Tests.Json;
 
     /// <summary>
-    /// Before/after micro-benchmark for the binary read path of
-    /// <c>CosmosSystemTextJsonSerializer.FromStream</c>, isolating the
-    /// transcode-buffer allocation. MediumRun + MemoryDiagnoser, with an
-    /// Op/s column (throughput; higher = less CPU per operation).
+    /// Before/after micro-benchmark for both read paths of
+    /// <c>CosmosSystemTextJsonSerializer.FromStream</c>. MediumRun +
+    /// MemoryDiagnoser, with an Op/s column (throughput; higher = less CPU
+    /// per operation).
     ///
-    /// Each method mirrors the SDK binary branch exactly
-    /// (ReadAll -&gt; TryCreateFromBuffer -&gt; transcode -&gt; deserialize):
-    ///   Before = JsonSerializer.Deserialize&lt;T&gt;(cosmosObject.ToString())                       // UTF-16 string
-    ///   After  = WriteTo(JsonWriter Text, pooled) + Deserialize&lt;T&gt;(ReadOnlySpan&lt;byte&gt;) + Dispose
+    /// Each method mirrors the SDK branch exactly:
+    ///   Binary_Old = JsonSerializer.Deserialize&lt;T&gt;(cosmosObject.ToString())                       // UTF-16 string
+    ///   Binary_New = WriteTo(JsonWriter Text, pooled) + Deserialize&lt;T&gt;(ReadOnlySpan&lt;byte&gt;) + Dispose // span + ArrayPool
+    ///   Text_Old   = new StreamReader(stream).ReadToEnd() + Deserialize&lt;T&gt;(string)                  // UTF-16 string
+    ///   Text_New   = Deserialize&lt;T&gt;(stream)                                                          // streamed, no buffer
+    ///
+    /// Note: the text path has no transcode buffer, so there is nothing to pool;
+    /// its "New" is the stream optimization only.
     /// </summary>
     [Config(typeof(MediumRunConfig))]
     [MemoryDiagnoser]
@@ -48,6 +52,7 @@ namespace Microsoft.Azure.Cosmos.Performance.Tests.Json
         public int DocumentCount;
 
         private CosmosObject cosmosObject;
+        private byte[] textUtf8;
 
         [GlobalSetup]
         public void Setup()
@@ -67,24 +72,42 @@ namespace Microsoft.Azure.Cosmos.Performance.Tests.Json
             }
 
             sb.Append("]}");
+            string json = sb.ToString();
 
-            byte[] binaryBuffer = JsonTestUtils.ConvertTextToBinary(sb.ToString());
+            this.textUtf8 = Encoding.UTF8.GetBytes(json);
+
+            byte[] binaryBuffer = JsonTestUtils.ConvertTextToBinary(json);
             this.cosmosObject = CosmosObject.CreateFromBuffer(binaryBuffer);
         }
 
-        [Benchmark(Description = "Before (ToString -> Deserialize<string>)", Baseline = true)]
+        [Benchmark(Description = "Binary Before")]
         public object Binary_Old()
         {
             string text = this.cosmosObject.ToString();
             return System.Text.Json.JsonSerializer.Deserialize<FamilyRoot>(text, Options);
         }
 
-        [Benchmark(Description = "After (WriteTo pooled -> Deserialize<ReadOnlySpan<byte>> -> Dispose)")]
+        [Benchmark(Description = "Binary After")]
         public object Binary_Pooled()
         {
             using JsonWriter jsonWriter = (JsonWriter)JsonWriter.Create(JsonSerializationFormat.Text, pooled: true);
             this.cosmosObject.WriteTo(jsonWriter);
             return System.Text.Json.JsonSerializer.Deserialize<FamilyRoot>(jsonWriter.GetResult().Span, Options);
+        }
+
+        [Benchmark(Description = "Text Before")]
+        public object Text_Old()
+        {
+            using MemoryStream stream = new (this.textUtf8, writable: false);
+            using StreamReader reader = new (stream);
+            return System.Text.Json.JsonSerializer.Deserialize<FamilyRoot>(reader.ReadToEnd(), Options);
+        }
+
+        [Benchmark(Description = "Text After")]
+        public object Text_New()
+        {
+            using MemoryStream stream = new (this.textUtf8, writable: false);
+            return System.Text.Json.JsonSerializer.Deserialize<FamilyRoot>(stream, Options);
         }
 
         private class FamilyRoot

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Json/StjBinaryPooledBenchmark.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Json/StjBinaryPooledBenchmark.cs
@@ -1,0 +1,142 @@
+// ----------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ----------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Performance.Tests.Json
+{
+    using System.IO;
+    using System.Text;
+    using System.Text.Json;
+    using BenchmarkDotNet.Attributes;
+    using Microsoft.Azure.Cosmos.CosmosElements;
+    using Microsoft.Azure.Cosmos.Json;
+    using Microsoft.Azure.Cosmos.Tests.Json;
+
+    /// <summary>
+    /// A/B/C micro-benchmark for the binary read path of
+    /// <c>CosmosSystemTextJsonSerializer.FromStream</c>, isolating the
+    /// transcode-buffer allocation. Uses the team's <see cref="SdkBenchmarkConfiguration"/>
+    /// (Op/s throughput, percentiles, MemoryDiagnoser + ThreadingDiagnoser).
+    ///
+    /// Each method mirrors the SDK binary branch exactly
+    /// (ReadAll -&gt; TryCreateFromBuffer -&gt; transcode -&gt; deserialize):
+    ///   Old    = JsonSerializer.Deserialize&lt;T&gt;(cosmosObject.ToString())          // UTF-16 string
+    ///   New    = WriteTo(JsonWriter Text) + Deserialize&lt;T&gt;(ReadOnlySpan&lt;byte&gt;)   // PR #5908
+    ///   Pooled = WriteTo(JsonWriter Text, pooled) + Deserialize + Dispose         // this prototype
+    /// </summary>
+    [Config(typeof(SdkBenchmarkConfiguration))]
+    public class StjBinaryPooledBenchmark
+    {
+        private static readonly JsonSerializerOptions Options = new ()
+        {
+            PropertyNameCaseInsensitive = true,
+        };
+
+        [Params(1, 100, 1000)]
+        public int DocumentCount;
+
+        private CosmosObject cosmosObject;
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            string unit = File.ReadAllText("samplepayload.json");
+
+            StringBuilder sb = new ();
+            sb.Append("{\"id\":\"root\",\"items\":[");
+            for (int i = 0; i < this.DocumentCount; i++)
+            {
+                if (i > 0)
+                {
+                    sb.Append(',');
+                }
+
+                sb.Append(unit);
+            }
+
+            sb.Append("]}");
+
+            byte[] binaryBuffer = JsonTestUtils.ConvertTextToBinary(sb.ToString());
+            this.cosmosObject = CosmosObject.CreateFromBuffer(binaryBuffer);
+        }
+
+        [Benchmark(Description = "Binary_Old (ToString -> Deserialize<string>)", Baseline = true)]
+        public object Binary_Old()
+        {
+            string text = this.cosmosObject.ToString();
+            return System.Text.Json.JsonSerializer.Deserialize<FamilyRoot>(text, Options);
+        }
+
+        [Benchmark(Description = "Binary_New (WriteTo -> Deserialize<ReadOnlySpan<byte>>)")]
+        public object Binary_New()
+        {
+            IJsonWriter jsonWriter = JsonWriter.Create(JsonSerializationFormat.Text);
+            this.cosmosObject.WriteTo(jsonWriter);
+            return System.Text.Json.JsonSerializer.Deserialize<FamilyRoot>(jsonWriter.GetResult().Span, Options);
+        }
+
+        [Benchmark(Description = "Binary_Pooled (WriteTo pooled -> Deserialize -> Dispose)")]
+        public object Binary_Pooled()
+        {
+            using JsonWriter jsonWriter = (JsonWriter)JsonWriter.Create(JsonSerializationFormat.Text, pooled: true);
+            this.cosmosObject.WriteTo(jsonWriter);
+            return System.Text.Json.JsonSerializer.Deserialize<FamilyRoot>(jsonWriter.GetResult().Span, Options);
+        }
+
+        private class FamilyRoot
+        {
+            public string Id { get; set; }
+
+            public Family[] Items { get; set; }
+        }
+
+        private class Family
+        {
+            public string Id { get; set; }
+
+            public string LastName { get; set; }
+
+            public Parent[] Parents { get; set; }
+
+            public Child[] Children { get; set; }
+
+            public Location Location { get; set; }
+
+            public bool IsRegistered { get; set; }
+        }
+
+        private class Parent
+        {
+            public string FirstName { get; set; }
+
+            public string Relationship { get; set; }
+        }
+
+        private class Child
+        {
+            public string FirstName { get; set; }
+
+            public string Gender { get; set; }
+
+            public int Grade { get; set; }
+
+            public Pet[] Pets { get; set; }
+        }
+
+        private class Pet
+        {
+            public string GivenName { get; set; }
+
+            public string Type { get; set; }
+        }
+
+        private class Location
+        {
+            public string State { get; set; }
+
+            public string County { get; set; }
+
+            public string City { get; set; }
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Json/StjBinaryPooledBenchmark.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Performance.Tests/Json/StjBinaryPooledBenchmark.cs
@@ -10,6 +10,7 @@ namespace Microsoft.Azure.Cosmos.Performance.Tests.Json
     using BenchmarkDotNet.Attributes;
     using BenchmarkDotNet.Columns;
     using BenchmarkDotNet.Configs;
+    using BenchmarkDotNet.Diagnosers;
     using BenchmarkDotNet.Jobs;
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Json;
@@ -21,6 +22,12 @@ namespace Microsoft.Azure.Cosmos.Performance.Tests.Json
     /// transcode-buffer allocation. MediumRun + MemoryDiagnoser, with an
     /// Op/s column (throughput; higher = less CPU per operation).
     ///
+    /// CPU hardware counters (cycles, cache misses, branch mispredictions) are
+    /// also collected. These require an ELEVATED (Administrator) console on
+    /// Windows; run from an admin shell, otherwise the counter columns are
+    /// silently omitted. (Hardware counters are x86/x64 only - they are not
+    /// available on Arm64 hosts.)
+    ///
     /// Each method mirrors the SDK binary branch exactly
     /// (ReadAll -&gt; TryCreateFromBuffer -&gt; transcode -&gt; deserialize):
     ///   Before = JsonSerializer.Deserialize&lt;T&gt;(cosmosObject.ToString())                       // UTF-16 string
@@ -28,6 +35,11 @@ namespace Microsoft.Azure.Cosmos.Performance.Tests.Json
     /// </summary>
     [Config(typeof(MediumRunConfig))]
     [MemoryDiagnoser]
+    [HardwareCounters(
+        HardwareCounter.TotalCycles,
+        HardwareCounter.CacheMisses,
+        HardwareCounter.BranchInstructions,
+        HardwareCounter.BranchMispredictions)]
     public class StjBinaryPooledBenchmark
     {
         private class MediumRunConfig : ManualConfig

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Json/CosmosSystemTextJsonSerializerTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Json/CosmosSystemTextJsonSerializerTest.cs
@@ -7,6 +7,7 @@
     using System.Reflection;
     using System.Text.Json;
     using Microsoft.Azure.Cosmos.Tests.Poco.STJ;
+    using Microsoft.Azure.Documents;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     [TestClass]
@@ -240,5 +241,40 @@
             Assert.AreSame(memoryStream, result);
         }
 
+        [TestMethod]
+        public void TestFromStreamBinaryFormat()
+        {
+            // Arrange - build a binary-encoded CloneableStream to exercise the pooled binary read path.
+            BinaryRoundTripDoc original = new() { Id = "abc", Name = "widget", Count = 42 };
+            string json;
+            using (Stream textStream = this.stjSerializer.ToStream(original))
+            using (StreamReader reader = new(textStream))
+            {
+                json = reader.ReadToEnd();
+            }
+
+            byte[] binary = JsonTestUtils.ConvertTextToBinary(json);
+            using CloneableStream binaryStream = new(
+                internalStream: new MemoryStream(binary, index: 0, count: binary.Length, writable: false, publiclyVisible: true),
+                allowUnsafeDataAccess: true);
+
+            // Act.
+            BinaryRoundTripDoc result = this.stjSerializer.FromStream<BinaryRoundTripDoc>(binaryStream);
+
+            // Assert - binary path yields the same object as the text path.
+            Assert.IsNotNull(result);
+            Assert.AreEqual(original.Id, result.Id);
+            Assert.AreEqual(original.Name, result.Name);
+            Assert.AreEqual(original.Count, result.Count);
+        }
+
+        private sealed class BinaryRoundTripDoc
+        {
+            public string Id { get; set; }
+
+            public string Name { get; set; }
+
+            public int Count { get; set; }
+        }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Json/CosmosSystemTextJsonSerializerTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Json/CosmosSystemTextJsonSerializerTest.cs
@@ -6,6 +6,8 @@
     using System.Linq;
     using System.Reflection;
     using System.Text.Json;
+    using Microsoft.Azure.Cosmos.CosmosElements;
+    using Microsoft.Azure.Cosmos.Json;
     using Microsoft.Azure.Cosmos.Tests.Poco.STJ;
     using Microsoft.Azure.Documents;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -241,11 +243,13 @@
             Assert.AreSame(memoryStream, result);
         }
 
-        [TestMethod]
-        public void TestFromStreamBinaryFormat()
+        [DataTestMethod]
+        [DataRow(3)]      // small payload: single rented buffer, no Resize
+        [DataRow(2000)]   // large payload: forces JsonMemoryWriter.Resize (pooled rent/copy/return)
+        public void TestFromStreamBinaryFormat(int nameLength)
         {
             // Arrange - build a binary-encoded CloneableStream to exercise the pooled binary read path.
-            BinaryRoundTripDoc original = new() { Id = "abc", Name = "widget", Count = 42 };
+            BinaryRoundTripDoc original = new() { Id = "abc", Name = new string('x', nameLength), Count = 42 };
             string json;
             using (Stream textStream = this.stjSerializer.ToStream(original))
             using (StreamReader reader = new(textStream))
@@ -254,6 +258,12 @@
             }
 
             byte[] binary = JsonTestUtils.ConvertTextToBinary(json);
+
+            // Pin the conditions that route FromStream into the pooled binary branch, so the test
+            // fails loudly instead of silently falling back to the text path if they ever regress.
+            Assert.AreEqual((byte)JsonSerializationFormat.Binary, binary[0]);
+            Assert.IsTrue(CosmosObject.TryCreateFromBuffer(binary, out _));
+
             using CloneableStream binaryStream = new(
                 internalStream: new MemoryStream(binary, index: 0, count: binary.Length, writable: false, publiclyVisible: true),
                 allowUnsafeDataAccess: true);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Json/CosmosSystemTextJsonSerializerTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Json/CosmosSystemTextJsonSerializerTest.cs
@@ -312,7 +312,6 @@
                 NegativeFraction = -123456.789,
                 SmallFraction = 0.000000123,
                 Zero = 0,
-                NegativeZero = -0.0,
             };
             string json = this.Serialize(original);
 
@@ -357,6 +356,7 @@
                 Assert.AreEqual(string.Empty, result.EmptyText);
                 Assert.IsNotNull(result.EmptyList);
                 Assert.AreEqual(0, result.EmptyList.Count);
+                Assert.IsNull(result.NullList);
                 Assert.IsNull(result.Nested);
             }
         }
@@ -422,7 +422,11 @@
         private T DeserializeViaBinaryPath<T>(string json)
         {
             byte[] binary = JsonTestUtils.ConvertTextToBinary(json);
+
+            // Pin the conditions that route FromStream into the pooled binary branch, so the test
+            // fails loudly instead of silently falling back to the text path if they ever regress.
             Assert.AreEqual((byte)JsonSerializationFormat.Binary, binary[0]);
+            Assert.IsTrue(CosmosObject.TryCreateFromBuffer(binary, out _));
 
             using CloneableStream stream = new(
                 internalStream: new MemoryStream(binary, index: 0, count: binary.Length, writable: false, publiclyVisible: true),
@@ -454,8 +458,6 @@
             public double SmallFraction { get; set; }
 
             public int Zero { get; set; }
-
-            public double NegativeZero { get; set; }
         }
 
         private sealed class ComplexDoc

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Json/CosmosSystemTextJsonSerializerTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Json/CosmosSystemTextJsonSerializerTest.cs
@@ -5,6 +5,7 @@
     using System.IO;
     using System.Linq;
     using System.Reflection;
+    using System.Text;
     using System.Text.Json;
     using Microsoft.Azure.Cosmos.CosmosElements;
     using Microsoft.Azure.Cosmos.Json;
@@ -276,6 +277,217 @@
             Assert.AreEqual(original.Id, result.Id);
             Assert.AreEqual(original.Name, result.Name);
             Assert.AreEqual(original.Count, result.Count);
+        }
+
+        [DataTestMethod]
+        [DataRow("ascii simple value")]
+        [DataRow("")]
+        [DataRow("quotes \" backslash \\ and slash /")]
+        [DataRow("whitespace\ttab\r\nnewline")]
+        [DataRow("accents: café ñ über Ångström")]
+        [DataRow("cjk: 日本語 中文 한국어")]
+        [DataRow("emoji surrogate pairs: \uD83D\uDE00\uD83C\uDF89\uD835\uDD4F")]
+        [DataRow("control chars: \u0001\u0002\u001F end")]
+        [DataRow("literal escape sequence text: \\u0041 \\n \\t")]
+        public void TestStringValueRoundTripAcrossFormats(string value)
+        {
+            StringHolder original = new() { Value = value };
+            string json = this.Serialize(original);
+
+            Assert.AreEqual(value, this.DeserializeViaTextPath<StringHolder>(json).Value);
+            Assert.AreEqual(value, this.DeserializeViaBinaryPath<StringHolder>(json).Value);
+        }
+
+        [TestMethod]
+        public void TestNumericEdgeCasesAcrossFormats()
+        {
+            NumberHolder original = new()
+            {
+                MaxLong = long.MaxValue,
+                MinLong = long.MinValue,
+                MaxInt = int.MaxValue,
+                MinInt = int.MinValue,
+                MaxDouble = double.MaxValue,
+                MinDouble = double.MinValue,
+                NegativeFraction = -123456.789,
+                SmallFraction = 0.000000123,
+                Zero = 0,
+                NegativeZero = -0.0,
+            };
+            string json = this.Serialize(original);
+
+            foreach (NumberHolder result in new[]
+            {
+                this.DeserializeViaTextPath<NumberHolder>(json),
+                this.DeserializeViaBinaryPath<NumberHolder>(json),
+            })
+            {
+                Assert.AreEqual(original.MaxLong, result.MaxLong);
+                Assert.AreEqual(original.MinLong, result.MinLong);
+                Assert.AreEqual(original.MaxInt, result.MaxInt);
+                Assert.AreEqual(original.MinInt, result.MinInt);
+                Assert.AreEqual(original.MaxDouble, result.MaxDouble);
+                Assert.AreEqual(original.MinDouble, result.MinDouble);
+                Assert.AreEqual(original.NegativeFraction, result.NegativeFraction);
+                Assert.AreEqual(original.SmallFraction, result.SmallFraction);
+                Assert.AreEqual(original.Zero, result.Zero);
+            }
+        }
+
+        [TestMethod]
+        public void TestNullAndEmptyAcrossFormats()
+        {
+            ComplexDoc original = new()
+            {
+                NullText = null,
+                EmptyText = string.Empty,
+                EmptyList = new List<int>(),
+                NullList = null,
+                Nested = null,
+            };
+            string json = this.Serialize(original);
+
+            foreach (ComplexDoc result in new[]
+            {
+                this.DeserializeViaTextPath<ComplexDoc>(json),
+                this.DeserializeViaBinaryPath<ComplexDoc>(json),
+            })
+            {
+                Assert.IsNull(result.NullText);
+                Assert.AreEqual(string.Empty, result.EmptyText);
+                Assert.IsNotNull(result.EmptyList);
+                Assert.AreEqual(0, result.EmptyList.Count);
+                Assert.IsNull(result.Nested);
+            }
+        }
+
+        [TestMethod]
+        public void TestComprehensiveRoundTripAcrossFormats()
+        {
+            ComplexDoc original = new()
+            {
+                NullText = null,
+                EmptyText = string.Empty,
+                Text = "mixed café 日本語 \uD83D\uDE00 \"quote\" \\slash\\",
+                Flag = true,
+                When = new DateTime(2026, 6, 10, 13, 45, 59, DateTimeKind.Utc),
+                Identifier = Guid.Parse("3f7686c0-8cca-5292-e25a-511be5205e05"),
+                Numbers = new List<int> { -1, 0, 1, int.MaxValue, int.MinValue },
+                EmptyList = new List<int>(),
+                Nested = new Address { City = "Seattle", Zip = "98052" },
+                Addresses = new List<Address>
+                {
+                    new() { City = "Redmond", Zip = "98052" },
+                    new() { City = "São Paulo", Zip = "01000" },
+                },
+            };
+            string json = this.Serialize(original);
+
+            foreach (ComplexDoc result in new[]
+            {
+                this.DeserializeViaTextPath<ComplexDoc>(json),
+                this.DeserializeViaBinaryPath<ComplexDoc>(json),
+            })
+            {
+                Assert.IsNull(result.NullText);
+                Assert.AreEqual(original.EmptyText, result.EmptyText);
+                Assert.AreEqual(original.Text, result.Text);
+                Assert.AreEqual(original.Flag, result.Flag);
+                Assert.AreEqual(original.When, result.When);
+                Assert.AreEqual(original.Identifier, result.Identifier);
+                CollectionAssert.AreEqual(original.Numbers, result.Numbers);
+                Assert.AreEqual(0, result.EmptyList.Count);
+                Assert.AreEqual(original.Nested.City, result.Nested.City);
+                Assert.AreEqual(original.Nested.Zip, result.Nested.Zip);
+                Assert.AreEqual(original.Addresses.Count, result.Addresses.Count);
+                Assert.AreEqual(original.Addresses[1].City, result.Addresses[1].City);
+            }
+        }
+
+        private string Serialize<T>(T value)
+        {
+            using Stream stream = this.stjSerializer.ToStream(value);
+            using StreamReader reader = new(stream);
+            return reader.ReadToEnd();
+        }
+
+        // A plain (non-CloneableStream) MemoryStream routes FromStream through the text DeserializeStream path.
+        private T DeserializeViaTextPath<T>(string json)
+        {
+            using MemoryStream stream = new(Encoding.UTF8.GetBytes(json), writable: false);
+            return this.stjSerializer.FromStream<T>(stream);
+        }
+
+        // A binary-format CloneableStream routes FromStream through the pooled binary transcode path.
+        private T DeserializeViaBinaryPath<T>(string json)
+        {
+            byte[] binary = JsonTestUtils.ConvertTextToBinary(json);
+            Assert.AreEqual((byte)JsonSerializationFormat.Binary, binary[0]);
+
+            using CloneableStream stream = new(
+                internalStream: new MemoryStream(binary, index: 0, count: binary.Length, writable: false, publiclyVisible: true),
+                allowUnsafeDataAccess: true);
+            return this.stjSerializer.FromStream<T>(stream);
+        }
+
+        private sealed class StringHolder
+        {
+            public string Value { get; set; }
+        }
+
+        private sealed class NumberHolder
+        {
+            public long MaxLong { get; set; }
+
+            public long MinLong { get; set; }
+
+            public int MaxInt { get; set; }
+
+            public int MinInt { get; set; }
+
+            public double MaxDouble { get; set; }
+
+            public double MinDouble { get; set; }
+
+            public double NegativeFraction { get; set; }
+
+            public double SmallFraction { get; set; }
+
+            public int Zero { get; set; }
+
+            public double NegativeZero { get; set; }
+        }
+
+        private sealed class ComplexDoc
+        {
+            public string Text { get; set; }
+
+            public string EmptyText { get; set; }
+
+            public string NullText { get; set; }
+
+            public bool Flag { get; set; }
+
+            public DateTime When { get; set; }
+
+            public Guid Identifier { get; set; }
+
+            public List<int> Numbers { get; set; }
+
+            public List<int> EmptyList { get; set; }
+
+            public List<int> NullList { get; set; }
+
+            public Address Nested { get; set; }
+
+            public List<Address> Addresses { get; set; }
+        }
+
+        private sealed class Address
+        {
+            public string City { get; set; }
+
+            public string Zip { get; set; }
         }
 
         private sealed class BinaryRoundTripDoc

--- a/changelog.md
+++ b/changelog.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Other Changes
 
+- [#5908](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5908) Performance: Avoid full-document `string` allocation in `CosmosSystemTextJsonSerializer` read paths (binary and text). UTF-8 bytes are now fed directly into `Utf8JsonReader` via `JsonSerializer.Deserialize<T>(Stream, ...)` and `Deserialize<T>(ReadOnlySpan<byte>, ...)`, eliminating LOH pressure from per-read full-document string materialization.
+
 ### <a name="3.62.0-preview.0"/> [3.62.0-preview.0](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.62.0-preview.0) - 2026-6-1
 
 #### Features Added

--- a/changelog.md
+++ b/changelog.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Other Changes
 
-- [#5908](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5908) Performance: Avoid full-document `string` allocation in `CosmosSystemTextJsonSerializer` read paths (binary and text). UTF-8 bytes are now fed directly into `Utf8JsonReader` via `JsonSerializer.Deserialize<T>(Stream, ...)` and `Deserialize<T>(ReadOnlySpan<byte>, ...)`, eliminating LOH pressure from per-read full-document string materialization.
+- [#5908](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5908) Performance: Avoid full-document UTF-16 `string` allocation and redundant UTF-8↔UTF-16 transcoding in `CosmosSystemTextJsonSerializer` read paths (binary and text). UTF-8 bytes are now fed directly into `Utf8JsonReader` via `JsonSerializer.Deserialize<T>(Stream, ...)` and `Deserialize<T>(ReadOnlySpan<byte>, ...)`, reducing CPU, memory bandwidth, and GC pressure (including LOH pressure for larger documents).
 
 ### <a name="3.62.0-preview.0"/> [3.62.0-preview.0](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.62.0-preview.0) - 2026-6-1
 

--- a/changelog.md
+++ b/changelog.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Other Changes
 
-- [#5908](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5908) Performance: Avoid full-document UTF-16 `string` allocation and redundant UTF-8↔UTF-16 transcoding in `CosmosSystemTextJsonSerializer` read paths (binary and text). UTF-8 bytes are now fed directly into `Utf8JsonReader` via `JsonSerializer.Deserialize<T>(Stream, ...)` and `Deserialize<T>(ReadOnlySpan<byte>, ...)`, reducing CPU, memory bandwidth, and GC pressure (including LOH pressure for larger documents).
+- [#5908](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5908) Performance: Avoid full-document UTF-16 `string` allocation and redundant UTF-8↔UTF-16 transcoding in `CosmosSystemTextJsonSerializer` read paths (binary and text). UTF-8 bytes are now fed directly into `Utf8JsonReader` via `JsonSerializer.Deserialize<T>(Stream, ...)` and `Deserialize<T>(ReadOnlySpan<byte>, ...)`. The binary transcode buffer is additionally rented from the shared `ArrayPool<byte>`, eliminating Large Object Heap (Gen2) collections for larger documents. Reduces CPU, memory bandwidth, and GC pressure on every read.
 
 ### <a name="3.62.0-preview.0"/> [3.62.0-preview.0](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.62.0-preview.0) - 2026-6-1
 


### PR DESCRIPTION
## Description

Both read paths in `CosmosSystemTextJsonSerializer` currently materialize the entire response document as a UTF-16 `System.String` before parsing. This PR feeds the UTF-8 bytes directly into `Utf8JsonReader` instead, eliminating the allocation and the redundant UTF-8 ↔ UTF-16 transcoding on every read.

**Binary path:** replace `cosmosObject.ToString()` (which produces a UTF-16 `string`) with `cosmosObject.WriteTo(textJsonWriter)` + `JsonSerializer.Deserialize(ReadOnlySpan, ...)`.

**Text path (`DeserializeStream`):** replace `StreamReader.ReadToEnd()` + `Deserialize(string, ...)` with `JsonSerializer.Deserialize(Stream, ...)`.

Both changes are semantically equivalent for Cosmos response bodies (UTF-8 JSON), no public API impact. Reduces CPU, allocations, and GC/LOH pressure on every read.

## Additional change: pool the binary transcode buffer (ArrayPool)

The binary read path must transcode Cosmos binary JSON to text before STJ can parse it. That transcode buffer (`JsonMemoryWriter.buffer`) was a plain `new byte[]` grown via `Array.Resize`, landing on the Large Object Heap for larger documents. This change makes the buffer **opt-in poolable**: `JsonWriter.Create(..., pooled: true)` rents from the shared `ArrayPool<byte>` and the serializer disposes the writer right after `Deserialize` (safe, because STJ copies values out during deserialization). Non-pooled callers are unchanged.

To support deterministic disposal, `IJsonWriter` now extends `IDisposable` (every implementer already derives from `JsonWriter`, so nothing new needs implementing).

Touches the shared JSON writer classes (`JsonMemoryWriter`, `JsonWriter`, `JsonWriter.JsonTextWriter`) — opt-in only; all existing JSON unit tests pass (455 JSON + serializer tests green).

## Benchmarks
<img width="1779" height="910" alt="image" src="https://github.com/user-attachments/assets/1624efdb-54a1-4b9b-8533-cb1bb167ac4d" />

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Closing issues

n/a

## Changelog

- [x] I have added a changelog entry under `### Unreleased` in `changelog.md`
  for the user-facing impact of this change.
