### PR TITLE
[Internal] FaultInjection Tests: Fixes unreliable metadata response-delay assertions

### DIFF
--- a/Microsoft.Azure.Cosmos/FaultInjection/tests/FaultInjectionDirectModeTests.cs
+++ b/Microsoft.Azure.Cosmos/FaultInjection/tests/FaultInjectionDirectModeTests.cs
@@ -89,8 +89,8 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
             {
                 await this.highThroughputContainer.DeleteContainerAsync();
             }
-            this.client.Dispose();
-            this.fiClient.Dispose();
+            this.client?.Dispose();
+            this.fiClient?.Dispose();
         }
 
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/FaultInjection/tests/FaultInjectionMetadataTests.cs
+++ b/Microsoft.Azure.Cosmos/FaultInjection/tests/FaultInjectionMetadataTests.cs
@@ -141,20 +141,20 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
 
                 delayRule.Enable();
 
-                ValueStopwatch stopwatch = ValueStopwatch.StartNew();
-                TimeSpan elapsed;
-
-                ItemResponse<FaultInjectionTestObject> _ = await this.fiContainer.CreateItemAsync<FaultInjectionTestObject>(
+                ItemResponse<FaultInjectionTestObject> response = await this.fiContainer.CreateItemAsync<FaultInjectionTestObject>(
                    new FaultInjectionTestObject { Id = "deleteme", Pk = "deleteme" });
 
-                elapsed = stopwatch.Elapsed;
-                stopwatch.Stop();
                 delayRule.Disable();
 
+                // Validate the response delay rule was injected into the address refresh metadata call.
                 this.ValidateRuleHit(delayRule, 1);
 
-                //Check the create time is at least as long as the delay in the rule
-                Assert.IsTrue(elapsed.TotalSeconds >= 15);
+                // Metadata calls (address refresh) are issued over HTTP with a request timeout and are
+                // transparently retried by the SDK. The injected delay therefore surfaces as a timed-out and
+                // retried metadata request rather than as added end-to-end latency on the operation, so the
+                // wall-clock time of the operation is not a reliable signal. Validate instead that the rule
+                // was applied and the operation still succeeds despite the injected delay.
+                Assert.AreEqual(HttpStatusCode.Created, response.StatusCode);
             }
             finally
             {
@@ -436,20 +436,20 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
 
                 delayRule.Enable();
 
-                ValueStopwatch stopwatch = ValueStopwatch.StartNew();
-                TimeSpan elapsed;
-
-                ItemResponse<FaultInjectionTestObject> _ = await this.fiContainer.CreateItemAsync<FaultInjectionTestObject>(
+                ItemResponse<FaultInjectionTestObject> response = await this.fiContainer.CreateItemAsync<FaultInjectionTestObject>(
                    new FaultInjectionTestObject { Id = "deleteme", Pk = "deleteme" });
 
-                elapsed = stopwatch.Elapsed;
-                stopwatch.Stop();
                 delayRule.Disable();
 
+                // Validate the response delay rule was injected into the partition key range metadata call.
                 this.ValidateRuleHit(delayRule, 1);
 
-                //Check the create time is at least as long as the delay in the rule
-                Assert.IsTrue(elapsed.TotalSeconds >= 15);
+                // Metadata calls (partition key range refresh) are issued over HTTP with a request timeout and
+                // are transparently retried by the SDK. The injected delay therefore surfaces as a timed-out and
+                // retried metadata request rather than as added end-to-end latency on the operation, so the
+                // wall-clock time of the operation is not a reliable signal. Validate instead that the rule
+                // was applied and the operation still succeeds despite the injected delay.
+                Assert.AreEqual(HttpStatusCode.Created, response.StatusCode);
             }
             finally
             {
@@ -501,20 +501,20 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
 
                 delayRule.Enable();
 
-                ValueStopwatch stopwatch = ValueStopwatch.StartNew();
-                TimeSpan elapsed;
-
-                ItemResponse<FaultInjectionTestObject> _ = await this.fiContainer.CreateItemAsync<FaultInjectionTestObject>(
+                ItemResponse<FaultInjectionTestObject> response = await this.fiContainer.CreateItemAsync<FaultInjectionTestObject>(
                    new FaultInjectionTestObject { Id = "deleteme", Pk = "deleteme" });
 
-                elapsed = stopwatch.Elapsed;
-                stopwatch.Stop();
                 delayRule.Disable();
 
+                // Validate the response delay rule was injected into the collection (container) metadata read.
                 this.ValidateRuleHit(delayRule, 1);
 
-                //Check the create time is at least as long as the delay in the rule
-                Assert.IsTrue(elapsed.TotalSeconds >= 6);
+                // Metadata calls (collection read) are issued over HTTP with a request timeout and are
+                // transparently retried by the SDK. The injected delay therefore surfaces as a timed-out and
+                // retried metadata request rather than as added end-to-end latency on the operation, so the
+                // wall-clock time of the operation is not a reliable signal. Validate instead that the rule
+                // was applied and the operation still succeeds despite the injected delay.
+                Assert.AreEqual(HttpStatusCode.Created, response.StatusCode);
             }
             finally
             {

--- a/Microsoft.Azure.Cosmos/FaultInjection/tests/FaultInjectionMetadataTests.cs
+++ b/Microsoft.Azure.Cosmos/FaultInjection/tests/FaultInjectionMetadataTests.cs
@@ -149,11 +149,18 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
                 // Validate the response delay rule was injected into the address refresh metadata call.
                 this.ValidateRuleHit(delayRule, 1);
 
-                // Metadata calls (address refresh) are issued over HTTP with a request timeout and are
-                // transparently retried by the SDK. The injected delay therefore surfaces as a timed-out and
-                // retried metadata request rather than as added end-to-end latency on the operation, so the
-                // wall-clock time of the operation is not a reliable signal. Validate instead that the rule
-                // was applied and the operation still succeeds despite the injected delay.
+                // Metadata calls (address refresh) route through HttpTimeoutPolicyControlPlaneRetriableHotPath,
+                // whose first attempt times out after 1s. The injected delay (> 1s) therefore surfaces as a
+                // timed-out metadata request that the SDK transparently retries, rather than as added
+                // end-to-end latency on the operation, so the wall-clock time of the operation is not a
+                // reliable signal (a sub-1s delay that avoids the timeout would be swamped by connection and
+                // cross-region latency and is equally unreliable). Validate the delay's effect deterministically
+                // instead: the rule was applied, the injected delay forced at least one failed/retried metadata
+                // request (GetFailedRequestCount, which is 0 when no fault is applied), and the operation still
+                // succeeds despite the injected delay.
+                Assert.IsTrue(
+                    response.Diagnostics.GetFailedRequestCount() >= 1,
+                    "Expected the injected metadata response delay to produce at least one failed/retried request.");
                 Assert.AreEqual(HttpStatusCode.Created, response.StatusCode);
             }
             finally
@@ -444,11 +451,18 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
                 // Validate the response delay rule was injected into the partition key range metadata call.
                 this.ValidateRuleHit(delayRule, 1);
 
-                // Metadata calls (partition key range refresh) are issued over HTTP with a request timeout and
-                // are transparently retried by the SDK. The injected delay therefore surfaces as a timed-out and
-                // retried metadata request rather than as added end-to-end latency on the operation, so the
-                // wall-clock time of the operation is not a reliable signal. Validate instead that the rule
-                // was applied and the operation still succeeds despite the injected delay.
+                // Metadata calls (partition key range refresh) route through HttpTimeoutPolicyControlPlaneRetriableHotPath,
+                // whose first attempt times out after 1s. The injected delay (> 1s) therefore surfaces as a
+                // timed-out metadata request that the SDK transparently retries, rather than as added
+                // end-to-end latency on the operation, so the wall-clock time of the operation is not a
+                // reliable signal (a sub-1s delay that avoids the timeout would be swamped by connection and
+                // cross-region latency and is equally unreliable). Validate the delay's effect deterministically
+                // instead: the rule was applied, the injected delay forced at least one failed/retried metadata
+                // request (GetFailedRequestCount, which is 0 when no fault is applied), and the operation still
+                // succeeds despite the injected delay.
+                Assert.IsTrue(
+                    response.Diagnostics.GetFailedRequestCount() >= 1,
+                    "Expected the injected metadata response delay to produce at least one failed/retried request.");
                 Assert.AreEqual(HttpStatusCode.Created, response.StatusCode);
             }
             finally
@@ -509,11 +523,18 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
                 // Validate the response delay rule was injected into the collection (container) metadata read.
                 this.ValidateRuleHit(delayRule, 1);
 
-                // Metadata calls (collection read) are issued over HTTP with a request timeout and are
-                // transparently retried by the SDK. The injected delay therefore surfaces as a timed-out and
-                // retried metadata request rather than as added end-to-end latency on the operation, so the
-                // wall-clock time of the operation is not a reliable signal. Validate instead that the rule
-                // was applied and the operation still succeeds despite the injected delay.
+                // Metadata calls (collection read) route through HttpTimeoutPolicyControlPlaneRetriableHotPath,
+                // whose first attempt times out after 1s. The injected delay (> 1s) therefore surfaces as a
+                // timed-out metadata request that the SDK transparently retries, rather than as added
+                // end-to-end latency on the operation, so the wall-clock time of the operation is not a
+                // reliable signal (a sub-1s delay that avoids the timeout would be swamped by connection and
+                // cross-region latency and is equally unreliable). Validate the delay's effect deterministically
+                // instead: the rule was applied, the injected delay forced at least one failed/retried metadata
+                // request (GetFailedRequestCount, which is 0 when no fault is applied), and the operation still
+                // succeeds despite the injected delay.
+                Assert.IsTrue(
+                    response.Diagnostics.GetFailedRequestCount() >= 1,
+                    "Expected the injected metadata response delay to produce at least one failed/retried request.");
                 Assert.AreEqual(HttpStatusCode.Created, response.StatusCode);
             }
             finally


