### PR TITLE
ChangeFeed: Adds support for StartTime after partition merges

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ChangeFeed/ChangeFeedPartitionKeyResultSetIteratorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeed/ChangeFeedPartitionKeyResultSetIteratorCore.cs
@@ -59,13 +59,15 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
                 container: container,
                 mode: mode,
                 changeFeedStartFrom: startFrom,
-                options: requestOptions);
+                options: requestOptions,
+                startTime: startTime);
         }
 
         private readonly CosmosClientContext clientContext;
 
         private readonly ChangeFeedRequestOptions changeFeedOptions;
         private readonly ChangeFeedMode mode;
+        private readonly DateTime? startTime;
 
         private ChangeFeedStartFrom changeFeedStartFrom;
         private bool hasMoreResultsInternal;
@@ -74,13 +76,15 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
             ContainerInternal container,
             ChangeFeedMode mode,
             ChangeFeedStartFrom changeFeedStartFrom,
-            ChangeFeedRequestOptions options)
+            ChangeFeedRequestOptions options,
+            DateTime? startTime = null)
         {
             this.container = container ?? throw new ArgumentNullException(nameof(container));
             this.mode = mode;
             this.changeFeedStartFrom = changeFeedStartFrom ?? throw new ArgumentNullException(nameof(changeFeedStartFrom));
             this.clientContext = this.container.ClientContext;
             this.changeFeedOptions = options;
+            this.startTime = startTime;
 
             this.operationName = OpenTelemetryConstants.Operations.QueryChangeFeed;
         }
@@ -118,6 +122,19 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
                     // Set time headers if any
                     ChangeFeedStartFromRequestOptionPopulator visitor = new ChangeFeedStartFromRequestOptionPopulator(requestMessage);
                     this.changeFeedStartFrom.Accept(visitor);
+
+                    // When a merge happens, the child partition will contain documents ordered by LSN but the _ts/creation time
+                    // of the documents may not be sequential. So when reading the change feed by LSN, it is possible to encounter
+                    // documents with lower _ts. In order to guarantee we always get the documents after the customer's point start
+                    // time, we need to always pass the start time in the header alongside the continuation token.
+                    if (this.startTime.HasValue
+                        && this.startTime.Value != DateTime.MinValue.ToUniversalTime()
+                        && this.changeFeedStartFrom is ChangeFeedStartFromContinuationAndFeedRange)
+                    {
+                        requestMessage.Headers.Add(
+                            HttpConstants.HttpHeaders.IfModifiedSince,
+                            this.startTime.Value.ToString("r", CultureInfo.InvariantCulture));
+                    }
 
                     if (this.changeFeedOptions.PageSizeHint.HasValue)
                     {

--- a/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/ChangeFeedState.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/ChangeFeedState.cs
@@ -30,5 +30,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Pagination
         public static ChangeFeedState Time(DateTime time) => new ChangeFeedStateTime(time);
 
         public static ChangeFeedState Continuation(CosmosElement continuation) => new ChangeFeedStateContinuation(continuation);
+
+        public static ChangeFeedState ContinuationAndStartTime(CosmosElement continuation, DateTime startTime) => new ChangeFeedStateContinuationAndStartTime(continuation, startTime);
     }
 }

--- a/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/ChangeFeedStateContinuationAndStartTime.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/ChangeFeedStateContinuationAndStartTime.cs
@@ -1,0 +1,46 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.ChangeFeed.Pagination
+{
+    using System;
+    using Microsoft.Azure.Cosmos.CosmosElements;
+
+#if INTERNAL
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+#pragma warning disable SA1600 // Elements should be documented
+    public
+#else
+    internal
+#endif 
+        sealed class ChangeFeedStateContinuationAndStartTime : ChangeFeedState
+    {
+        public ChangeFeedStateContinuationAndStartTime(CosmosElement continuation, DateTime startTime)
+        {
+            this.ContinuationToken = continuation ?? throw new ArgumentNullException(nameof(continuation));
+
+            if (startTime.Kind != DateTimeKind.Utc)
+            {
+                throw new ArgumentOutOfRangeException($"{nameof(startTime)}.{nameof(DateTime.Kind)} must be {nameof(DateTimeKind)}.{nameof(DateTimeKind.Utc)}");
+            }
+
+            this.StartTime = startTime;
+        }
+
+        public CosmosElement ContinuationToken { get; }
+
+        public DateTime StartTime { get; }
+
+        public override void Accept<TInput>(
+            IChangeFeedStateVisitor<TInput> visitor,
+            TInput input) => visitor.Visit(this, input);
+
+        public override TOutput Accept<TInput, TOutput>(
+            IChangeFeedStateVisitor<TInput, TOutput> visitor,
+            TInput input) => visitor.Visit(this, input);
+
+        public override TResult Accept<TResult>(
+            IChangeFeedStateTransformer<TResult> visitor) => visitor.Transform(this);
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/ChangeFeedStateCosmosElementSerializer.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/ChangeFeedStateCosmosElementSerializer.cs
@@ -14,10 +14,12 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Pagination
     {
         private const string TypePropertyName = "type";
         private const string ValuePropertyName = "value";
+        private const string StartTimePropertyName = "startTime";
 
         private const string BeginningTypeValue = "beginning";
         private const string TimeTypeValue = "time";
         private const string ContinuationTypeValue = "continuation";
+        private const string ContinuationAndStartTimeTypeValue = "continuationAndStartTime";
         private const string NowTypeValue = "now";
 
         public static TryCatch<ChangeFeedState> MonadicFromCosmosElement(CosmosElement cosmosElement)
@@ -81,7 +83,64 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Pagination
                                     $"expected change feed state to have a string value property: {cosmosElement}"));
                         }
 
-                        state = ChangeFeedState.Continuation(valuePropertyValue);
+                        // startTime is an optional field on a continuation token. When present, the state
+                        // also carries a start time so If-Modified-Since can be sent alongside the
+                        // continuation token (post-merge filtering). Keeping it optional on the existing
+                        // "continuation" type - rather than introducing a new type - preserves backward
+                        // compatibility: an older SDK that predates this feature simply ignores the
+                        // unknown startTime field instead of failing to parse the token.
+                        if (cosmosObject.TryGetValue(StartTimePropertyName, out CosmosString continuationStartTimePropertyValue))
+                        {
+                            if (!DateTime.TryParse(
+                                continuationStartTimePropertyValue.Value,
+                                CultureInfo.InvariantCulture,
+                                DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal | DateTimeStyles.AllowWhiteSpaces,
+                                out DateTime continuationStartTimeUtc))
+                            {
+                                return TryCatch<ChangeFeedState>.FromException(
+                                    new FormatException(
+                                        $"failed to parse start time value: {cosmosElement}"));
+                            }
+
+                            state = ChangeFeedState.ContinuationAndStartTime(valuePropertyValue, continuationStartTimeUtc);
+                        }
+                        else
+                        {
+                            state = ChangeFeedState.Continuation(valuePropertyValue);
+                        }
+                    }
+                    break;
+
+                case ContinuationAndStartTimeTypeValue:
+                    {
+                        // Legacy type kept for defensive backward compatibility. New tokens serialize as
+                        // the "continuation" type with an optional startTime field (see above).
+                        if (!cosmosObject.TryGetValue(ValuePropertyName, out CosmosString valuePropertyValue))
+                        {
+                            return TryCatch<ChangeFeedState>.FromException(
+                                new FormatException(
+                                    $"expected change feed state to have a string value property: {cosmosElement}"));
+                        }
+
+                        if (!cosmosObject.TryGetValue(StartTimePropertyName, out CosmosString startTimePropertyValue))
+                        {
+                            return TryCatch<ChangeFeedState>.FromException(
+                                new FormatException(
+                                    $"expected change feed state to have a string startTime property: {cosmosElement}"));
+                        }
+
+                        if (!DateTime.TryParse(
+                            startTimePropertyValue.Value,
+                            CultureInfo.InvariantCulture,
+                            DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal | DateTimeStyles.AllowWhiteSpaces,
+                            out DateTime startTimeUtc))
+                        {
+                            return TryCatch<ChangeFeedState>.FromException(
+                                new FormatException(
+                                    $"failed to parse start time value: {cosmosElement}"));
+                        }
+
+                        state = ChangeFeedState.ContinuationAndStartTime(valuePropertyValue, startTimeUtc);
                     }
                     break;
 
@@ -157,6 +216,25 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Pagination
                     {
                         { TypePropertyName, ContinuationTypeValueSingleton },
                         { ValuePropertyName, changeFeedStateContinuation.ContinuationToken }
+                    });
+            }
+
+            public CosmosElement Transform(ChangeFeedStateContinuationAndStartTime changeFeedStateContinuationAndStartTime)
+            {
+                // Serialize as the existing "continuation" type plus an optional startTime field so that
+                // older SDKs (which don't understand a dedicated continuationAndStartTime type) can still
+                // parse the token and simply ignore the extra startTime, rather than throwing.
+                return CosmosObject.Create(
+                    new Dictionary<string, CosmosElement>()
+                    {
+                        { TypePropertyName, ContinuationTypeValueSingleton },
+                        { ValuePropertyName, changeFeedStateContinuationAndStartTime.ContinuationToken },
+                        {
+                            StartTimePropertyName,
+                            CosmosString.Create(changeFeedStateContinuationAndStartTime.StartTime.ToString(
+                                "o",
+                                CultureInfo.InvariantCulture))
+                        }
                     });
             }
 

--- a/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/ChangeFeedStateCosmosElementSerializer.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/ChangeFeedStateCosmosElementSerializer.cs
@@ -89,10 +89,17 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Pagination
                         // "continuation" type - rather than introducing a new type - preserves backward
                         // compatibility: an older SDK that predates this feature simply ignores the
                         // unknown startTime field instead of failing to parse the token.
-                        if (cosmosObject.TryGetValue(StartTimePropertyName, out CosmosString continuationStartTimePropertyValue))
+                        if (cosmosObject.TryGetValue(StartTimePropertyName, out CosmosElement continuationStartTimePropertyValue))
                         {
+                            if (!(continuationStartTimePropertyValue is CosmosString continuationStartTimeString))
+                            {
+                                return TryCatch<ChangeFeedState>.FromException(
+                                    new FormatException(
+                                        $"expected change feed state to have a string startTime property: {cosmosElement}"));
+                            }
+
                             if (!DateTime.TryParse(
-                                continuationStartTimePropertyValue.Value,
+                                continuationStartTimeString.Value,
                                 CultureInfo.InvariantCulture,
                                 DateTimeStyles.AssumeUniversal | DateTimeStyles.AdjustToUniversal | DateTimeStyles.AllowWhiteSpaces,
                                 out DateTime continuationStartTimeUtc))

--- a/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/IChangeFeedStateTransformer{TResult}.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/IChangeFeedStateTransformer{TResult}.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Pagination
         TResult Transform(ChangeFeedStateBeginning changeFeedStateBeginning);
         TResult Transform(ChangeFeedStateTime changeFeedStateTime);
         TResult Transform(ChangeFeedStateContinuation changeFeedStateContinuation);
+        TResult Transform(ChangeFeedStateContinuationAndStartTime changeFeedStateContinuationAndStartTime);
         TResult Transform(ChangeFeedStateNow changeFeedStateNow);
     }
 }

--- a/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/IChangeFeedStateVisitor{TInput,TOutput}.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/IChangeFeedStateVisitor{TInput,TOutput}.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Pagination
         TOutput Visit(ChangeFeedStateBeginning changeFeedStateBeginning, TInput input);
         TOutput Visit(ChangeFeedStateTime changeFeedStateTime, TInput input);
         TOutput Visit(ChangeFeedStateContinuation changeFeedStateContinuation, TInput input);
+        TOutput Visit(ChangeFeedStateContinuationAndStartTime changeFeedStateContinuationAndStartTime, TInput input);
         TOutput Visit(ChangeFeedStateNow changeFeedStateNow, TInput input);
     }
 }

--- a/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/IChangeFeedStateVisitor{TInput}.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeed/Pagination/IChangeFeedStateVisitor{TInput}.cs
@@ -16,6 +16,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Pagination
         void Visit(ChangeFeedStateBeginning changeFeedStateBeginning, TInput input);
         void Visit(ChangeFeedStateTime changeFeedStateTime, TInput input);
         void Visit(ChangeFeedStateContinuation changeFeedStateContinuation, TInput input);
