### PR TITLE
Query: Fixes 410/1002 PartitionKeyRangeGone surfacing during partition split/merge

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/v2Query/PartitionKeyRangeGoneRetryPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v2Query/PartitionKeyRangeGoneRetryPolicy.cs
@@ -9,18 +9,20 @@ namespace Microsoft.Azure.Cosmos
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Cosmos.Common;
+    using Microsoft.Azure.Cosmos.Core.Trace;
     using Microsoft.Azure.Cosmos.Routing;
     using Microsoft.Azure.Cosmos.Tracing;
     using Microsoft.Azure.Documents;
 
     internal class PartitionKeyRangeGoneRetryPolicy : IDocumentClientRetryPolicy
     {
+        private const int MaxRetryCount = 10;
         private readonly CollectionCache collectionCache;
         private readonly IDocumentClientRetryPolicy nextRetryPolicy;
         private readonly PartitionKeyRangeCache partitionKeyRangeCache;
         private readonly string collectionLink;
         private readonly ITrace trace;
-        private bool retried;
+        private int retryCount;
 
         public PartitionKeyRangeGoneRetryPolicy(
             CollectionCache collectionCache,
@@ -106,12 +108,25 @@ namespace Microsoft.Azure.Cosmos
             }
 
             if (statusCode == HttpStatusCode.Gone
-                && subStatusCode == SubStatusCodes.PartitionKeyRangeGone)
+                && (subStatusCode == SubStatusCodes.PartitionKeyRangeGone
+                    || subStatusCode == SubStatusCodes.CompletingSplit
+                    || subStatusCode == SubStatusCodes.CompletingPartitionMigration))
             {
-                if (this.retried)
+                this.retryCount++;
+                if (this.retryCount > MaxRetryCount)
                 {
+                    DefaultTrace.TraceWarning(
+                        "PartitionKeyRangeGoneRetryPolicy: exhausted the maximum of {0} retries on 410/{1}; not retrying.",
+                        MaxRetryCount,
+                        (int)subStatusCode.Value);
                     return ShouldRetryResult.NoRetry();
                 }
+
+                DefaultTrace.TraceInformation(
+                    "PartitionKeyRangeGoneRetryPolicy: refreshing the routing map and retrying on 410/{0} (attempt {1} of {2}).",
+                    (int)subStatusCode.Value,
+                    this.retryCount,
+                    MaxRetryCount);
 
                 using (DocumentServiceRequest request = DocumentServiceRequest.Create(
                     OperationType.Read,
@@ -138,7 +153,6 @@ namespace Microsoft.Azure.Cosmos
                     }
                 }
 
-                this.retried = true;
                 return ShouldRetryResult.RetryAfter(TimeSpan.FromSeconds(0));
             }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyRangeHandlerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyRangeHandlerTests.cs
@@ -690,6 +690,98 @@ namespace Microsoft.Azure.Cosmos.Tests
         }
 
         [TestMethod]
