### PR TITLE
Direct: Refactors OpenTcpConnectionTimeout negative-value warning trace to DocumentClient

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ConnectionPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/ConnectionPolicy.cs
@@ -451,9 +451,10 @@ namespace Microsoft.Azure.Cosmos
         /// values in [<see cref="TimeSpan.Zero"/>, 1 second) are treated as 0 (use <see cref="RequestTimeout"/>)
         /// and values greater than or equal to 1 second are rounded up to the nearest whole second
         /// (for example, 2.3 seconds becomes 3 seconds).
-        /// Negative values are not recommended and will emit a warning trace. They are preserved
-        /// on this property for backward compatibility; at the transport boundary they are truncated
-        /// to whole seconds and the <c>TransportClient.Options.OpenTimeout</c> getter returns
+        /// Negative values are not recommended. They are preserved on this property for backward
+        /// compatibility and will cause <c>DocumentClient</c> to emit a warning trace at client
+        /// construction time; at the transport boundary they are truncated to whole seconds and
+        /// the <c>TransportClient.Options.OpenTimeout</c> getter returns
         /// <see cref="RequestTimeout"/> for any stored value that is not greater than <see cref="TimeSpan.Zero"/>.
         /// </remarks>
         public TimeSpan? OpenTcpConnectionTimeout

--- a/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
@@ -13,7 +13,6 @@ namespace Microsoft.Azure.Cosmos
     using System.Net.Http;
     using System.Net.Security;
     using System.Security.Cryptography.X509Certificates;
-    using Microsoft.Azure.Cosmos.Core.Trace;
     using Microsoft.Azure.Cosmos.FaultInjection;
     using Microsoft.Azure.Cosmos.Fluent;
     using Microsoft.Azure.Documents;
@@ -618,9 +617,10 @@ namespace Microsoft.Azure.Cosmos
         /// (for example, 2.3 seconds becomes 3 seconds).
         /// </item>
         /// </list>
-        /// Negative values are not recommended and will emit a warning trace. They are preserved
-        /// on this property for backward compatibility. At the transport boundary they are converted
-        /// to whole seconds via truncation (e.g. −5.7 s → −5) and ultimately reach the
+        /// Negative values are not recommended. They are preserved on this property for backward
+        /// compatibility and will cause <c>DocumentClient</c> to emit a warning trace at client
+        /// construction time. At the transport boundary they are converted to whole seconds via
+        /// truncation (e.g. −5.7 s → −5) and ultimately reach the
         /// <c>TransportClient.Options.OpenTimeout</c> getter, which returns
         /// <see cref="RequestTimeout"/> for any value that is not greater than
         /// <see cref="TimeSpan.Zero"/>.
@@ -630,14 +630,6 @@ namespace Microsoft.Azure.Cosmos
             get => this.openTcpConnectionTimeout;
             set
             {
-                if (value.HasValue && value.Value < TimeSpan.Zero)
-                {
-                    DefaultTrace.TraceWarning(
-                        "OpenTcpConnectionTimeout value {0} is negative. Negative values are not recommended; "
-                        + "the TransportClient will fall back to the configured RequestTimeout.",
-                        value.Value);
-                }
-
                 this.openTcpConnectionTimeout = value;
                 this.ValidateDirectTCPSettings();
             }