+        void Visit(ChangeFeedStateContinuationAndStartTime changeFeedStateContinuationAndStartTime, TInput input);
         void Visit(ChangeFeedStateNow changeFeedStateNow, TInput input);
     }
 }

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/Bootstrapping/PartitionSynchronizerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/Bootstrapping/PartitionSynchronizerCore.cs
@@ -107,7 +107,10 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Bootstrapping
                 await overlappingRanges.ForEachAsync(
                     async addedRange =>
                     {
-                        DocumentServiceLease newLease = await this.leaseManager.CreateLeaseIfNotExistAsync(addedRange, lastContinuationToken);
+                        DocumentServiceLease newLease = await this.leaseManager.CreateLeaseIfNotExistAsync(
+                            addedRange,
+                            lastContinuationToken,
+                            partitionBasedLease.StartTime);
                         if (newLease != null)
                         {
                             newLeases.Enqueue(newLease);
@@ -123,7 +126,10 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Bootstrapping
                 PartitionKeyRange mergedRange = overlappingRanges[0];
                 DefaultTrace.TraceInformation("Lease {0} merged into {1}", leaseToken, mergedRange.Id);
 
-                DocumentServiceLease newLease = await this.leaseManager.CreateLeaseIfNotExistAsync((FeedRangeEpk)partitionBasedLease.FeedRange, lastContinuationToken);
+                DocumentServiceLease newLease = await this.leaseManager.CreateLeaseIfNotExistAsync(
+                    (FeedRangeEpk)partitionBasedLease.FeedRange,
+                    lastContinuationToken,
+                    partitionBasedLease.StartTime);
                 if (newLease != null)
                 {
                     newLeases.Enqueue(newLease);
@@ -155,7 +161,10 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Bootstrapping
                 {
                     Documents.Routing.Range<string> partitionRange = overlappingRanges[i].ToRange();
                     Documents.Routing.Range<string> mergedRange = new Documents.Routing.Range<string>(min, partitionRange.Max, true, false);
-                    DocumentServiceLease newLease = await this.leaseManager.CreateLeaseIfNotExistAsync(new FeedRangeEpk(mergedRange), lastContinuationToken);
+                    DocumentServiceLease newLease = await this.leaseManager.CreateLeaseIfNotExistAsync(
+                        new FeedRangeEpk(mergedRange),
+                        lastContinuationToken,
+                        feedRangeBasedLease.StartTime);
                     if (newLease != null)
                     {
                         newLeases.Add(newLease);
@@ -166,7 +175,10 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Bootstrapping
 
                 // Add the last range with the original max and the last min from the split
                 Documents.Routing.Range<string> lastRangeAfterSplit = new Documents.Routing.Range<string>(min, max, true, false);
-                DocumentServiceLease lastLease = await this.leaseManager.CreateLeaseIfNotExistAsync(new FeedRangeEpk(lastRangeAfterSplit), lastContinuationToken);
+                DocumentServiceLease lastLease = await this.leaseManager.CreateLeaseIfNotExistAsync(
+                    new FeedRangeEpk(lastRangeAfterSplit),
+                    lastContinuationToken,
+                    feedRangeBasedLease.StartTime);
                 if (lastLease != null)
                 {
                     newLeases.Add(lastLease);

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedProcessorBuilder.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedProcessorBuilder.cs
@@ -126,7 +126,7 @@ namespace Microsoft.Azure.Cosmos
         /// </summary>
         /// <remarks>
         /// This is only used when:
-        /// (1) Lease store is not initialized and is ignored if a lease exists and has continuation token.
+        /// (1) Lease store is not initialized and is ignored if a lease exists and has a continuation token.
         /// (2) StartContinuation is not specified.
         /// (3) StartTime is not specified.
         /// </remarks>
@@ -144,14 +144,16 @@ namespace Microsoft.Azure.Cosmos
 
         /// <summary>
         /// Sets the time (exclusive) to start looking for changes after.
+        /// The start time is persisted in the lease document so that it is honored across processor restarts.
         /// </summary>
         /// <remarks>
-        /// This is only used when:
-        /// (1) Lease store is not initialized and is ignored if a lease exists and has continuation token.
-        /// (2) StartContinuation is not specified.
+        /// The start time is persisted in the lease and sent as the If-Modified-Since header alongside the
+        /// continuation token on subsequent change feed requests. This ensures documents are returned after
+        /// the specified time even after partition merges.
+        /// Passing <see cref="DateTime.MinValue"/> clears the persisted start time from the lease document.
         /// If this is specified, StartFromBeginning is ignored.
         /// </remarks>
-        /// <param name="startTime">Date and time when to start looking for changes.</param>
+        /// <param name="startTime">Date and time when to start looking for changes. Use <see cref="DateTime.MinValue"/> to clear a previously persisted start time.</param>
         /// <returns>The instance of <see cref="ChangeFeedProcessorBuilder"/> to use.</returns>
         public ChangeFeedProcessorBuilder WithStartTime(DateTime startTime)
         {
@@ -165,7 +167,8 @@ namespace Microsoft.Azure.Cosmos
                 throw new ArgumentNullException(nameof(startTime));
             }
 
-            this.changeFeedProcessorOptions.StartTime = startTime;
+            this.changeFeedProcessorOptions.StartTime = startTime == DateTime.MinValue ? null : startTime;
+            this.changeFeedProcessorOptions.IsStartTimeUserExplicit = true;
             return this;
         }
 

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedProcessorBuilder.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedProcessorBuilder.cs
@@ -151,7 +151,9 @@ namespace Microsoft.Azure.Cosmos
         /// continuation token on subsequent change feed requests. This ensures documents are returned after
         /// the specified time even after partition merges.
         /// Passing <see cref="DateTime.MinValue"/> clears the persisted start time from the lease document.
-        /// If this is specified, StartFromBeginning is ignored.
+        /// After it is cleared, a lease without a continuation starts from the current time unless
+        /// <see cref="WithStartFromBeginning"/> is also configured.
+        /// A non-MinValue start time takes precedence over StartFromBeginning.
         /// </remarks>
         /// <param name="startTime">Date and time when to start looking for changes. Use <see cref="DateTime.MinValue"/> to clear a previously persisted start time.</param>
         /// <returns>The instance of <see cref="ChangeFeedProcessorBuilder"/> to use.</returns>
@@ -162,11 +164,7 @@ namespace Microsoft.Azure.Cosmos
                 throw new InvalidOperationException($"Using the '{nameof(WithStartTime)}' option with ChangeFeedProcessor is not supported with {ChangeFeedMode.AllVersionsAndDeletes} mode.");
             }
 
-            if (startTime == null)
-            {
-                throw new ArgumentNullException(nameof(startTime));
-            }
-
+            // DateTime.MinValue is the explicit opt-out for a start time persisted by an earlier run.
             this.changeFeedProcessorOptions.StartTime = startTime == DateTime.MinValue ? null : startTime;
             this.changeFeedProcessorOptions.IsStartTimeUserExplicit = true;
             return this;

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedProcessorCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/ChangeFeedProcessorCore.cs
@@ -93,6 +93,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
                 bool shouldAnchorStartTime =
                     !this.changeFeedProcessorOptions.StartFromBeginning
                     && this.changeFeedProcessorOptions.StartTime == null
+                    && !this.changeFeedProcessorOptions.IsStartTimeUserExplicit
                     && string.IsNullOrEmpty(this.changeFeedProcessorOptions.StartContinuation)
                     && this.changeFeedProcessorOptions.Mode != ChangeFeedMode.AllVersionsAndDeletes;
 
@@ -143,7 +144,9 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed
                         this.leaseContainer,
                         leaseContainerPrefix,
                         this.instanceName,
-                        changeFeedMode: this.changeFeedProcessorOptions.Mode)
+                        changeFeedMode: this.changeFeedProcessorOptions.Mode,
+                        startTime: this.changeFeedProcessorOptions.StartTime,
+                        isStartTimeUserExplicit: this.changeFeedProcessorOptions.IsStartTimeUserExplicit)
                     .ConfigureAwait(false);
             }
 

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/Configuration/ChangeFeedProcessorOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/Configuration/ChangeFeedProcessorOptions.cs
@@ -39,8 +39,9 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Configuration
         /// Gets or sets the start request continuation token to start looking for changes after.
         /// </summary>
         /// <remarks>
-        /// This is only used when lease store is not initialized and is ignored if a lease exists and has continuation token.
-        /// If this is specified, both StartTime and StartFromBeginning are ignored.
+        /// This is only used when lease store is not initialized and is ignored if a lease exists and has a continuation token.
+        /// If this is specified, StartFromBeginning is ignored. StartTime is ignored for the initial start position
+        /// but is still persisted in the lease and sent as If-Modified-Since alongside the continuation token.
         /// </remarks>
         /// <seealso cref="ChangeFeedOptions.RequestContinuation"/>
         public string StartContinuation { get; set; }
@@ -49,9 +50,12 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Configuration
         /// Gets or sets the time (exclusive) to start looking for changes after.
         /// </summary>
         /// <remarks>
-        /// This is only used when:
-        /// (1) Lease store is not initialized and is ignored if a lease exists and has continuation token.
-        /// (2) StartContinuation is not specified.
+        /// When set, the start time is persisted in the lease document and sent as the If-Modified-Since
+        /// header alongside the continuation token on subsequent change feed requests. This ensures
+        /// documents are returned after the specified time even after partition merges.
+        /// The start time is honored across processor restarts via persistence in the lease.
+        /// If StartContinuation is specified, this property is ignored for the initial start position
+        /// but is still persisted and sent alongside the continuation token.
         /// If this is specified, StartFromBeginning is ignored.
         /// </remarks>
         /// <seealso cref="ChangeFeedOptions.StartTime"/>
@@ -71,12 +75,18 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Configuration
         }
 
         /// <summary>
+        /// Gets a value indicating whether the start time was explicitly set by the user
+        /// via the builder (as opposed to being auto-anchored by the processor on startup).
+        /// </summary>
+        public bool IsStartTimeUserExplicit { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether change feed in the Azure Cosmos DB service should start from beginning (true) or from current (false).
         /// By default it's start from current (false).
         /// </summary>
         /// <remarks>
         /// This is only used when:
-        /// (1) Lease store is not initialized and is ignored if a lease exists and has continuation token.
+        /// (1) Lease store is not initialized and is ignored if a lease exists and has a continuation token.
         /// (2) StartContinuation is not specified.
         /// (3) StartTime is not specified.
         /// </remarks>

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedProcessing/FeedProcessorFactoryCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/FeedProcessing/FeedProcessorFactoryCore.cs
@@ -31,16 +31,26 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedProcessing
             if (observer == null) throw new ArgumentNullException(nameof(observer));
             if (lease == null) throw new ArgumentNullException(nameof(lease));
 
+            if (this.changeFeedProcessorOptions.IsStartTimeUserExplicit)
+            {
+                lease.StartTime = this.changeFeedProcessorOptions.StartTime;
+            }
+
+            string startContinuation = !string.IsNullOrEmpty(lease.ContinuationToken) ?
+                    lease.ContinuationToken :
+                    this.changeFeedProcessorOptions.StartContinuation;
+
+            DateTime? effectiveStartTime = lease.StartTime 
+                ?? (string.IsNullOrEmpty(startContinuation) ? this.changeFeedProcessorOptions.StartTime : null);
+
             ProcessorOptions options = new ProcessorOptions
             {
-                StartContinuation = !string.IsNullOrEmpty(lease.ContinuationToken) ?
-                    lease.ContinuationToken :
-                    this.changeFeedProcessorOptions.StartContinuation,
+                StartContinuation = startContinuation,
                 LeaseToken = lease.CurrentLeaseToken,
                 FeedPollDelay = this.changeFeedProcessorOptions.FeedPollDelay,
                 MaxItemCount = this.changeFeedProcessorOptions.MaxItemCount,
                 StartFromBeginning = this.changeFeedProcessorOptions.StartFromBeginning,
-                StartTime = this.changeFeedProcessorOptions.StartTime,
+                StartTime = effectiveStartTime,
                 FeedRange = lease.FeedRange,
             };
 
@@ -51,7 +61,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.FeedProcessing
                 continuationToken: options.StartContinuation,
                 maxItemCount: options.MaxItemCount,
                 container: this.container,
-                startTime: options.StartTime,
+                startTime: effectiveStartTime,
                 startFromBeginning: options.StartFromBeginning);
 
             return new FeedProcessorCore(observer, iterator, options, checkpointer);

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLease.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLease.cs
@@ -75,5 +75,12 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
         /// Gets or sets the ChangeFeedMode.
         /// </summary>
         public abstract string Mode { get; set; }
+
+        /// <summary>
+        /// Gets or sets the start time used for change feed requests.
+        /// When set, the If-Modified-Since header is sent alongside the continuation token
+        /// to ensure documents are returned after this time even after partition merges.
+        /// </summary>
+        public virtual DateTime? StartTime { get; set; }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLease.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLease.cs
@@ -81,6 +81,6 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
         /// When set, the If-Modified-Since header is sent alongside the continuation token
         /// to ensure documents are returned after this time even after partition merges.
         /// </summary>
-        public virtual DateTime? StartTime { get; set; }
+        public abstract DateTime? StartTime { get; set; }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseCheckpointerCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseCheckpointerCore.cs
@@ -46,6 +46,11 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
                         throw new LeaseLostException(lease);
                     }
                     serverLease.ContinuationToken = continuationToken;