### PR DESCRIPTION
## Description

While running the fault injection test suite against a live multi-region account, three metadata response-delay tests were consistently failing. Investigation showed this is a **test-design issue, not a fault injection library bug** — the library injects the delay correctly every time (the rule hit count increments), but the test assertions were based on an invalid assumption.

### Root cause

The tests asserted that an injected metadata-refresh delay (e.g. 15s) would manifest as added wall-clock latency on a subsequent data operation:

```csharp
Assert.IsTrue(elapsed.TotalSeconds >= 15);
```

Operation diagnostics show what actually happens: the injected delay causes the metadata HTTP call to hit its **request timeout** (`TaskCanceledException`), after which the SDK **transparently retries** the metadata request and succeeds:

```
"Read Collection": DurationInMs:1034, ExceptionType:"TaskCanceledException"   ← injected delay hit the request timeout
                   DurationInMs:212,  StatusCode:"OK"                         ← SDK retried and succeeded
```

So the full delay is never observed end-to-end, and the operation completes in ~1–4s regardless of the injected delay or account topology. (In `PKRangeResponseDelayTest`, the rule was even hit 3× while the operation finished in 3.7s.) This is correct SDK behavior — metadata refreshes are resilient to slow responses — so the wall-clock assertion can never hold.

### Changes