--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -929,11 +929,23 @@ namespace Microsoft.Azure.Cosmos
                 {
                     // Values in [TimeSpan.Zero, 1 second) become 0 (use RequestTimeout).
                     // Values >= 1 second round up to the nearest whole second, clamped to int.MaxValue.
-                    // Negative values are truncated via (int)TotalSeconds, preserving pre-PR behavior.
+                    // Negative values are truncated via (int)TotalSeconds, preserving pre-PR behavior,
+                    // and a warning trace is emitted (Direct mode only) because negative timeouts
+                    // cause the TransportClient to fall back to the configured RequestTimeout.
+                    // The warning is gated on Direct mode because openConnectionTimeoutInSeconds is
+                    // not consumed in Gateway mode, so the message would be misleading there.
                     TimeSpan openTcpConnectionTimeout = connectionPolicy.OpenTcpConnectionTimeout.Value;
 
                     if (openTcpConnectionTimeout < TimeSpan.Zero)
                     {
+                        if (connectionPolicy.ConnectionMode == ConnectionMode.Direct)
+                        {
+                            DefaultTrace.TraceWarning(
+                                "OpenTcpConnectionTimeout value {0} is negative. Negative values are not recommended; "
+                                + "the TransportClient will fall back to the configured RequestTimeout.",
+                                openTcpConnectionTimeout);
+                        }
+
                         this.openConnectionTimeoutInSeconds = (int)openTcpConnectionTimeout.TotalSeconds;
                     }
                     else if (openTcpConnectionTimeout < TimeSpan.FromSeconds(1))

--- a/Microsoft.Azure.Cosmos/src/Fluent/CosmosClientBuilder.cs
+++ b/Microsoft.Azure.Cosmos/src/Fluent/CosmosClientBuilder.cs
@@ -438,9 +438,10 @@ namespace Microsoft.Azure.Cosmos.Fluent
         /// At the transport boundary, values in [<see cref="TimeSpan.Zero"/>, 1 second) are treated as 0
         /// (use the configured request timeout). Values greater than or equal to 1 second are rounded up to
         /// the nearest whole second (for example, 2.3 seconds becomes 3 seconds).
-        /// Negative values are not recommended and will emit a warning trace. They are preserved for
-        /// backward compatibility; at the transport boundary they are truncated to whole seconds and the
-        /// TransportClient returns the configured request timeout for any stored value not greater than zero.
+        /// Negative values are not recommended. They are preserved for backward compatibility and will
+        /// cause the underlying <c>DocumentClient</c> to emit a warning trace at client construction time;
+        /// at the transport boundary they are truncated to whole seconds and the TransportClient returns
+        /// the configured request timeout for any stored value not greater than zero.
         /// </param>
         /// <param name="maxRequestsPerTcpConnection">
         /// Controls the number of requests allowed simultaneously over a single TCP connection. When more requests are in flight simultaneously, the direct/TCP client will open additional connections.

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
@@ -922,24 +922,6 @@ namespace Microsoft.Azure.Cosmos.Tests
         }
 
         [TestMethod]