+
+                    // Propagate start time to the persisted lease so subsequent processors
+                    // can send If-Modified-Since alongside the continuation token.
+                    serverLease.StartTime = lease.StartTime;
+
                     return serverLease;
                 }).ConfigureAwait(false);
         }

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseCore.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseCore.cs
@@ -98,6 +98,9 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
         [JsonProperty("Mode", NullValueHandling = NullValueHandling.Ignore)]
         public override string Mode { get; set; }
 
+        [JsonProperty("StartTime", NullValueHandling = NullValueHandling.Ignore)]
+        public override DateTime? StartTime { get; set; }
+
         public override string ToString()
         {
             return string.Format(

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseCoreEpk.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseCoreEpk.cs
@@ -69,6 +69,9 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
         [JsonProperty("Mode", NullValueHandling = NullValueHandling.Ignore)]
         public override string Mode { get; set; }
 
+        [JsonProperty("StartTime", NullValueHandling = NullValueHandling.Ignore)]
+        public override DateTime? StartTime { get; set; }
+
         [JsonProperty("timestamp")]
         private DateTime? ExplicitTimestamp { get; set; }
 

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseManager.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseManager.cs
@@ -23,11 +23,33 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
         public abstract Task<DocumentServiceLease> CreateLeaseIfNotExistAsync(PartitionKeyRange partitionKeyRange, string continuationToken);
 
         /// <summary>
+        /// Checks whether the lease exists and creates it if it does not exist for a physical partition.
+        /// </summary>
+        /// <param name="partitionKeyRange">Partition for the lease.</param>
+        /// <param name="continuationToken">Continuation token if it exists.</param>
+        /// <param name="startTime">Persisted start time inherited from the parent lease.</param>
+        public virtual Task<DocumentServiceLease> CreateLeaseIfNotExistAsync(
+            PartitionKeyRange partitionKeyRange,
+            string continuationToken,
+            DateTime? startTime) => this.CreateLeaseIfNotExistAsync(partitionKeyRange, continuationToken);
+
+        /// <summary>
         /// Checks whether the lease exists and creates it if it does not exist for a range.
         /// </summary>
         /// <param name="feedRange">Feed range for the lease.</param>
         /// <param name="continuationToken">Continuation token if it exists.</param>
         public abstract Task<DocumentServiceLease> CreateLeaseIfNotExistAsync(FeedRangeEpk feedRange, string continuationToken);
+
+        /// <summary>
+        /// Checks whether the lease exists and creates it if it does not exist for a range.
+        /// </summary>
+        /// <param name="feedRange">Feed range for the lease.</param>
+        /// <param name="continuationToken">Continuation token if it exists.</param>
+        /// <param name="startTime">Persisted start time inherited from the parent lease.</param>
+        public virtual Task<DocumentServiceLease> CreateLeaseIfNotExistAsync(
+            FeedRangeEpk feedRange,
+            string continuationToken,
+            DateTime? startTime) => this.CreateLeaseIfNotExistAsync(feedRange, continuationToken);
 
         /// <summary>
         /// Delete the lease.

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseManagerCosmos.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseManagerCosmos.cs
@@ -106,6 +106,14 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
                     }
                     serverLease.Owner = this.options.HostName;
                     serverLease.Properties = lease.Properties;
+
+                    // Persist user-explicit start time on the lease during acquisition
+                    // to ensure it survives restarts even for partitions that never checkpoint.
+                    if (this.options.IsStartTimeUserExplicit)
+                    {
+                        serverLease.StartTime = this.options.StartTime;
+                    }
+
                     return serverLease;
                 }).ConfigureAwait(false);
         }

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseManagerCosmos.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseManagerCosmos.cs
@@ -120,7 +120,12 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
 
         public override Task<DocumentServiceLease> CreateLeaseIfNotExistAsync(
             PartitionKeyRange partitionKeyRange, 
-            string continuationToken)
+            string continuationToken) => this.CreateLeaseIfNotExistAsync(partitionKeyRange, continuationToken, startTime: null);
+
+        public override Task<DocumentServiceLease> CreateLeaseIfNotExistAsync(
+            PartitionKeyRange partitionKeyRange,
+            string continuationToken,
+            DateTime? startTime)
         {
             if (partitionKeyRange == null)
             {
@@ -135,7 +140,8 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
                 LeaseToken = leaseToken,
                 ContinuationToken = continuationToken,
                 FeedRange = new FeedRangeEpk(partitionKeyRange.ToRange()),
-                Mode = this.GetChangeFeedMode()
+                Mode = this.GetChangeFeedMode(),
+                StartTime = startTime,
             };
 
             this.requestOptionsFactory.AddPartitionKeyIfNeeded(
@@ -147,7 +153,12 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
 
         public override Task<DocumentServiceLease> CreateLeaseIfNotExistAsync(
             FeedRangeEpk feedRange,
-            string continuationToken)
+            string continuationToken) => this.CreateLeaseIfNotExistAsync(feedRange, continuationToken, startTime: null);
+
+        public override Task<DocumentServiceLease> CreateLeaseIfNotExistAsync(
+            FeedRangeEpk feedRange,
+            string continuationToken,
+            DateTime? startTime)
         {
             if (feedRange == null)
             {
@@ -162,7 +173,8 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
                 LeaseToken = leaseToken,
                 ContinuationToken = continuationToken,
                 FeedRange = feedRange,
-                Mode = this.GetChangeFeedMode()
+                Mode = this.GetChangeFeedMode(),
+                StartTime = startTime,
             };
 
             this.requestOptionsFactory.AddPartitionKeyIfNeeded(

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseManagerInMemory.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseManagerInMemory.cs
@@ -47,7 +47,12 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
 
         public override Task<DocumentServiceLease> CreateLeaseIfNotExistAsync(
             PartitionKeyRange partitionKeyRange,
-            string continuationToken)
+            string continuationToken) => this.CreateLeaseIfNotExistAsync(partitionKeyRange, continuationToken, startTime: null);
+
+        public override Task<DocumentServiceLease> CreateLeaseIfNotExistAsync(
+            PartitionKeyRange partitionKeyRange,
+            string continuationToken,
+            DateTime? startTime)
         {
             if (partitionKeyRange == null)
             {
@@ -60,7 +65,8 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
                 LeaseId = leaseToken,
                 LeaseToken = leaseToken,
                 ContinuationToken = continuationToken,
-                FeedRange = new FeedRangeEpk(partitionKeyRange.ToRange())
+                FeedRange = new FeedRangeEpk(partitionKeyRange.ToRange()),
+                StartTime = startTime,
             };
 
             return this.TryCreateDocumentServiceLeaseAsync(documentServiceLease);
@@ -68,7 +74,12 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
 
         public override Task<DocumentServiceLease> CreateLeaseIfNotExistAsync(
             FeedRangeEpk feedRange,
-            string continuationToken)
+            string continuationToken) => this.CreateLeaseIfNotExistAsync(feedRange, continuationToken, startTime: null);
+
+        public override Task<DocumentServiceLease> CreateLeaseIfNotExistAsync(
+            FeedRangeEpk feedRange,
+            string continuationToken,
+            DateTime? startTime)
         {
             if (feedRange == null)
             {
@@ -81,7 +92,8 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
                 LeaseId = leaseToken,
                 LeaseToken = leaseToken,
                 ContinuationToken = continuationToken,
-                FeedRange = feedRange
+                FeedRange = feedRange,
+                StartTime = startTime,
             };
 
             return this.TryCreateDocumentServiceLeaseAsync(documentServiceLease);

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseStoreManagerBuilder.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseStoreManagerBuilder.cs
@@ -23,7 +23,9 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
             ContainerInternal leaseContainer,
             string leaseContainerPrefix,
             string instanceName,
-            ChangeFeedMode changeFeedMode)
+            ChangeFeedMode changeFeedMode,
+            DateTime? startTime = null,
+            bool isStartTimeUserExplicit = false)
         {
             ContainerProperties containerProperties = await leaseContainer.GetCachedContainerPropertiesAsync(forceRefresh: false, NoOpTrace.Singleton, cancellationToken: default);
 
@@ -60,7 +62,8 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
                 .WithLeaseContainer(leaseContainer)
                 .WithRequestOptionsFactory(requestOptionsFactory)
                 .WithHostName(instanceName)
-                .WithChangeFeedMode(changeFeedMode);
+                .WithChangeFeedMode(changeFeedMode)
+                .WithStartTime(startTime, isStartTimeUserExplicit);
 
             return leaseStoreManagerBuilder.Build();
         }
@@ -103,6 +106,13 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
         private DocumentServiceLeaseStoreManagerBuilder WithChangeFeedMode(ChangeFeedMode changeFeedMode)
         {
             this.options.Mode = changeFeedMode ?? throw new ArgumentNullException(nameof(changeFeedMode));
+            return this;
+        }
+
+        private DocumentServiceLeaseStoreManagerBuilder WithStartTime(DateTime? startTime, bool isUserExplicit)
+        {
+            this.options.StartTime = startTime;
+            this.options.IsStartTimeUserExplicit = isUserExplicit;
             return this;
         }
 

--- a/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseStoreManagerOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/ChangeFeedProcessor/LeaseManagement/DocumentServiceLeaseStoreManagerOptions.cs
@@ -4,6 +4,8 @@
 
 namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
 {
+    using System;
+
     internal class DocumentServiceLeaseStoreManagerOptions
     {
         private const string PartitionLeasePrefixSeparator = "..";
@@ -18,5 +20,19 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement
         }
 
         internal ChangeFeedMode Mode { get; set; }
+
+        /// <summary>
+        /// Gets or sets the start time to persist on leases during acquisition.
+        /// When set, this value is stored on every lease during AcquireAsync to ensure
+        /// it survives processor restarts even for partitions that never checkpoint.
+        /// A null value means "clear the start time from the lease".
+        /// </summary>
+        internal DateTime? StartTime { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether the StartTime was explicitly set by the user.
+        /// When false, the start time on the lease is not modified during acquisition.
+        /// </summary>
+        internal bool IsStartTimeUserExplicit { get; set; }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/Headers/Headers.cs
+++ b/Microsoft.Azure.Cosmos/src/Headers/Headers.cs
@@ -18,7 +18,7 @@ namespace Microsoft.Azure.Cosmos
     /// <seealso cref="RequestMessage"/>
     public class Headers : IEnumerable
     {
-        internal static readonly string SDKSUPPORTEDCAPABILITIES = SDKSupportedCapabilitiesHelpers.GetSDKSupportedCapabilities().ToString(
+        internal static readonly string SDKSUPPORTEDCAPABILITIES = Microsoft.Azure.Cosmos.SDKSupportedCapabilitiesHelpers.GetSDKSupportedCapabilities().ToString(
             CultureInfo.InvariantCulture);
 
         internal virtual SubStatusCodes SubStatusCode

--- a/Microsoft.Azure.Cosmos/src/Headers/SDKSupportedCapabilitiesHelpers.cs
+++ b/Microsoft.Azure.Cosmos/src/Headers/SDKSupportedCapabilitiesHelpers.cs
@@ -1,0 +1,16 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos
+{
+    internal static class SDKSupportedCapabilitiesHelpers
+    {
+        public static ulong GetSDKSupportedCapabilities()
+        {
+            return (ulong)(Microsoft.Azure.Documents.SDKSupportedCapabilities.PartitionMerge
+                | Microsoft.Azure.Documents.SDKSupportedCapabilities.ChangeFeedWithStartTimePostMerge
+                | Microsoft.Azure.Documents.SDKSupportedCapabilities.IgnoreUnknownRntbdTokens);
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/src/Pagination/NetworkAttachedDocumentContainer.cs
+++ b/Microsoft.Azure.Cosmos/src/Pagination/NetworkAttachedDocumentContainer.cs
@@ -371,7 +371,9 @@ namespace Microsoft.Azure.Cosmos.Pagination
                 double requestCharge = responseMessage.Headers.RequestCharge;
                 string activityId = responseMessage.Headers.ActivityId;
                 int itemCount = int.Parse(responseMessage.Headers.ItemCount);
-                ChangeFeedState state = ChangeFeedState.Continuation(CosmosString.Create(responseMessage.Headers.ETag));
+                ChangeFeedState state = NetworkAttachedDocumentContainer.CreateChangeFeedStateFromResponse(
+                    feedRangeState.State,
+                    responseMessage.Headers.ETag);
                 Dictionary<string, string> additionalHeaders = GetAdditionalHeaders(
                     responseMessage.Headers.CosmosMessageHeaders,
                     ChangeFeedPage.BannedHeaders);
@@ -458,6 +460,22 @@ namespace Microsoft.Azure.Cosmos.Pagination
                 message.Headers.IfNoneMatch = (changeFeedStateContinuation.ContinuationToken as CosmosString).Value;
             }
 
+            public void Visit(ChangeFeedStateContinuationAndStartTime changeFeedStateContinuationAndStartTime, RequestMessage message)
+            {
+                // When a merge happens, the child partition will contain documents ordered by LSN but the _ts/creation time
+                // of the documents may not be sequential. So when reading the change feed by LSN, it is possible to encounter
+                // documents with lower _ts. In order to guarantee we always get the documents after the customer's point start
+                // time, we need to always pass the start time in the header alongside the continuation token.
+                if (changeFeedStateContinuationAndStartTime.StartTime != ChangeFeedStateRequestMessagePopulator.StartFromBeginningTime)
+                {
+                    message.Headers.Add(
+                        HttpConstants.HttpHeaders.IfModifiedSince,
+                        changeFeedStateContinuationAndStartTime.StartTime.ToString("r", CultureInfo.InvariantCulture));
+                }
+
+                message.Headers.IfNoneMatch = (changeFeedStateContinuationAndStartTime.ContinuationToken as CosmosString).Value;
+            }
+
             public void Visit(ChangeFeedStateNow changeFeedStateNow, RequestMessage message)
             {
                 message.Headers.IfNoneMatch = ChangeFeedStateRequestMessagePopulator.IfNoneMatchAllHeaderValue;
@@ -476,6 +494,28 @@ namespace Microsoft.Azure.Cosmos.Pagination
             }
 
             return additionalHeaders;
+        }
+
+        /// <summary>
+        /// Creates the appropriate <see cref="ChangeFeedState"/> after receiving a response.
+        /// When the previous state was time-based, preserves the start time alongside the continuation token
+        /// to handle partition merge scenarios where documents may be out of time order.
+        /// </summary>
+        private static ChangeFeedState CreateChangeFeedStateFromResponse(ChangeFeedState previousState, string etag)
+        {
+            CosmosElement continuationToken = CosmosString.Create(etag);
+
+            if (previousState is ChangeFeedStateTime changeFeedStateTime)
+            {
+                return ChangeFeedState.ContinuationAndStartTime(continuationToken, changeFeedStateTime.StartTime);
+            }
+
+            if (previousState is ChangeFeedStateContinuationAndStartTime existingComposite)
+            {
+                return ChangeFeedState.ContinuationAndStartTime(continuationToken, existingComposite.StartTime);
+            }
+
+            return ChangeFeedState.Continuation(continuationToken);
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/DynamicTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/ChangeFeed/DynamicTests.cs
@@ -12,6 +12,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
     using Microsoft.Azure.Cosmos.Scripts;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
 
     [TestClass]
     [TestCategory("ChangeFeed")]
@@ -407,6 +408,156 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
             Assert.AreEqual("doc5.doc6.doc7.doc8.doc9.", accumulator);
         }
 
+        [TestMethod]
+        public async Task TestWithStartTime_ValidatesEtagInHeaders()
+        {
+            ChangeFeedHeaderValidationHandler headerHandler = new ChangeFeedHeaderValidationHandler();
+
+            foreach (int id in Enumerable.Range(0, 100))
+            {
+                await this.Container.CreateItemAsync<dynamic>(new { id = $"doc{id}", pk = Guid.NewGuid().ToString() });
+            }
+
+            // Inject validating handler
+            CosmosClient client = this.GetClient();
+            RequestHandler currentInnerHandler = client.RequestHandler.InnerHandler;
+            client.RequestHandler.InnerHandler = headerHandler;
+            headerHandler.InnerHandler = currentInnerHandler;
+
+            try
+            {
+                DateTime startTime = DateTime.UtcNow.AddMinutes(-5);
+                string expectedIfModifiedSince = startTime.ToString("r", System.Globalization.CultureInfo.InvariantCulture);
+
+                ManualResetEvent allDocsProcessed = new ManualResetEvent(false);
+
+                int processedDocCount = 0;
+                Container.ChangeFeedHandlerWithManualCheckpoint<dynamic> onChangesDelegate = async (
+                    ChangeFeedProcessorContext context,
+                    IReadOnlyCollection<dynamic> docs,
+                    Func<Task> checkpointAsync,
+                    CancellationToken token) =>
+                    {
+                        processedDocCount += docs.Count;
+
+                        // Persist the continuation token to the lease before signaling the test,
+                        // so the checkpoint is guaranteed to complete before the processor is
+                        // stopped and a new one is constructed against the same lease.
+                        await checkpointAsync();
+
+                        allDocsProcessed.Set();
+                    };
+                ChangeFeedProcessor processor = this.Container
+                    .GetChangeFeedProcessorBuilderWithManualCheckpoint("test", onChangesDelegate)
+                    .WithStartTime(startTime)
+                    .WithInstanceName("random")
+                    .WithLeaseContainer(this.LeaseContainer).Build();
+               
+                await StartProcessorAndValidateHeadersAsync(processor, allDocsProcessed, headerHandler, expectedIfModifiedSince);
+                Dictionary<string, string> continuationTokens = await this.ValidateLeaseDocumentsAsync(startTime);
+
+                allDocsProcessed.Reset();
+
+                processor = this.Container
+                    .GetChangeFeedProcessorBuilderWithManualCheckpoint("test", onChangesDelegate)
+                    .WithInstanceName("random")
+                    .WithLeaseContainer(this.LeaseContainer).Build();
+
+                await StartProcessorAndValidateHeadersAsync(processor, allDocsProcessed, headerHandler, expectedIfModifiedSince, processDocuments: false);
+                continuationTokens = await this.ValidateLeaseDocumentsAsync(startTime, continuationTokens);
+
+                allDocsProcessed.Reset();
+
+                DateTime startTime1 = startTime + TimeSpan.FromMinutes(1);
+                processor = this.Container
+                    .GetChangeFeedProcessorBuilderWithManualCheckpoint("test", onChangesDelegate)
+                    .WithInstanceName("random")
+                    .WithStartTime(startTime1)
+                    .WithLeaseContainer(this.LeaseContainer).Build();
+
+                expectedIfModifiedSince = startTime1.ToString("r", System.Globalization.CultureInfo.InvariantCulture);
+
+                await StartProcessorAndValidateHeadersAsync(processor, allDocsProcessed, headerHandler, expectedIfModifiedSince, processDocuments: false);
+                continuationTokens = await this.ValidateLeaseDocumentsAsync(startTime1, continuationTokens);
+
+                allDocsProcessed.Reset();
+                processor = this.Container
+                    .GetChangeFeedProcessorBuilderWithManualCheckpoint("test", onChangesDelegate)
+                    .WithInstanceName("random")
+                    .WithLeaseContainer(this.LeaseContainer).Build();
+
+                await StartProcessorAndValidateHeadersAsync(processor, allDocsProcessed, headerHandler, expectedIfModifiedSince, processDocuments: false);
+                continuationTokens = await this.ValidateLeaseDocumentsAsync(startTime1, continuationTokens);
+
+                allDocsProcessed.Reset();
+                startTime1 = DateTime.MinValue;
+                processor = this.Container
+                    .GetChangeFeedProcessorBuilderWithManualCheckpoint("test", onChangesDelegate)
+                    .WithInstanceName("random")
+                    .WithStartTime(startTime1)
+                    .WithLeaseContainer(this.LeaseContainer).Build();
+
+                await StartProcessorAndValidateHeadersAsync(processor, allDocsProcessed, headerHandler, expectedIfModifiedSince: null, processDocuments: false);
+                await this.ValidateLeaseDocumentsAsync(expectedStartTime: null, continuationTokens);
+            }
+            finally
+            {
+                // Restore original handler chain
+                client.RequestHandler.InnerHandler = currentInnerHandler;
+            }
+        }
+
+        private static async Task StartProcessorAndValidateHeadersAsync(
+            ChangeFeedProcessor processor,
+            ManualResetEvent allDocsProcessed,
+            ChangeFeedHeaderValidationHandler headerHandler,
+            string expectedIfModifiedSince,
+            bool processDocuments = true)
+        {
+            headerHandler.CapturedRequests.Clear();
+            await processor.StartAsync();
+            bool isStartOk = allDocsProcessed.WaitOne(10 * BaseChangeFeedClientHelper.ChangeFeedSetupTime);
+            await processor.StopAsync();
+            if (processDocuments)
+            {
+                Assert.IsTrue(isStartOk, "Timed out waiting for docs to process");
+            }
+
+            bool foundSubsequentWithEtag = false;
+            ulong changeFeedWithStartTimePostMergeFlag = (ulong)Microsoft.Azure.Documents.SDKSupportedCapabilities.ChangeFeedWithStartTimePostMerge;
+            for (int i = 0; i < headerHandler.CapturedRequests.Count; i++)
+            {
+                RequestMessage subsequentRequest = headerHandler.CapturedRequests[i];
+                string subsequentIfNoneMatch = subsequentRequest.Headers.IfNoneMatch;
+                if (subsequentIfNoneMatch != null)
+                {
+                    foundSubsequentWithEtag = true;
+                    Assert.AreNotEqual("*", subsequentIfNoneMatch, "If-None-Match should be a specific etag, not '*'.");
+                }
+
+                string ifModifiedSince = subsequentRequest.Headers[Microsoft.Azure.Documents.HttpConstants.HttpHeaders.IfModifiedSince];
+
+                if (expectedIfModifiedSince != null)
+                {
+                    Assert.IsNotNull(ifModifiedSince, "If-Modified-Since header should be set on the first change feed request with start time.");
+                    Assert.AreEqual(expectedIfModifiedSince, ifModifiedSince, "If-Modified-Since header value should match the start time.");
+                }
+                else
+                {
+                    Assert.IsNull(ifModifiedSince, "If-Modified-Since header should not be set when start time is cleared.");
+                }
+
+                string sdkCapabilities = subsequentRequest.Headers[Microsoft.Azure.Documents.HttpConstants.HttpHeaders.SDKSupportedCapabilities];
+                Assert.IsNotNull(sdkCapabilities, "SDKSupportedCapabilities header should be present on change feed requests.");
+                ulong capabilitiesValue = ulong.Parse(sdkCapabilities);
+                Assert.IsTrue(
+                    (capabilitiesValue & changeFeedWithStartTimePostMergeFlag) == changeFeedWithStartTimePostMergeFlag,
+                    $"SDKSupportedCapabilities header should include ChangeFeedWithStartTimePostMerge flag. Actual value: {capabilitiesValue}");
+            }
+
+            Assert.IsTrue(foundSubsequentWithEtag, "Expected at least one subsequent request with If-None-Match (etag) header.");
+        }
+
         private async Task ValidateContextAsync(ChangeFeedProcessorContext changeFeedProcessorContext)
         {
             Assert.IsNotNull(changeFeedProcessorContext.LeaseToken);
@@ -429,5 +580,124 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests.ChangeFeed
             Assert.IsNotNull(partitionKeyRanges);
         }
 
+        /// <summary>
+        /// <summary>
+        /// Validates that all lease documents in the lease container have the expected StartTime
+        /// and verifies ContinuationToken state. Returns the per-lease continuation tokens observed
+        /// so callers can assert they are preserved / advance across processor restarts.
+        /// </summary>
+        /// <param name="expectedStartTime">The StartTime expected on every lease, or null if it should be cleared.</param>
+        /// <param name="previousContinuationTokens">
+        /// Continuation tokens captured from a prior validation. When provided, every lease that had a
+        /// token before must still have a non-empty token whose LSN does not regress across the restart.
+        /// </param>
+        private async Task<Dictionary<string, string>> ValidateLeaseDocumentsAsync(
+            DateTime? expectedStartTime,
+            IReadOnlyDictionary<string, string> previousContinuationTokens = null)
+        {
+            using FeedIterator<JObject> iterator = this.LeaseContainer.GetItemQueryIterator<JObject>();
+            int leaseCount = 0;
+            bool foundLeaseWithContinuation = false;
+            Dictionary<string, string> continuationTokens = new Dictionary<string, string>();
+            while (iterator.HasMoreResults)
+            {
+                FeedResponse<JObject> page = await iterator.ReadNextAsync();
+                foreach (JObject lease in page)
+                {
+                    string leaseId = lease.Value<string>("id");
+                    if (leaseId.Contains(".info") || leaseId.Contains(".lock"))
+                    {
+                        // Skip store initialization markers
+                        continue;
+                    }
+
+                    leaseCount++;
+
+                    string continuationToken = lease.Value<string>("ContinuationToken");
+                    if (!string.IsNullOrEmpty(continuationToken))
+                    {
+                        foundLeaseWithContinuation = true;
+
+                        // The change feed continuation token is the response ETag, i.e. a (quoted) numeric LSN.
+                        Assert.IsTrue(
+                            TryParseLsn(continuationToken, out long _),
+                            $"Lease '{leaseId}' ContinuationToken '{continuationToken}' should be a numeric LSN etag.");
+
+                        continuationTokens[leaseId] = continuationToken;
+                    }
+
+                    // Once a lease has checkpointed, restarting the processor must never wipe or roll back
+                    // its progress (that would indicate data loss / an unwanted re-anchor).
+                    if (previousContinuationTokens != null
+                        && previousContinuationTokens.TryGetValue(leaseId, out string previousToken))
+                    {
+                        Assert.IsFalse(
+                            string.IsNullOrEmpty(continuationToken),
+                            $"Lease '{leaseId}' lost its ContinuationToken across restart (progress wiped).");
+
+                        if (TryParseLsn(previousToken, out long previousLsn)
+                            && TryParseLsn(continuationToken, out long currentLsn))
+                        {
+                            Assert.IsTrue(
+                                currentLsn >= previousLsn,
+                                $"Lease '{leaseId}' ContinuationToken regressed across restart: {previousToken} -> {continuationToken}.");
+                        }
+                    }
+
+                    JToken startTimeToken = lease["StartTime"];
+                    if (expectedStartTime.HasValue)
+                    {
+                        Assert.IsNotNull(startTimeToken, $"Lease '{leaseId}' should have StartTime persisted.");
+                        DateTime actualStartTime = startTimeToken.Value<DateTime>();
+                        Assert.AreEqual(expectedStartTime.Value, actualStartTime, $"Lease '{leaseId}' StartTime mismatch.");
+                    }
+                    else
+                    {
+                        Assert.IsNull(startTimeToken, $"Lease '{leaseId}' should not have StartTime when cleared.");
+                    }
+                }
+            }
+
+            Assert.IsTrue(leaseCount > 0, "Expected at least one lease document in the lease container.");
+            Assert.IsTrue(foundLeaseWithContinuation, "Expected at least one lease with a ContinuationToken.");
+
+            return continuationTokens;
+        }
+
+        /// <summary>
+        /// Parses a change feed continuation token (the response ETag, optionally surrounded by quotes)
+        /// into its numeric LSN.
+        /// </summary>
+        private static bool TryParseLsn(string continuationToken, out long lsn)
+        {
+            lsn = 0;
+            if (string.IsNullOrEmpty(continuationToken))
+            {
+                return false;
+            }
+
+            string trimmed = continuationToken.Trim().Trim('"');
+            return long.TryParse(
+                trimmed,
+                System.Globalization.NumberStyles.Integer,
+                System.Globalization.CultureInfo.InvariantCulture,
+                out lsn);
+        }
+    }
+
+    internal class ChangeFeedHeaderValidationHandler : RequestHandler
+    {
+        public List<RequestMessage> CapturedRequests { get; } = new List<RequestMessage>();
+
+        public override Task<ResponseMessage> SendAsync(RequestMessage request, CancellationToken cancellationToken)
+        {
+            if (request.ResourceType == Microsoft.Azure.Documents.ResourceType.Document
+                && request.OperationType == Microsoft.Azure.Documents.OperationType.ReadFeed)
+            {
+                this.CapturedRequests.Add(request);
+            }
+
+            return base.SendAsync(request, cancellationToken);
+        }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/FeedToken/ChangeFeedIteratorCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/FeedToken/ChangeFeedIteratorCoreTests.cs
@@ -698,6 +698,98 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.FeedRanges
             }
         }
 
+        /// <summary>
+        /// Validates that when using ChangeFeedStartFrom.Time, the If-Modified-Since header is sent
+        /// on the first request and the If-None-Match (etag) header is sent on subsequent requests
+        /// as the continuation token.
+        /// </summary>
+        [TestMethod]
+        public async Task ChangeFeedIteratorCore_StartFromTime_ValidatesEtagInHeaders()
+        {
+            ChangeFeedHeaderValidationHandler headerHandler = new ChangeFeedHeaderValidationHandler();
+
+            ContainerInternal itemsCore = await this.InitializeContainerAsync();
+            await this.CreateRandomItems(itemsCore, 10, randomPartitionKey: true);
+
+            // Inject validating handler
+            RequestHandler currentInnerHandler = this.GetClient().RequestHandler.InnerHandler;
+            this.GetClient().RequestHandler.InnerHandler = headerHandler;
+            headerHandler.InnerHandler = currentInnerHandler;
+
+            try
+            {
+                DateTime startTime = DateTime.UtcNow.AddMinutes(-5);
+                string expectedIfModifiedSince = startTime.ToString("r", System.Globalization.CultureInfo.InvariantCulture);
+
+                ChangeFeedIteratorCore feedIterator = itemsCore.GetChangeFeedStreamIterator(
+                    ChangeFeedStartFrom.Time(startTime),
+                    ChangeFeedMode.Incremental,
+                    new ChangeFeedRequestOptions()
+                    {
+                        PageSizeHint = 1,
+                    }) as ChangeFeedIteratorCore;
+
+                // First read — should have If-Modified-Since but no If-None-Match (etag)
+                await feedIterator.ReadNextAsync(this.cancellationToken);
+                Assert.IsTrue(headerHandler.CapturedRequests.Count > 0, "Expected at least one request to be captured.");
+
+                RequestMessage firstCapturedRequest = headerHandler.CapturedRequests[0];
+                string ifModifiedSince = firstCapturedRequest.Headers[Microsoft.Azure.Documents.HttpConstants.HttpHeaders.IfModifiedSince];
+                Assert.IsNotNull(ifModifiedSince, "If-Modified-Since header should be set on the first change feed request with start time.");
+                Assert.AreEqual(expectedIfModifiedSince, ifModifiedSince, "If-Modified-Since header value should match the start time.");
+
+                string ifNoneMatch = firstCapturedRequest.Headers.IfNoneMatch;
+                Assert.IsNull(ifNoneMatch, "If-None-Match (etag) header should not be set on the first change feed request.");
+
+                // Validate SDKSupportedCapabilities includes ChangeFeedWithStartTimePostMerge on the first request
+                string sdkCapabilities = firstCapturedRequest.Headers[Microsoft.Azure.Documents.HttpConstants.HttpHeaders.SDKSupportedCapabilities];
+                Assert.IsNotNull(sdkCapabilities, "SDKSupportedCapabilities header should be present on the first change feed request.");
+                ulong capabilitiesValue = ulong.Parse(sdkCapabilities);
+                ulong changeFeedWithStartTimePostMergeFlag = (ulong)Microsoft.Azure.Documents.SDKSupportedCapabilities.ChangeFeedWithStartTimePostMerge;
+                Assert.IsTrue(
+                    (capabilitiesValue & changeFeedWithStartTimePostMergeFlag) == changeFeedWithStartTimePostMergeFlag,
+                    $"SDKSupportedCapabilities header should include ChangeFeedWithStartTimePostMerge flag on first request. Actual value: {capabilitiesValue}");
+
+                while (feedIterator.HasMoreResults)
+                {
+                    // After reading the first page, subsequent requests should include If-None-Match (the etag/continuation)
+                    headerHandler.CapturedRequests.Clear();
+
+                    using (ResponseMessage feedResponse = await feedIterator.ReadNextAsync(this.cancellationToken))
+                    {
+                        Assert.IsTrue(headerHandler.CapturedRequests.Count > 0, "Expected at least one request in the second read.");
+
+                        RequestMessage capturedRequest = headerHandler.CapturedRequests[0];
+                        ifNoneMatch = capturedRequest.Headers.IfNoneMatch;
+                        Assert.IsNotNull(ifNoneMatch, "If-None-Match (etag) header should be set on subsequent change feed requests as the continuation.");
+                        Assert.AreNotEqual("*", ifNoneMatch, "If-None-Match should be a specific etag, not '*'.");
+
+                        // The If-Modified-Since should still be present on subsequent requests (for merge handling)
+                        ifModifiedSince = capturedRequest.Headers[Microsoft.Azure.Documents.HttpConstants.HttpHeaders.IfModifiedSince];
+                        Assert.IsNotNull(ifModifiedSince, "If-Modified-Since should still be present on subsequent requests for start time based change feed.");
+
+                        // Validate that SDKSupportedCapabilities header includes ChangeFeedWithStartTimePostMerge
+                        sdkCapabilities = capturedRequest.Headers[Microsoft.Azure.Documents.HttpConstants.HttpHeaders.SDKSupportedCapabilities];
+                        Assert.IsNotNull(sdkCapabilities, "SDKSupportedCapabilities header should be present on change feed requests.");
+                        capabilitiesValue = ulong.Parse(sdkCapabilities);
+                        Assert.IsTrue(
+                            (capabilitiesValue & changeFeedWithStartTimePostMergeFlag) == changeFeedWithStartTimePostMergeFlag,
+                            $"SDKSupportedCapabilities header should include ChangeFeedWithStartTimePostMerge flag. Actual value: {capabilitiesValue}");
+
+                        if (feedResponse.StatusCode == HttpStatusCode.NotModified)
+                        {
+                            break;
+                        }
+                    }
+                }
+            }
+            finally
+            {
+                // Restore original handler chain
+                this.GetClient().RequestHandler.InnerHandler = currentInnerHandler;
+            }
+        }
+
         [TestMethod]
         public async Task TestCancellationTokenAsync()
         {
@@ -1261,6 +1353,23 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.FeedRanges
             public override Task<ResponseMessage> SendAsync(RequestMessage request, CancellationToken cancellationToken)
             {
                 this.LastUsedToken = cancellationToken;
+                return base.SendAsync(request, cancellationToken);
+            }
+        }
+
+        private class ChangeFeedHeaderValidationHandler : RequestHandler
+        {
+            public List<RequestMessage> CapturedRequests { get; } = new List<RequestMessage>();
+
+            public override Task<ResponseMessage> SendAsync(RequestMessage request, CancellationToken cancellationToken)
+            {
+                // Capture only change feed requests (ReadFeed on Document resource type with A-IM header)
+                if (request.ResourceType == Documents.ResourceType.Document
+                    && request.OperationType == Documents.OperationType.ReadFeed)
+                {
+                    this.CapturedRequests.Add(request);
+                }
+
                 return base.SendAsync(request, cancellationToken);
             }
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/FeedToken/ChangeFeedIteratorCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/FeedToken/ChangeFeedIteratorCoreTests.cs
@@ -729,8 +729,13 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.FeedRanges
                         PageSizeHint = 1,
                     }) as ChangeFeedIteratorCore;
 
-                // First read — should have If-Modified-Since but no If-None-Match (etag)
-                await feedIterator.ReadNextAsync(this.cancellationToken);
+                string continuationToken;
+                using (ResponseMessage firstResponse = await feedIterator.ReadNextAsync(this.cancellationToken))
+                {
+                    continuationToken = firstResponse.Headers.ContinuationToken;
+                }
+
+                // First read should have If-Modified-Since but no If-None-Match (etag).
                 Assert.IsTrue(headerHandler.CapturedRequests.Count > 0, "Expected at least one request to be captured.");
 
                 RequestMessage firstCapturedRequest = headerHandler.CapturedRequests[0];
@@ -750,25 +755,35 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.FeedRanges
                     (capabilitiesValue & changeFeedWithStartTimePostMergeFlag) == changeFeedWithStartTimePostMergeFlag,
                     $"SDKSupportedCapabilities header should include ChangeFeedWithStartTimePostMerge flag on first request. Actual value: {capabilitiesValue}");
 
-                while (feedIterator.HasMoreResults)
+                Assert.IsFalse(string.IsNullOrEmpty(continuationToken), "The first response should return a continuation token.");
+                StringAssert.Contains(continuationToken, "startTime", "The continuation token should persist the original start time.");
+
+                headerHandler.CapturedRequests.Clear();
+                feedIterator = itemsCore.GetChangeFeedStreamIterator(
+                    ChangeFeedStartFrom.ContinuationToken(continuationToken),
+                    ChangeFeedMode.Incremental,
+                    new ChangeFeedRequestOptions()
+                    {
+                        PageSizeHint = 1,
+                    }) as ChangeFeedIteratorCore;
+
+                bool receivedNotModified = false;
+                while (!receivedNotModified)
                 {
-                    // After reading the first page, subsequent requests should include If-None-Match (the etag/continuation)
                     headerHandler.CapturedRequests.Clear();
 
                     using (ResponseMessage feedResponse = await feedIterator.ReadNextAsync(this.cancellationToken))
                     {
-                        Assert.IsTrue(headerHandler.CapturedRequests.Count > 0, "Expected at least one request in the second read.");
+                        Assert.IsTrue(headerHandler.CapturedRequests.Count > 0, "Expected a request from the resumed iterator.");
 
                         RequestMessage capturedRequest = headerHandler.CapturedRequests[0];
                         ifNoneMatch = capturedRequest.Headers.IfNoneMatch;
-                        Assert.IsNotNull(ifNoneMatch, "If-None-Match (etag) header should be set on subsequent change feed requests as the continuation.");
+                        Assert.IsNotNull(ifNoneMatch, "The resumed iterator should send the persisted continuation as If-None-Match.");
                         Assert.AreNotEqual("*", ifNoneMatch, "If-None-Match should be a specific etag, not '*'.");
 
-                        // The If-Modified-Since should still be present on subsequent requests (for merge handling)
                         ifModifiedSince = capturedRequest.Headers[Microsoft.Azure.Documents.HttpConstants.HttpHeaders.IfModifiedSince];
-                        Assert.IsNotNull(ifModifiedSince, "If-Modified-Since should still be present on subsequent requests for start time based change feed.");
+                        Assert.AreEqual(expectedIfModifiedSince, ifModifiedSince, "The resumed iterator should preserve the original start time.");
 
-                        // Validate that SDKSupportedCapabilities header includes ChangeFeedWithStartTimePostMerge
                         sdkCapabilities = capturedRequest.Headers[Microsoft.Azure.Documents.HttpConstants.HttpHeaders.SDKSupportedCapabilities];
                         Assert.IsNotNull(sdkCapabilities, "SDKSupportedCapabilities header should be present on change feed requests.");
                         capabilitiesValue = ulong.Parse(sdkCapabilities);
@@ -778,9 +793,25 @@ namespace Microsoft.Azure.Cosmos.EmulatorTests.FeedRanges
 
                         if (feedResponse.StatusCode == HttpStatusCode.NotModified)
                         {
-                            break;
+                            receivedNotModified = true;
                         }
                     }
+                }
+
+                await this.CreateRandomItems(itemsCore, 1, randomPartitionKey: true);
+                headerHandler.CapturedRequests.Clear();
+
+                using (ResponseMessage feedResponse = await feedIterator.ReadNextAsync(this.cancellationToken))
+                {
+                    Assert.AreEqual(HttpStatusCode.OK, feedResponse.StatusCode, "The resumed iterator should read a document added after NotModified.");
+                    Assert.IsTrue(headerHandler.CapturedRequests.Count > 0, "Expected a request after the NotModified transition.");
+
+                    RequestMessage capturedRequest = headerHandler.CapturedRequests[0];
+                    Assert.IsNotNull(capturedRequest.Headers.IfNoneMatch, "If-None-Match should survive a NotModified transition.");
+                    Assert.AreEqual(
+                        expectedIfModifiedSince,
+                        capturedRequest.Headers[Microsoft.Azure.Documents.HttpConstants.HttpHeaders.IfModifiedSince],
+                        "If-Modified-Since should survive a NotModified transition.");
                 }
             }
             finally

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/GatewayTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/GatewayTests.cs
@@ -2779,11 +2779,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 accumulator = await this.ReadChangeFeedToEnd(client, coll.SelfLink, options);
                 Assert.AreEqual(string.Empty, accumulator);
 
-                // 8. If-None-Match wins.
+                // 8. Both If-None-Match and If-Modified-Since apply — start time filters documents at the continuation position.
                 options.StartTime = timestamps[1];
                 options.RequestContinuation = lsns[0].ToString();
                 accumulator = await this.ReadChangeFeedToEnd(client, coll.SelfLink, options);
-                Assert.AreEqual("doc2.", accumulator);
+                Assert.AreEqual(string.Empty, accumulator);
             }
             finally
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ChangeFeedProcessorCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ChangeFeedProcessorCoreTests.cs
@@ -9,9 +9,11 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
+    using System.Reflection;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.ChangeFeed.Configuration;
+    using Microsoft.Azure.Cosmos.ChangeFeed.FeedProcessing;
     using Microsoft.Azure.Cosmos.ChangeFeed.LeaseManagement;
     using Microsoft.Azure.Cosmos.Tests;
     using Microsoft.Azure.Cosmos.Tracing;
