### PR TITLE
[Internal] Distributed Transaction: Adds XML Remarks Documenting Per-container Pipeline Bypass

### DIFF
--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedReadTransaction.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedReadTransaction.cs
@@ -37,6 +37,11 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="id">The unique identifier of the item to read.</param>
         /// <param name="requestOptions">Options for the read operation.</param>
         /// <returns>The current <see cref="DistributedReadTransaction"/> instance for method chaining.</returns>
+        /// <remarks>
+        /// The distributed transaction bypasses the per-container request pipeline. Only the database and
+        /// container identifiers are extracted from <paramref name="container"/>; container-level behaviors
+        /// such as custom serializers, client-side encryption policies, or decorator wrappers are not applied.
+        /// </remarks>
         public abstract DistributedReadTransaction ReadItem(
             Container container,
             PartitionKey partitionKey,

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionConstants.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionConstants.cs
@@ -32,6 +32,15 @@ namespace Microsoft.Azure.Cosmos
             return $"dbs/{database}/colls/{container}";
         }
 
+        /// <summary>
+        /// Validates that the <paramref name="container"/> belongs to <paramref name="expectedClient"/>
+        /// and extracts the database and container identifiers.
+        /// </summary>
+        /// <remarks>
+        /// Only the name identifiers (Database.Id and Container.Id) are used by the distributed transaction
+        /// pipeline. Per-container behaviors such as custom serializers, client-side encryption policies,
+        /// or decorator wrappers attached to the <see cref="Container"/> instance are not honored downstream.
+        /// </remarks>
         internal static (string databaseId, string containerId) ValidateAndUnpackContainer(
             Container container,
             CosmosClient expectedClient)

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedWriteTransaction.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedWriteTransaction.cs
@@ -27,6 +27,11 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="resource">The resource to create.</param>
         /// <param name="requestOptions">Options for the create operation.</param>
         /// <returns>The current <see cref="DistributedWriteTransaction"/> instance for method chaining.</returns>
