### PR TITLE
[Internal] Thin Client Integration: Fixes Exclude regions check for thinclient mode.

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Routing/LocationCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/LocationCache.cs
@@ -982,14 +982,17 @@ namespace Microsoft.Azure.Cosmos.Routing
 
         /// <summary>
         /// Resolves the applicable thin client endpoints for a request, honoring per-request
-        /// <see cref="DocumentServiceRequestContext.ExcludeRegions"/>. Mirrors the gateway
-        /// path in <see cref="GetApplicableEndpoints(DocumentServiceRequest, bool)"/>.
+        /// <see cref="DocumentServiceRequestContext.ExcludeRegions"/>. Uses the same preferred-
+        /// location filter as the gateway path in <see cref="GetApplicableEndpoints(DocumentServiceRequest, bool)"/>,
+        /// differing only in which fallback endpoint is selected.
         /// </summary>
         /// <remarks>
-        /// When all preferred regions are excluded, falls back to the first thin client write
-        /// endpoint (which itself falls back to <see cref="defaultEndpoint"/> at initialization
-        /// time). This keeps requests on the thin client routing path rather than dropping back
-        /// to the gateway endpoint and breaking thin client port semantics.
+        /// When all preferred regions are excluded, this method always falls back to the first
+        /// thin client write endpoint (<c>snapshot.ThinClientWriteEndpoints[0]</c>) for both reads
+        /// and writes. This deliberately diverges from the gateway path's fallback selection
+        /// (which uses <see cref="defaultEndpoint"/>, or <c>WriteEndpoints[0]</c> under PPAF for
+        /// reads) because <see cref="defaultEndpoint"/> resolves to the gateway port (443) and
+        /// would break thin client port semantics if used here.
         /// </remarks>
         private ReadOnlyCollection<Uri> GetApplicableThinClientEndpoints(
             DocumentServiceRequest request,

--- a/Microsoft.Azure.Cosmos/src/Routing/LocationCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/LocationCache.cs
@@ -955,15 +955,44 @@ namespace Microsoft.Azure.Cosmos.Routing
             }
 
             DatabaseAccountLocationsInfo snapshot = this.locationInfo;
-            ReadOnlyCollection<Uri> endpoints = isReadRequest
-                ? snapshot.ThinClientReadEndpoints
-                : snapshot.ThinClientWriteEndpoints;
+            ReadOnlyCollection<Uri> endpoints = this.GetApplicableThinClientEndpoints(request, isReadRequest, snapshot);
 
             int locationIndex = request.RequestContext.LocationIndexToRoute.GetValueOrDefault(0);
             Uri chosenEndpoint = endpoints[locationIndex % endpoints.Count];
 
             request.RequestContext.RouteToLocation(chosenEndpoint);
             return chosenEndpoint;
+        }
+
+        /// <summary>
+        /// Resolves the applicable thin client endpoints for a request, honoring per-request
+        /// <see cref="DocumentServiceRequestContext.ExcludeRegions"/>. Mirrors the gateway
+        /// path in <see cref="GetApplicableEndpoints(DocumentServiceRequest, bool)"/>.
+        /// </summary>
+        /// <remarks>
+        /// When all preferred regions are excluded, falls back to the first thin client write
+        /// endpoint (which itself falls back to <see cref="defaultEndpoint"/> at initialization
+        /// time). This keeps requests on the thin client routing path rather than dropping back
+        /// to the gateway endpoint and breaking thin client port semantics.
+        /// </remarks>
+        private ReadOnlyCollection<Uri> GetApplicableThinClientEndpoints(
+            DocumentServiceRequest request,
+            bool isReadRequest,
+            DatabaseAccountLocationsInfo snapshot)
+        {
+            IReadOnlyList<string> excludeRegions = request.RequestContext?.ExcludeRegions;
+            if (excludeRegions == null || excludeRegions.Count == 0)
+            {
+                return isReadRequest ? snapshot.ThinClientReadEndpoints : snapshot.ThinClientWriteEndpoints;
+            }
+
+            Uri fallbackEndpoint = snapshot.ThinClientWriteEndpoints[0];
+
+            return GetApplicableEndpoints(
+                isReadRequest ? snapshot.ThinClientReadEndpointByLocation : snapshot.ThinClientWriteEndpointByLocation,
+                snapshot.EffectivePreferredLocations,
+                fallbackEndpoint,
+                excludeRegions);
         }
 
         private void SetServicePointConnectionLimit(Uri endpoint)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosAvailabilityStrategyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosAvailabilityStrategyTests.cs
@@ -593,11 +593,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                        // ClientRetryPolicy.ShouldRetryOnSessionNotAvailable retries wire 2 to the
                        // WRITE region (RetryLocationIndex = 0, RetryRequestOnPreferredLocations = false).
                        // When the write region differs from region1 and has no fault, wire 2 succeeds
-                       // in ~50-100ms — beating any threshold >= 50ms. Use 10ms to guarantee the hedge
-                       // timer fires before primary's wire-2 retry can complete, so the hedge arm is
-                       // dispatched (requestNumber > 0) and HedgeContext is stamped in diagnostics.
-                       threshold: TimeSpan.FromMilliseconds(100),
-                       thresholdStep: TimeSpan.FromMilliseconds(50)),
+                       // in ~50-100ms — beating any threshold >= 50ms.
+                       threshold: TimeSpan.FromMilliseconds(50),
+                       thresholdStep: TimeSpan.FromMilliseconds(20)),
                 Serializer = this.cosmosSystemTextJsonSerializer
             };
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosAvailabilityStrategyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosAvailabilityStrategyTests.cs
@@ -596,8 +596,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                        // in ~50-100ms — beating any threshold >= 50ms. Use 10ms to guarantee the hedge
                        // timer fires before primary's wire-2 retry can complete, so the hedge arm is
                        // dispatched (requestNumber > 0) and HedgeContext is stamped in diagnostics.
-                       threshold: TimeSpan.FromMilliseconds(10),
-                       thresholdStep: TimeSpan.FromMilliseconds(10)),
+                       threshold: TimeSpan.FromMilliseconds(100),
+                       thresholdStep: TimeSpan.FromMilliseconds(50)),
                 Serializer = this.cosmosSystemTextJsonSerializer
             };
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosAvailabilityStrategyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosAvailabilityStrategyTests.cs
@@ -587,10 +587,17 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             CosmosClientOptions clientOptions = new CosmosClientOptions()
             {
                 ConnectionMode = ConnectionMode.Direct,
-                ApplicationPreferredRegions = isPreferredLocationsEmpty ? new List<string>() :new List<string>() { region1, region2 },
+                ApplicationPreferredRegions = isPreferredLocationsEmpty ? new List<string>() : new List<string>() { region1, region2 },
                 AvailabilityStrategy = AvailabilityStrategy.CrossRegionHedgingStrategy(
-                        threshold: TimeSpan.FromMilliseconds(200),
-                        thresholdStep: TimeSpan.FromMilliseconds(50)),
+                       // Threshold is intentionally aggressive: for single-master read 404/1002,
+                       // ClientRetryPolicy.ShouldRetryOnSessionNotAvailable retries wire 2 to the
+                       // WRITE region (RetryLocationIndex = 0, RetryRequestOnPreferredLocations = false).
+                       // When the write region differs from region1 and has no fault, wire 2 succeeds
+                       // in ~50-100ms — beating any threshold >= 50ms. Use 10ms to guarantee the hedge
+                       // timer fires before primary's wire-2 retry can complete, so the hedge arm is
+                       // dispatched (requestNumber > 0) and HedgeContext is stamped in diagnostics.
+                       threshold: TimeSpan.FromMilliseconds(10),
+                       thresholdStep: TimeSpan.FromMilliseconds(10)),
                 Serializer = this.cosmosSystemTextJsonSerializer
             };
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemThinClientTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemThinClientTests.cs
@@ -1,4 +1,4 @@
-﻿//------------------------------------------------------------
+//------------------------------------------------------------
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 //------------------------------------------------------------
 