@@ -683,6 +685,142 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
 
             // Assert — ShutdownAsync was still invoked
             leaseStoreManager.Verify(l => l.ShutdownAsync(), Times.Once);
+        }
+
+        [TestMethod]
+        public void FeedProcessorFactory_AutoAnchoredStartTime_WithContinuationToken_DoesNotForwardStartTimeToIterator()
+        {
+            // Regression guard: when the user did NOT provide a start time, ChangeFeedProcessorCore.StartAsync
+            // auto-anchors StartTime to "now - 1s" on every restart. If a lease from a previous run carries a
+            // continuation token, forwarding that anchored time to the iterator would emit If-Modified-Since
+            // alongside If-None-Match, causing the service's combined filter to silently drop every document
+            // created while the processor was stopped. The anchored time must NOT reach the iterator here.
+            DateTime anchoredStartTime = DateTime.UtcNow.AddSeconds(-1);
+            ChangeFeedProcessorOptions options = new ChangeFeedProcessorOptions
+            {
+                StartTime = anchoredStartTime,
+                IsStartTimeUserExplicit = false,
+            };
+
+            DocumentServiceLeaseCore lease = new DocumentServiceLeaseCore
+            {
+                LeaseId = "0",
+                LeaseToken = "0",
+                ContinuationToken = "old-lsn-continuation",
+            };
+
+            DateTime? iteratorStartTime = ChangeFeedProcessorCoreTests.GetIteratorStartTime(options, lease);
+
+            Assert.IsNull(
+                iteratorStartTime,
+                "Auto-anchored start time must not be combined with a continuation token.");
+        }
+
+        [TestMethod]
+        public void FeedProcessorFactory_UserExplicitStartTime_WithContinuationToken_ForwardsStartTimeToIterator()
+        {
+            // The merge scenario feature: when the user explicitly set a start time, it MUST be forwarded
+            // alongside the continuation token so If-Modified-Since filters out documents predating the
+            // user's requested start time even when reading by LSN.
+            DateTime explicitStartTime = DateTime.UtcNow.AddMinutes(-30);
+            ChangeFeedProcessorOptions options = new ChangeFeedProcessorOptions
+            {
+                StartTime = explicitStartTime,
+                IsStartTimeUserExplicit = true,
+            };
+
+            DocumentServiceLeaseCore lease = new DocumentServiceLeaseCore
+            {
+                LeaseId = "0",
+                LeaseToken = "0",
+                ContinuationToken = "old-lsn-continuation",
+            };
+
+            DateTime? iteratorStartTime = ChangeFeedProcessorCoreTests.GetIteratorStartTime(options, lease);
+
+            Assert.AreEqual(
+                explicitStartTime,
+                iteratorStartTime,
+                "User-explicit start time must be forwarded to the iterator alongside the continuation token.");
+        }
+
+        [TestMethod]
+        public void FeedProcessorFactory_AutoAnchoredStartTime_WithoutContinuationToken_ForwardsStartTimeToIterator()
+        {
+            // Cold start (no continuation token): the anchored start time is the intended initial read position
+            // (PR #5617). Because there is no continuation token, it is sent as a plain start-time read (not
+            // combined with If-None-Match), so it must still be forwarded to the iterator.
+            DateTime anchoredStartTime = DateTime.UtcNow.AddSeconds(-1);
+            ChangeFeedProcessorOptions options = new ChangeFeedProcessorOptions
+            {
+                StartTime = anchoredStartTime,
+                IsStartTimeUserExplicit = false,
+            };
+
+            DocumentServiceLeaseCore lease = new DocumentServiceLeaseCore
+            {
+                LeaseId = "0",
+                LeaseToken = "0",
+                ContinuationToken = null,
+            };
+
+            DateTime? iteratorStartTime = ChangeFeedProcessorCoreTests.GetIteratorStartTime(options, lease);
+
+            Assert.AreEqual(
+                anchoredStartTime,
+                iteratorStartTime,
+                "On cold start (no continuation token) the anchored start time must drive the initial read.");
+        }
+
+        private static DateTime? GetIteratorStartTime(
+            ChangeFeedProcessorOptions options,
+            DocumentServiceLease lease)
+        {
+            FeedProcessorFactoryCore factory = new FeedProcessorFactoryCore(
+                ChangeFeedProcessorCoreTests.GetMockedContainer("monitored"),
+                options,
+                Mock.Of<DocumentServiceLeaseCheckpointer>());
+
+            FeedProcessor processor = factory.Create(lease, Mock.Of<ChangeFeedObserver>());
+
+            FeedIterator iterator = (FeedIterator)typeof(FeedProcessorCore)
+                .GetField("resultSetIterator", BindingFlags.Instance | BindingFlags.NonPublic)
+                .GetValue(processor);
+
+            return (DateTime?)iterator.GetType()
+                .GetField("startTime", BindingFlags.Instance | BindingFlags.NonPublic)
+                .GetValue(iterator);
+        }
+
+        [TestMethod]
+        public void FeedProcessorFactory_PersistedLeaseStartTime_WithContinuationToken_ForwardsStartTimeToIterator()
+        {
+            // Restart scenario: the user set a start time in a previous run (persisted on the lease), then
+            // restarts WITHOUT calling WithStartTime (IsStartTimeUserExplicit == false). The persisted
+            // lease.StartTime is a real user value, so it must still be forwarded alongside the continuation
+            // token so If-Modified-Since keeps filtering documents predating the user's start time.
+            DateTime persistedStartTime = DateTime.UtcNow.AddMinutes(-5);
+            ChangeFeedProcessorOptions options = new ChangeFeedProcessorOptions
+            {
+                // On this restart StartAsync would auto-anchor since the user did not re-specify a start time.
+                StartTime = DateTime.UtcNow.AddSeconds(-1),
+                IsStartTimeUserExplicit = false,
+            };
+
+            DocumentServiceLeaseCore lease = new DocumentServiceLeaseCore
+            {
+                LeaseId = "0",
+                LeaseToken = "0",
+                ContinuationToken = "old-lsn-continuation",
+                StartTime = persistedStartTime,
+            };
+
+            DateTime? iteratorStartTime = ChangeFeedProcessorCoreTests.GetIteratorStartTime(options, lease);
+
+            Assert.AreEqual(
+                persistedStartTime,
+                iteratorStartTime,
+                "A persisted user start time on the lease must be forwarded to the iterator on restart.");
         }
 
         private static ChangeFeedProcessorCore CreateProcessor(

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ChangeFeedProcessorCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ChangeFeedProcessorCoreTests.cs
@@ -823,6 +823,32 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
                 "A persisted user start time on the lease must be forwarded to the iterator on restart.");
         }
 