+        /// <remarks>
+        /// The distributed transaction bypasses the per-container request pipeline. Only the database and
+        /// container identifiers are extracted from <paramref name="container"/>; container-level behaviors
+        /// such as custom serializers, client-side encryption policies, or decorator wrappers are not applied.
+        /// </remarks>
         public abstract DistributedWriteTransaction CreateItem<T>(
             Container container,
             PartitionKey partitionKey,
@@ -43,6 +48,11 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="streamPayload">A <see cref="Stream"/> containing the JSON serialization of the item.</param>
         /// <param name="requestOptions">Options for the create operation.</param>
         /// <returns>The current <see cref="DistributedWriteTransaction"/> instance for method chaining.</returns>
+        /// <remarks>
+        /// The distributed transaction bypasses the per-container request pipeline. Only the database and
+        /// container identifiers are extracted from <paramref name="container"/>; container-level behaviors
+        /// such as custom serializers, client-side encryption policies, or decorator wrappers are not applied.
+        /// </remarks>
         public abstract DistributedWriteTransaction CreateItemStream(
             Container container,
             PartitionKey partitionKey,
@@ -60,6 +70,11 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="resource">The resource with updated values.</param>
         /// <param name="requestOptions">Options for the replace operation.</param>
         /// <returns>The current <see cref="DistributedWriteTransaction"/> instance for method chaining.</returns>
+        /// <remarks>
+        /// The distributed transaction bypasses the per-container request pipeline. Only the database and
+        /// container identifiers are extracted from <paramref name="container"/>; container-level behaviors
+        /// such as custom serializers, client-side encryption policies, or decorator wrappers are not applied.
+        /// </remarks>
         public abstract DistributedWriteTransaction ReplaceItem<T>(
             Container container,
             PartitionKey partitionKey,
@@ -76,6 +91,11 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="streamPayload">A <see cref="Stream"/> containing the JSON serialization of the replacement item.</param>
         /// <param name="requestOptions">Options for the replace operation.</param>
         /// <returns>The current <see cref="DistributedWriteTransaction"/> instance for method chaining.</returns>
+        /// <remarks>
+        /// The distributed transaction bypasses the per-container request pipeline. Only the database and
+        /// container identifiers are extracted from <paramref name="container"/>; container-level behaviors
+        /// such as custom serializers, client-side encryption policies, or decorator wrappers are not applied.
+        /// </remarks>
         public abstract DistributedWriteTransaction ReplaceItemStream(
             Container container,
             PartitionKey partitionKey,
@@ -91,6 +111,11 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="id">The unique identifier of the item to delete.</param>
         /// <param name="requestOptions">Options for the delete operation.</param>
         /// <returns>The current <see cref="DistributedWriteTransaction"/> instance for method chaining.</returns>
+        /// <remarks>
+        /// The distributed transaction bypasses the per-container request pipeline. Only the database and
+        /// container identifiers are extracted from <paramref name="container"/>; container-level behaviors
+        /// such as custom serializers, client-side encryption policies, or decorator wrappers are not applied.
+        /// </remarks>
         public abstract DistributedWriteTransaction DeleteItem(
             Container container,
             PartitionKey partitionKey,
@@ -106,6 +131,11 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="patchOperations">The list of <see cref="PatchOperation"/> to apply to the item.</param>
         /// <param name="requestOptions">Options for the patch operation</param>
         /// <returns>The current <see cref="DistributedWriteTransaction"/> instance for method chaining.</returns>
+        /// <remarks>
+        /// The distributed transaction bypasses the per-container request pipeline. Only the database and
+        /// container identifiers are extracted from <paramref name="container"/>; container-level behaviors
+        /// such as custom serializers, client-side encryption policies, or decorator wrappers are not applied.
+        /// </remarks>
         public abstract DistributedWriteTransaction PatchItem(
             Container container,
             PartitionKey partitionKey,
@@ -122,6 +152,11 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="streamPayload">A <see cref="Stream"/> containing the JSON serialization of the patch operations.</param>
         /// <param name="requestOptions">Options for the patch operation.</param>
         /// <returns>The current <see cref="DistributedWriteTransaction"/> instance for method chaining.</returns>
+        /// <remarks>
+        /// The distributed transaction bypasses the per-container request pipeline. Only the database and
+        /// container identifiers are extracted from <paramref name="container"/>; container-level behaviors
+        /// such as custom serializers, client-side encryption policies, or decorator wrappers are not applied.
+        /// </remarks>
         public abstract DistributedWriteTransaction PatchItemStream(
             Container container,
             PartitionKey partitionKey,
@@ -140,6 +175,11 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="resource">The resource to upsert.</param>
         /// <param name="requestOptions">Options for the upsert operation.</param>
         /// <returns>The current <see cref="DistributedWriteTransaction"/> instance for method chaining.</returns>
+        /// <remarks>
+        /// The distributed transaction bypasses the per-container request pipeline. Only the database and
+        /// container identifiers are extracted from <paramref name="container"/>; container-level behaviors
+        /// such as custom serializers, client-side encryption policies, or decorator wrappers are not applied.
+        /// </remarks>
         public abstract DistributedWriteTransaction UpsertItem<T>(
             Container container,
             PartitionKey partitionKey,
@@ -157,6 +197,11 @@ namespace Microsoft.Azure.Cosmos
         /// <param name="streamPayload">A <see cref="Stream"/> containing the JSON serialization of the item.</param>
         /// <param name="requestOptions">Options for the upsert operation.</param>
         /// <returns>The current <see cref="DistributedWriteTransaction"/> instance for method chaining.</returns>
+        /// <remarks>
+        /// The distributed transaction bypasses the per-container request pipeline. Only the database and
+        /// container identifiers are extracted from <paramref name="container"/>; container-level behaviors
+        /// such as custom serializers, client-side encryption policies, or decorator wrappers are not applied.
+        /// </remarks>
         public abstract DistributedWriteTransaction UpsertItemStream(
             Container container,
             PartitionKey partitionKey,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetPreviewSDKAPI.net6.json
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetPreviewSDKAPI.net6.json
@@ -1005,10 +1005,10 @@
     "Microsoft.Azure.Cosmos.DistributedReadTransaction;Microsoft.Azure.Cosmos.DistributedTransaction;IsAbstract:True;IsSealed:False;IsInterface:False;IsEnum:False;IsClass:True;IsValueType:False;IsNested:False;IsGenericType:False;IsSerializable:False": {
       "Subclasses": {},
       "Members": {
-        "Microsoft.Azure.Cosmos.DistributedReadTransaction ReadItem(System.String, System.String, Microsoft.Azure.Cosmos.PartitionKey, System.String, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions)": {
+        "Microsoft.Azure.Cosmos.DistributedReadTransaction ReadItem(Microsoft.Azure.Cosmos.Container, Microsoft.Azure.Cosmos.PartitionKey, System.String, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "Microsoft.Azure.Cosmos.DistributedReadTransaction ReadItem(System.String, System.String, Microsoft.Azure.Cosmos.PartitionKey, System.String, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions);IsAbstract:True;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+          "MethodInfo": "Microsoft.Azure.Cosmos.DistributedReadTransaction ReadItem(Microsoft.Azure.Cosmos.Container, Microsoft.Azure.Cosmos.PartitionKey, System.String, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions);IsAbstract:True;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
         }
       },
       "NestedTypes": {}
@@ -1018,10 +1018,10 @@
         "Microsoft.Azure.Cosmos.DistributedReadTransaction;Microsoft.Azure.Cosmos.DistributedTransaction;IsAbstract:True;IsSealed:False;IsInterface:False;IsEnum:False;IsClass:True;IsValueType:False;IsNested:False;IsGenericType:False;IsSerializable:False": {
           "Subclasses": {},
           "Members": {
-            "Microsoft.Azure.Cosmos.DistributedReadTransaction ReadItem(System.String, System.String, Microsoft.Azure.Cosmos.PartitionKey, System.String, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions)": {
+            "Microsoft.Azure.Cosmos.DistributedReadTransaction ReadItem(Microsoft.Azure.Cosmos.Container, Microsoft.Azure.Cosmos.PartitionKey, System.String, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions)": {
               "Type": "Method",
               "Attributes": [],
-              "MethodInfo": "Microsoft.Azure.Cosmos.DistributedReadTransaction ReadItem(System.String, System.String, Microsoft.Azure.Cosmos.PartitionKey, System.String, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions);IsAbstract:True;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+              "MethodInfo": "Microsoft.Azure.Cosmos.DistributedReadTransaction ReadItem(Microsoft.Azure.Cosmos.Container, Microsoft.Azure.Cosmos.PartitionKey, System.String, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions);IsAbstract:True;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
             }
           },
           "NestedTypes": {}
@@ -1029,50 +1029,50 @@
         "Microsoft.Azure.Cosmos.DistributedWriteTransaction;Microsoft.Azure.Cosmos.DistributedTransaction;IsAbstract:True;IsSealed:False;IsInterface:False;IsEnum:False;IsClass:True;IsValueType:False;IsNested:False;IsGenericType:False;IsSerializable:False": {
           "Subclasses": {},
           "Members": {
-            "Microsoft.Azure.Cosmos.DistributedWriteTransaction CreateItem[T](System.String, System.String, Microsoft.Azure.Cosmos.PartitionKey, System.String, T, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions)": {
+            "Microsoft.Azure.Cosmos.DistributedWriteTransaction CreateItem[T](Microsoft.Azure.Cosmos.Container, Microsoft.Azure.Cosmos.PartitionKey, System.String, T, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions)": {
               "Type": "Method",
               "Attributes": [],
-              "MethodInfo": "Microsoft.Azure.Cosmos.DistributedWriteTransaction CreateItem[T](System.String, System.String, Microsoft.Azure.Cosmos.PartitionKey, System.String, T, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions);IsAbstract:True;IsStatic:False;IsVirtual:True;IsGenericMethod:True;IsConstructor:False;IsFinal:False;"
+              "MethodInfo": "Microsoft.Azure.Cosmos.DistributedWriteTransaction CreateItem[T](Microsoft.Azure.Cosmos.Container, Microsoft.Azure.Cosmos.PartitionKey, System.String, T, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions);IsAbstract:True;IsStatic:False;IsVirtual:True;IsGenericMethod:True;IsConstructor:False;IsFinal:False;"
             },
-            "Microsoft.Azure.Cosmos.DistributedWriteTransaction CreateItemStream(System.String, System.String, Microsoft.Azure.Cosmos.PartitionKey, System.String, System.IO.Stream, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions)": {
+            "Microsoft.Azure.Cosmos.DistributedWriteTransaction CreateItemStream(Microsoft.Azure.Cosmos.Container, Microsoft.Azure.Cosmos.PartitionKey, System.String, System.IO.Stream, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions)": {
               "Type": "Method",
               "Attributes": [],
-              "MethodInfo": "Microsoft.Azure.Cosmos.DistributedWriteTransaction CreateItemStream(System.String, System.String, Microsoft.Azure.Cosmos.PartitionKey, System.String, System.IO.Stream, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions);IsAbstract:True;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+              "MethodInfo": "Microsoft.Azure.Cosmos.DistributedWriteTransaction CreateItemStream(Microsoft.Azure.Cosmos.Container, Microsoft.Azure.Cosmos.PartitionKey, System.String, System.IO.Stream, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions);IsAbstract:True;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
             },
-            "Microsoft.Azure.Cosmos.DistributedWriteTransaction DeleteItem(System.String, System.String, Microsoft.Azure.Cosmos.PartitionKey, System.String, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions)": {
+            "Microsoft.Azure.Cosmos.DistributedWriteTransaction DeleteItem(Microsoft.Azure.Cosmos.Container, Microsoft.Azure.Cosmos.PartitionKey, System.String, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions)": {
               "Type": "Method",
               "Attributes": [],
-              "MethodInfo": "Microsoft.Azure.Cosmos.DistributedWriteTransaction DeleteItem(System.String, System.String, Microsoft.Azure.Cosmos.PartitionKey, System.String, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions);IsAbstract:True;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+              "MethodInfo": "Microsoft.Azure.Cosmos.DistributedWriteTransaction DeleteItem(Microsoft.Azure.Cosmos.Container, Microsoft.Azure.Cosmos.PartitionKey, System.String, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions);IsAbstract:True;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
             },
-            "Microsoft.Azure.Cosmos.DistributedWriteTransaction PatchItem(System.String, System.String, Microsoft.Azure.Cosmos.PartitionKey, System.String, System.Collections.Generic.IReadOnlyList`1[Microsoft.Azure.Cosmos.PatchOperation], Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions)": {
+            "Microsoft.Azure.Cosmos.DistributedWriteTransaction PatchItem(Microsoft.Azure.Cosmos.Container, Microsoft.Azure.Cosmos.PartitionKey, System.String, System.Collections.Generic.IReadOnlyList`1[Microsoft.Azure.Cosmos.PatchOperation], Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions)": {
               "Type": "Method",
               "Attributes": [],
-              "MethodInfo": "Microsoft.Azure.Cosmos.DistributedWriteTransaction PatchItem(System.String, System.String, Microsoft.Azure.Cosmos.PartitionKey, System.String, System.Collections.Generic.IReadOnlyList`1[Microsoft.Azure.Cosmos.PatchOperation], Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions);IsAbstract:True;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+              "MethodInfo": "Microsoft.Azure.Cosmos.DistributedWriteTransaction PatchItem(Microsoft.Azure.Cosmos.Container, Microsoft.Azure.Cosmos.PartitionKey, System.String, System.Collections.Generic.IReadOnlyList`1[Microsoft.Azure.Cosmos.PatchOperation], Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions);IsAbstract:True;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
             },
-            "Microsoft.Azure.Cosmos.DistributedWriteTransaction PatchItemStream(System.String, System.String, Microsoft.Azure.Cosmos.PartitionKey, System.String, System.IO.Stream, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions)": {
+            "Microsoft.Azure.Cosmos.DistributedWriteTransaction PatchItemStream(Microsoft.Azure.Cosmos.Container, Microsoft.Azure.Cosmos.PartitionKey, System.String, System.IO.Stream, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions)": {
               "Type": "Method",
               "Attributes": [],
-              "MethodInfo": "Microsoft.Azure.Cosmos.DistributedWriteTransaction PatchItemStream(System.String, System.String, Microsoft.Azure.Cosmos.PartitionKey, System.String, System.IO.Stream, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions);IsAbstract:True;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+              "MethodInfo": "Microsoft.Azure.Cosmos.DistributedWriteTransaction PatchItemStream(Microsoft.Azure.Cosmos.Container, Microsoft.Azure.Cosmos.PartitionKey, System.String, System.IO.Stream, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions);IsAbstract:True;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
             },
-            "Microsoft.Azure.Cosmos.DistributedWriteTransaction ReplaceItem[T](System.String, System.String, Microsoft.Azure.Cosmos.PartitionKey, System.String, T, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions)": {
+            "Microsoft.Azure.Cosmos.DistributedWriteTransaction ReplaceItem[T](Microsoft.Azure.Cosmos.Container, Microsoft.Azure.Cosmos.PartitionKey, System.String, T, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions)": {
               "Type": "Method",
               "Attributes": [],
-              "MethodInfo": "Microsoft.Azure.Cosmos.DistributedWriteTransaction ReplaceItem[T](System.String, System.String, Microsoft.Azure.Cosmos.PartitionKey, System.String, T, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions);IsAbstract:True;IsStatic:False;IsVirtual:True;IsGenericMethod:True;IsConstructor:False;IsFinal:False;"
+              "MethodInfo": "Microsoft.Azure.Cosmos.DistributedWriteTransaction ReplaceItem[T](Microsoft.Azure.Cosmos.Container, Microsoft.Azure.Cosmos.PartitionKey, System.String, T, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions);IsAbstract:True;IsStatic:False;IsVirtual:True;IsGenericMethod:True;IsConstructor:False;IsFinal:False;"
             },
-            "Microsoft.Azure.Cosmos.DistributedWriteTransaction ReplaceItemStream(System.String, System.String, Microsoft.Azure.Cosmos.PartitionKey, System.String, System.IO.Stream, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions)": {
+            "Microsoft.Azure.Cosmos.DistributedWriteTransaction ReplaceItemStream(Microsoft.Azure.Cosmos.Container, Microsoft.Azure.Cosmos.PartitionKey, System.String, System.IO.Stream, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions)": {
               "Type": "Method",
               "Attributes": [],
-              "MethodInfo": "Microsoft.Azure.Cosmos.DistributedWriteTransaction ReplaceItemStream(System.String, System.String, Microsoft.Azure.Cosmos.PartitionKey, System.String, System.IO.Stream, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions);IsAbstract:True;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+              "MethodInfo": "Microsoft.Azure.Cosmos.DistributedWriteTransaction ReplaceItemStream(Microsoft.Azure.Cosmos.Container, Microsoft.Azure.Cosmos.PartitionKey, System.String, System.IO.Stream, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions);IsAbstract:True;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
             },
-            "Microsoft.Azure.Cosmos.DistributedWriteTransaction UpsertItem[T](System.String, System.String, Microsoft.Azure.Cosmos.PartitionKey, System.String, T, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions)": {
+            "Microsoft.Azure.Cosmos.DistributedWriteTransaction UpsertItem[T](Microsoft.Azure.Cosmos.Container, Microsoft.Azure.Cosmos.PartitionKey, System.String, T, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions)": {
               "Type": "Method",
               "Attributes": [],
-              "MethodInfo": "Microsoft.Azure.Cosmos.DistributedWriteTransaction UpsertItem[T](System.String, System.String, Microsoft.Azure.Cosmos.PartitionKey, System.String, T, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions);IsAbstract:True;IsStatic:False;IsVirtual:True;IsGenericMethod:True;IsConstructor:False;IsFinal:False;"
+              "MethodInfo": "Microsoft.Azure.Cosmos.DistributedWriteTransaction UpsertItem[T](Microsoft.Azure.Cosmos.Container, Microsoft.Azure.Cosmos.PartitionKey, System.String, T, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions);IsAbstract:True;IsStatic:False;IsVirtual:True;IsGenericMethod:True;IsConstructor:False;IsFinal:False;"
             },
-            "Microsoft.Azure.Cosmos.DistributedWriteTransaction UpsertItemStream(System.String, System.String, Microsoft.Azure.Cosmos.PartitionKey, System.String, System.IO.Stream, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions)": {
+            "Microsoft.Azure.Cosmos.DistributedWriteTransaction UpsertItemStream(Microsoft.Azure.Cosmos.Container, Microsoft.Azure.Cosmos.PartitionKey, System.String, System.IO.Stream, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions)": {
               "Type": "Method",
               "Attributes": [],
-              "MethodInfo": "Microsoft.Azure.Cosmos.DistributedWriteTransaction UpsertItemStream(System.String, System.String, Microsoft.Azure.Cosmos.PartitionKey, System.String, System.IO.Stream, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions);IsAbstract:True;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+              "MethodInfo": "Microsoft.Azure.Cosmos.DistributedWriteTransaction UpsertItemStream(Microsoft.Azure.Cosmos.Container, Microsoft.Azure.Cosmos.PartitionKey, System.String, System.IO.Stream, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions);IsAbstract:True;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
             }
           },
           "NestedTypes": {}
@@ -1121,11 +1121,9 @@
           "Attributes": [],
           "MethodInfo": "Boolean get_IsSuccessStatusCode();IsAbstract:False;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
         },
-        "Boolean IsSuccessStatusCode[System.Text.Json.Serialization.JsonIgnoreAttribute()]": {
+        "Boolean IsSuccessStatusCode": {
           "Type": "Property",
-          "Attributes": [
-            "JsonIgnoreAttribute"
-          ],
+          "Attributes": [],
           "MethodInfo": "Boolean IsSuccessStatusCode;CanRead:True;CanWrite:False;Boolean get_IsSuccessStatusCode();IsAbstract:False;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
         },
         "Double get_RequestCharge()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
@@ -1135,12 +1133,9 @@
           ],
           "MethodInfo": "Double get_RequestCharge();IsAbstract:False;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
         },
-        "Double RequestCharge[System.Text.Json.Serialization.JsonIncludeAttribute()]-[System.Text.Json.Serialization.JsonPropertyNameAttribute(\"requestCharge\")]": {
+        "Double RequestCharge": {
           "Type": "Property",
-          "Attributes": [
-            "JsonIncludeAttribute",
-            "JsonPropertyNameAttribute"
-          ],
+          "Attributes": [],
           "MethodInfo": "Double RequestCharge;CanRead:True;CanWrite:True;Double get_RequestCharge();IsAbstract:False;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
         },
         "Int32 get_Index()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
@@ -1150,12 +1145,9 @@
           ],
           "MethodInfo": "Int32 get_Index();IsAbstract:False;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
         },
-        "Int32 Index[System.Text.Json.Serialization.JsonIncludeAttribute()]-[System.Text.Json.Serialization.JsonPropertyNameAttribute(\"index\")]": {
+        "Int32 Index": {
           "Type": "Property",
-          "Attributes": [
-            "JsonIncludeAttribute",
-            "JsonPropertyNameAttribute"
-          ],
+          "Attributes": [],
           "MethodInfo": "Int32 Index;CanRead:True;CanWrite:True;Int32 get_Index();IsAbstract:False;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
         },
         "System.IO.Stream get_ResourceStream()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
@@ -1165,11 +1157,9 @@
           ],
           "MethodInfo": "System.IO.Stream get_ResourceStream();IsAbstract:False;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
         },
-        "System.IO.Stream ResourceStream[System.Text.Json.Serialization.JsonIgnoreAttribute()]": {
+        "System.IO.Stream ResourceStream": {
           "Type": "Property",
-          "Attributes": [
-            "JsonIgnoreAttribute"
-          ],
+          "Attributes": [],
           "MethodInfo": "System.IO.Stream ResourceStream;CanRead:True;CanWrite:True;System.IO.Stream get_ResourceStream();IsAbstract:False;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
         },
         "System.Net.HttpStatusCode get_StatusCode()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
@@ -1179,20 +1169,14 @@
           ],
           "MethodInfo": "System.Net.HttpStatusCode get_StatusCode();IsAbstract:False;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
         },
-        "System.Net.HttpStatusCode StatusCode[System.Text.Json.Serialization.JsonIncludeAttribute()]-[System.Text.Json.Serialization.JsonPropertyNameAttribute(\"statusCode\")]": {
+        "System.Net.HttpStatusCode StatusCode": {
           "Type": "Property",
-          "Attributes": [
-            "JsonIncludeAttribute",
-            "JsonPropertyNameAttribute"
-          ],
+          "Attributes": [],
           "MethodInfo": "System.Net.HttpStatusCode StatusCode;CanRead:True;CanWrite:True;System.Net.HttpStatusCode get_StatusCode();IsAbstract:False;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
         },
-        "System.String ETag[System.Text.Json.Serialization.JsonIncludeAttribute()]-[System.Text.Json.Serialization.JsonPropertyNameAttribute(\"etag\")]": {
+        "System.String ETag": {
           "Type": "Property",
-          "Attributes": [
-            "JsonIncludeAttribute",
-            "JsonPropertyNameAttribute"
-          ],
+          "Attributes": [],
           "MethodInfo": "System.String ETag;CanRead:True;CanWrite:True;System.String get_ETag();IsAbstract:False;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
         },
         "System.String get_ETag()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
@@ -1201,56 +1185,6 @@
             "CompilerGeneratedAttribute"
           ],
           "MethodInfo": "System.String get_ETag();IsAbstract:False;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
-        },
-        "System.String get_PartitionKeyRangeId()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
-          "Type": "Method",
-          "Attributes": [
-            "CompilerGeneratedAttribute"
-          ],
-          "MethodInfo": "System.String get_PartitionKeyRangeId();IsAbstract:False;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
-        },
-        "System.String get_SessionToken()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
-          "Type": "Method",
-          "Attributes": [
-            "CompilerGeneratedAttribute"
-          ],
-          "MethodInfo": "System.String get_SessionToken();IsAbstract:False;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
-        },
-        "System.String PartitionKeyRangeId[System.Text.Json.Serialization.JsonIncludeAttribute()]-[System.Text.Json.Serialization.JsonPropertyNameAttribute(\"partitionKeyRangeId\")]": {
-          "Type": "Property",
-          "Attributes": [
-            "JsonIncludeAttribute",
-            "JsonPropertyNameAttribute"
-          ],
-          "MethodInfo": "System.String PartitionKeyRangeId;CanRead:True;CanWrite:True;System.String get_PartitionKeyRangeId();IsAbstract:False;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
-        },
-        "System.String SessionToken[System.Text.Json.Serialization.JsonIncludeAttribute()]-[System.Text.Json.Serialization.JsonPropertyNameAttribute(\"sessionToken\")]": {
-          "Type": "Property",
-          "Attributes": [
-            "JsonIncludeAttribute",
-            "JsonPropertyNameAttribute"
-          ],
-          "MethodInfo": "System.String SessionToken;CanRead:True;CanWrite:True;System.String get_SessionToken();IsAbstract:False;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
-        },
-        "UInt32 get_SubStatusCodeValue()": {
-          "Type": "Method",
-          "Attributes": [],
-          "MethodInfo": "UInt32 get_SubStatusCodeValue();IsAbstract:False;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
-        },
-        "UInt32 SubStatusCodeValue[System.Text.Json.Serialization.JsonIncludeAttribute()]-[System.Text.Json.Serialization.JsonPropertyNameAttribute(\"subStatusCode\")]": {
-          "Type": "Property",
-          "Attributes": [
-            "JsonIncludeAttribute",
-            "JsonPropertyNameAttribute"
-          ],
-          "MethodInfo": "UInt32 SubStatusCodeValue;CanRead:True;CanWrite:True;UInt32 get_SubStatusCodeValue();IsAbstract:False;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
-        },
-        "Void .ctor()[System.Text.Json.Serialization.JsonConstructorAttribute()]": {
-          "Type": "Constructor",
-          "Attributes": [
-            "JsonConstructorAttribute"
-          ],
-          "MethodInfo": "Void .ctor()"
         }
       },
       "NestedTypes": {}
@@ -1468,50 +1402,50 @@
     "Microsoft.Azure.Cosmos.DistributedWriteTransaction;Microsoft.Azure.Cosmos.DistributedTransaction;IsAbstract:True;IsSealed:False;IsInterface:False;IsEnum:False;IsClass:True;IsValueType:False;IsNested:False;IsGenericType:False;IsSerializable:False": {
       "Subclasses": {},
       "Members": {
-        "Microsoft.Azure.Cosmos.DistributedWriteTransaction CreateItem[T](System.String, System.String, Microsoft.Azure.Cosmos.PartitionKey, System.String, T, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions)": {
+        "Microsoft.Azure.Cosmos.DistributedWriteTransaction CreateItem[T](Microsoft.Azure.Cosmos.Container, Microsoft.Azure.Cosmos.PartitionKey, System.String, T, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "Microsoft.Azure.Cosmos.DistributedWriteTransaction CreateItem[T](System.String, System.String, Microsoft.Azure.Cosmos.PartitionKey, System.String, T, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions);IsAbstract:True;IsStatic:False;IsVirtual:True;IsGenericMethod:True;IsConstructor:False;IsFinal:False;"
+          "MethodInfo": "Microsoft.Azure.Cosmos.DistributedWriteTransaction CreateItem[T](Microsoft.Azure.Cosmos.Container, Microsoft.Azure.Cosmos.PartitionKey, System.String, T, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions);IsAbstract:True;IsStatic:False;IsVirtual:True;IsGenericMethod:True;IsConstructor:False;IsFinal:False;"
         },
-        "Microsoft.Azure.Cosmos.DistributedWriteTransaction CreateItemStream(System.String, System.String, Microsoft.Azure.Cosmos.PartitionKey, System.String, System.IO.Stream, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions)": {
+        "Microsoft.Azure.Cosmos.DistributedWriteTransaction CreateItemStream(Microsoft.Azure.Cosmos.Container, Microsoft.Azure.Cosmos.PartitionKey, System.String, System.IO.Stream, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "Microsoft.Azure.Cosmos.DistributedWriteTransaction CreateItemStream(System.String, System.String, Microsoft.Azure.Cosmos.PartitionKey, System.String, System.IO.Stream, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions);IsAbstract:True;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+          "MethodInfo": "Microsoft.Azure.Cosmos.DistributedWriteTransaction CreateItemStream(Microsoft.Azure.Cosmos.Container, Microsoft.Azure.Cosmos.PartitionKey, System.String, System.IO.Stream, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions);IsAbstract:True;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
         },
-        "Microsoft.Azure.Cosmos.DistributedWriteTransaction DeleteItem(System.String, System.String, Microsoft.Azure.Cosmos.PartitionKey, System.String, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions)": {
+        "Microsoft.Azure.Cosmos.DistributedWriteTransaction DeleteItem(Microsoft.Azure.Cosmos.Container, Microsoft.Azure.Cosmos.PartitionKey, System.String, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "Microsoft.Azure.Cosmos.DistributedWriteTransaction DeleteItem(System.String, System.String, Microsoft.Azure.Cosmos.PartitionKey, System.String, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions);IsAbstract:True;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+          "MethodInfo": "Microsoft.Azure.Cosmos.DistributedWriteTransaction DeleteItem(Microsoft.Azure.Cosmos.Container, Microsoft.Azure.Cosmos.PartitionKey, System.String, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions);IsAbstract:True;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
         },
-        "Microsoft.Azure.Cosmos.DistributedWriteTransaction PatchItem(System.String, System.String, Microsoft.Azure.Cosmos.PartitionKey, System.String, System.Collections.Generic.IReadOnlyList`1[Microsoft.Azure.Cosmos.PatchOperation], Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions)": {
+        "Microsoft.Azure.Cosmos.DistributedWriteTransaction PatchItem(Microsoft.Azure.Cosmos.Container, Microsoft.Azure.Cosmos.PartitionKey, System.String, System.Collections.Generic.IReadOnlyList`1[Microsoft.Azure.Cosmos.PatchOperation], Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "Microsoft.Azure.Cosmos.DistributedWriteTransaction PatchItem(System.String, System.String, Microsoft.Azure.Cosmos.PartitionKey, System.String, System.Collections.Generic.IReadOnlyList`1[Microsoft.Azure.Cosmos.PatchOperation], Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions);IsAbstract:True;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+          "MethodInfo": "Microsoft.Azure.Cosmos.DistributedWriteTransaction PatchItem(Microsoft.Azure.Cosmos.Container, Microsoft.Azure.Cosmos.PartitionKey, System.String, System.Collections.Generic.IReadOnlyList`1[Microsoft.Azure.Cosmos.PatchOperation], Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions);IsAbstract:True;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
         },
-        "Microsoft.Azure.Cosmos.DistributedWriteTransaction PatchItemStream(System.String, System.String, Microsoft.Azure.Cosmos.PartitionKey, System.String, System.IO.Stream, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions)": {
+        "Microsoft.Azure.Cosmos.DistributedWriteTransaction PatchItemStream(Microsoft.Azure.Cosmos.Container, Microsoft.Azure.Cosmos.PartitionKey, System.String, System.IO.Stream, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "Microsoft.Azure.Cosmos.DistributedWriteTransaction PatchItemStream(System.String, System.String, Microsoft.Azure.Cosmos.PartitionKey, System.String, System.IO.Stream, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions);IsAbstract:True;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+          "MethodInfo": "Microsoft.Azure.Cosmos.DistributedWriteTransaction PatchItemStream(Microsoft.Azure.Cosmos.Container, Microsoft.Azure.Cosmos.PartitionKey, System.String, System.IO.Stream, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions);IsAbstract:True;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
         },
-        "Microsoft.Azure.Cosmos.DistributedWriteTransaction ReplaceItem[T](System.String, System.String, Microsoft.Azure.Cosmos.PartitionKey, System.String, T, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions)": {
+        "Microsoft.Azure.Cosmos.DistributedWriteTransaction ReplaceItem[T](Microsoft.Azure.Cosmos.Container, Microsoft.Azure.Cosmos.PartitionKey, System.String, T, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "Microsoft.Azure.Cosmos.DistributedWriteTransaction ReplaceItem[T](System.String, System.String, Microsoft.Azure.Cosmos.PartitionKey, System.String, T, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions);IsAbstract:True;IsStatic:False;IsVirtual:True;IsGenericMethod:True;IsConstructor:False;IsFinal:False;"
+          "MethodInfo": "Microsoft.Azure.Cosmos.DistributedWriteTransaction ReplaceItem[T](Microsoft.Azure.Cosmos.Container, Microsoft.Azure.Cosmos.PartitionKey, System.String, T, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions);IsAbstract:True;IsStatic:False;IsVirtual:True;IsGenericMethod:True;IsConstructor:False;IsFinal:False;"
         },
-        "Microsoft.Azure.Cosmos.DistributedWriteTransaction ReplaceItemStream(System.String, System.String, Microsoft.Azure.Cosmos.PartitionKey, System.String, System.IO.Stream, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions)": {
+        "Microsoft.Azure.Cosmos.DistributedWriteTransaction ReplaceItemStream(Microsoft.Azure.Cosmos.Container, Microsoft.Azure.Cosmos.PartitionKey, System.String, System.IO.Stream, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "Microsoft.Azure.Cosmos.DistributedWriteTransaction ReplaceItemStream(System.String, System.String, Microsoft.Azure.Cosmos.PartitionKey, System.String, System.IO.Stream, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions);IsAbstract:True;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+          "MethodInfo": "Microsoft.Azure.Cosmos.DistributedWriteTransaction ReplaceItemStream(Microsoft.Azure.Cosmos.Container, Microsoft.Azure.Cosmos.PartitionKey, System.String, System.IO.Stream, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions);IsAbstract:True;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
         },
-        "Microsoft.Azure.Cosmos.DistributedWriteTransaction UpsertItem[T](System.String, System.String, Microsoft.Azure.Cosmos.PartitionKey, System.String, T, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions)": {
+        "Microsoft.Azure.Cosmos.DistributedWriteTransaction UpsertItem[T](Microsoft.Azure.Cosmos.Container, Microsoft.Azure.Cosmos.PartitionKey, System.String, T, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "Microsoft.Azure.Cosmos.DistributedWriteTransaction UpsertItem[T](System.String, System.String, Microsoft.Azure.Cosmos.PartitionKey, System.String, T, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions);IsAbstract:True;IsStatic:False;IsVirtual:True;IsGenericMethod:True;IsConstructor:False;IsFinal:False;"
+          "MethodInfo": "Microsoft.Azure.Cosmos.DistributedWriteTransaction UpsertItem[T](Microsoft.Azure.Cosmos.Container, Microsoft.Azure.Cosmos.PartitionKey, System.String, T, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions);IsAbstract:True;IsStatic:False;IsVirtual:True;IsGenericMethod:True;IsConstructor:False;IsFinal:False;"
         },
-        "Microsoft.Azure.Cosmos.DistributedWriteTransaction UpsertItemStream(System.String, System.String, Microsoft.Azure.Cosmos.PartitionKey, System.String, System.IO.Stream, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions)": {
+        "Microsoft.Azure.Cosmos.DistributedWriteTransaction UpsertItemStream(Microsoft.Azure.Cosmos.Container, Microsoft.Azure.Cosmos.PartitionKey, System.String, System.IO.Stream, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "Microsoft.Azure.Cosmos.DistributedWriteTransaction UpsertItemStream(System.String, System.String, Microsoft.Azure.Cosmos.PartitionKey, System.String, System.IO.Stream, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions);IsAbstract:True;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+          "MethodInfo": "Microsoft.Azure.Cosmos.DistributedWriteTransaction UpsertItemStream(Microsoft.Azure.Cosmos.Container, Microsoft.Azure.Cosmos.PartitionKey, System.String, System.IO.Stream, Microsoft.Azure.Cosmos.DistributedTransactionRequestOptions);IsAbstract:True;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
         }
       },
       "NestedTypes": {}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedReadTransactionCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedReadTransactionCoreTests.cs
@@ -268,7 +268,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 .ReturnsAsync(BuildReadSuccessResponse(1));
 
             DistributedReadTransaction tx = new DistributedReadTransactionCore(contextMock.Object)
-                .ReadItem(Database, Collection, TestPartitionKey, ItemId);
+                .ReadItem(BuildMockContainer(), TestPartitionKey, ItemId);
 
             DistributedTransactionResponse response = await tx.CommitTransactionAsync(CancellationToken.None);
             Assert.IsTrue(response.IsSuccessStatusCode);
@@ -298,7 +298,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 .ReturnsAsync(BuildReadErrorResponse(HttpStatusCode.ServiceUnavailable));
 
             DistributedReadTransaction tx = new DistributedReadTransactionCore(contextMock.Object)
-                .ReadItem(Database, Collection, TestPartitionKey, ItemId);
+                .ReadItem(BuildMockContainer(), TestPartitionKey, ItemId);
 
             // First commit returns a server error — instance is still consumed.
             DistributedTransactionResponse response = await tx.CommitTransactionAsync(CancellationToken.None);
@@ -339,7 +339,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                     });
 
             DistributedReadTransaction tx = new DistributedReadTransactionCore(contextMock.Object)
-                .ReadItem(Database, Collection, TestPartitionKey, ItemId);
+                .ReadItem(BuildMockContainer(), TestPartitionKey, ItemId);
 
             const int RacerCount = 16;
             using ManualResetEventSlim gate = new ManualResetEventSlim(initialState: false);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedReadTransactionCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedReadTransactionCoreTests.cs
@@ -446,6 +446,10 @@ namespace Microsoft.Azure.Cosmos.Tests
             Mock<CosmosClientContext> contextMock = new Mock<CosmosClientContext>();
 
             contextMock
+                .Setup(c => c.Client)
+                .Returns(DistributedReadTransactionCoreTests.SharedMockClient);
+
+            contextMock
                 .Setup(c => c.DocumentClient)
                 .Returns(new MockDocumentClient());
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedWriteTransactionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedWriteTransactionTests.cs
@@ -478,7 +478,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 .ReturnsAsync(BuildSuccessResponse(1));
 
             DistributedWriteTransaction tx = new DistributedWriteTransactionCore(contextMock.Object)
-                .CreateItem(Database, Container, new PartitionKey("pk"), "item-id", new TestItem());
+                .CreateItem(BuildMockContainer(), new PartitionKey("pk"), "item-id", new TestItem());
 
             // First commit should succeed
             DistributedTransactionResponse response = await tx.CommitTransactionAsync(CancellationToken.None);
@@ -510,7 +510,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 .ReturnsAsync(BuildErrorResponse(HttpStatusCode.Conflict));
 
             DistributedWriteTransaction tx = new DistributedWriteTransactionCore(contextMock.Object)
-                .CreateItem(Database, Container, new PartitionKey("pk"), "item-id", new TestItem());
+                .CreateItem(BuildMockContainer(), new PartitionKey("pk"), "item-id", new TestItem());
 
             // First commit returns an error (but the call was made — idempotency token was consumed)
             DistributedTransactionResponse response = await tx.CommitTransactionAsync(CancellationToken.None);
@@ -552,7 +552,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                     });
 
             DistributedWriteTransaction tx = new DistributedWriteTransactionCore(contextMock.Object)
-                .CreateItem(Database, Container, new PartitionKey("pk"), "item-id", new TestItem());
+                .CreateItem(BuildMockContainer(), new PartitionKey("pk"), "item-id", new TestItem());
 
             // First commit attempt: a transient network exception escapes to the caller.
             await Assert.ThrowsExceptionAsync<HttpRequestException>(
@@ -598,7 +598,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                     });
 
             DistributedWriteTransaction tx = new DistributedWriteTransactionCore(contextMock.Object)
-                .CreateItem(Database, Container, new PartitionKey("pk"), "item-id", new TestItem());
+                .CreateItem(BuildMockContainer(), new PartitionKey("pk"), "item-id", new TestItem());
 
             await Assert.ThrowsExceptionAsync<OperationCanceledException>(
                 () => tx.CommitTransactionAsync(cts.Token));
@@ -641,7 +641,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                     });
 
             DistributedWriteTransaction tx = new DistributedWriteTransactionCore(contextMock.Object)
-                .CreateItem(Database, Container, new PartitionKey("pk"), "item-id", new TestItem());
+                .CreateItem(BuildMockContainer(), new PartitionKey("pk"), "item-id", new TestItem());
 
             const int RacerCount = 16;
             using ManualResetEventSlim gate = new ManualResetEventSlim(initialState: false);


### PR DESCRIPTION
This pull request clarifies the behavior of distributed transactions in Azure Cosmos DB by updating documentation comments and related test code. The main change is to explicitly document that distributed transactions bypass per-container request pipeline features (such as custom serializers, client-side encryption, and decorators), and only use the database and container identifiers from the `Container` object. Additionally, the tests are updated to use mock containers, reflecting this clarified contract.

**Documentation improvements:**

* Added `<remarks>` to all distributed transaction methods in `DistributedReadTransaction` and `DistributedWriteTransaction` to state that only database and container identifiers are used, and per-container behaviors (custom serializers, encryption, decorators) are not applied. [[1]](diffhunk://#diff-cd1e54d2426e528e2ca1d5c43f14d2bee1d0dae0d8754c83bee8bcb2de7c835fR40-R44) [[2]](diffhunk://#diff-f9ec0d1444fc185a1ddc561a0187fd6c980277b524f5449eb50fd95ef9fe3887R30-R34) [[3]](diffhunk://#diff-f9ec0d1444fc185a1ddc561a0187fd6c980277b524f5449eb50fd95ef9fe3887R51-R55) [[4]](diffhunk://#diff-f9ec0d1444fc185a1ddc561a0187fd6c980277b524f5449eb50fd95ef9fe3887R73-R77) [[5]](diffhunk://#diff-f9ec0d1444fc185a1ddc561a0187fd6c980277b524f5449eb50fd95ef9fe3887R94-R98) [[6]](diffhunk://#diff-f9ec0d1444fc185a1ddc561a0187fd6c980277b524f5449eb50fd95ef9fe3887R114-R118) [[7]](diffhunk://#diff-f9ec0d1444fc185a1ddc561a0187fd6c980277b524f5449eb50fd95ef9fe3887R134-R138) [[8]](diffhunk://#diff-f9ec0d1444fc185a1ddc561a0187fd6c980277b524f5449eb50fd95ef9fe3887R155-R159) [[9]](diffhunk://#diff-f9ec0d1444fc185a1ddc561a0187fd6c980277b524f5449eb50fd95ef9fe3887R178-R182) [[10]](diffhunk://#diff-f9ec0d1444fc185a1ddc561a0187fd6c980277b524f5449eb50fd95ef9fe3887R200-R204)
* Added similar remarks to the `ValidateAndUnpackContainer` helper in `DistributedTransactionConstants.cs` to reinforce that only identifier fields are honored, not container-level behaviors.

**Test updates:**

* Updated distributed transaction tests to use `BuildMockContainer()` instead of passing database/container names directly, aligning with the clarified contract that only container identifiers are used and container instances are not honored for custom behaviors. [[1]](diffhunk://#diff-89783f09d7f71bf1c87194273268d83add06045863fde380561fbd0c8e35b8e4L271-R271) [[2]](diffhunk://#diff-89783f09d7f71bf1c87194273268d83add06045863fde380561fbd0c8e35b8e4L301-R301) [[3]](diffhunk://#diff-89783f09d7f71bf1c87194273268d83add06045863fde380561fbd0c8e35b8e4L342-R342) [[4]](diffhunk://#diff-3e469317420944669144eef45cac1a9510a39698d82b908a22d6a7b80fc31085L481-R481) [[5]](diffhunk://#diff-3e469317420944669144eef45cac1a9510a39698d82b908a22d6a7b80fc31085L513-R513) [[6]](diffhunk://#diff-3e469317420944669144eef45cac1a9510a39698d82b908a22d6a7b80fc31085L555-R555) [[7]](diffhunk://#diff-3e469317420944669144eef45cac1a9510a39698d82b908a22d6a7b80fc31085L601-R601) [[8]](diffhunk://#diff-3e469317420944669144eef45cac1a9510a39698d82b908a22d6a7b80fc31085L644-R644)