@@ -1605,6 +1605,98 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                 // If no exception was thrown, proceed with the actual request
                 return base.SendAsync(request, cancellationToken);
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("ThinClient")]
+        public async Task ReadItem_WithExcludeRegions_OnThinClient_PinsToNonExcludedReadRegion()
+        {
+            const string CentralUs = "Central US";
+            const string EastUs2 = "East US 2";
+            
+            List<string> excludeRegions = new List<string>
+            {
+                CentralUs
+            };
+
+            Environment.SetEnvironmentVariable(ConfigurationManager.ThinClientModeEnabled, "True");
+            string connectionString = Environment.GetEnvironmentVariable("COSMOSDB_THINCLIENT");
+           
+            if (string.IsNullOrEmpty(connectionString))
+            {
+                Assert.Fail("Set environment variable COSMOSDB_THINCLIENT to run the test");
+            }
+
+            JsonSerializerOptions jsonSerializerOptions = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = null,
+                PropertyNameCaseInsensitive = true,
+                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            };
+
+            CosmosClient cosmosClient = new CosmosClient(
+                connectionString,
+                new CosmosClientOptions
+                {
+                    ConnectionMode = ConnectionMode.Gateway,
+                    ApplicationPreferredRegions = new List<string> {CentralUs, EastUs2 },
+                    Serializer = new MultiRegionSetupHelpers.CosmosSystemTextJsonSerializer(jsonSerializerOptions),
+                });
+
+            Database cosmosDatabase = null;
+            try
+            {
+                cosmosDatabase = await cosmosClient.CreateDatabaseIfNotExistsAsync("TestDb_" + Guid.NewGuid());
+                Container cosmosContainer = await cosmosDatabase.CreateContainerIfNotExistsAsync(
+                    "TestContainer_" + Guid.NewGuid(),
+                    "/pk");
+
+                TestObject seed = new TestObject
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    Pk = Guid.NewGuid().ToString(),
+                    Other = "exclude-regions read fixture",
+                };
+                ItemResponse<TestObject> createResponse = await cosmosContainer.CreateItemAsync(seed, new PartitionKey(seed.Pk));
+
+                await Task.Delay(TimeSpan.FromSeconds(30));
+
+                ItemResponse<TestObject> readResponse = await cosmosContainer.ReadItemAsync<TestObject>(
+                    seed.Id,
+                    new PartitionKey(seed.Pk),
+                    new ItemRequestOptions
+                    {
+                        ExcludeRegions = excludeRegions,
+                    });
+
+                string readDiagnostics = readResponse.Diagnostics.ToString();
+
+                Assert.AreEqual(HttpStatusCode.OK, readResponse.StatusCode);
+                Assert.AreEqual(seed.Id, readResponse.Resource.Id);
+                foreach (string excludedRegion in excludeRegions)
+                {
+                    string excludedHost = excludedRegion.Replace(" ", string.Empty).ToLowerInvariant() + ".documents.azure.com:10650";
+                    Assert.IsFalse(
+                        readDiagnostics.Contains(excludedHost),
+                        $"Read with ExcludeRegions=[{string.Join(",", excludeRegions)}] must not route to '{excludedHost}'.");
+                }
+            }
+            finally
+            {
+                if (cosmosDatabase != null)
+                {
+                    try
+                    {
+                        await cosmosDatabase.DeleteAsync();
+                    }
+                    catch
+                    {
+                    }
+                }
+
+                cosmosClient.Dispose();
+                Environment.SetEnvironmentVariable(ConfigurationManager.ThinClientModeEnabled, "False");
             }
         }
     }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemThinClientTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemThinClientTests.cs
@@ -123,6 +123,17 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             return itemsCreated;
         }
 
+        private static void AssertExcludedRegionsNotInDiagnostics(string diagnostics)
+        {
+            foreach (string excludedRegion in ExcludeRegions)
+            {
+                string excludedHost = excludedRegion.Replace(" ", string.Empty).ToLowerInvariant() + ".documents.azure.com:10250";
+                Assert.IsFalse(
+                    diagnostics.Contains(excludedHost),
+                    $"Operation with ExcludeRegions=[{string.Join(",", ExcludeRegions)}] must not route to '{excludedHost}'. Diagnostics: {diagnostics}");
+            }
+        }
+
         [TestMethod]
         [TestCategory("ThinClient")]
         public async Task RegionalDatabaseAccountNameIsEmptyInPayload()
@@ -471,6 +482,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Assert.AreEqual(HttpStatusCode.Created, response.StatusCode);
                 string diagnostics = response.Diagnostics.ToString();
                 Assert.IsTrue(diagnostics.Contains("|F4"), "Diagnostics User Agent should contain '|F4' for ThinClient");
+                AssertExcludedRegionsNotInDiagnostics(diagnostics);
             }
         }
 
@@ -684,6 +696,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
                 Assert.AreEqual(item.Id, response.Resource.Id);
                 Assert.IsTrue(diagnostics.Contains("|F4"), "Diagnostics User Agent should contain '|F4' for ThinClient");
+                AssertExcludedRegionsNotInDiagnostics(diagnostics);
             }
         }
 
@@ -726,13 +739,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.IsTrue(
                 diagnostics.Contains("|F4"),
                 "Read should route through the thin client pipeline (|F4 user agent token).");
-            foreach (string excludedRegion in ExcludeRegions)
-            {
-                string excludedHost = excludedRegion.Replace(" ", string.Empty).ToLowerInvariant() + ".documents.azure.com:10650";
-                Assert.IsFalse(
-                    diagnostics.Contains(excludedHost),
-                    $"Hedged read with ExcludeRegions=[{string.Join(",", ExcludeRegions)}] must not route to '{excludedHost}'.");
-            }
+            AssertExcludedRegionsNotInDiagnostics(diagnostics);
         }
 
         [TestMethod]
@@ -758,6 +765,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
                 Assert.AreEqual("Updated " + item.Other, response.Resource.Other);
                 Assert.IsTrue(diagnostics.Contains("|F4"), "Diagnostics User Agent should contain '|F4' for ThinClient");
+                AssertExcludedRegionsNotInDiagnostics(diagnostics);
             }
         }
 
@@ -775,6 +783,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 string diagnostics = response.Diagnostics.ToString();
                 Assert.IsTrue(response.StatusCode == HttpStatusCode.Created || response.StatusCode == HttpStatusCode.OK);
                 Assert.IsTrue(diagnostics.Contains("|F4"), "Diagnostics User Agent should contain '|F4' for ThinClient");
+                AssertExcludedRegionsNotInDiagnostics(diagnostics);
             }
         }
 
@@ -793,6 +802,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 string diagnostics = response.Diagnostics.ToString();
                 Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
                 Assert.IsTrue(diagnostics.Contains("|F4"), "Diagnostics User Agent should contain '|F4' for ThinClient");
+                AssertExcludedRegionsNotInDiagnostics(diagnostics);
             }
         }
 
@@ -812,6 +822,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                         string diagnostics = response.Diagnostics.ToString();
                         Assert.AreEqual(HttpStatusCode.Created, response.StatusCode);
                         Assert.IsTrue(diagnostics.Contains("|F4"), "Diagnostics User Agent should contain '|F4' for ThinClient");
+                        AssertExcludedRegionsNotInDiagnostics(diagnostics);
                     }
                 }
             }
@@ -833,6 +844,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     string diagnostics = response.Diagnostics.ToString();
                     Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
                     Assert.IsTrue(diagnostics.Contains("|F4"), "Diagnostics User Agent should contain '|F4' for ThinClient");
+                    AssertExcludedRegionsNotInDiagnostics(diagnostics);
                 }
             }
         }
@@ -862,6 +874,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                         string diagnostics = response.Diagnostics.ToString();
                         Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
                         Assert.IsTrue(diagnostics.Contains("|F4"), "Diagnostics User Agent should contain '|F4' for ThinClient");
+                        AssertExcludedRegionsNotInDiagnostics(diagnostics);
                     }
                 }
             }
@@ -883,6 +896,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                         string diagnostics = response.Diagnostics.ToString();
                         Assert.IsTrue(response.StatusCode == HttpStatusCode.Created || response.StatusCode == HttpStatusCode.OK);
                         Assert.IsTrue(diagnostics.Contains("|F4"), "Diagnostics User Agent should contain '|F4' for ThinClient");