+        [TestMethod]
+        public void FeedProcessorFactory_PersistedLeaseStartTime_WithoutContinuationToken_ForwardsStartTimeToIterator()
+        {
+            DateTime persistedStartTime = DateTime.UtcNow.AddMinutes(-5);
+            ChangeFeedProcessorOptions options = new ChangeFeedProcessorOptions
+            {
+                StartTime = DateTime.UtcNow.AddSeconds(-1),
+                IsStartTimeUserExplicit = false,
+            };
+
+            DocumentServiceLeaseCore lease = new DocumentServiceLeaseCore
+            {
+                LeaseId = "0",
+                LeaseToken = "0",
+                ContinuationToken = null,
+                StartTime = persistedStartTime,
+            };
+
+            DateTime? iteratorStartTime = ChangeFeedProcessorCoreTests.GetIteratorStartTime(options, lease);
+
+            Assert.AreEqual(
+                persistedStartTime,
+                iteratorStartTime,
+                "A persisted start time must remain the initial read position before the first checkpoint.");
+        }
+
         private static ChangeFeedProcessorCore CreateProcessor(
             out Mock<ChangeFeedObserverFactory> factory,
             out Mock<ChangeFeedObserver> observer)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ChangeFeedStateCosmosElementSerializerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ChangeFeedStateCosmosElementSerializerTests.cs