+        public async Task PartitionKeyRangeGoneRetryPolicyRetriesUpToMaxOnPartitionKeyRangeGone()
+        {
+            ITrace trace = Trace.GetRootTrace("TestTrace");
+            PartitionKeyRangeGoneRetryPolicy policy = CreateRetryPolicyWithEmptyRoutingMap(trace);
+
+            for (int i = 0; i < 10; i++)
+            {
+                ShouldRetryResult shouldRetryResult = await policy.ShouldRetryAsync(
+                    new DocumentClientException("partition gone", HttpStatusCode.Gone, SubStatusCodes.PartitionKeyRangeGone),
+                    default);
+                Assert.IsTrue(shouldRetryResult.ShouldRetry, $"Attempt {i} should retry (within max retry budget).");
+                Assert.AreEqual(0, shouldRetryResult.BackoffTime.Ticks);
+            }
+
+            ShouldRetryResult afterMax = await policy.ShouldRetryAsync(
+                new DocumentClientException("partition gone", HttpStatusCode.Gone, SubStatusCodes.PartitionKeyRangeGone),
+                default);
+            Assert.IsFalse(afterMax.ShouldRetry, "Should stop retrying after the max retry budget is exhausted.");
+        }
+
+        [TestMethod]
+        public async Task PartitionKeyRangeGoneRetryPolicyRetriesOnCompletingSplit()
+        {
+            ITrace trace = Trace.GetRootTrace("TestTrace");
+            PartitionKeyRangeGoneRetryPolicy policy = CreateRetryPolicyWithEmptyRoutingMap(trace);
+
+            ShouldRetryResult shouldRetryResult = await policy.ShouldRetryAsync(
+                new DocumentClientException("completing split", HttpStatusCode.Gone, SubStatusCodes.CompletingSplit),
+                default);
+
+            Assert.IsTrue(shouldRetryResult.ShouldRetry, "410/CompletingSplit (1007) must be retried after refreshing the routing map.");
+            Assert.AreEqual(0, shouldRetryResult.BackoffTime.Ticks);
+        }
+
+        [TestMethod]
+        public async Task PartitionKeyRangeGoneRetryPolicyRetriesOnCompletingPartitionMigration()
+        {
+            ITrace trace = Trace.GetRootTrace("TestTrace");
+            PartitionKeyRangeGoneRetryPolicy policy = CreateRetryPolicyWithEmptyRoutingMap(trace);
+
+            ShouldRetryResult shouldRetryResult = await policy.ShouldRetryAsync(
+                new DocumentClientException("completing migration", HttpStatusCode.Gone, SubStatusCodes.CompletingPartitionMigration),
+                default);
+
+            Assert.IsTrue(shouldRetryResult.ShouldRetry, "410/CompletingPartitionMigration (1008) must be retried after refreshing the routing map.");
+            Assert.AreEqual(0, shouldRetryResult.BackoffTime.Ticks);
+        }
+
+        private static PartitionKeyRangeGoneRetryPolicy CreateRetryPolicyWithEmptyRoutingMap(ITrace trace)
+        {
+            PartitionKeyDefinition partitionKeyDefinition = new PartitionKeyDefinition();
+            partitionKeyDefinition.Paths.Add("pk");
+
+            const string collectionRid = "DvZRAOvLgDM=";
+            ContainerProperties containerProperties = ContainerProperties.CreateWithResourceId(collectionRid);
+            containerProperties.Id = "TestContainer";
+            containerProperties.PartitionKey = partitionKeyDefinition;
+
+            Mock<IDocumentClientInternal> mockDocumentClient = new Mock<IDocumentClientInternal>();
+            mockDocumentClient.Setup(client => client.ServiceEndpoint).Returns(new Uri("https://foo"));
+
+            using GlobalEndpointManager endpointManager = new(mockDocumentClient.Object, new ConnectionPolicy());
+
+            Mock<Common.CollectionCache> collectionCache = new Mock<Common.CollectionCache>(MockBehavior.Strict, false);
+            collectionCache.Setup(c => c.ResolveCollectionAsync(It.IsAny<DocumentServiceRequest>(), It.IsAny<CancellationToken>(), trace))
+                .ReturnsAsync(containerProperties);
+
+            // An empty range list makes TryCreateCompleteRoutingMap return null, which makes the
+            // policy skip the force-refresh lookup — keeping the mock surface minimal while still
+            // exercising the retry-budget and sub-status branches.
+            CollectionRoutingMap collectionRoutingMap = CollectionRoutingMap.TryCreateCompleteRoutingMap(new List<Tuple<PartitionKeyRange, ServiceIdentity>>(), collectionRid, false);
+            Mock<PartitionKeyRangeCache> partitionKeyRangeCache = new Mock<PartitionKeyRangeCache>(
+                MockBehavior.Strict,
+                new Mock<ICosmosAuthorizationTokenProvider>().Object,
+                new Mock<IStoreModel>().Object,
+                collectionCache.Object,
+                endpointManager,
+                false,
+                false);
+            partitionKeyRangeCache.Setup(c => c.TryLookupAsync(collectionRid, null, It.IsAny<DocumentServiceRequest>(), trace))
+                .ReturnsAsync(collectionRoutingMap);
+
+            string collectionLink = "dbs/DvZRAA==/colls/DvZRAOvLgDM=/";
+            return new PartitionKeyRangeGoneRetryPolicy(
+                collectionCache.Object,
+                partitionKeyRangeCache.Object,
+                collectionLink,
+                null,
+                trace);
+        }
+
+        [TestMethod]
         public async Task InvalidPartitionRetryPolicyWithNextRetryPolicy()
         {
             using CosmosClient client = MockCosmosUtil.CreateMockCosmosClient();

--- a/changelog.md
+++ b/changelog.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [5583](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5583) LINQ: Fixes `.Any()` on `Dictionary`/`IDictionary`/`IReadOnlyDictionary` properties returning no results by wrapping dictionary access with `OBJECTTOARRAY()` so dictionary entries (and predicates on `KeyValuePair.Key`/`Value`) are iterated correctly.
 - [5298](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5298) LINQ: Fixes constant folding for closure-captured variables inside MemberInitExpression (resolves #1664). Previously, the recursion that partially evaluates expressions terminated whenever it encountered a `MemberInitExpression` node, so captured variables inside object initializers were not folded, producing invalid translated SQL.
+- Query: Fixes transient `410/1002` (`PartitionKeyRangeGone`) errors surfacing to query callers during a partition split or merge. The query-path `PartitionKeyRangeGoneRetryPolicy` previously retried only once and ignored the in-progress `410/1007` (`CompletingSplit`) and `410/1008` (`CompletingPartitionMigration`) sub-status codes; it now refreshes the routing map and retries those sub-statuses up to 10 times (matching the bulk execution retry policy) before surfacing the error.
 
 #### Other Changes
 


### PR DESCRIPTION
## Description

`PartitionKeyRangeGoneRetryPolicy` (wired on the v2 query path via `DefaultDocumentQueryExecutionContext` when `resourceTypeEnum.IsPartitioned()`) previously:

- retried `410/1002` (`PartitionKeyRangeGone`) **only once**, and
- **ignored** the in-progress `410/1007` (`CompletingSplit`) and `410/1008` (`CompletingPartitionMigration`) sub-status codes (they fell through to the next policy).

As a result, during a slow / in-progress partition **split or merge**, query callers could see a transient `410` surfaced as a hard error — whereas `BulkExecutionRetryPolicy` (the reference implementation) retries up to 10× and covers all three sub-statuses.

## Fix

`PartitionKeyRangeGoneRetryPolicy` now:
- replaces the one-shot `bool retried` with a bounded `retryCount` (`MaxRetryCount = 10`, matching `BulkExecutionRetryPolicy.MaxRetryOn410`),
- retries `PartitionKeyRangeGone` **+** `CompletingSplit` **+** `CompletingPartitionMigration`, force-refreshing the routing map per attempt,
- keeps `RetryAfter(TimeSpan.Zero)`, and
- emits per-attempt + exhaustion diagnostics via `DefaultTrace`.

## Tests

Adds 3 unit tests to `PartitionKeyRangeHandlerTests` that **fail on the old code** and pass with the fix:
- `PartitionKeyRangeGoneRetryPolicyRetriesUpToMaxOnPartitionKeyRangeGone`
- `PartitionKeyRangeGoneRetryPolicyRetriesOnCompletingSplit`
- `PartitionKeyRangeGoneRetryPolicyRetriesOnCompletingPartitionMigration`

`dotnet test --filter FullyQualifiedName~PartitionKeyRangeGone` → **14/14 passed** (no regression in the existing policy tests).

## Changelog

Added under `### Unreleased` → `#### Bugs Fixed`.

## Cross-SDK note

The same gap exists in the **Java** SDK (`PartitionKeyRangeGoneRetryPolicy.java` — single retry, no `CompletingSplit`/`CompletingPartitionMigration`, with a literal `// TODO: this need testing`) and likely **Python**; **JS** already covers `CompletingSplit` on the item path. Peer-SDK fixes are tracking-only and out of scope for this PR.

## Notes for reviewers

This fixes the **v2 query** retry layer. Point reads/writes use a different layer (`ClientRetryPolicy`) and are out of scope. No public API change.

---
🤖 Generated via the Seon workflow (research → spec → human-gate → repro-confirmed implementation).