- **`FaultInjectionMetadataTests`** — `AddressRefreshResponseDelayTest`, `PKRangeResponseDelayTest`, and `CollectionReadResponseDelayTest`: replaced the brittle elapsed-time assertions with deterministic validation that the delay rule was applied (`ValidateRuleHit`) **and** the operation still succeeds despite the injected delay (`StatusCode == Created`).
- **`FaultInjectionDirectModeTests.Cleanup`** — made `client`/`fiClient` disposal null-safe (`?.`), matching the other test classes. Previously, a test that failed before the fault-injection client was created threw a masking `NullReferenceException` during cleanup.

### Verification

All 37 builder/unit/metadata tests pass (32 builder/unit + 5 metadata). The fixed tests run in 1–4s and validate the injected rule deterministically.

> Note: the remaining `FaultInjectionDirectModeTests` failures observed locally are account-topology dependent (several tests document "must be a single master account" / hardcode replica & region counts, one is statistically flaky by design, and the custom-status mapping case is core-SDK behavior). They were intentionally left unchanged so they continue to validate correctly against the intended CI account.

## Type of change

- [x] Bug fix (test reliability; no shipped-package source changed)

## Changelog

No changelog entry required — changes are test-only (`Microsoft.Azure.Cosmos/FaultInjection/tests/**`); no shipped-package source under `src/**` is modified, and there is no customer-observable impact.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>