@@ -66,5 +66,76 @@ namespace Microsoft.Azure.Cosmos.Tests.ChangeFeed
 
             Assert.AreEqual(changeFeedContinuation.ContinuationToken, continuation);
         }
+
+        [TestMethod]
+        public void ContinuationAndStartTime()
+        {
+            CosmosString continuation = CosmosString.Create("someEtag");
+            DateTime startTime = new DateTime(2023, 1, 15, 10, 30, 0, DateTimeKind.Utc);
+            ChangeFeedState state = ChangeFeedState.ContinuationAndStartTime(continuation, startTime);
+            CosmosElement cosmosElement = ChangeFeedStateCosmosElementSerializer.ToCosmosElement(state);
+            TryCatch<ChangeFeedState> monadicState = ChangeFeedStateCosmosElementSerializer.MonadicFromCosmosElement(cosmosElement);
+            Assert.IsTrue(monadicState.Succeeded);
+            if (!(monadicState.Result is ChangeFeedStateContinuationAndStartTime changeFeedContinuationAndStartTime))
+            {
+                Assert.Fail();
+                return;
+            }
+
+            Assert.AreEqual(changeFeedContinuationAndStartTime.ContinuationToken, continuation);
+            Assert.AreEqual(changeFeedContinuationAndStartTime.StartTime, startTime);
+        }
+
+        [TestMethod]
+        public void ContinuationAndStartTime_SerializesAsContinuationTypeWithOptionalStartTime()
+        {
+            CosmosString continuation = CosmosString.Create("someEtag");
+            DateTime startTime = new DateTime(2023, 1, 15, 10, 30, 0, DateTimeKind.Utc);
+            ChangeFeedState state = ChangeFeedState.ContinuationAndStartTime(continuation, startTime);
+
+            CosmosElement cosmosElement = ChangeFeedStateCosmosElementSerializer.ToCosmosElement(state);
+            CosmosObject cosmosObject = (CosmosObject)cosmosElement;
+
+            // For backward compatibility the token uses the existing "continuation" type with an
+            // optional "startTime" field, rather than a dedicated (new) type value.
+            Assert.IsTrue(cosmosObject.TryGetValue("type", out CosmosString typeValue));
+            Assert.AreEqual("continuation", typeValue.Value);
+            Assert.IsTrue(cosmosObject.TryGetValue("value", out CosmosString _));
+            Assert.IsTrue(cosmosObject.TryGetValue("startTime", out CosmosString _));
+        }
+
+        [TestMethod]
+        public void Continuation_LegacyContinuationAndStartTimeType_StillParses()
+        {
+            // Tokens produced by an intermediate build could carry the legacy dedicated type value.
+            // Ensure they still deserialize into ChangeFeedStateContinuationAndStartTime.
+            CosmosObject legacyToken = CosmosObject.Create(
+                new System.Collections.Generic.Dictionary<string, CosmosElement>()
+                {
+                    { "type", CosmosString.Create("continuationAndStartTime") },
+                    { "value", CosmosString.Create("someEtag") },
+                    { "startTime", CosmosString.Create(new DateTime(2023, 1, 15, 10, 30, 0, DateTimeKind.Utc).ToString("o", System.Globalization.CultureInfo.InvariantCulture)) },
+                });
+
+            TryCatch<ChangeFeedState> monadicState = ChangeFeedStateCosmosElementSerializer.MonadicFromCosmosElement(legacyToken);
+            Assert.IsTrue(monadicState.Succeeded);
+            Assert.IsTrue(monadicState.Result is ChangeFeedStateContinuationAndStartTime);
+        }
+
+        [TestMethod]
+        public void Continuation_TypeWithoutStartTime_ParsesAsPlainContinuation()
+        {
+            // An older token (no startTime) must continue to deserialize as a plain continuation.
+            CosmosObject token = CosmosObject.Create(
+                new System.Collections.Generic.Dictionary<string, CosmosElement>()
+                {
+                    { "type", CosmosString.Create("continuation") },
+                    { "value", CosmosString.Create("someEtag") },
+                });
+
+            TryCatch<ChangeFeedState> monadicState = ChangeFeedStateCosmosElementSerializer.MonadicFromCosmosElement(token);
+            Assert.IsTrue(monadicState.Succeeded);
+            Assert.IsTrue(monadicState.Result is ChangeFeedStateContinuation);
+        }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ChangeFeedStateCosmosElementSerializerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/ChangeFeedStateCosmosElementSerializerTests.cs
@@ -137,5 +137,41 @@ namespace Microsoft.Azure.Cosmos.Tests.ChangeFeed
             Assert.IsTrue(monadicState.Succeeded);
             Assert.IsTrue(monadicState.Result is ChangeFeedStateContinuation);
         }
