### PR TITLE
Pagination + RetryPolicies: Fixes CancellationToken not being honored across PartitionKeyRangeCache, query pagination, and retry/backoff paths

### DIFF
--- a/Microsoft.Azure.Cosmos/FaultInjection/README.md
+++ b/Microsoft.Azure.Cosmos/FaultInjection/README.md
@@ -28,10 +28,13 @@ This result will return a server error to the customer: `FaultInjectionServerErr
 | `Timeout`               | 408:0        | The operation did not complete within the allocated time.                   |
 | `PartitionIsSplitting`  | 410:1007     | The partition is currently splitting.                                       |
 | `PartitionIsMigrating`  | 410:1008     | The partition is currently migrating.                                       |
+| `LeaseNotFound`         | 410:1022     | The replica's lease for the addressed documentServiceId is not found. Fires during partition merge / lease handoff. |
 | `SendDelay`             | n/a          | Will inject a delay to the request before it is sent to the backend.         |
 | `ResponseDelay`         | n/a          | Will inject a delay to the request after a response is received from the backend before returning the result. |
 | `ConnectionDelay`       | n/a          | Used to simulate high channel acquisition.                                  |
 | `ServiceUnavailable`    | 503:0        | The service is currently unavailable.                                       |
+
+> Note: `FaultInjectionConditionBuilder.WithOperationType(FaultInjectionOperationType.MetadataRequest)` targets metadata HEAD requests (e.g., the consistency-barrier `Head/Collection` requests the SDK issues under Strong / Bounded-Staleness consistency to verify `GlobalCommittedLSN` before returning a read).
 
 ##### `FaultInjectionConnectionErrorResult`
 

--- a/Microsoft.Azure.Cosmos/FaultInjection/src/FaultInjectionOperationType.cs
+++ b/Microsoft.Azure.Cosmos/FaultInjection/src/FaultInjectionOperationType.cs
@@ -79,6 +79,15 @@ namespace Microsoft.Azure.Cosmos.FaultInjection
         MetadataQueryPlan,
 
         /// <summary>
+        /// Metadata / barrier HEAD requests (e.g., consistency-barrier
+        /// <c>Head</c> against the <c>Collection</c> resource the SDK issues under
+        /// Strong / Bounded-Staleness consistency to verify <c>GlobalCommittedLSN</c>
+        /// on a replica before returning a read result).
+        /// Maps to <see cref="Microsoft.Azure.Documents.OperationType.Head"/>.
+        /// </summary>
+        MetadataRequest,
+
+        /// <summary>
         /// All operation types. Default value.
         /// </summary>
         All,

--- a/Microsoft.Azure.Cosmos/FaultInjection/src/implementation/FaultInjectionRuleProcessor.cs
+++ b/Microsoft.Azure.Cosmos/FaultInjection/src/implementation/FaultInjectionRuleProcessor.cs
@@ -354,6 +354,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection
                 FaultInjectionOperationType.MetadataPartitionKeyRange => OperationType.ReadFeed,
                 FaultInjectionOperationType.MetadataRefreshAddresses => OperationType.Invalid,
                 FaultInjectionOperationType.MetadataQueryPlan => OperationType.QueryPlan,
+                FaultInjectionOperationType.MetadataRequest => OperationType.Head,
                 _ => throw new ArgumentException($"FaultInjectionOperationType: {faultInjectionOperationType} is not supported"),
             };
         }
@@ -376,6 +377,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection
                 FaultInjectionOperationType.MetadataPartitionKeyRange => ResourceType.PartitionKeyRange,
                 FaultInjectionOperationType.MetadataRefreshAddresses => ResourceType.Address,
                 FaultInjectionOperationType.MetadataQueryPlan => ResourceType.Document,
+                FaultInjectionOperationType.MetadataRequest => ResourceType.Collection,
                 _ => throw new ArgumentException($"FaultInjectionOperationType: {faultInjectionOperationType} is not supported"),
             };
         }

--- a/Microsoft.Azure.Cosmos/FaultInjection/src/implementation/FaultInjectionServerErrorResultInternal.cs
+++ b/Microsoft.Azure.Cosmos/FaultInjection/src/implementation/FaultInjectionServerErrorResultInternal.cs
@@ -258,6 +258,20 @@ namespace Microsoft.Azure.Cosmos.FaultInjection
                     };
 
                     return storeResponse;
+
+                case FaultInjectionServerErrorType.LeaseNotFound:
+                    INameValueCollection leaseNotFoundHeaders = args.RequestHeaders;
+                    leaseNotFoundHeaders.Set(WFConstants.BackendHeaders.SubStatus, ((int)SubStatusCodes.LeaseNotFound).ToString(CultureInfo.InvariantCulture));
+                    leaseNotFoundHeaders.Set(WFConstants.BackendHeaders.LocalLSN, lsn);
+
+                    storeResponse = new StoreResponse()
+                    {
+                        Status = 410,
+                        Headers = leaseNotFoundHeaders,
+                        ResponseBody = new MemoryStream(FaultInjectionResponseEncoding.GetBytes($"Fault Injection Server Error: Lease Not Found, rule: {ruleId}"))
+                    };
+
+                    return storeResponse;
                 case FaultInjectionServerErrorType.ServiceUnavailable:
                     INameValueCollection serviceUnavailableHeaders = args.RequestHeaders;
                     serviceUnavailableHeaders.Set(WFConstants.BackendHeaders.LocalLSN, lsn);

--- a/Microsoft.Azure.Cosmos/FaultInjection/tests/FaultInjectionDirectModeTests.cs
+++ b/Microsoft.Azure.Cosmos/FaultInjection/tests/FaultInjectionDirectModeTests.cs
@@ -1799,25 +1799,23 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
         }
 
         // -----------------------------------------------------------------------------
-        // Issue #5906 / ICM 21000001041367 — partition merge / lease handoff repro
+        // Partition merge / lease handoff repro.
         //
-        // Customer-observed symptom: under a partition merge / lease handoff the SDK
-        // returned 410/1022 (LeaseNotFound) to in-flight cross-partition FeedIterator
-        // pages. The retry plumbing (Direct GoneAndRetryWithRequestRetryPolicy ->
-        // ClientRetryPolicy cross-region retry, PR #5108 in 3.50.0 + #5469 in 3.55.0)
-        // eventually succeeded against the destination region, but each page-level
-        // retry chain ran past the operation-level CancellationToken. End-to-end
-        // wall-clock was ~100 s for a 30 s user CT.
+        // During a partition merge / lease handoff, the backend may return 410/1022
+        // (LeaseNotFound) to in-flight cross-partition FeedIterator pages. The retry
+        // plumbing (Direct GoneAndRetryWithRequestRetryPolicy -> ClientRetryPolicy
+        // cross-region retry) eventually succeeds against the destination region, but
+        // each page-level retry chain can run past the operation-level
+        // CancellationToken.
         //
         // This test installs a LeaseNotFound fault on the primary region only and
         // asserts the operation-level CancellationToken is honored within a small
-        // tolerance window. EXPECTED TO FAIL on master until #5906 ships a fix to
-        // ClientRetryPolicy.ShouldRetryAsync + FeedIterator prefetch CT propagation.
+        // tolerance window.
         // -----------------------------------------------------------------------------
         [TestMethod]
         [Timeout(Timeout)]
         [Owner("tomasvaron")]
-        [Description("Repro for issue #5906: FeedIterator + 410/1022 LeaseNotFound should honor the operation CancellationToken")]
+        [Description("FeedIterator + 410/1022 LeaseNotFound should honor the operation CancellationToken")]
         public async Task FaultInjectionLeaseNotFound_FeedIteratorHonorsCancellationToken()
         {
             // Build preferred regions list with non-write regions first so reads land on a remote region.
@@ -1939,7 +1937,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
                 elapsedSeconds <= cancellationBudgetSeconds + gracePeriodSeconds,
                 $"Operation ran for {elapsedSeconds}s under a {cancellationBudgetSeconds}s CancellationToken "
                 + $"(allowed: <= {cancellationBudgetSeconds + gracePeriodSeconds}s). "
-                + $"CT was not honored in a timely manner — see GitHub issue #5906. "
+                + $"CT was not honored in a timely manner. "
                 + $"Observed exception: {observed?.GetType().FullName ?? "<none>"}. "
                 + $"Rule hit count: {queryLeaseNotFoundRule.GetHitCount()}.");
 
@@ -1953,28 +1951,25 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
 
 
         // -----------------------------------------------------------------------------
-        // Issue #5906 — companion test: verify the operation CancellationToken is
-        // honored when delays accumulate across barrier (Head/Collection) requests.
+        // Companion test: verify the operation CancellationToken is honored when delays
+        // accumulate across barrier (Head/Collection) requests.
         //
         // Under Strong / Bounded Staleness consistency the SDK issues HTTP HEAD
         // requests against the `Collection` resource to validate that a replica's
         // GlobalCommittedLSN satisfies the barrier before returning a read result.
-        // Each barrier is a separate RNTBD round-trip; the SDK can issue several in
-        // a row when waiting for the replica to catch up, or when failing over to a
-        // secondary region (as in the original ICM 21000001041367 diagnostic, which
-        // captured 6 such barriers in West US 2 after cross-region failover from
-        // Central US).
+        // Each barrier is a separate RNTBD round-trip; the SDK can issue several in a
+        // row when waiting for the replica to catch up, or when failing over to a
+        // secondary region.
         //
         // This test injects a 20-second delay on every metadata (Head) response in
         // the primary region and asserts the user's 5-second CancellationToken is
         // honored within a small tolerance — i.e., the SDK must NOT spin in the
-        // barrier loop past the user's deadline. EXPECTED TO FAIL on master until
-        // #5906 ships a CT-aware path that pre-empts in-flight barrier waits.
+        // barrier loop past the user's deadline.
         // -----------------------------------------------------------------------------
         [TestMethod]
         [Timeout(Timeout)]
         [Owner("tomasvaron")]
-        [Description("Repro for issue #5906: CancellationToken must be honored between barrier (Head/Collection) requests")]
+        [Description("CancellationToken must be honored between barrier (Head/Collection) requests")]
         public async Task FaultInjectionMetadataRequestDelay_HonorsCancellationToken()
         {
             // Build preferred regions list with non-write regions first so reads land on a remote region
@@ -2084,8 +2079,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
                 elapsedSeconds <= cancellationBudgetSeconds + gracePeriodSeconds,
                 $"Operation ran for {elapsedSeconds}s under a {cancellationBudgetSeconds}s CancellationToken "
                 + $"(allowed: <= {cancellationBudgetSeconds + gracePeriodSeconds}s). "
-                + $"Barrier responses delayed by {barrierDelaySeconds}s blocked the operation past the CT — "
-                + $"see GitHub issue #5906. "
+                + $"Barrier responses delayed by {barrierDelaySeconds}s blocked the operation past the CT. "
                 + $"Observed exception: {observed?.GetType().FullName ?? "<none>"}. "
                 + $"Barrier rule hit count: {barrierDelayRule.GetHitCount()}.");
 

--- a/Microsoft.Azure.Cosmos/FaultInjection/tests/FaultInjectionDirectModeTests.cs
+++ b/Microsoft.Azure.Cosmos/FaultInjection/tests/FaultInjectionDirectModeTests.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
     using System;
     using System.Collections.Generic;
     using System.Collections.ObjectModel;
+    using System.Diagnostics;
     using System.Linq;
     using System.Net;
     using System.Text.Json;
@@ -1040,6 +1041,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
         [DataRow(FaultInjectionOperationType.ReadItem, FaultInjectionServerErrorType.Timeout, 410, 20001, DisplayName = "Timeout")]
         [DataRow(FaultInjectionOperationType.ReadItem, FaultInjectionServerErrorType.PartitionIsMigrating, 410, 1008, DisplayName = "PartitionIsMigrating")]
         [DataRow(FaultInjectionOperationType.ReadItem, FaultInjectionServerErrorType.PartitionIsSplitting, 410, 1007, DisplayName = "PartitionIsSplitting")]
+        [DataRow(FaultInjectionOperationType.ReadItem, FaultInjectionServerErrorType.LeaseNotFound, 410, 1022, DisplayName = "LeaseNotFound")]
         [DataRow(FaultInjectionOperationType.CreateItem, FaultInjectionServerErrorType.Gone, 410, 21005, DisplayName = "Gone Write")]
         [DataRow(FaultInjectionOperationType.CreateItem, FaultInjectionServerErrorType.InternalServerError, 500, 0, DisplayName = "InternalServerError Write")]
         [DataRow(FaultInjectionOperationType.CreateItem, FaultInjectionServerErrorType.RetryWith, 449, 0, DisplayName = "RetryWith Write")]
@@ -1048,6 +1050,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
         [DataRow(FaultInjectionOperationType.CreateItem, FaultInjectionServerErrorType.Timeout, 410, 20001, DisplayName = "Timeout Write")]
         [DataRow(FaultInjectionOperationType.CreateItem, FaultInjectionServerErrorType.PartitionIsMigrating, 410, 1008, DisplayName = "PartitionIsMigrating Write")]
         [DataRow(FaultInjectionOperationType.CreateItem, FaultInjectionServerErrorType.PartitionIsSplitting, 410, 1007, DisplayName = "PartitionIsSplitting Write")]
+        [DataRow(FaultInjectionOperationType.CreateItem, FaultInjectionServerErrorType.LeaseNotFound, 410, 1022, DisplayName = "LeaseNotFound Write")]
         public async Task FaultInjectionServerErrorRule_ServerErrorResponseTest(
             FaultInjectionOperationType faultInjectionOperationType,
             FaultInjectionServerErrorType serverErrorType,
@@ -1794,6 +1797,304 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
                     rule);
             }
         }
+
+        // -----------------------------------------------------------------------------
+        // Issue #5906 / ICM 21000001041367 — partition merge / lease handoff repro
+        //
+        // Customer-observed symptom: under a partition merge / lease handoff the SDK
+        // returned 410/1022 (LeaseNotFound) to in-flight cross-partition FeedIterator
+        // pages. The retry plumbing (Direct GoneAndRetryWithRequestRetryPolicy ->
+        // ClientRetryPolicy cross-region retry, PR #5108 in 3.50.0 + #5469 in 3.55.0)
+        // eventually succeeded against the destination region, but each page-level
+        // retry chain ran past the operation-level CancellationToken. End-to-end
+        // wall-clock was ~100 s for a 30 s user CT.
+        //
+        // This test installs a LeaseNotFound fault on the primary region only and
+        // asserts the operation-level CancellationToken is honored within a small
+        // tolerance window. EXPECTED TO FAIL on master until #5906 ships a fix to
+        // ClientRetryPolicy.ShouldRetryAsync + FeedIterator prefetch CT propagation.
+        // -----------------------------------------------------------------------------
+        [TestMethod]
+        [Timeout(Timeout)]
+        [Owner("tomasvaron")]
+        [Description("Repro for issue #5906: FeedIterator + 410/1022 LeaseNotFound should honor the operation CancellationToken")]
+        public async Task FaultInjectionLeaseNotFound_FeedIteratorHonorsCancellationToken()
+        {
+            // Build preferred regions list with non-write regions first so reads land on a remote region.
+            List<string> preferredRegions = new List<string>();
+            GlobalEndpointManager globalEndpointManager = this.client.DocumentClient.GlobalEndpointManager;
+            if (globalEndpointManager != null)
+            {
+                (List<string> writeRegions, List<string> readRegions) = await this.GetReadWriteEndpoints(globalEndpointManager);
+                for (int i = 0; i < readRegions.Count; i++)
+                {
+                    if (writeRegions != null && writeRegions.Contains(readRegions[i]))
+                    {
+                        preferredRegions.Add(readRegions[i]);
+                    }
+                    else
+                    {
+                        preferredRegions.Insert(0, readRegions[i]);
+                    }
+                }
+            }
+
+            Assert.IsTrue(
+                preferredRegions.Count > 0,
+                "Multi-region test environment setup failed — no regions available. "
+                + "Ensure the test account has multiple regions configured so the cross-region retry path can be exercised.");
+
+            // Inject 410/1022 LeaseNotFound on Query (and ReadItem) against the primary region only.
+            // WithTimes(int.MaxValue) lets the fault fire on every matching request throughout the rule's
+            // lifetime so the SDK's cross-region retry chain keeps recurring against the local region.
+            string queryLeaseNotFoundRuleId = "queryLeaseNotFoundRule-" + Guid.NewGuid();
+            FaultInjectionRule queryLeaseNotFoundRule = new FaultInjectionRuleBuilder(
+                id: queryLeaseNotFoundRuleId,
+                condition: new FaultInjectionConditionBuilder()
+                    .WithOperationType(FaultInjectionOperationType.QueryItem)
+                    .WithRegion(preferredRegions[0])
+                    .Build(),
+                result: FaultInjectionResultBuilder.GetResultBuilder(FaultInjectionServerErrorType.LeaseNotFound)
+                    .WithTimes(int.MaxValue)
+                    .Build())
+                .WithDuration(TimeSpan.FromMinutes(5))
+                .Build();
+            queryLeaseNotFoundRule.Disable();
+
+            string readLeaseNotFoundRuleId = "readLeaseNotFoundRule-" + Guid.NewGuid();
+            FaultInjectionRule readLeaseNotFoundRule = new FaultInjectionRuleBuilder(
+                id: readLeaseNotFoundRuleId,
+                condition: new FaultInjectionConditionBuilder()
+                    .WithOperationType(FaultInjectionOperationType.ReadItem)
+                    .WithRegion(preferredRegions[0])
+                    .Build(),
+                result: FaultInjectionResultBuilder.GetResultBuilder(FaultInjectionServerErrorType.LeaseNotFound)
+                    .WithTimes(int.MaxValue)
+                    .Build())
+                .WithDuration(TimeSpan.FromMinutes(5))
+                .Build();
+            readLeaseNotFoundRule.Disable();
+
+            FaultInjector faultInjector = new FaultInjector(new List<FaultInjectionRule> { queryLeaseNotFoundRule, readLeaseNotFoundRule });
+
+            CosmosClientOptions cosmosClientOptions = new CosmosClientOptions()
+            {
+                ConsistencyLevel = ConsistencyLevel.Session,
+                ApplicationPreferredRegions = preferredRegions,
+                FaultInjector = faultInjector,
+                Serializer = this.serializer,
+            };
+
+            this.fiClient = new CosmosClient(this.connectionString, cosmosClientOptions);
+            this.fiDatabase = this.fiClient.GetDatabase(TestCommon.FaultInjectionDatabaseName);
+            this.fiContainer = this.fiDatabase.GetContainer(TestCommon.FaultInjectionContainerName);
+
+            // The query is a small cross-partition TOP 1 with ORDER BY — mirrors the failing customer
+            // diagnostic's parameterized Shape (SELECT TOP 1 ... WHERE binary-predicate ORDER BY one-field).
+            string query = "SELECT TOP 1 c.id FROM c WHERE c.pk != '' ORDER BY c.pk ASC";
+
+            const int cancellationBudgetSeconds = 5;
+            // Bound for how long after the CT fires we are willing to wait before declaring the SDK
+            // failed to honor the token. The customer-observed gap was ~70 seconds.
+            const int gracePeriodSeconds = 2;
+
+            using CancellationTokenSource cts = new CancellationTokenSource(TimeSpan.FromSeconds(cancellationBudgetSeconds));
+
+            queryLeaseNotFoundRule.Enable();
+            readLeaseNotFoundRule.Enable();
+
+            FeedIterator<FaultInjectionTestObject> feedIterator = this.fiContainer.GetItemQueryIterator<FaultInjectionTestObject>(query);
+
+            Stopwatch sw = Stopwatch.StartNew();
+            Exception observed = null;
+            try
+            {
+                while (feedIterator.HasMoreResults)
+                {
+                    await feedIterator.ReadNextAsync(cts.Token);
+                }
+            }
+            catch (Exception ex)
+            {
+                observed = ex;
+            }
+            finally
+            {
+                sw.Stop();
+                queryLeaseNotFoundRule.Disable();
+                readLeaseNotFoundRule.Disable();
+            }
+
+            long elapsedSeconds = sw.ElapsedMilliseconds / 1000;
+
+            // Sanity: the fault rule must actually have fired (otherwise the test is meaningless).
+            Assert.IsTrue(
+                queryLeaseNotFoundRule.GetHitCount() > 0,
+                "Fault injection rule for LeaseNotFound never fired; test setup is invalid.");
+
+            // The contract: once the operation-level CancellationToken expires, the SDK should surface
+            // OperationCanceledException within a small grace period. It MUST NOT keep retrying for
+            // tens of additional seconds while the user's token is already cancelled.
+            Assert.IsTrue(
+                elapsedSeconds <= cancellationBudgetSeconds + gracePeriodSeconds,
+                $"Operation ran for {elapsedSeconds}s under a {cancellationBudgetSeconds}s CancellationToken "
+                + $"(allowed: <= {cancellationBudgetSeconds + gracePeriodSeconds}s). "
+                + $"CT was not honored in a timely manner — see GitHub issue #5906. "
+                + $"Observed exception: {observed?.GetType().FullName ?? "<none>"}. "
+                + $"Rule hit count: {queryLeaseNotFoundRule.GetHitCount()}.");
+
+            // We also expect OperationCanceledException (or a derived TaskCanceledException) to surface,
+            // not a CosmosException wrapping the injected fault.
+            Assert.IsNotNull(observed, "Expected the operation to be cancelled, but it completed normally.");
+            Assert.IsTrue(
+                observed is OperationCanceledException,
+                $"Expected OperationCanceledException, got {observed.GetType().FullName}: {observed.Message}");
+        }
+
+
+        // -----------------------------------------------------------------------------
+        // Issue #5906 — companion test: verify the operation CancellationToken is
+        // honored when delays accumulate across barrier (Head/Collection) requests.
+        //
+        // Under Strong / Bounded Staleness consistency the SDK issues HTTP HEAD
+        // requests against the `Collection` resource to validate that a replica's
+        // GlobalCommittedLSN satisfies the barrier before returning a read result.
+        // Each barrier is a separate RNTBD round-trip; the SDK can issue several in
+        // a row when waiting for the replica to catch up, or when failing over to a
+        // secondary region (as in the original ICM 21000001041367 diagnostic, which
+        // captured 6 such barriers in West US 2 after cross-region failover from
+        // Central US).
+        //
+        // This test injects a 20-second delay on every metadata (Head) response in
+        // the primary region and asserts the user's 5-second CancellationToken is
+        // honored within a small tolerance — i.e., the SDK must NOT spin in the
+        // barrier loop past the user's deadline. EXPECTED TO FAIL on master until
+        // #5906 ships a CT-aware path that pre-empts in-flight barrier waits.
+        // -----------------------------------------------------------------------------
+        [TestMethod]
+        [Timeout(Timeout)]
+        [Owner("tomasvaron")]
+        [Description("Repro for issue #5906: CancellationToken must be honored between barrier (Head/Collection) requests")]
+        public async Task FaultInjectionMetadataRequestDelay_HonorsCancellationToken()
+        {
+            // Build preferred regions list with non-write regions first so reads land on a remote region
+            // — that's the path where Strong-consistency barriers actually fire.
+            List<string> preferredRegions = new List<string>();
+            GlobalEndpointManager globalEndpointManager = this.client.DocumentClient.GlobalEndpointManager;
+            if (globalEndpointManager != null)
+            {
+                (List<string> writeRegions, List<string> readRegions) = await this.GetReadWriteEndpoints(globalEndpointManager);
+                for (int i = 0; i < readRegions.Count; i++)
+                {
+                    if (writeRegions != null && writeRegions.Contains(readRegions[i]))
+                    {
+                        preferredRegions.Add(readRegions[i]);
+                    }
+                    else
+                    {
+                        preferredRegions.Insert(0, readRegions[i]);
+                    }
+                }
+            }
+
+            Assert.IsTrue(
+                preferredRegions.Count > 0,
+                "Multi-region test environment setup failed — no regions available. "
+                + "Ensure the test account has multiple regions configured so the barrier path can be exercised.");
+
+            const int barrierDelaySeconds = 20;
+            const int cancellationBudgetSeconds = 5;
+            const int gracePeriodSeconds = 2;
+
+            // Inject a long delay on every Head (barrier) request in the primary region.
+            string barrierDelayRuleId = "barrierDelayRule-" + Guid.NewGuid();
+            FaultInjectionRule barrierDelayRule = new FaultInjectionRuleBuilder(
+                id: barrierDelayRuleId,
+                condition: new FaultInjectionConditionBuilder()
+                    .WithOperationType(FaultInjectionOperationType.MetadataRequest)
+                    .WithRegion(preferredRegions[0])
+                    .Build(),
+                result: FaultInjectionResultBuilder.GetResultBuilder(FaultInjectionServerErrorType.ResponseDelay)
+                    .WithDelay(TimeSpan.FromSeconds(barrierDelaySeconds))
+                    .WithTimes(int.MaxValue)
+                    .Build())
+                .WithDuration(TimeSpan.FromMinutes(5))
+                .Build();
+            barrierDelayRule.Disable();
+
+            FaultInjector faultInjector = new FaultInjector(new List<FaultInjectionRule> { barrierDelayRule });
+
+            // Strong consistency + read from a secondary region is the path that issues barrier
+            // Head/Collection requests.
+            CosmosClientOptions cosmosClientOptions = new CosmosClientOptions()
+            {
+                ConsistencyLevel = ConsistencyLevel.Strong,
+                ApplicationPreferredRegions = preferredRegions,
+                FaultInjector = faultInjector,
+                Serializer = this.serializer,
+            };
+
+            this.fiClient = new CosmosClient(this.connectionString, cosmosClientOptions);
+            this.fiDatabase = this.fiClient.GetDatabase(TestCommon.FaultInjectionDatabaseName);
+            this.fiContainer = this.fiDatabase.GetContainer(TestCommon.FaultInjectionContainerName);
+
+            barrierDelayRule.Enable();
+
+            using CancellationTokenSource cts = new CancellationTokenSource(TimeSpan.FromSeconds(cancellationBudgetSeconds));
+
+            Stopwatch sw = Stopwatch.StartNew();
+            Exception observed = null;
+            try
+            {
+                // Read an item that was pre-seeded by GetOrCreateMultiRegionFIDatabaseAndContainersAsync.
+                _ = await this.fiContainer.ReadItemAsync<FaultInjectionTestObject>(
+                    id: "testId",
+                    partitionKey: new PartitionKey("pk"),
+                    cancellationToken: cts.Token);
+            }
+            catch (Exception ex)
+            {
+                observed = ex;
+            }
+            finally
+            {
+                sw.Stop();
+                barrierDelayRule.Disable();
+            }
+
+            long elapsedSeconds = sw.ElapsedMilliseconds / 1000;
+
+            // Sanity: the barrier delay rule must actually have fired. If it did not, this account /
+            // environment is not exercising the Head/Collection barrier path (e.g., the SDK is reading
+            // from the write region under Strong and skipping barriers entirely). In that case the
+            // test cannot conclude anything about CT honor and should be marked inconclusive instead
+            // of green.
+            if (barrierDelayRule.GetHitCount() == 0)
+            {
+                Assert.Inconclusive(
+                    "Metadata/Head barrier fault never fired — the SDK did not issue a Head/Collection request "
+                    + "during the Read under Strong consistency from this preferred region. Verify the test account "
+                    + "supports Strong consistency cross-region reads and that the SDK's barrier path is reachable.");
+            }
+
+            // The contract: once the operation-level CancellationToken expires, the SDK should surface
+            // OperationCanceledException within a small grace period — even if barrier responses are
+            // still pending in the background.
+            Assert.IsTrue(
+                elapsedSeconds <= cancellationBudgetSeconds + gracePeriodSeconds,
+                $"Operation ran for {elapsedSeconds}s under a {cancellationBudgetSeconds}s CancellationToken "
+                + $"(allowed: <= {cancellationBudgetSeconds + gracePeriodSeconds}s). "
+                + $"Barrier responses delayed by {barrierDelaySeconds}s blocked the operation past the CT — "
+                + $"see GitHub issue #5906. "
+                + $"Observed exception: {observed?.GetType().FullName ?? "<none>"}. "
+                + $"Barrier rule hit count: {barrierDelayRule.GetHitCount()}.");
+
+            Assert.IsNotNull(observed, "Expected the operation to be cancelled, but it completed normally.");
+            Assert.IsTrue(
+                observed is OperationCanceledException,
+                $"Expected OperationCanceledException, got {observed.GetType().FullName}: {observed.Message}");
+        }
+
 
         private async Task<(List<string>, List<string>)> GetReadWriteEndpoints(GlobalEndpointManager globalEndpointManager)
         {

--- a/Microsoft.Azure.Cosmos/FaultInjection/tests/FaultInjectionGatewayModeTests.cs
+++ b/Microsoft.Azure.Cosmos/FaultInjection/tests/FaultInjectionGatewayModeTests.cs
@@ -695,6 +695,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
         [DataRow(FaultInjectionOperationType.ReadItem, FaultInjectionServerErrorType.Timeout, (int)StatusCodes.RequestTimeout, (int)SubStatusCodes.Unknown, DisplayName = "Timeout")]
         [DataRow(FaultInjectionOperationType.ReadItem, FaultInjectionServerErrorType.PartitionIsMigrating, (int)StatusCodes.Gone, (int)SubStatusCodes.CompletingPartitionMigration, DisplayName = "PartitionIsMigrating")]
         [DataRow(FaultInjectionOperationType.ReadItem, FaultInjectionServerErrorType.PartitionIsSplitting, (int)StatusCodes.Gone, (int)SubStatusCodes.CompletingSplit, DisplayName = "PartitionIsSplitting")]
+        [DataRow(FaultInjectionOperationType.ReadItem, FaultInjectionServerErrorType.LeaseNotFound, (int)StatusCodes.Gone, (int)SubStatusCodes.LeaseNotFound, DisplayName = "LeaseNotFound")]
         [DataRow(FaultInjectionOperationType.CreateItem, FaultInjectionServerErrorType.Gone, (int)StatusCodes.Gone, (int)SubStatusCodes.ServerGenerated410, DisplayName = "Gone - write")]
         [DataRow(FaultInjectionOperationType.CreateItem, FaultInjectionServerErrorType.InternalServerError, (int)StatusCodes.InternalServerError, (int)SubStatusCodes.Unknown, DisplayName = "InternalServerError - write")]
         [DataRow(FaultInjectionOperationType.CreateItem, FaultInjectionServerErrorType.TooManyRequests, (int)StatusCodes.TooManyRequests, (int)SubStatusCodes.RUBudgetExceeded, DisplayName = "TooManyRequests - write")]
@@ -702,6 +703,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
         [DataRow(FaultInjectionOperationType.CreateItem, FaultInjectionServerErrorType.Timeout, (int)StatusCodes.RequestTimeout, (int)SubStatusCodes.Unknown, DisplayName = "Timeout - write")]
         [DataRow(FaultInjectionOperationType.CreateItem, FaultInjectionServerErrorType.PartitionIsMigrating, (int)StatusCodes.Gone, (int)SubStatusCodes.CompletingPartitionMigration, DisplayName = "PartitionIsMigrating - write")]
         [DataRow(FaultInjectionOperationType.CreateItem, FaultInjectionServerErrorType.PartitionIsSplitting, (int)StatusCodes.Gone, (int)SubStatusCodes.CompletingSplit, DisplayName = "PartitionIsSplitting - write")]
+        [DataRow(FaultInjectionOperationType.CreateItem, FaultInjectionServerErrorType.LeaseNotFound, (int)StatusCodes.Gone, (int)SubStatusCodes.LeaseNotFound, DisplayName = "LeaseNotFound - write")]
         public async Task FIGatewayServerResponse(
             FaultInjectionOperationType faultInjectionOperationType, 
             FaultInjectionServerErrorType faultInjectionServerErrorType,


### PR DESCRIPTION
## Description

Fixes Azure/azure-cosmos-dotnet-v3#5906.

When a customer's operation-level `CancellationToken` expires during a cross-partition `FeedIterator` page (or any retry-driven `ReadItem` / point-write), the SDK was continuing to do work past the deadline. The two main offenders:

1. **`PartitionKeyRangeCache` lookups** used by query pagination (cross-partition fan-out, split / merge handling, and PKRange cache refresh between pages) ran `do { ... await ProcessMessageAsync(...) ... } while(...)` against `forceRefresh = true` without checking the caller's CT between iterations. A 410/1022 storm during a partition merge cutover could keep the loop spinning until the per-attempt RNTBD timeout fired, well past the customer's deadline.
2. **Retry policies** (`ClientRetryPolicy`, `ResourceThrottleRetryPolicy`, `WebExceptionRetryPolicy`, `BulkExecutionRetryPolicy`) did not short-circuit when the operation CT was already cancelled, so each policy would schedule another backoff `Task.Delay` against the same expired token, surfacing as a stalled operation rather than `OperationCanceledException`.

The end-to-end symptom was the same as #5906: ~99–133 s wall-clock under a 30 s `CancellationToken`, with the entire stall sitting inside `Prefetching` / `PartitionKeyRangeCache` refresh paths and no forward progress on transport requests.

This PR plumbs the operation-level `CancellationToken` end-to-end and adds `ThrowIfCancellationRequested` short-circuits inside the retry loops, so cancellation is observed within the next backoff slot (not after the full retry budget elapses).

## Cancellation honor fixes

### Retry policies — early CT short-circuit

All four retry policies now check `cancellationToken.IsCancellationRequested` *before* scheduling the next backoff `Task.Delay`, so a cancelled operation stops within the current attempt rather than burning the full retry budget:

- **`ClientRetryPolicy.ShouldRetryAsync`** — cross-region retries on `Gone (410)` / `LeaseNotFound (410/1022)` and other transient backend status codes. The pre-cancelled path also avoids `RefreshLocationAsync` round-trips that would otherwise hold the operation open.
- **`ResourceThrottleRetryPolicy.ShouldRetryAsync`** — `429` throttling backoffs (up to 60 s by default, which is what dominated the original stall).
- **`WebExceptionRetryPolicy.ShouldRetryAsync`** — exponential backoff on retriable HTTP / socket exceptions.
- **`BulkExecutionRetryPolicy.ShouldRetryAsync` (both overloads) and `ShouldRetryInternalAsync`** — defense-in-depth `ThrowIfCancellationRequested` at the top of the internal method covers the race where the token cancels between the public guard and the cache call.

### `PartitionKeyRangeCache` — CT inside the refresh loop

- `TryGetOverlappingRangesAsync`, `TryGetPartitionKeyRangeByIdAsync`, and `TryLookupAsync` now accept a `CancellationToken` parameter.
- `GetRoutingMapForCollectionAsync` checks the token at the top of every iteration of its `do { ... } while(...)` refresh loop, surfacing `OperationCanceledException` instead of issuing another gateway round-trip when the caller's deadline has passed.
- The legacy 4-arg `TryLookupAsync` overload is retained for back-compat (callers like `AddressResolver` and `DocumentClient` that have no CT in scope are documented as a deferred follow-up).

### Query pagination + FeedRange plumbing — forward the operation CT end-to-end

Each of these methods previously either accepted no CT or accepted one and dropped it before reaching `PartitionKeyRangeCache`. They now thread the caller's CT all the way down:

- **`ContainerCore.GetFeedRangesAsync`** → `PartitionKeyRangeCache.TryGetOverlappingRangesAsync`
- **`FeedRange.GetEffectiveRangesAsync`** — abstract `FeedRangeInternal` plus all three overrides (`FeedRangeEpk`, `FeedRangePartitionKey`, `FeedRangePartitionKeyRange`), with `ThrowIfCancellationRequested` at the top of the synchronous overrides and CT forwarded into both `TryGetPartitionKeyRangeByIdAsync` calls in `FeedRangePartitionKeyRange`.
- **All `FeedRange` callers** updated to pass the operation CT: `FeedRangePartitionKeyRangeExtractor` (3 sites), `ContainerCore.Items` (2 sites), `CosmosQueryClientCore`.
- **`PartitionRoutingHelper`** — `TryGetTargetRangeFromContinuationTokenRangeAsync`, `GetReplacementRangesAsync`, and `TryAddPartitionKeyRangeToContinuationTokenAsync` gained CT parameters with `ThrowIfCancellationRequested` short-circuits, and forward the CT to every `TryGetOverlappingRangesAsync` and `TryGetRangeByEffectivePartitionKeyAsync` call — including the empty-`providedPartitionKeyRanges` (`WHERE false`) branch and the forward-continuation branch that had previously dropped the token.
- **`PartitionKeyRangeHandler`** — 3 caller updates to forward CT into the helper above.
- **v2 `DefaultDocumentQueryExecutionContext.ExecuteOnceAsync`** — private `TryGetTargetPartitionKeyRangeAsync` gained CT; 3 caller updates.
- **`FeedRangeCompositeContinuation.HandleSplitAsync`** — private `TryGetOverlappingRangesAsync` helper gained CT.

### Additional CT-honor paths

- **`CosmosHttpClientCore`** — gateway HTTP retry loop now honors CT between attempts.
- **`GlobalAddressResolver`** — open-connection paths honor the supplied CT.
- **`RequestInvokerHandler`** — operation CT is forwarded into the request pipeline.

## Test coverage

### Unit tests pinning the contract at every plumbed layer

Each plumbing point above has a dedicated unit test that would fail if the contract regresses (CT dropped on the way down, OCE not surfaced, retry policy schedules another delay past the deadline). Pattern: `Mock<...>(MockBehavior.Strict)` plus `.Callback<...>(... => captured = ct)` so the assertion verifies the *same CT instance* reaches the underlying provider — not just that the method completes.

- **`PartitionKeyRangeCacheTest`**
  - `TryGetPartitionKeyRangeByIdAsync_WithCancelledToken` — short-circuit before any store-model call (`Times.Never`).
  - `GetRoutingMapForCollectionAsync_TokenCancelledMidRetryLoop` — cancels inside the first `ProcessMessageAsync` callback; asserts no second iteration of the `do { ... } while(...)` loop runs.
- **`FeedRangeTests`**
  - `FeedRangeEPK_GetEffectiveRangesAsync_WithCancelledToken_ThrowsOperationCanceledException`
  - `FeedRangePK_GetEffectiveRangesAsync_WithCancelledToken_ThrowsOperationCanceledException`
  - `FeedRangePKRangeId_GetEffectiveRangesAsync_PropagatesCancellationTokenToRoutingMapProvider`
- **`PartitionRoutingHelperTest`**
  - `GetReplacementRangesAsync_PropagatesCancellationTokenToRoutingMapProvider`
  - `TryGetTargetRangeFromContinuationTokenRangeAsync_WithCancelledToken_ThrowsOperationCanceledException`
  - `TryGetTargetRangeFromContinuationTokenRangeAsync_EmptyProvidedRanges_PropagatesCancellationTokenToRoutingMapProvider` — pins the `WHERE false` / empty-provided-ranges branch that the deep reviewer flagged.
- **`BulkExecutionRetryPolicyTests`** — cancelled-token short-circuit on both public overloads.
- **`ClientRetryPolicyTests`** — cancelled-token short-circuit covers the 410 / 1022 cross-region path.
- **`ResourceThrottleRetryPolicyTests`** — cancelled-token short-circuit on 429 backoff path; asserts no `Task.Delay` is scheduled.
- **`WebExceptionRetryPolicyTests`** — cancelled-token short-circuit on retriable HTTP / socket exception backoff.
- **`CosmosHttpClientCoreTests`** — gateway HTTP retry loop CT honor.
- **`NetworkAttachedDocumentContainerTests`** — CT propagation through the change-feed `MonadicRefreshProviderAsync` path.
- **`PartitionKeyRangeHandlerTests`** — Moq fixtures updated to bind the new CT parameter.

### Fault-injection end-to-end repro tests

Deterministic e2e tests that fail on `master` and pass on this branch. Each pairs a fault rule with a CT shorter than the SDK's default retry budget and asserts (a) `OperationCanceledException` is surfaced and (b) wall-clock stays inside the budget + a small grace period.

- **`FaultInjectionLeaseNotFound_FeedIteratorHonorsCancellationToken`** (Direct mode) — cross-partition `FeedIterator` running `SELECT TOP 1 ... ORDER BY`; injects `LeaseNotFound (410/1022)` on `QueryItem` / `ReadItem` against the primary region with `WithTimes(int.MaxValue)`; secondary region also injected with a deterministic delay; 5 s CT, ≤ 7 s wall-clock assertion. Includes a cold-start warm-up `ReadItemAsync` (catches `NotFound`) before enabling the rule and starting the stopwatch, so the boundary is not raced by the first-request channel-open / cache-build.
- **`FaultInjectionMetadataRequestDelay_HonorsCancellationToken`** (Direct mode) — Strong-consistency multi-region read with preferred regions ordered to force the consistency-barrier `Head/Collection` path; injects `ResponseDelay(20 s)` on every `MetadataRequest` in the primary region; 5 s CT; returns `Assert.Inconclusive` if the harness doesn't actually exercise the barrier path so it can't false-pass.
- **`FaultInjectionGateway_ResponseDelay_HonorsCancellationToken`** (Gateway mode) — Gateway-mode twin with a matching cold-start warm-up.

### Fault-injection primitives added to support these tests

- **`FaultInjectionServerErrorType.LeaseNotFound`** (`410 / 1022`) — Direct (`StoreResponse`) + Gateway (`HttpResponseMessage`) result paths, modeled on the existing `PartitionIsMigrating` (`410 / 1008`).
- **`FaultInjectionOperationType.MetadataRequest`** → `OperationType.Head` — lets fault rules target the consistency-barrier requests issued under Strong / Bounded-Staleness consistency.
- Gateway and Direct status-code `[DataRow]` smoke tables extended with `LeaseNotFound`.
- `Microsoft.Azure.Cosmos/FaultInjection/README.md` updated with the new error-type row and a `MetadataRequest` note.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Closing issues

closes #5906

## Changelog

- [x] I have added a changelog entry under `### Unreleased` in `changelog.md`
  for the user-facing impact of this change.
- [ ] No changelog entry is required because this PR is one of:
  documentation-only, test-only, CI / build-only, or a pure internal refactor
  with no observable customer impact.

The changelog entry under `### Other Changes` also discloses that callers whose token fires after the SDK has already started a retry attempt or a metadata refresh may now observe the original retriable `CosmosException` (e.g. `429`, `410/1022`) instead of an `OperationCanceledException`, depending on which phase of the backoff / refresh was active. The contract that the operation no longer keeps running past the caller's deadline is unchanged.