-        public void OpenTcpConnectionTimeoutNegativeTimeSpanPassesThroughWithWarning()
-        {
-            CosmosClientOptions options = new CosmosClientOptions
-            {
-                ConnectionMode = ConnectionMode.Direct,
-            };
-
-            // Negative values are passed through unchanged (warning is logged but value is preserved).
-            options.OpenTcpConnectionTimeout = TimeSpan.FromMilliseconds(-1);
-            Assert.AreEqual(TimeSpan.FromMilliseconds(-1), options.OpenTcpConnectionTimeout,
-                "Negative value should be preserved unchanged on the property.");
-
-            options.OpenTcpConnectionTimeout = TimeSpan.FromSeconds(-30);
-            Assert.AreEqual(TimeSpan.FromSeconds(-30), options.OpenTcpConnectionTimeout,
-                "Negative value should be preserved unchanged on the property.");
-        }
-
-        [TestMethod]
         public void OpenTcpConnectionTimeoutZeroIsAllowedAndRoundTripsThroughConnectionPolicy()
         {
             CosmosClientOptions options = new CosmosClientOptions

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DocumentClientOpenTcpConnectionTimeoutWarningTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DocumentClientOpenTcpConnectionTimeoutWarningTests.cs
@@ -1,0 +1,270 @@
+﻿//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+namespace Microsoft.Azure.Cosmos.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using Microsoft.Azure.Cosmos.Core.Trace;
+    using Microsoft.Azure.Cosmos.Fluent;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    /// <summary>
+    /// Pins the behavior contracted by the follow-up to PR #5873: the
+    /// negative-<see cref="CosmosClientOptions.OpenTcpConnectionTimeout"/>
+    /// warning trace is emitted by <c>DocumentClient</c> at client construction
+    /// (the consumer of the value), not by the
+    /// <c>CosmosClientOptions.OpenTcpConnectionTimeout</c> property setter.
+    /// </summary>
+    [TestClass]
+    [DoNotParallelize]
+    public class DocumentClientOpenTcpConnectionTimeoutWarningTests
+    {
+        private const string AccountEndpoint = "https://localhost:8081/";
+        private const string WarningSubstring = "OpenTcpConnectionTimeout";
+
+        private CapturingTraceListener listener;
+        private SourceLevels originalLevel;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            this.listener = new CapturingTraceListener();
+            DefaultTrace.TraceSource.Listeners.Add(this.listener);
+            this.originalLevel = DefaultTrace.TraceSource.Switch.Level;
+            DefaultTrace.TraceSource.Switch.Level = SourceLevels.Warning;
+        }
+
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            if (this.listener != null)
+            {
+                DefaultTrace.TraceSource.Listeners.Remove(this.listener);
+                this.listener.Dispose();
+                this.listener = null;
+            }
+
+            DefaultTrace.TraceSource.Switch.Level = this.originalLevel;
+        }
+
+        [TestMethod]
+        public void OpenTcpConnectionTimeoutNegativeEmitsWarningFromDocumentClient()
+        {
+            this.BuildClientWithOpenTcpConnectionTimeout(TimeSpan.FromSeconds(-30));
+
+            IReadOnlyList<CapturedTraceEvent> warnings = this.listener.SnapshotWarnings(WarningSubstring);
+            Assert.AreEqual(
+                1,
+                warnings.Count,
+                "DocumentClient should emit exactly one OpenTcpConnectionTimeout warning per construction with a negative value.");
+            StringAssert.Contains(warnings[0].Message, "negative");
+            StringAssert.Contains(warnings[0].Message, TimeSpan.FromSeconds(-30).ToString());
+        }
+
+        [TestMethod]
+        public void OpenTcpConnectionTimeoutNegativeIsTruncatedToWholeSecondsAndEmitsWarning()
+        {
+            CosmosClient cosmosClient = this.BuildClientWithOpenTcpConnectionTimeout(TimeSpan.FromSeconds(-5.7));
+
+            Microsoft.Azure.Cosmos.Tracing.TraceData.RntbdConnectionConfig tcpConfig =
+                cosmosClient.ClientConfigurationTraceDatum.RntbdConnectionConfig;
+
+            Assert.AreEqual(
+                -5,
+                tcpConfig.ConnectionTimeout,
+                "Negative OpenTcpConnectionTimeout values are truncated via (int)TotalSeconds at the transport boundary.");
+
+            IReadOnlyList<CapturedTraceEvent> warnings = this.listener.SnapshotWarnings(WarningSubstring);
+            Assert.AreEqual(
+                1,
+                warnings.Count,
+                "Truncation and warning emission must remain coupled to the negative branch.");
+        }
+
+        [TestMethod]
+        public void OpenTcpConnectionTimeoutSettingNegativeOnOptionsDoesNotEmitWarning()
+        {
+            CosmosClientOptions options = new CosmosClientOptions
+            {
+                ConnectionMode = ConnectionMode.Direct,
+            };
+
+            options.OpenTcpConnectionTimeout = TimeSpan.FromMilliseconds(-1);
+            options.OpenTcpConnectionTimeout = TimeSpan.FromSeconds(-30);
+
+            IReadOnlyList<CapturedTraceEvent> warnings = this.listener.SnapshotWarnings(WarningSubstring);
+            Assert.AreEqual(
+                0,
+                warnings.Count,
+                "Assigning a negative TimeSpan to CosmosClientOptions.OpenTcpConnectionTimeout must not emit a warning; the consumer (DocumentClient) owns that trace.");
+        }
+
+        [DataTestMethod]
+        [DataRow(0L)]
+        [DataRow(500L)]
+        [DataRow(1000L)]
+        [DataRow(2500L)]
+        [DataRow(7000L)]
+        public void OpenTcpConnectionTimeoutNonNegativeDoesNotEmitWarningFromDocumentClient(long milliseconds)
+        {
+            this.BuildClientWithOpenTcpConnectionTimeout(TimeSpan.FromMilliseconds(milliseconds));
+
+            IReadOnlyList<CapturedTraceEvent> warnings = this.listener.SnapshotWarnings(WarningSubstring);
+            Assert.AreEqual(
+                0,
+                warnings.Count,
+                $"Non-negative OpenTcpConnectionTimeout ({milliseconds} ms) must not produce the negative-value warning.");
+        }
+
+        [TestMethod]
+        public void OpenTcpConnectionTimeoutWarningEmittedOncePerDocumentClientConstruction()
+        {
+            this.BuildClientWithOpenTcpConnectionTimeout(TimeSpan.FromSeconds(-1));
+            this.BuildClientWithOpenTcpConnectionTimeout(TimeSpan.FromSeconds(-2));
+
+            IReadOnlyList<CapturedTraceEvent> warnings = this.listener.SnapshotWarnings(WarningSubstring);
+            Assert.AreEqual(
+                2,
+                warnings.Count,
+                "Two DocumentClient constructions with negative timeouts should emit exactly two warnings (once per construction, not once per setter call).");
+        }
+
+        [TestMethod]
+        public void OpenTcpConnectionTimeoutNegativeInGatewayModeDoesNotEmitWarning()
+        {
+            // Legacy path: a caller constructs a DocumentClient directly with a raw ConnectionPolicy
+            // whose ConnectionMode is Gateway. openConnectionTimeoutInSeconds is not consumed in
+            // Gateway mode, so the "fall back to RequestTimeout" message would be misleading and the
+            // warning is intentionally suppressed.
+            ConnectionPolicy policy = new ConnectionPolicy
+            {
+                ConnectionMode = ConnectionMode.Gateway,
+                OpenTcpConnectionTimeout = TimeSpan.FromSeconds(-30),
+            };
+
+            this.BuildClientFromConnectionPolicy(policy);
+
+            IReadOnlyList<CapturedTraceEvent> warnings = this.listener.SnapshotWarnings(WarningSubstring);
+            Assert.AreEqual(
+                0,
+                warnings.Count,
+                "Negative OpenTcpConnectionTimeout in Gateway mode must not emit the Direct-only warning.");
+        }
+
+        [TestMethod]
+        public void OpenTcpConnectionTimeoutNegativeThenOverwrittenWithNonNegativeDoesNotEmitWarning()
+        {
+            // Documents the timing-shift improvement over the original setter-side approach:
+            // assigning a negative TimeSpan and later overwriting it with a non-negative value
+            // before constructing the DocumentClient must produce zero warnings, because the
+            // warning is now driven by the constructed value (not the transient setter value).
+            CosmosClientOptions options = new CosmosClientOptions
+            {
+                ConnectionMode = ConnectionMode.Direct,
+                OpenTcpConnectionTimeout = TimeSpan.FromSeconds(-30),
+            };
+            options.OpenTcpConnectionTimeout = TimeSpan.FromSeconds(5);
+
+            ConnectionPolicy policy = options.GetConnectionPolicy(clientId: 0);
+            this.BuildClientFromConnectionPolicy(policy);
+
+            IReadOnlyList<CapturedTraceEvent> warnings = this.listener.SnapshotWarnings(WarningSubstring);
+            Assert.AreEqual(
+                0,
+                warnings.Count,
+                "Overwriting a transiently negative OpenTcpConnectionTimeout with a non-negative value before construction must not produce the negative-value warning.");
+        }
+
+        private CosmosClient BuildClientWithOpenTcpConnectionTimeout(TimeSpan openTcpConnectionTimeout)
+        {
+            CosmosClientOptions options = new CosmosClientOptions
+            {
+                ConnectionMode = ConnectionMode.Direct,
+                OpenTcpConnectionTimeout = openTcpConnectionTimeout,
+            };
+
+            ConnectionPolicy policy = options.GetConnectionPolicy(clientId: 0);
+            return this.BuildClientFromConnectionPolicy(policy);
+        }
+
+        private CosmosClient BuildClientFromConnectionPolicy(ConnectionPolicy policy)
+        {
+            CosmosClientBuilder builder = new CosmosClientBuilder(
+                accountEndpoint: AccountEndpoint,
+                authKeyOrResourceToken: MockCosmosUtil.RandomInvalidCorrectlyFormatedAuthKey);
+
+            return builder.Build(new MockDocumentClient(connectionPolicy: policy));
+        }
+
+        private sealed class CapturedTraceEvent
+        {
+            public CapturedTraceEvent(TraceEventType eventType, string message)
+            {
+                this.EventType = eventType;
+                this.Message = message;
+            }
+
+            public TraceEventType EventType { get; }
+
+            public string Message { get; }
+        }
+
+        private sealed class CapturingTraceListener : TraceListener
+        {
+            private readonly object syncRoot = new object();
+            private readonly List<CapturedTraceEvent> events = new List<CapturedTraceEvent>();
+
+            public override void TraceEvent(TraceEventCache eventCache, string source, TraceEventType eventType, int id, string message)
+            {
+                this.Capture(eventType, message);
+            }
+
+            public override void TraceEvent(TraceEventCache eventCache, string source, TraceEventType eventType, int id, string format, params object[] args)
+            {
+                string message = (args == null || args.Length == 0)
+                    ? format
+                    : string.Format(System.Globalization.CultureInfo.InvariantCulture, format, args);
+                this.Capture(eventType, message);
+            }
+
+            public override void Write(string message)
+            {
+                // No-op: per-event capture is sufficient.
+            }
+
+            public override void WriteLine(string message)
+            {
+                // No-op: per-event capture is sufficient.
+            }
+
+            public IReadOnlyList<CapturedTraceEvent> SnapshotWarnings(string messageSubstring)
+            {
+                lock (this.syncRoot)
+                {
+                    List<CapturedTraceEvent> matches = new List<CapturedTraceEvent>();
+                    foreach (CapturedTraceEvent captured in this.events)
+                    {
+                        if (captured.EventType == TraceEventType.Warning
+                            && captured.Message != null
+                            && captured.Message.IndexOf(messageSubstring, StringComparison.Ordinal) >= 0)
+                        {
+                            matches.Add(captured);
+                        }
+                    }
+
+                    return matches;
+                }
+            }
+
+            private void Capture(TraceEventType eventType, string message)
+            {
+                lock (this.syncRoot)
+                {
+                    this.events.Add(new CapturedTraceEvent(eventType, message));
+                }
+            }
+        }
+    }
+}