+
+        [DataTestMethod]
+        [DataRow("continuation")]
+        [DataRow("continuationAndStartTime")]
+        public void Continuation_InvalidStartTime_FailsWithFormatException(string type)
+        {
+            CosmosObject token = CosmosObject.Create(
+                new System.Collections.Generic.Dictionary<string, CosmosElement>()
+                {
+                    { "type", CosmosString.Create(type) },
+                    { "value", CosmosString.Create("someEtag") },
+                    { "startTime", CosmosString.Create("not-a-date") },
+                });
+
+            TryCatch<ChangeFeedState> monadicState = ChangeFeedStateCosmosElementSerializer.MonadicFromCosmosElement(token);
+
+            Assert.IsTrue(monadicState.Failed);
+            Assert.IsInstanceOfType(monadicState.Exception.InnerException, typeof(FormatException));
+        }
+
+        [TestMethod]
+        public void Continuation_NonStringStartTime_FailsWithFormatException()
+        {
+            CosmosObject token = CosmosObject.Create(
+                new System.Collections.Generic.Dictionary<string, CosmosElement>()
+                {
+                    { "type", CosmosString.Create("continuation") },
+                    { "value", CosmosString.Create("someEtag") },
+                    { "startTime", CosmosBoolean.Create(true) },
+                });
+
+            TryCatch<ChangeFeedState> monadicState = ChangeFeedStateCosmosElementSerializer.MonadicFromCosmosElement(token);
+
+            Assert.IsTrue(monadicState.Failed);
+            Assert.IsInstanceOfType(monadicState.Exception.InnerException, typeof(FormatException));
+        }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseManagerCosmosTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/DocumentServiceLeaseManagerCosmosTests.cs
@@ -87,6 +87,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         {
             RequestOptionsFactory requestOptionsFactory = GetRequestOptionsFactory(factoryType);
             string continuation = Guid.NewGuid().ToString();
+            DateTime startTime = DateTime.UtcNow.AddMinutes(-5);
             DocumentServiceLeaseStoreManagerOptions options = new DocumentServiceLeaseStoreManagerOptions
             {
                 HostName = Guid.NewGuid().ToString()
@@ -110,12 +111,13 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
                 options,
                 requestOptionsFactory);
 
-            DocumentServiceLease afterAcquire = await documentServiceLeaseManagerCosmos.CreateLeaseIfNotExistAsync(feedRangeEpk, continuation);
+            DocumentServiceLease afterAcquire = await documentServiceLeaseManagerCosmos.CreateLeaseIfNotExistAsync(feedRangeEpk, continuation, startTime);
 
             DocumentServiceLeaseCoreEpk epkBasedLease = (DocumentServiceLeaseCoreEpk)afterAcquire;
 
             Assert.IsNotNull(epkBasedLease);
             Assert.AreEqual(continuation, afterAcquire.ContinuationToken);
+            Assert.AreEqual(startTime, afterAcquire.StartTime);
             Assert.AreEqual(feedRangeEpk.Range.Min, ((FeedRangeEpk)epkBasedLease.FeedRange).Range.Min);
             Assert.AreEqual(feedRangeEpk.Range.Max, ((FeedRangeEpk)epkBasedLease.FeedRange).Range.Max);
             ValidateRequestOptionsFactory(requestOptionsFactory, epkBasedLease);
@@ -129,6 +131,7 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         {
             RequestOptionsFactory requestOptionsFactory = GetRequestOptionsFactory(factoryType);
             string continuation = Guid.NewGuid().ToString();
+            DateTime startTime = DateTime.UtcNow.AddMinutes(-5);
             DocumentServiceLeaseStoreManagerOptions options = new DocumentServiceLeaseStoreManagerOptions
             {
                 HostName = Guid.NewGuid().ToString()
@@ -157,12 +160,13 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
                 options,
                 requestOptionsFactory);
 
-            DocumentServiceLease afterAcquire = await documentServiceLeaseManagerCosmos.CreateLeaseIfNotExistAsync(partitionKeyRange, continuation);
+            DocumentServiceLease afterAcquire = await documentServiceLeaseManagerCosmos.CreateLeaseIfNotExistAsync(partitionKeyRange, continuation, startTime);
 
             DocumentServiceLeaseCore pkRangeBasedLease = (DocumentServiceLeaseCore)afterAcquire;
 
             Assert.IsNotNull(pkRangeBasedLease);
             Assert.AreEqual(continuation, afterAcquire.ContinuationToken);
+            Assert.AreEqual(startTime, afterAcquire.StartTime);
             Assert.AreEqual(partitionKeyRange.Id, pkRangeBasedLease.CurrentLeaseToken);
             ValidateRequestOptionsFactory(requestOptionsFactory, pkRangeBasedLease);
         }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/PartitionSynchronizerCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ChangeFeed/PartitionSynchronizerCoreTests.cs
@@ -49,11 +49,13 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         public async Task HandlePartitionGoneAsync_PKRangeBasedLease_Split()
         {
             string continuation = Guid.NewGuid().ToString();
+            DateTime startTime = DateTime.UtcNow.AddMinutes(-5);
             Documents.Routing.Range<string> range = new Documents.Routing.Range<string>("", "FF", true, false);
             DocumentServiceLeaseCore lease = new DocumentServiceLeaseCore()
             {
                 LeaseToken = "0",
                 ContinuationToken = continuation,
+                StartTime = startTime,
                 Owner = Guid.NewGuid().ToString(),
                 FeedRange = new FeedRangeEpk(range)
             };
@@ -94,19 +96,23 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
 
             leaseManager.Verify(l => l.CreateLeaseIfNotExistAsync(
                It.IsAny<Documents.PartitionKeyRange>(),
-               It.IsAny<string>()), Times.Exactly(2));
+               It.IsAny<string>(),
+               It.IsAny<DateTime?>()), Times.Exactly(2));
 
             leaseManager.Verify(l => l.CreateLeaseIfNotExistAsync(
                It.IsAny<FeedRangeEpk>(),
-               It.IsAny<string>()), Times.Never);
+               It.IsAny<string>(),
+               It.IsAny<DateTime?>()), Times.Never);
 
             leaseManager.Verify(l => l.CreateLeaseIfNotExistAsync(
                It.Is<Documents.PartitionKeyRange>(pkRange => pkRange.Id == resultingRanges[0].Id),
-               It.Is<string>(c => c == continuation)), Times.Once);
+               It.Is<string>(c => c == continuation),
+               It.Is<DateTime?>(value => value == startTime)), Times.Once);
 
             leaseManager.Verify(l => l.CreateLeaseIfNotExistAsync(
                It.Is<Documents.PartitionKeyRange>(pkRange => pkRange.Id == resultingRanges[1].Id),
-               It.Is<string>(c => c == continuation)), Times.Once);
+               It.Is<string>(c => c == continuation),
+               It.Is<DateTime?>(value => value == startTime)), Times.Once);
         }
 
         /// <summary>