+                        AssertExcludedRegionsNotInDiagnostics(diagnostics);
                     }
                 }
             }
@@ -904,6 +918,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     string diagnostics = response.Diagnostics.ToString();
                     Assert.AreEqual(HttpStatusCode.NoContent, response.StatusCode);
                     Assert.IsTrue(diagnostics.Contains("|F4"), "Diagnostics User Agent should contain '|F4' for ThinClient");
+                    AssertExcludedRegionsNotInDiagnostics(diagnostics);
                 }
             }
         }
@@ -925,6 +940,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             {
                 FeedResponse<TestObject> response = await iterator.ReadNextAsync();
                 count += response.Count;
+                AssertExcludedRegionsNotInDiagnostics(response.Diagnostics.ToString());
             }
 
             Assert.AreEqual(createdItems.Count, count);
@@ -1098,6 +1114,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 using (ResponseMessage response = await iterator.ReadNextAsync())
                 {
                     Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+                    AssertExcludedRegionsNotInDiagnostics(response.Diagnostics.ToString());
 
                     using (StreamReader reader = new StreamReader(response.Content))
                     {
@@ -1144,6 +1161,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             foreach (Task<ItemResponse<TestObject>> task in tasks)
             {
                 Assert.AreEqual(HttpStatusCode.Created, task.Result.StatusCode);
+                AssertExcludedRegionsNotInDiagnostics(task.Result.Diagnostics.ToString());
             }
 
             bulkClient.Dispose();
@@ -1165,6 +1183,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             TransactionalBatchResponse batchResponse = await batch.ExecuteAsync();
             Assert.AreEqual(HttpStatusCode.OK, batchResponse.StatusCode);
+            AssertExcludedRegionsNotInDiagnostics(batchResponse.Diagnostics.ToString());
 
             for (int i = 0; i < items.Count; i++)
             {
@@ -1213,6 +1232,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                     string diagnostics = response.Diagnostics.ToString();
                     Assert.IsTrue(diagnostics.Contains("|F4"), $"Page {pageCount}: Should use ThinClient");
+                    AssertExcludedRegionsNotInDiagnostics(diagnostics);
                 }
 
                 Assert.AreEqual(5, results.Count, "Should return all 5 items");
@@ -1281,6 +1301,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                     string diagnostics = response.Diagnostics.ToString();
                     Assert.IsTrue(diagnostics.Contains("|F4"), $"Page {pageCount}: Should use ThinClient");
+                    AssertExcludedRegionsNotInDiagnostics(diagnostics);
                 }
 
                 Assert.IsTrue(results.Count >= 9,
@@ -1361,6 +1382,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                     string diagnostics = response.Diagnostics.ToString();
                     Assert.IsTrue(diagnostics.Contains("|F4"), "Should use ThinClient mode");
+                    AssertExcludedRegionsNotInDiagnostics(diagnostics);
                 }
 
                 // Verify all items are returned
@@ -1445,6 +1467,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                 string diagnostics = response.Diagnostics.ToString();
                 Assert.IsTrue(diagnostics.Contains("|F4"), "Diagnostics User Agent should contain '|F4' for ThinClient change feed");
+                AssertExcludedRegionsNotInDiagnostics(diagnostics);
 
                 changeFeedResults.AddRange(response);
             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemThinClientTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemThinClientTests.cs
@@ -1,4 +1,4 @@
-//------------------------------------------------------------
+﻿//------------------------------------------------------------
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 //------------------------------------------------------------
 
@@ -25,6 +25,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
     [TestClass]
     public class CosmosItemThinClientTests
     {
+        private const string CentralUs = "Central US";
+        private const string EastUs2 = "East US 2";
+        private static readonly IReadOnlyList<string> PreferredRegions = new List<string> { CentralUs, EastUs2 };
+        private static readonly IReadOnlyList<string> ExcludeRegions = new List<string> { CentralUs };
+
         private string connectionString;
         private CosmosClient client;
         private Database database;
@@ -37,7 +42,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         {
             Environment.SetEnvironmentVariable(ConfigurationManager.ThinClientModeEnabled, "True");
             this.connectionString = Environment.GetEnvironmentVariable("COSMOSDB_THINCLIENT");
-
             if (string.IsNullOrEmpty(this.connectionString))
             {
                 Assert.Fail("Set environment variable COSMOSDB_THINCLIENT to run the tests");
@@ -51,13 +55,15 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             };
             this.cosmosSystemTextJsonSerializer = new MultiRegionSetupHelpers.CosmosSystemTextJsonSerializer(jsonSerializerOptions);
 
-            this.client = new CosmosClient(
-                  this.connectionString,
-                  new CosmosClientOptions()
-                  {
-                      ConnectionMode = ConnectionMode.Gateway,
-                      Serializer = this.cosmosSystemTextJsonSerializer,
-                  });
+            CosmosClientOptions clientOptions = new CosmosClientOptions()
+            {
+                ConnectionMode = ConnectionMode.Gateway,
+                ApplicationPreferredRegions = PreferredRegions,
+                Serializer = this.cosmosSystemTextJsonSerializer,
+            };
+            clientOptions.CustomHandlers.Add(new ExcludeRegionsInjectingHandler(ExcludeRegions));
+
+            this.client = new CosmosClient(this.connectionString, clientOptions);
 
             string uniqueDbName = "TestDb_" + Guid.NewGuid().ToString();
             this.database = await this.client.CreateDatabaseIfNotExistsAsync(uniqueDbName);
@@ -99,6 +105,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         private async Task<List<TestObject>> CreateItemsSafeAsync(IEnumerable<TestObject> items)
         {
             List<TestObject> itemsCreated = new List<TestObject>();
+            await Task.Delay(TimeSpan.FromSeconds(30));
             foreach (TestObject item in items)
             {
                 try
@@ -457,7 +464,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         {
             string pk = "pk_create";
             IEnumerable<TestObject> items = this.GenerateItems(pk);
-
+            await Task.Delay(TimeSpan.FromSeconds(30));
             foreach (TestObject item in items)
             {
                 ItemResponse<TestObject> response = await this.container.CreateItemAsync(item, new PartitionKey(item.Pk));
@@ -713,6 +720,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             string pk = "pk_upsert";
             IEnumerable<TestObject> items = this.GenerateItems(pk);
 
+            await Task.Delay(TimeSpan.FromSeconds(30));
             foreach (TestObject item in items)
             {
                 ItemResponse<TestObject> response = await this.container.UpsertItemAsync(item, new PartitionKey(item.Pk));
@@ -746,7 +754,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         {
             string pk = "pk_create_stream";
             IEnumerable<TestObject> items = this.GenerateItems(pk);
-
+            await Task.Delay(TimeSpan.FromSeconds(30));
             foreach (TestObject item in items)
             {
                 using (Stream stream = this.cosmosSystemTextJsonSerializer.ToStream(item))
@@ -817,7 +825,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         {
             string pk = "pk_upsert_stream";
             IEnumerable<TestObject> items = this.GenerateItems(pk);
-
+            await Task.Delay(TimeSpan.FromSeconds(30));
             foreach (TestObject item in items)
             {
                 using (Stream stream = this.cosmosSystemTextJsonSerializer.ToStream(item))
@@ -1061,21 +1069,23 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         [TestCategory("ThinClient")]
         public async Task BulkCreateItemsTest()
         {
-            CosmosClient bulkClient = new CosmosClient(
-                this.connectionString,
-                new CosmosClientOptions
-                {
-                    ConnectionMode = ConnectionMode.Gateway,
-                    Serializer = this.cosmosSystemTextJsonSerializer,
-                    AllowBulkExecution = true,
-                });
+            CosmosClientOptions bulkOptions = new CosmosClientOptions
+            {
+                ConnectionMode = ConnectionMode.Gateway,
+                ApplicationPreferredRegions = PreferredRegions,
+                Serializer = this.cosmosSystemTextJsonSerializer,
+                AllowBulkExecution = true,
+            };
+            bulkOptions.CustomHandlers.Add(new ExcludeRegionsInjectingHandler(ExcludeRegions));
+
+            CosmosClient bulkClient = new CosmosClient(this.connectionString, bulkOptions);
 
             string pk = "pk_bulk";
             List<TestObject> items = this.GenerateItems(pk).ToList();
             List<Task<ItemResponse<TestObject>>> tasks = new List<Task<ItemResponse<TestObject>>>();
 
             Container bulkContainer = bulkClient.GetContainer(this.database.Id, this.container.Id);
-
+            await Task.Delay(TimeSpan.FromSeconds(30));
             foreach (TestObject item in items)
             {
                 tasks.Add(bulkContainer.CreateItemAsync(item, new PartitionKey(item.Pk)));
@@ -1097,7 +1107,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         {
             string pk = "pk_batch";
             List<TestObject> items = this.GenerateItems(pk).Take(100).ToList();
-
+            await Task.Delay(TimeSpan.FromSeconds(30));
             TransactionalBatch batch = this.container.CreateTransactionalBatch(new PartitionKey(pk));
 
             foreach (TestObject item in items)
@@ -1608,94 +1618,29 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
         }
 
-        [TestMethod]
-        [TestCategory("ThinClient")]
-        public async Task CreateItem_WithExcludeRegions_OnThinClient_PinsToNonExcludedReadRegion()
+
+        private sealed class ExcludeRegionsInjectingHandler : RequestHandler
         {
-            const string CentralUs = "Central US";
-            const string EastUs2 = "East US 2";
-            
-            List<string> excludeRegions = new List<string>
-            {
-                CentralUs
-            };
+            private readonly IReadOnlyList<string> excludeRegions;
 
-            Environment.SetEnvironmentVariable(ConfigurationManager.ThinClientModeEnabled, "True");
-            string connectionString = Environment.GetEnvironmentVariable("COSMOSDB_THINCLIENT");
-
-            if (string.IsNullOrEmpty(connectionString))
+            public ExcludeRegionsInjectingHandler(IReadOnlyList<string> excludeRegions)
             {
-                Assert.Fail("Set environment variable COSMOSDB_THINCLIENT to run the test");
+                this.excludeRegions = excludeRegions;
             }
 
-            JsonSerializerOptions jsonSerializerOptions = new JsonSerializerOptions
+            public override Task<ResponseMessage> SendAsync(RequestMessage request, CancellationToken cancellationToken)
             {
-                PropertyNamingPolicy = null,
-                PropertyNameCaseInsensitive = true,
-                DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-            };
-
-            CosmosClient cosmosClient = new CosmosClient(
-                connectionString,
-                new CosmosClientOptions
+                if (request.RequestOptions == null)
                 {
-                    ConnectionMode = ConnectionMode.Gateway,
-                    ApplicationPreferredRegions = new List<string> { CentralUs, EastUs2 },
-                    Serializer = new MultiRegionSetupHelpers.CosmosSystemTextJsonSerializer(jsonSerializerOptions),
-                });
-
-            Database cosmosDatabase = null;
-            try
-            {
-                cosmosDatabase = await cosmosClient.CreateDatabaseIfNotExistsAsync("TestDb_" + Guid.NewGuid());
-                Container cosmosContainer = await cosmosDatabase.CreateContainerIfNotExistsAsync(
-                    "TestContainer_" + Guid.NewGuid(),
-                    "/pk");
-
-                TestObject seed = new TestObject
-                {
-                    Id = Guid.NewGuid().ToString(),
-                    Pk = Guid.NewGuid().ToString(),
-                    Other = "exclude-regions create fixture",
-                };
-                await Task.Delay(TimeSpan.FromSeconds(30));
-
-
-                ItemResponse<TestObject> createResponse = await cosmosContainer.CreateItemAsync(
-                    seed,
-                    new PartitionKey(seed.Pk),
-                    new ItemRequestOptions
-                    {
-                        ExcludeRegions = excludeRegions,
-                    });
-
-                string createDiagnostics = createResponse.Diagnostics.ToString();
-
-                Assert.AreEqual(HttpStatusCode.Created, createResponse.StatusCode);
-                Assert.AreEqual(seed.Id, createResponse.Resource.Id);
-                foreach (string excludedRegion in excludeRegions)
-                {
-                    string excludedHost = excludedRegion.Replace(" ", string.Empty).ToLowerInvariant() + ".documents.azure.com:10650";
-                    Assert.IsFalse(
-                        createDiagnostics.Contains(excludedHost),
-                        $"Create with ExcludeRegions=[{string.Join(",", excludeRegions)}] must not route to '{excludedHost}'.");
-                }
-            }
-            finally
-            {
-                if (cosmosDatabase != null)
-                {
-                    try
-                    {
-                        await cosmosDatabase.DeleteAsync();
-                    }
-                    catch
-                    {
-                    }
+                    request.RequestOptions = new RequestOptions();
                 }
 
-                cosmosClient.Dispose();
-                Environment.SetEnvironmentVariable(ConfigurationManager.ThinClientModeEnabled, "False");
+                if (request.RequestOptions.ExcludeRegions == null || request.RequestOptions.ExcludeRegions.Count == 0)
+                {
+                    request.RequestOptions.ExcludeRegions = new List<string>(this.excludeRegions);
+                }
+
+                return base.SendAsync(request, cancellationToken);
             }
         }
     }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemThinClientTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemThinClientTests.cs
@@ -739,6 +739,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.IsTrue(
                 diagnostics.Contains("|F4"),
                 "Read should route through the thin client pipeline (|F4 user agent token).");
+            Assert.IsTrue(
+                diagnostics.Contains($"\"Hedge Context\":[\"{EastUs2}\"]"),
+                $"Diagnostics should contain Hedge Context with only the non-excluded preferred region ('{EastUs2}'). Diagnostics: {diagnostics}");
             AssertExcludedRegionsNotInDiagnostics(diagnostics);
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemThinClientTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemThinClientTests.cs
@@ -1610,7 +1610,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
         [TestMethod]
         [TestCategory("ThinClient")]
-        public async Task ReadItem_WithExcludeRegions_OnThinClient_PinsToNonExcludedReadRegion()
+        public async Task CreateItem_WithExcludeRegions_OnThinClient_PinsToNonExcludedReadRegion()
         {
             const string CentralUs = "Central US";
             const string EastUs2 = "East US 2";
@@ -1622,7 +1622,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             Environment.SetEnvironmentVariable(ConfigurationManager.ThinClientModeEnabled, "True");
             string connectionString = Environment.GetEnvironmentVariable("COSMOSDB_THINCLIENT");
-           
+
             if (string.IsNullOrEmpty(connectionString))
             {
                 Assert.Fail("Set environment variable COSMOSDB_THINCLIENT to run the test");
@@ -1640,7 +1640,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 new CosmosClientOptions
                 {
                     ConnectionMode = ConnectionMode.Gateway,
-                    ApplicationPreferredRegions = new List<string> {CentralUs, EastUs2 },
+                    ApplicationPreferredRegions = new List<string> { CentralUs, EastUs2 },
                     Serializer = new MultiRegionSetupHelpers.CosmosSystemTextJsonSerializer(jsonSerializerOptions),
                 });
 
@@ -1656,30 +1656,29 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 {
                     Id = Guid.NewGuid().ToString(),
                     Pk = Guid.NewGuid().ToString(),
-                    Other = "exclude-regions read fixture",
+                    Other = "exclude-regions create fixture",
                 };
-                ItemResponse<TestObject> createResponse = await cosmosContainer.CreateItemAsync(seed, new PartitionKey(seed.Pk));
-
                 await Task.Delay(TimeSpan.FromSeconds(30));
 
-                ItemResponse<TestObject> readResponse = await cosmosContainer.ReadItemAsync<TestObject>(
-                    seed.Id,
+
+                ItemResponse<TestObject> createResponse = await cosmosContainer.CreateItemAsync(
+                    seed,
                     new PartitionKey(seed.Pk),
                     new ItemRequestOptions
                     {
                         ExcludeRegions = excludeRegions,
                     });
 
-                string readDiagnostics = readResponse.Diagnostics.ToString();
+                string createDiagnostics = createResponse.Diagnostics.ToString();
 
-                Assert.AreEqual(HttpStatusCode.OK, readResponse.StatusCode);
-                Assert.AreEqual(seed.Id, readResponse.Resource.Id);
+                Assert.AreEqual(HttpStatusCode.Created, createResponse.StatusCode);
+                Assert.AreEqual(seed.Id, createResponse.Resource.Id);
                 foreach (string excludedRegion in excludeRegions)
                 {
                     string excludedHost = excludedRegion.Replace(" ", string.Empty).ToLowerInvariant() + ".documents.azure.com:10650";
                     Assert.IsFalse(
-                        readDiagnostics.Contains(excludedHost),
-                        $"Read with ExcludeRegions=[{string.Join(",", excludeRegions)}] must not route to '{excludedHost}'.");
+                        createDiagnostics.Contains(excludedHost),
+                        $"Create with ExcludeRegions=[{string.Join(",", excludeRegions)}] must not route to '{excludedHost}'.");
                 }
             }
             finally

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemThinClientTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemThinClientTests.cs
@@ -689,6 +689,54 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
         [TestMethod]
         [TestCategory("ThinClient")]
+        public async Task ReadItem_WithHedgingAndExcludeRegions_OnThinClient_Succeeds()
+        {
+            CosmosClientOptions hedgingClientOptions = new CosmosClientOptions
+            {
+                ConnectionMode = ConnectionMode.Gateway,
+                ApplicationPreferredRegions = PreferredRegions,
+                Serializer = this.cosmosSystemTextJsonSerializer,
+                AvailabilityStrategy = AvailabilityStrategy.CrossRegionHedgingStrategy(
+                    threshold: TimeSpan.FromMilliseconds(100),
+                    thresholdStep: TimeSpan.FromMilliseconds(50)),
+            };
+
+            using CosmosClient hedgingClient = new CosmosClient(this.connectionString, hedgingClientOptions);
+            Container hedgingContainer = hedgingClient.GetContainer(this.database.Id, this.container.Id);
+            await Task.Delay(TimeSpan.FromSeconds(30));
+            TestObject seed = new TestObject
+            {
+                Id = Guid.NewGuid().ToString(),
+                Pk = "pk_hedging",
+                Other = "hedging composition fixture",
+            };
+            await hedgingContainer.CreateItemAsync(seed, new PartitionKey(seed.Pk));
+
+            ItemResponse<TestObject> readResponse = await hedgingContainer.ReadItemAsync<TestObject>(
+                seed.Id,
+                new PartitionKey(seed.Pk),
+                new ItemRequestOptions
+                {
+                    ExcludeRegions = new List<string>(ExcludeRegions),
+                });
+
+            string diagnostics = readResponse.Diagnostics.ToString();
+            Assert.AreEqual(HttpStatusCode.OK, readResponse.StatusCode);
+            Assert.AreEqual(seed.Id, readResponse.Resource.Id);
+            Assert.IsTrue(
+                diagnostics.Contains("|F4"),
+                "Read should route through the thin client pipeline (|F4 user agent token).");
+            foreach (string excludedRegion in ExcludeRegions)
+            {
+                string excludedHost = excludedRegion.Replace(" ", string.Empty).ToLowerInvariant() + ".documents.azure.com:10650";
+                Assert.IsFalse(
+                    diagnostics.Contains(excludedHost),
+                    $"Hedged read with ExcludeRegions=[{string.Join(",", ExcludeRegions)}] must not route to '{excludedHost}'.");
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("ThinClient")]
         public async Task ReplaceItemsTest()
         {
             string pk = "pk_replace";

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemThinClientTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemThinClientTests.cs
@@ -742,6 +742,52 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             AssertExcludedRegionsNotInDiagnostics(diagnostics);
         }
 
+        /// <summary>
+        /// When every preferred region is excluded,
+        /// <see cref="LocationCache.ResolveThinClientEndpoint"/> falls back to the primary thin
+        /// client write endpoint instead of failing the request. The operation must succeed and
+        /// route through the thin client pipeline.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("ThinClient")]
+        public async Task CreateItem_WithAllPreferredRegionsExcluded_OnThinClient_FallsBackToPrimaryWriteRegion()
+        {
+            List<string> allPreferredRegionsExcluded = new List<string>(PreferredRegions);
+
+            CosmosClientOptions fallbackClientOptions = new CosmosClientOptions
+            {
+                ConnectionMode = ConnectionMode.Gateway,
+                ApplicationPreferredRegions = PreferredRegions,
+                Serializer = this.cosmosSystemTextJsonSerializer,
+            };
+
+            using CosmosClient fallbackClient = new CosmosClient(this.connectionString, fallbackClientOptions);
+            Container fallbackContainer = fallbackClient.GetContainer(this.database.Id, this.container.Id);
+            await Task.Delay(TimeSpan.FromSeconds(30));
+
+            TestObject seed = new TestObject
+            {
+                Id = Guid.NewGuid().ToString(),
+                Pk = "pk_fallback",
+                Other = "all-preferred-excluded fallback fixture",
+            };
+
+            ItemResponse<TestObject> createResponse = await fallbackContainer.CreateItemAsync(
+                seed,
+                new PartitionKey(seed.Pk),
+                new ItemRequestOptions
+                {
+                    ExcludeRegions = allPreferredRegionsExcluded,
+                });
+
+            string diagnostics = createResponse.Diagnostics.ToString();
+            Assert.AreEqual(HttpStatusCode.Created, createResponse.StatusCode);
+            Assert.AreEqual(seed.Id, createResponse.Resource.Id);
+            Assert.IsTrue(
+                diagnostics.Contains("|F4"),
+                "Create should route through the thin client pipeline (|F4 user agent token).");
+        }
+
         [TestMethod]
         [TestCategory("ThinClient")]
         public async Task ReplaceItemsTest()

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GlobalEndpointManagerTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GlobalEndpointManagerTest.cs
@@ -725,13 +725,13 @@ namespace Microsoft.Azure.Cosmos
                     {
                         "thinClientWritableLocations",
                         JArray.Parse(@"[
-                            { 'name': 'ThinClientRegionWrite', 'databaseAccountEndpoint': 'https://thinclientwrite.documents.azure.com:10650/' }
+                            { 'name': 'ThinClientRegionWrite', 'databaseAccountEndpoint': 'https://thinclientwrite.documents.azure.com:10250/' }
                         ]")
                     },
                     {
                         "thinClientReadableLocations",
                         JArray.Parse(@"[
-                            { 'name': 'ThinClientRegionRead', 'databaseAccountEndpoint': 'https://thinclientread.documents.azure.com:10650/' }
+                            { 'name': 'ThinClientRegionRead', 'databaseAccountEndpoint': 'https://thinclientread.documents.azure.com:10250/' }
                         ]")
                     }
                 }
@@ -776,9 +776,9 @@ namespace Microsoft.Azure.Cosmos
                 Uri thinClientWriteEndpoint = gem.ResolveThinClientEndpoint(writeRequest);
 
                 // Assert: 
-                Assert.AreEqual("https://thinclientread.documents.azure.com:10650/", thinClientReadEndpoint.AbsoluteUri);
+                Assert.AreEqual("https://thinclientread.documents.azure.com:10250/", thinClientReadEndpoint.AbsoluteUri);
 
-                Assert.AreEqual("https://thinclientwrite.documents.azure.com:10650/", thinClientWriteEndpoint.AbsoluteUri);
+                Assert.AreEqual("https://thinclientwrite.documents.azure.com:10250/", thinClientWriteEndpoint.AbsoluteUri);
             }
             finally
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/LocationCacheTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/LocationCacheTests.cs
@@ -2007,27 +2007,81 @@ namespace Microsoft.Azure.Cosmos.Client.Tests
         }
 
 
-        [TestMethod]
-        public void ValidateResolveThinClientEndpoint_HonorsExcludeRegionsTest()
+        [DataTestMethod]
+        [DataRow(true, "https://region2-read.documents.azure.com:10250/", DisplayName = "Read request honors ExcludeRegions on multi-write account")]
+        [DataRow(false, "https://region2-write.documents.azure.com:10250/", DisplayName = "Write request honors ExcludeRegions on multi-write account")]
+        public void ValidateResolveThinClientEndpoint_MultiWriteAccount_HonorsExcludeRegionsForBothReadAndWriteTest(
+            bool isReadRequest,
+            string expectedThinClientEndpointUri)
         {
-            // Arrange: multi-write account with 3 regions; identical region names across gateway and thin client.
+            LocationCache cache = BuildMultiWriteThinClientCacheForExcludeRegionsTest();
+
+            DocumentServiceRequest request = DocumentServiceRequest.Create(
+                isReadRequest ? OperationType.Read : OperationType.Create,
+                ResourceType.Document,
+                AuthorizationTokenType.PrimaryMasterKey);
+            request.RequestContext.ExcludeRegions = new List<string> { "Region1", "Region3" };
+
+            Uri resolved = cache.ResolveThinClientEndpoint(request, isReadRequest);
+
+            Assert.AreEqual(
+                expectedThinClientEndpointUri,
+                resolved.AbsoluteUri,
+                $"isReadRequest={isReadRequest} must pin to Region2's thin client {(isReadRequest ? "read" : "write")} endpoint (the only non-excluded preferred region).");
+        }
+
+        [DataTestMethod]
+        [DataRow(true, DisplayName = "Read request falls back to ThinClientWriteEndpoints[0] when all preferred regions excluded")]
+        [DataRow(false, DisplayName = "Write request falls back to ThinClientWriteEndpoints[0] when all preferred regions excluded")]
+        public void ValidateResolveThinClientEndpoint_AllPreferredRegionsExcluded_FallsBackToPrimaryThinClientWriteEndpointTest(bool isReadRequest)
+        {
+            LocationCache cache = BuildMultiWriteThinClientCacheForExcludeRegionsTest();
+
+            Uri expectedFallback = cache.ThinClientWriteEndpoints[0];
+
+            DocumentServiceRequest request = DocumentServiceRequest.Create(
+                isReadRequest ? OperationType.Read : OperationType.Create,
+                ResourceType.Document,
+                AuthorizationTokenType.PrimaryMasterKey);
+            request.RequestContext.ExcludeRegions = new List<string> { "Region1", "Region2", "Region3" };
+
+            Uri resolved = cache.ResolveThinClientEndpoint(request, isReadRequest);
+
+            Assert.AreEqual(
+                expectedFallback,
+                resolved,
+                "When every preferred region is excluded, resolution must fall back to ThinClientWriteEndpoints[0] regardless of read/write.");
+        }
+
+        [TestMethod]
+        public void ValidateResolveThinClientEndpoint_SingleWriteAccount_ReadHonorsExcludeRegions_WriteFallsBackToPrimaryTest()
+        {
+            // Single-master account: 1 write region (Region1) + 3 read regions (Region1, Region2, Region3).
+            // Reads honor ExcludeRegions; writes always pin to the single write region (regardless of ExcludeRegions).
+            // Distinct read vs write thin client hostnames so wrong-dictionary regressions fail the assertion.
             Collection<AccountRegion> writeRegions = new Collection<AccountRegion>()
+            {
+                new AccountRegion { Name = "Region1", Endpoint = "https://region1.documents.azure.com" },
+            };
+
+            Collection<AccountRegion> readRegions = new Collection<AccountRegion>()
             {
                 new AccountRegion { Name = "Region1", Endpoint = "https://region1.documents.azure.com" },
                 new AccountRegion { Name = "Region2", Endpoint = "https://region2.documents.azure.com" },
                 new AccountRegion { Name = "Region3", Endpoint = "https://region3.documents.azure.com" },
             };
 
-            Collection<AccountRegion> readRegions = writeRegions;
-
             Collection<AccountRegion> thinClientWrites = new Collection<AccountRegion>()
             {
-                new AccountRegion { Name = "Region1", Endpoint = "https://region1.documents.azure.com:10250/" },
-                new AccountRegion { Name = "Region2", Endpoint = "https://region2.documents.azure.com:10250/" },
-                new AccountRegion { Name = "Region3", Endpoint = "https://region3.documents.azure.com:10250/" },
+                new AccountRegion { Name = "Region1", Endpoint = "https://region1-write.documents.azure.com:10250/" },
             };
 
-            Collection<AccountRegion> thinClientReads = thinClientWrites;
+            Collection<AccountRegion> thinClientReads = new Collection<AccountRegion>()
+            {
+                new AccountRegion { Name = "Region1", Endpoint = "https://region1-read.documents.azure.com:10250/" },
+                new AccountRegion { Name = "Region2", Endpoint = "https://region2-read.documents.azure.com:10250/" },
+                new AccountRegion { Name = "Region3", Endpoint = "https://region3-read.documents.azure.com:10250/" },
+            };
 
             AccountProperties accountProps = new AccountProperties
             {
@@ -2035,6 +2089,69 @@ namespace Microsoft.Azure.Cosmos.Client.Tests
                 WriteLocationsInternal = writeRegions,
                 ThinClientReadableLocationsInternal = thinClientReads,
                 ThinClientWritableLocationsInternal = thinClientWrites,
+                EnableMultipleWriteLocations = false,
+            };
+
+            LocationCache cache = new LocationCache(
+                preferredLocations: new List<string> { "Region1", "Region2", "Region3" }.AsReadOnly(),
+                defaultEndpoint: new Uri("https://defaultendpoint.documents.azure.com"),
+                enableEndpointDiscovery: true,
+                connectionLimit: 50,
+                useMultipleWriteLocations: false);
+
+            cache.OnDatabaseAccountRead(accountProps);
+
+            List<string> excludeRegions = new List<string> { "Region1", "Region2" };
+
+            DocumentServiceRequest readRequest = DocumentServiceRequest.Create(
+                OperationType.Read, ResourceType.Document, AuthorizationTokenType.PrimaryMasterKey);
+            readRequest.RequestContext.ExcludeRegions = excludeRegions;
+            Assert.AreEqual(
+                "https://region3-read.documents.azure.com:10250/",
+                cache.ResolveThinClientEndpoint(readRequest, isReadRequest: true).AbsoluteUri,
+                "Single-master read with two preferred regions excluded must pin to the remaining preferred read region.");
+
+            DocumentServiceRequest writeRequest = DocumentServiceRequest.Create(
+                OperationType.Create, ResourceType.Document, AuthorizationTokenType.PrimaryMasterKey);
+            writeRequest.RequestContext.ExcludeRegions = excludeRegions;
+            Assert.AreEqual(
+                "https://region1-write.documents.azure.com:10250/",
+                cache.ResolveThinClientEndpoint(writeRequest, isReadRequest: false).AbsoluteUri,
+                "Single-master write must route to the only thin client write endpoint regardless of ExcludeRegions.");
+        }
+
+        private static LocationCache BuildMultiWriteThinClientCacheForExcludeRegionsTest()
+        {
+            // Gateway regions are shared (gateway port 443) but thin client read and write endpoints
+            // use distinct hostnames so a wrong-dictionary regression (e.g., reads accidentally
+            // resolving from the write dictionary or vice versa) fails the assertion.
+            Collection<AccountRegion> regions = new Collection<AccountRegion>()
+            {
+                new AccountRegion { Name = "Region1", Endpoint = "https://region1.documents.azure.com" },
+                new AccountRegion { Name = "Region2", Endpoint = "https://region2.documents.azure.com" },
+                new AccountRegion { Name = "Region3", Endpoint = "https://region3.documents.azure.com" },
+            };
+
+            Collection<AccountRegion> thinClientWriteRegions = new Collection<AccountRegion>()
+            {
+                new AccountRegion { Name = "Region1", Endpoint = "https://region1-write.documents.azure.com:10250/" },
+                new AccountRegion { Name = "Region2", Endpoint = "https://region2-write.documents.azure.com:10250/" },
+                new AccountRegion { Name = "Region3", Endpoint = "https://region3-write.documents.azure.com:10250/" },
+            };
+
+            Collection<AccountRegion> thinClientReadRegions = new Collection<AccountRegion>()
+            {
+                new AccountRegion { Name = "Region1", Endpoint = "https://region1-read.documents.azure.com:10250/" },
+                new AccountRegion { Name = "Region2", Endpoint = "https://region2-read.documents.azure.com:10250/" },
+                new AccountRegion { Name = "Region3", Endpoint = "https://region3-read.documents.azure.com:10250/" },
+            };
+
+            AccountProperties accountProps = new AccountProperties
+            {
+                ReadLocationsInternal = regions,
+                WriteLocationsInternal = regions,
+                ThinClientReadableLocationsInternal = thinClientReadRegions,
+                ThinClientWritableLocationsInternal = thinClientWriteRegions,
                 EnableMultipleWriteLocations = true,
             };
 
@@ -2046,21 +2163,7 @@ namespace Microsoft.Azure.Cosmos.Client.Tests
                 useMultipleWriteLocations: true);
 
             cache.OnDatabaseAccountRead(accountProps);
-
-            // Act: write request with the primary region excluded — must resolve to the next preferred thin client write endpoint.
-            DocumentServiceRequest writeRequest = DocumentServiceRequest.Create(
-                OperationType.Create,
-                ResourceType.Document,
-                AuthorizationTokenType.PrimaryMasterKey);
-            writeRequest.RequestContext.ExcludeRegions = new List<string> { "Region1", "Region3" };
-
-            Uri resolvedThinWrite = cache.ResolveThinClientEndpoint(writeRequest, isReadRequest: false);
-
-            // Assert: ExcludeRegions is honored — Region2 is the only non-excluded preferred region.
-            Assert.AreEqual(
-                "https://region2.documents.azure.com:10250/",
-                resolvedThinWrite.AbsoluteUri,
-                "ResolveThinClientEndpoint must skip excluded regions and pick the first non-excluded preferred thin client endpoint.");
+            return cache;
         }
 
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/LocationCacheTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/LocationCacheTests.cs
@@ -1926,6 +1926,69 @@ namespace Microsoft.Azure.Cosmos.Client.Tests
             Assert.AreEqual("https://writelocation.documents.azure.com/", cache.WriteEndpoints[0].AbsoluteUri);
         }
 
+        /// <summary>
+        /// Regression test for issue #5789. <see cref="LocationCache.ResolveThinClientEndpoint"/>
+        /// must filter the thin client endpoint list by <see cref="DocumentServiceRequestContext.ExcludeRegions"/>,
+        /// matching the gateway-path behavior in <see cref="LocationCache.GetApplicableEndpoints(DocumentServiceRequest, bool)"/>.
+        /// Before the fix, ExcludeRegions was silently ignored on the thin client path and every request collapsed
+        /// onto the first thin client endpoint.
+        /// </summary>
+        [TestMethod]
+        public void ValidateResolveThinClientEndpoint_HonorsExcludeRegionsTest()
+        {
+            // Arrange: multi-write account with 3 regions; identical region names across gateway and thin client.
+            Collection<AccountRegion> writeRegions = new Collection<AccountRegion>()
+            {
+                new AccountRegion { Name = "Region1", Endpoint = "https://region1.documents.azure.com" },
+                new AccountRegion { Name = "Region2", Endpoint = "https://region2.documents.azure.com" },
+                new AccountRegion { Name = "Region3", Endpoint = "https://region3.documents.azure.com" },
+            };
+
+            Collection<AccountRegion> readRegions = writeRegions;
+
+            Collection<AccountRegion> thinClientWrites = new Collection<AccountRegion>()
+            {
+                new AccountRegion { Name = "Region1", Endpoint = "https://region1.documents.azure.com:10650/" },
+                new AccountRegion { Name = "Region2", Endpoint = "https://region2.documents.azure.com:10650/" },
+                new AccountRegion { Name = "Region3", Endpoint = "https://region3.documents.azure.com:10650/" },
+            };
+
+            Collection<AccountRegion> thinClientReads = thinClientWrites;
+
+            AccountProperties accountProps = new AccountProperties
+            {
+                ReadLocationsInternal = readRegions,
+                WriteLocationsInternal = writeRegions,
+                ThinClientReadableLocationsInternal = thinClientReads,
+                ThinClientWritableLocationsInternal = thinClientWrites,
+                EnableMultipleWriteLocations = true,
+            };
+
+            LocationCache cache = new LocationCache(
+                preferredLocations: new List<string> { "Region1", "Region2", "Region3" }.AsReadOnly(),
+                defaultEndpoint: new Uri("https://defaultendpoint.documents.azure.com"),
+                enableEndpointDiscovery: true,
+                connectionLimit: 50,
+                useMultipleWriteLocations: true);
+
+            cache.OnDatabaseAccountRead(accountProps);
+
+            // Act: write request with the primary region excluded — must resolve to the next preferred thin client write endpoint.
+            DocumentServiceRequest writeRequest = DocumentServiceRequest.Create(
+                OperationType.Create,
+                ResourceType.Document,
+                AuthorizationTokenType.PrimaryMasterKey);
+            writeRequest.RequestContext.ExcludeRegions = new List<string> { "Region1", "Region3" };
+
+            Uri resolvedThinWrite = cache.ResolveThinClientEndpoint(writeRequest, isReadRequest: false);
+
+            // Assert: ExcludeRegions is honored — Region2 is the only non-excluded preferred region.
+            Assert.AreEqual(
+                "https://region2.documents.azure.com:10650/",
+                resolvedThinWrite.AbsoluteUri,
+                "ResolveThinClientEndpoint must skip excluded regions and pick the first non-excluded preferred thin client endpoint.");
+        }
+
 
         private ReadOnlyCollection<Uri> GetApplicableRegions(bool isReadRequest, bool useMultipleWriteLocations, bool usesPreferredLocations, List<string> excludeRegions, bool isDefaultEndpointARegionalEndpoint)
         {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/LocationCacheTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/LocationCacheTests.cs
@@ -1824,7 +1824,7 @@ namespace Microsoft.Azure.Cosmos.Client.Tests
 
             Collection<AccountRegion> thinClientWrites = new Collection<AccountRegion>()
             {
-                new AccountRegion { Name = "ThinClientWriteLocation", Endpoint = "https://thinclient-write.documents.azure.com:10650/" }
+                new AccountRegion { Name = "ThinClientWriteLocation", Endpoint = "https://thinclient-write.documents.azure.com:10250/" }
             };
 
             AccountProperties accountProps = new AccountProperties
@@ -1851,7 +1851,7 @@ namespace Microsoft.Azure.Cosmos.Client.Tests
                 Uri resolvedReadEndpoint = cache.ResolveThinClientEndpoint(readRequest, isReadRequest: true);
 
                 // Assert:
-                Assert.AreEqual("https://thinclient-write.documents.azure.com:10650/", resolvedReadEndpoint.AbsoluteUri,
+                Assert.AreEqual("https://thinclient-write.documents.azure.com:10250/", resolvedReadEndpoint.AbsoluteUri,
                     "Read request should fallback to thin client write endpoint when no thin client read endpoint is available.");
             }
         }
@@ -1872,12 +1872,12 @@ namespace Microsoft.Azure.Cosmos.Client.Tests
 
             Collection<AccountRegion> thinClientReads = new Collection<AccountRegion>()
             {
-                new AccountRegion { Name = "ThinClientReadLocation", Endpoint = "https://thinclient-read.documents.azure.com:10650/" }
+                new AccountRegion { Name = "ThinClientReadLocation", Endpoint = "https://thinclient-read.documents.azure.com:10250/" }
             };
 
             Collection<AccountRegion> thinClientWrites = new Collection<AccountRegion>()
             {
-                new AccountRegion { Name = "ThinClientWriteLocation", Endpoint = "https://thinclient-write.documents.azure.com:10650/" }
+                new AccountRegion { Name = "ThinClientWriteLocation", Endpoint = "https://thinclient-write.documents.azure.com:10250/" }
             };
 
             AccountProperties accountProps = new AccountProperties
@@ -1916,10 +1916,10 @@ namespace Microsoft.Azure.Cosmos.Client.Tests
             Uri resolvedThinWrite = cache.ResolveThinClientEndpoint(writeRequest, isReadRequest: false);
 
             // Assert:
-            Assert.AreEqual("https://thinclient-read.documents.azure.com:10650/", resolvedThinRead.AbsoluteUri,
+            Assert.AreEqual("https://thinclient-read.documents.azure.com:10250/", resolvedThinRead.AbsoluteUri,
                 "ThinClient read endpoint must match the one we provided in ThinClientReadableLocationsInternal");
 
-            Assert.AreEqual("https://thinclient-write.documents.azure.com:10650/", resolvedThinWrite.AbsoluteUri,
+            Assert.AreEqual("https://thinclient-write.documents.azure.com:10250/", resolvedThinWrite.AbsoluteUri,
                 "ThinClient write endpoint must match the one we provided in ThinClientWritableLocationsInternal");
 
             Assert.AreEqual("https://readlocation.documents.azure.com/", cache.ReadEndpoints[0].AbsoluteUri);
@@ -1951,8 +1951,8 @@ namespace Microsoft.Azure.Cosmos.Client.Tests
 
             // Service advertises both directions → both flags true.
             cache.OnDatabaseAccountRead(BuildAccountProperties(
-                thinClientReadEndpoint: "https://thin-read.documents.azure.com:10650/",
-                thinClientWriteEndpoint: "https://thin-write.documents.azure.com:10650/"));
+                thinClientReadEndpoint: "https://thin-read.documents.azure.com:10250/",
+                thinClientWriteEndpoint: "https://thin-write.documents.azure.com:10250/"));
             Assert.IsTrue(cache.HasThinClientReadLocations);
             Assert.IsTrue(cache.HasThinClientWriteLocations);
 
@@ -1960,7 +1960,7 @@ namespace Microsoft.Azure.Cosmos.Client.Tests
             // independence: a regression that aliased the two flags would fail here).
             cache.OnDatabaseAccountRead(BuildAccountProperties(
                 thinClientReadEndpoint: null,
-                thinClientWriteEndpoint: "https://thin-write.documents.azure.com:10650/"));
+                thinClientWriteEndpoint: "https://thin-write.documents.azure.com:10250/"));
             Assert.IsFalse(cache.HasThinClientReadLocations);
             Assert.IsTrue(cache.HasThinClientWriteLocations);
 
@@ -1973,8 +1973,8 @@ namespace Microsoft.Azure.Cosmos.Client.Tests
 
             // Service re-advertises both directions → both flags come back true (re-engagement).
             cache.OnDatabaseAccountRead(BuildAccountProperties(
-                thinClientReadEndpoint: "https://thin-read.documents.azure.com:10650/",
-                thinClientWriteEndpoint: "https://thin-write.documents.azure.com:10650/"));
+                thinClientReadEndpoint: "https://thin-read.documents.azure.com:10250/",
+                thinClientWriteEndpoint: "https://thin-write.documents.azure.com:10250/"));
             Assert.IsTrue(cache.HasThinClientReadLocations);
             Assert.IsTrue(cache.HasThinClientWriteLocations);
         }
@@ -2022,9 +2022,9 @@ namespace Microsoft.Azure.Cosmos.Client.Tests
 
             Collection<AccountRegion> thinClientWrites = new Collection<AccountRegion>()
             {
-                new AccountRegion { Name = "Region1", Endpoint = "https://region1.documents.azure.com:10650/" },
-                new AccountRegion { Name = "Region2", Endpoint = "https://region2.documents.azure.com:10650/" },
-                new AccountRegion { Name = "Region3", Endpoint = "https://region3.documents.azure.com:10650/" },
+                new AccountRegion { Name = "Region1", Endpoint = "https://region1.documents.azure.com:10250/" },
+                new AccountRegion { Name = "Region2", Endpoint = "https://region2.documents.azure.com:10250/" },
+                new AccountRegion { Name = "Region3", Endpoint = "https://region3.documents.azure.com:10250/" },
             };
 
             Collection<AccountRegion> thinClientReads = thinClientWrites;
@@ -2058,7 +2058,7 @@ namespace Microsoft.Azure.Cosmos.Client.Tests
 
             // Assert: ExcludeRegions is honored — Region2 is the only non-excluded preferred region.
             Assert.AreEqual(
-                "https://region2.documents.azure.com:10650/",
+                "https://region2.documents.azure.com:10250/",
                 resolvedThinWrite.AbsoluteUri,
                 "ResolveThinClientEndpoint must skip excluded regions and pick the first non-excluded preferred thin client endpoint.");
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyRangeFailoverTests/MockSetupsHelper.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyRangeFailoverTests/MockSetupsHelper.cs
@@ -148,14 +148,14 @@ namespace Microsoft.Azure.Cosmos.Tests
                     {
                         "thinClientWritableLocations",
                         JArray.Parse(@"[
-                            { 'name': 'East US', 'databaseAccountEndpoint': 'https://thinclientwrite-eastus.documents.azure.com:10650/' }
+                            { 'name': 'East US', 'databaseAccountEndpoint': 'https://thinclientwrite-eastus.documents.azure.com:10250/' }
                         ]")
                     },
                     {
                         "thinClientReadableLocations",
                         JArray.Parse(@"[
-                            { 'name': 'East US', 'databaseAccountEndpoint': 'https://thinclientread-eastus.documents.azure.com:10650/' },
-                            { 'name': 'West US', 'databaseAccountEndpoint': 'https://thinclientread-westus.documents.azure.com:10650/' }
+                            { 'name': 'East US', 'databaseAccountEndpoint': 'https://thinclientread-eastus.documents.azure.com:10250/' },
+                            { 'name': 'West US', 'databaseAccountEndpoint': 'https://thinclientread-westus.documents.azure.com:10250/' }
                         ]")
                     }
                 };

--- a/changelog.md
+++ b/changelog.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Bugs Fixed
 
+- [#](https://github.com/Azure/azure-cosmos-dotnet-v3/issues/) ThinClient: Fixes per-request `ExcludeRegions` being ignored when thin client mode is enabled, so thin client requests now route to the same region the gateway path would have chosen.
+
 #### Other Changes
 
 ### <a name="3.62.0-preview.0"/> [3.62.0-preview.0](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.62.0-preview.0) - 2026-6-1

--- a/changelog.md
+++ b/changelog.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Bugs Fixed
 
-- [#](https://github.com/Azure/azure-cosmos-dotnet-v3/issues/) ThinClient: Fixes per-request `ExcludeRegions` being ignored when thin client mode is enabled, so thin client requests now route to the same region the gateway path would have chosen.
+- [5928](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5928) ThinClient: Fixes per-request `ExcludeRegions` being ignored when thin client mode is enabled, so thin client requests now route to the same region the gateway path would have chosen.
 
 #### Other Changes
 


### PR DESCRIPTION
# Pull Request Template

## Description

This change resolves an issue where per-request region exclusions were not honored when the SDK operated in thin client mode. Previously, requests configured with ExcludeRegions would still route to theprimary thin client endpoint regardless of the customer's regional preferences, preventing them from steering traffic away from specific regions during operational events. With this fix, thin client requestrouting now filters available endpoints against the excluded region list in a manner consistent with the standard gateway path, restoring expected behavior for both individual operations and cross-region hedging scenarios. The change is scoped narrowly to the thin client resolution path, preserves all existing routing semantics when no exclusions are specified, and is covered by new unit and integration test.

Code cleanup: Update thinclient port to 10250 from 10650 as that's the new port thinclient is available at.

Fix CosmosAvailabiltyStrategyTests: Fix threshold value due to hub region caching introduced in this PR https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5648
## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)


## Closing issues

To automatically close an issue: closes #5789

## Changelog

- [X] I have added a changelog entry under `### Unreleased` in `changelog.md`
  for the user-facing impact of this change.


If the second box is checked, briefly justify here:

>