--- a/changelog.md
+++ b/changelog.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Other Changes
 
+- [5916](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5916) Direct: Moves the `OpenTcpConnectionTimeout` negative-value warning trace from `CosmosClientOptions` to `DocumentClient`. The warning is now emitted once per client construction (instead of once per property assignment) and is gated on `ConnectionMode == Direct`, so it no longer false-positives when a negative value is later overwritten with a non-negative one or when running in Gateway mode where the timeout is not consumed.
 ### <a name="3.62.0-preview.0"/> [3.62.0-preview.0](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.62.0-preview.0) - 2026-6-1
 
 #### Features Added


### PR DESCRIPTION
Follow-up to #5873 addressing @kundadebdatta's comment: move the negative-`TimeSpan` warning trace out of the `CosmosClientOptions.OpenTcpConnectionTimeout` setter and into `DocumentClient`, where the value is consumed.

- `CosmosClientOptions`: remove the setter-side `DefaultTrace.TraceWarning`
- `DocumentClient`: emit the warning inside the existing `openTcpConnectionTimeout < TimeSpan.Zero` branch.
- `ConnectionPolicy` / `CosmosClientBuilder`: XML-doc wording sync.
- Tests: drop the obsolete setter-warning test; add `DocumentClientOpenTcpConnectionTimeoutWarningTests` covering negative-emits-warning, truncation-with-warning, setter-silent, non-negative-silent (parameterized), and once-per-construction.
- Changelog: `Unreleased` > `Other Changes` entry (PR #5873 already shipped in 3.61.0-preview.0).