@@ -116,11 +122,13 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         public async Task HandlePartitionGoneAsync_EpkBasedLease_Split()
         {
             string continuation = Guid.NewGuid().ToString();
+            DateTime startTime = DateTime.UtcNow.AddMinutes(-5);
             Documents.Routing.Range<string> range = new Documents.Routing.Range<string>("AA", "EE", true, false);
             DocumentServiceLeaseCoreEpk lease = new DocumentServiceLeaseCoreEpk()
             {
                 LeaseToken = "AA-BB",
                 ContinuationToken = continuation,
+                StartTime = startTime,
                 Owner = Guid.NewGuid().ToString(),
                 FeedRange = new FeedRangeEpk(range)
             };
@@ -162,23 +170,28 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
 
             leaseManager.Verify(l => l.CreateLeaseIfNotExistAsync(
                It.IsAny<Documents.PartitionKeyRange>(),
-               It.IsAny<string>()), Times.Never);
+               It.IsAny<string>(),
+               It.IsAny<DateTime?>()), Times.Never);
 
             leaseManager.Verify(l => l.CreateLeaseIfNotExistAsync(
                It.IsAny<FeedRangeEpk>(),
-               It.IsAny<string>()), Times.Exactly(3));
+               It.IsAny<string>(),
+               It.IsAny<DateTime?>()), Times.Exactly(3));
 
             leaseManager.Verify(l => l.CreateLeaseIfNotExistAsync(
                It.Is<FeedRangeEpk>(epk => epk.Range.Min == range.Min && epk.Range.Max == resultingRanges[0].MaxExclusive),
-               It.Is<string>(c => c == continuation)), Times.Once);
+               It.Is<string>(c => c == continuation),
+               It.Is<DateTime?>(value => value == startTime)), Times.Once);
 
             leaseManager.Verify(l => l.CreateLeaseIfNotExistAsync(
                It.Is<FeedRangeEpk>(epk => epk.Range.Min == resultingRanges[1].MinInclusive && epk.Range.Max == resultingRanges[1].MaxExclusive),
-               It.Is<string>(c => c == continuation)), Times.Once);
+               It.Is<string>(c => c == continuation),
+               It.Is<DateTime?>(value => value == startTime)), Times.Once);
 
             leaseManager.Verify(l => l.CreateLeaseIfNotExistAsync(
                It.Is<FeedRangeEpk>(epk => epk.Range.Min == resultingRanges[2].MinInclusive && epk.Range.Max == range.Max),
-               It.Is<string>(c => c == continuation)), Times.Once);
+               It.Is<string>(c => c == continuation),
+               It.Is<DateTime?>(value => value == startTime)), Times.Once);
         }
 
         /// <summary>
@@ -188,11 +201,13 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
         public async Task HandlePartitionGoneAsync_PKRangeBasedLease_Merge()
         {
             string continuation = Guid.NewGuid().ToString();
+            DateTime startTime = DateTime.UtcNow.AddMinutes(-5);
             Documents.Routing.Range<string> range = new Documents.Routing.Range<string>("", "BB", true, false);
             DocumentServiceLeaseCore lease = new DocumentServiceLeaseCore()
             {
                 LeaseToken = "0",
                 ContinuationToken = continuation,
+                StartTime = startTime,
                 Owner = Guid.NewGuid().ToString(),
                 FeedRange = new FeedRangeEpk(range)
             };
@@ -232,15 +247,18 @@ namespace Microsoft.Azure.Cosmos.ChangeFeed.Tests
 
             leaseManager.Verify(l => l.CreateLeaseIfNotExistAsync(
                It.IsAny<Documents.PartitionKeyRange>(),
-               It.IsAny<string>()), Times.Never);
+               It.IsAny<string>(),
+               It.IsAny<DateTime?>()), Times.Never);
 
             leaseManager.Verify(l => l.CreateLeaseIfNotExistAsync(
                It.IsAny<FeedRangeEpk>(),
-               It.IsAny<string>()), Times.Once);
+               It.IsAny<string>(),
+               It.IsAny<DateTime?>()), Times.Once);
 
             leaseManager.Verify(l => l.CreateLeaseIfNotExistAsync(
                It.Is<FeedRangeEpk>(epKRange => epKRange.Range.Min == range.Min && epKRange.Range.Max == range.Max),
-               It.Is<string>(c => c == continuation)), Times.Once);
+               It.Is<string>(c => c == continuation),
+               It.Is<DateTime?>(value => value == startTime)), Times.Once);
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/ContractTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/ContractTests.cs
@@ -28,8 +28,8 @@ namespace Microsoft.Azure.Cosmos.Contracts
             Assert.AreEqual(HttpConstants.Versions.v2020_07_15, HttpConstants.Versions.CurrentVersion);
             CollectionAssert.AreEqual(Encoding.UTF8.GetBytes(HttpConstants.Versions.v2020_07_15), HttpConstants.Versions.CurrentVersionUTF8);
 
-            ulong capabilitites = SDKSupportedCapabilitiesHelpers.GetSDKSupportedCapabilities();
-            Assert.AreEqual((ulong)(SDKSupportedCapabilities.PartitionMerge | SDKSupportedCapabilities.IgnoreUnknownRntbdTokens), capabilitites & (ulong)(SDKSupportedCapabilities.PartitionMerge | SDKSupportedCapabilities.IgnoreUnknownRntbdTokens));
+            ulong capabilitites = Microsoft.Azure.Cosmos.SDKSupportedCapabilitiesHelpers.GetSDKSupportedCapabilities();
+            Assert.AreEqual((ulong)(SDKSupportedCapabilities.PartitionMerge | SDKSupportedCapabilities.ChangeFeedWithStartTimePostMerge | SDKSupportedCapabilities.IgnoreUnknownRntbdTokens), capabilitites & (ulong)(SDKSupportedCapabilities.PartitionMerge | SDKSupportedCapabilities.ChangeFeedWithStartTimePostMerge | SDKSupportedCapabilities.IgnoreUnknownRntbdTokens));
         }
 
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/InMemoryContainer.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Pagination/InMemoryContainer.cs
@@ -762,7 +762,16 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
 
                 if (filteredChanges.Count == 0)
                 {
-                    ChangeFeedState notModifiedResponseState = new ChangeFeedStateTime(DateTime.UtcNow);
+                    ChangeFeedState notModifiedResponseState;
+                    if (feedRangeState.State is ChangeFeedStateContinuationAndStartTime composite)
+                    {
+                        notModifiedResponseState = composite; // preserve as-is
+                    }
+                    else
+                    {
+                        notModifiedResponseState = new ChangeFeedStateTime(DateTime.UtcNow);
+                    }
+
                     return Task.FromResult(
                     TryCatch<ChangeFeedPage>.FromResult(
                         new ChangeFeedNotModifiedPage(
@@ -780,7 +789,19 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
                         { "LSN", CosmosNumber64.Create(lastChange.LogicalSequenceNumber) }
                     });
 
-                ChangeFeedState responseState = ChangeFeedState.Continuation(continuationToken);
+                ChangeFeedState responseState;
+                if (feedRangeState.State is ChangeFeedStateTime changeFeedStateTime)
+                {
+                    responseState = ChangeFeedState.ContinuationAndStartTime(continuationToken, changeFeedStateTime.StartTime);
+                }
+                else if (feedRangeState.State is ChangeFeedStateContinuationAndStartTime existingComposite)
+                {
+                    responseState = ChangeFeedState.ContinuationAndStartTime(continuationToken, existingComposite.StartTime);
+                }
+                else
+                {
+                    responseState = ChangeFeedState.Continuation(continuationToken);
+                }
 
                 List<CosmosObject> documents = new List<CosmosObject>();
                 foreach (Change change in filteredChanges)
@@ -1738,6 +1759,15 @@ namespace Microsoft.Azure.Cosmos.Tests.Pagination
                 DateTime now = DateTime.UtcNow;
                 ChangeFeedStateTime startTime = new ChangeFeedStateTime(now);
                 return this.Visit(startTime, input);
+            }
+
+            public bool Visit(ChangeFeedStateContinuationAndStartTime changeFeedStateContinuationAndStartTime, Change input)
+            {
+                // For in-memory tests, apply both the continuation-based filter and the time-based filter
+                ChangeFeedStateContinuation continuationState = new ChangeFeedStateContinuation(changeFeedStateContinuationAndStartTime.ContinuationToken);
+                bool passesLsn = this.Visit(continuationState, input);
+                bool passesTime = input.Record.Timestamp >= changeFeedStateContinuationAndStartTime.StartTime;
+                return passesLsn && passesTime;
             }
         }
 

--- a/changelog.md
+++ b/changelog.md
@@ -84,6 +84,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [5648](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5648) Hub Region Caching: Caches discovered hub region per partition on successful response during 403/3 discovery chain, enabling subsequent requests to skip the discovery and route directly to the cached hub.
 - [#5549](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5549) Adds AAD token revocation (CAE / Emergency) transparent retry handling
 
+- [5931](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5931) ChangeFeed: Add support for StartTime for merged partitions
+
 #### Breaking Changes
 
 - [5970](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5970) Thin Client: Starting with this release, thin client mode is enabled by default. Accounts and workloads that authenticate with resource tokens are not supported in thin client mode, so customers relying on resource token authentication will experience a breaking change on upgrade. To continue using resource token authentication, opt out of thin client mode by setting the environment variable `AZURE_COSMOS_THIN_CLIENT_ENABLED=false`.


### PR DESCRIPTION
# Pull Request Template

## Description

In CosmosDB with in a partition, glsn and timestamp have relationship that they will increase in the same order.
But with Partition merge in CosmosDB maintains the original  glsn of the documents across partitions and lays them out in the glsn order. This ordering does not guarantee that time ordering is maintained with glsn order for any documents before partition merge. 
Since ChangeFeed with starttime just uses glsn as the continuation token it is not sufficient to maintain the time order.

Without this change: The service throws a bad request to keep the customer expectation intact. -> "StartTime/IfModifiedSince is not currently supported with merged partitions"

With this change: we send original start time with every request which the service will use to not return any documents before this time if the document's glsn is higher than the continuation token.

Similar change in Java -> https://github.com/Azure/azure-sdk-for-java/pull/32496/changes
## Type of change

Please delete options that are not relevant.

- [] New feature (non-breaking change which adds functionality)

## Closing issues

To automatically close an issue: closes #IssueNumber

## Changelog

- [x] I have added a changelog entry under `### Unreleased` in `changelog.md`
  for the user-facing impact of this change.

>
