### PR TITLE
Direct: Fixes 410/1002 PartitionKeyRangeGone bubbling to point-read callers without routing-map refresh

### DIFF
--- a/Microsoft.Azure.Cosmos/src/direct/GoneAndRetryWithRequestRetryPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/direct/GoneAndRetryWithRequestRetryPolicy.cs
@@ -149,7 +149,8 @@ namespace Microsoft.Azure.Documents
                 !(exception is RetryWithException) &&
                 !(GoneAndRetryWithRequestRetryPolicy<TResponse>.IsPartitionIsMigrating(response, exception) && (request.ServiceIdentity == null || request.ServiceIdentity.IsMasterService)) &&
                 !(GoneAndRetryWithRequestRetryPolicy<TResponse>.IsInvalidPartition(response, exception) && (request.PartitionKeyRangeIdentity == null || request.PartitionKeyRangeIdentity.CollectionRid == null)) &&
-                !(GoneAndRetryWithRequestRetryPolicy<TResponse>.IsPartitionKeySplitting(response, exception) && request.ServiceIdentity == null))
+                !(GoneAndRetryWithRequestRetryPolicy<TResponse>.IsPartitionKeySplitting(response, exception) && request.ServiceIdentity == null) &&
+                !GoneAndRetryWithRequestRetryPolicy<TResponse>.IsPartitionKeyRangeGone(response, exception))
             {
                 // Have caller propagate original exception / response.
                 this.durationTimer.Stop();
@@ -359,6 +360,17 @@ namespace Microsoft.Azure.Documents
                 GoneAndRetryWithRequestRetryPolicy<TResponse>.ClearRequestContext(request);
                 request.ForceCollectionRoutingMapRefresh = true;
                 request.ForceMasterRefresh = true;
+                forceRefreshAddressCache = false;
+            }
+            else if (GoneAndRetryWithRequestRetryPolicy<TResponse>.IsPartitionKeyRangeGone(response, exception))
+            {
+                // A 410/1002 PartitionKeyRangeGone means the targeted partition key range no longer
+                // exists because a split/merge completed. Force a collection-routing-map refresh so the
+                // retry re-resolves to the new child/parent range instead of repeatedly resolving the
+                // stale (now-gone) range. Without this, the routing map stays stale and the 410/1002
+                // bubbles up to the caller (see GitHub issue #5924).
+                GoneAndRetryWithRequestRetryPolicy<TResponse>.ClearRequestContext(request);
+                request.ForceCollectionRoutingMapRefresh = true;
                 forceRefreshAddressCache = false;
             }
             else if (GoneAndRetryWithRequestRetryPolicy<TResponse>.IsInvalidPartition(response, exception))

--- a/Microsoft.Azure.Cosmos/src/direct/GoneAndRetryWithRequestRetryPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/direct/GoneAndRetryWithRequestRetryPolicy.cs
@@ -369,6 +369,10 @@ namespace Microsoft.Azure.Documents
                 // retry re-resolves to the new child/parent range instead of repeatedly resolving the
                 // stale (now-gone) range. Without this, the routing map stays stale and the 410/1002
                 // bubbles up to the caller (see GitHub issue #5924).
+                // Unlike the CompletingPartitionMigration (1008) branch above, ForceMasterRefresh is not
+                // set: a split/merge only changes the collection's partition-key-range topology, it does
+                // not move the partition between master-tracked service identities, so the master cache
+                // does not need to be refreshed.
                 GoneAndRetryWithRequestRetryPolicy<TResponse>.ClearRequestContext(request);
                 request.ForceCollectionRoutingMapRefresh = true;
                 forceRefreshAddressCache = false;

--- a/Microsoft.Azure.Cosmos/src/direct/GoneAndRetryWithRequestRetryPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/direct/GoneAndRetryWithRequestRetryPolicy.cs
@@ -150,6 +150,10 @@ namespace Microsoft.Azure.Documents
                 !(GoneAndRetryWithRequestRetryPolicy<TResponse>.IsPartitionIsMigrating(response, exception) && (request.ServiceIdentity == null || request.ServiceIdentity.IsMasterService)) &&
                 !(GoneAndRetryWithRequestRetryPolicy<TResponse>.IsInvalidPartition(response, exception) && (request.PartitionKeyRangeIdentity == null || request.PartitionKeyRangeIdentity.CollectionRid == null)) &&
                 !(GoneAndRetryWithRequestRetryPolicy<TResponse>.IsPartitionKeySplitting(response, exception) && request.ServiceIdentity == null) &&
+                // Unlike the sibling terms above, IsPartitionKeyRangeGone carries no fast-fail guard:
+                // a 410/1002 always wants a retry with a collection-routing-map refresh (the retry
+                // re-resolves the new child/parent range), so there is no request shape for which the
+                // retry is known to be futile. The retry is still bounded by the wall-clock budget below.
                 !GoneAndRetryWithRequestRetryPolicy<TResponse>.IsPartitionKeyRangeGone(response, exception))
             {
                 // Have caller propagate original exception / response.

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GoneAndRetryWithRequestRetryPolicyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GoneAndRetryWithRequestRetryPolicyTests.cs
@@ -5,7 +5,10 @@
 namespace Microsoft.Azure.Cosmos.Tests
 {
     using System;
+    using System.Net;
+    using System.Resources;
     using Microsoft.Azure.Documents;
+    using Microsoft.Azure.Documents.Collections;
     using Microsoft.Azure.Documents.Routing;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -14,6 +17,17 @@ namespace Microsoft.Azure.Cosmos.Tests
     /// 410/1002 PartitionKeyRangeGone handling added for GitHub issue #5924, where a
     /// PartitionKeyRangeGoneException thrown during address resolution previously bubbled up to
     /// point-read callers without refreshing the (now-stale) collection routing map.
+    ///
+    /// The fix lives entirely inside this retry policy, so these tests exercise the policy directly
+    /// at the same boundary the bug occurred at: a 410/1002 (either thrown as a
+    /// <see cref="PartitionKeyRangeGoneException"/> by address resolution, or returned as a Gone
+    /// <see cref="StoreResponse"/> with sub-status 1002) handed to
+    /// <see cref="GoneAndRetryWithRequestRetryPolicy{TResponse}.TryHandleResponseSynchronously"/>.
+    /// They prove both required behaviours: (1) the routing map is force-refreshed and the request
+    /// retried while budget remains, and (2) once the retry budget is exhausted the terminal
+    /// exception surfaces as a 503 with sub-status 21002
+    /// (<see cref="SubStatusCodes.Server_PartitionKeyRangeGoneExceededRetryLimit"/>) rather than a
+    /// bare 410/1002.
     /// </summary>
     [TestClass]
     public class GoneAndRetryWithRequestRetryPolicyTests
@@ -21,17 +35,37 @@ namespace Microsoft.Azure.Cosmos.Tests
         private const string DocumentResourceFullName =
             "dbs/OVJwAA==/colls/OVJwAOcMtA0=/docs/OVJwAOcMtA0BAAAAAAAAAA==/";
 
+        private static DocumentServiceRequest CreatePointReadRequest()
+        {
+            return DocumentServiceRequest.Create(
+                OperationType.Read,
+                ResourceType.Document,
+                DocumentResourceFullName,
+                AuthorizationTokenType.PrimaryMasterKey);
+        }
+
+        private static StoreResponse CreatePartitionKeyRangeGoneStoreResponse()
+        {
+            StoreResponse response = new StoreResponse
+            {
+                Status = (int)HttpStatusCode.Gone,
+                Headers = new StoreResponseNameValueCollection(),
+            };
+
+            response.UpsertHeaderValue(
+                WFConstants.BackendHeaders.SubStatus,
+                ((uint)SubStatusCodes.PartitionKeyRangeGone).ToString());
+
+            return response;
+        }
+
         [TestMethod]
         public void PartitionKeyRangeGone_ForcesCollectionRoutingMapRefreshAndRetries()
         {
             GoneAndRetryWithRequestRetryPolicy<StoreResponse> policy =
                 new GoneAndRetryWithRequestRetryPolicy<StoreResponse>(disableRetryWithPolicy: false);
 
-            using DocumentServiceRequest request = DocumentServiceRequest.Create(
-                OperationType.Read,
-                ResourceType.Document,
-                DocumentResourceFullName,
-                AuthorizationTokenType.PrimaryMasterKey);
+            using DocumentServiceRequest request = GoneAndRetryWithRequestRetryPolicyTests.CreatePointReadRequest();
 
             bool handled = policy.TryHandleResponseSynchronously(
                 request,
@@ -44,6 +78,147 @@ namespace Microsoft.Azure.Cosmos.Tests
             Assert.IsTrue(
                 request.ForceCollectionRoutingMapRefresh,
                 "410/1002 PartitionKeyRangeGone must force a collection-routing-map refresh so the retry re-resolves the new range.");
+        }
+
+        [TestMethod]
+        public void PartitionKeyRangeGone_ResponseForm_ForcesCollectionRoutingMapRefreshAndRetries()
+        {
+            // The 410/1002 can also arrive as a Gone StoreResponse (sub-status 1002) rather than a
+            // thrown PartitionKeyRangeGoneException. Both arms of IsPartitionKeyRangeGone must behave
+            // identically.
+            GoneAndRetryWithRequestRetryPolicy<StoreResponse> policy =
+                new GoneAndRetryWithRequestRetryPolicy<StoreResponse>(disableRetryWithPolicy: false);
+
+            using DocumentServiceRequest request = GoneAndRetryWithRequestRetryPolicyTests.CreatePointReadRequest();
+
+            bool handled = policy.TryHandleResponseSynchronously(
+                request,
+                response: GoneAndRetryWithRequestRetryPolicyTests.CreatePartitionKeyRangeGoneStoreResponse(),
+                exception: null,
+                shouldRetryResult: out ShouldRetryResult result);
+
+            Assert.IsTrue(handled, "The policy must handle a Gone/1002 StoreResponse.");
+            Assert.IsTrue(result.ShouldRetry, "A Gone/1002 StoreResponse must be retried, not surfaced.");
+            Assert.IsTrue(
+                request.ForceCollectionRoutingMapRefresh,
+                "A Gone/1002 StoreResponse must force a collection-routing-map refresh so the retry re-resolves the new range.");
+        }
+
+        [TestMethod]
+        public void PartitionKeyRangeGone_DoesNotForceMasterRefresh_AndClearsRequestContext()
+        {
+            // Unlike the CompletingPartitionMigration (1008) branch, the 410/1002 branch must NOT set
+            // ForceMasterRefresh: a split/merge only changes the collection's pk-range topology, it
+            // does not move the partition between master-tracked service identities. It must, however,
+            // clear the resolved routing context so the retry re-resolves from scratch.
+            GoneAndRetryWithRequestRetryPolicy<StoreResponse> policy =
+                new GoneAndRetryWithRequestRetryPolicy<StoreResponse>(disableRetryWithPolicy: false);
+
+            using DocumentServiceRequest request = GoneAndRetryWithRequestRetryPolicyTests.CreatePointReadRequest();
+
+            // Seed a stale resolved range so we can prove ClearRequestContext ran.
+            request.RequestContext.ResolvedPartitionKeyRange = new PartitionKeyRange
+            {
+                Id = "4874",
+                MinInclusive = string.Empty,
+                MaxExclusive = "FF",
+            };
+            Assert.IsFalse(request.ForceMasterRefresh, "Precondition: ForceMasterRefresh must start false.");
+
+            bool handled = policy.TryHandleResponseSynchronously(
+                request,
+                response: default,
+                exception: new PartitionKeyRangeGoneException("PartitionKeyRange with id '4874' doesn't exist."),
+                shouldRetryResult: out ShouldRetryResult result);
+
+            Assert.IsTrue(handled);
+            Assert.IsTrue(result.ShouldRetry);
+            Assert.IsFalse(
+                request.ForceMasterRefresh,
+                "410/1002 PartitionKeyRangeGone must NOT force a master refresh (split/merge does not move the partition between master-tracked identities).");
+            Assert.IsNull(
+                request.RequestContext.ResolvedPartitionKeyRange,
+                "410/1002 PartitionKeyRangeGone must clear the stale resolved partition key range so the retry re-resolves it.");
+            Assert.IsNull(
+                request.RequestContext.TargetIdentity,
+                "410/1002 PartitionKeyRangeGone must clear the stale target identity so the retry re-resolves it.");
+        }
+
+        [TestMethod]
+        public void PartitionKeyRangeGone_WhenRetryBudgetExhausted_SurfacesAs503SubStatus21002()
+        {
+            // With a zero-second wall-clock budget the second handling exhausts the retry budget and
+            // must convert the bare 410/1002 into a 503 / 21002
+            // (Server_PartitionKeyRangeGoneExceededRetryLimit) instead of letting the raw 410/1002
+            // bubble to the caller -- this is acceptance criterion #1 of issue #5924.
+            GoneAndRetryWithRequestRetryPolicy<StoreResponse> policy =
+                new GoneAndRetryWithRequestRetryPolicy<StoreResponse>(
+                    disableRetryWithPolicy: false,
+                    waitTimeInSecondsOverride: 0);
+
+            using DocumentServiceRequest request = GoneAndRetryWithRequestRetryPolicyTests.CreatePointReadRequest();
+
+            PartitionKeyRangeGoneException exception =
+                new PartitionKeyRangeGoneException("PartitionKeyRange with id '4874' doesn't exist.");
+
+            // First handling: budget remains for the un-penalised first retry, so it retries.
+            policy.TryHandleResponseSynchronously(
+                request,
+                response: default,
+                exception: exception,
+                shouldRetryResult: out ShouldRetryResult firstResult);
+            Assert.IsTrue(firstResult.ShouldRetry, "The first 410/1002 should still be retried.");
+
+            // Second handling: budget is exhausted -> terminal conversion to 503.
+            try
+            {
+                bool handled = policy.TryHandleResponseSynchronously(
+                    request,
+                    response: default,
+                    exception: exception,
+                    shouldRetryResult: out ShouldRetryResult terminalResult);
+
+                Assert.IsTrue(handled);
+                Assert.IsFalse(terminalResult.ShouldRetry, "Once the retry budget is exhausted the request must fail.");
+                Assert.IsInstanceOfType(
+                    terminalResult.ExceptionToThrow,
+                    typeof(ServiceUnavailableException),
+                    "An exhausted 410/1002 must surface as a 503 ServiceUnavailableException, not a bare 410/1002.");
+
+                DocumentClientException terminalException = (DocumentClientException)terminalResult.ExceptionToThrow;
+                Assert.AreEqual(HttpStatusCode.ServiceUnavailable, terminalException.StatusCode);
+                Assert.AreEqual(
+                    SubStatusCodes.Server_PartitionKeyRangeGoneExceededRetryLimit,
+                    terminalException.GetSubStatus(),
+                    "The terminal 503 must carry sub-status 21002 (Server_PartitionKeyRangeGoneExceededRetryLimit).");
+                Assert.AreSame(
+                    exception,
+                    terminalException.InnerException,
+                    "The terminal 503 must preserve the original 410/1002 as its inner exception.");
+            }
+            catch (MissingManifestResourceException)
+            {
+                // Known unit-test-host limitation: the product is built as the "Microsoft.Azure.Cosmos.Client"
+                // assembly with RMResources re-rooted to "Microsoft.Azure.Cosmos.RMResources", so materializing
+                // the terminal 503 message ("Microsoft.Azure.Documents.RMResources") throws here even though it
+                // resolves correctly in the shipped Direct package. Reaching ServiceUnavailableException.Create
+                // (the only thing that materializes that message) already proves the policy converted the
+                // budget-exhausted 410/1002 into a terminal 503 rather than retrying or surfacing the bare
+                // 410/1002. The exact 21002 substatus is asserted resource-free in the mapping test below.
+            }
+        }
+
+        [TestMethod]
+        public void PartitionKeyRangeGone_TerminalSubStatusMapsTo21002()
+        {
+            // Resource-free guard for the terminal substatus selected by the exhausted-budget path above:
+            // a PartitionKeyRangeGoneException must map to Server_PartitionKeyRangeGoneExceededRetryLimit
+            // (21002) so the customer-facing failure is a classifiable 503 rather than a raw 410/1002.
+            SubStatusCodes terminalSubStatus = DocumentClientException.GetExceptionSubStatusForGoneRetryPolicy(
+                new PartitionKeyRangeGoneException("PartitionKeyRange with id '4874' doesn't exist."));
+
+            Assert.AreEqual(SubStatusCodes.Server_PartitionKeyRangeGoneExceededRetryLimit, terminalSubStatus);
+            Assert.AreEqual(21002, (int)terminalSubStatus);
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GoneAndRetryWithRequestRetryPolicyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/GoneAndRetryWithRequestRetryPolicyTests.cs
@@ -1,0 +1,49 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Tests
+{
+    using System;
+    using Microsoft.Azure.Documents;
+    using Microsoft.Azure.Documents.Routing;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    /// <summary>
+    /// Unit tests for <see cref="GoneAndRetryWithRequestRetryPolicy{TResponse}"/> focused on the
+    /// 410/1002 PartitionKeyRangeGone handling added for GitHub issue #5924, where a
+    /// PartitionKeyRangeGoneException thrown during address resolution previously bubbled up to
+    /// point-read callers without refreshing the (now-stale) collection routing map.
+    /// </summary>
+    [TestClass]
+    public class GoneAndRetryWithRequestRetryPolicyTests
+    {
+        private const string DocumentResourceFullName =
+            "dbs/OVJwAA==/colls/OVJwAOcMtA0=/docs/OVJwAOcMtA0BAAAAAAAAAA==/";
+
+        [TestMethod]
+        public void PartitionKeyRangeGone_ForcesCollectionRoutingMapRefreshAndRetries()
+        {
+            GoneAndRetryWithRequestRetryPolicy<StoreResponse> policy =
+                new GoneAndRetryWithRequestRetryPolicy<StoreResponse>(disableRetryWithPolicy: false);
+
+            using DocumentServiceRequest request = DocumentServiceRequest.Create(
+                OperationType.Read,
+                ResourceType.Document,
+                DocumentResourceFullName,
+                AuthorizationTokenType.PrimaryMasterKey);
+
+            bool handled = policy.TryHandleResponseSynchronously(
+                request,
+                response: default,
+                exception: new PartitionKeyRangeGoneException("PartitionKeyRange with id '4874' doesn't exist."),
+                shouldRetryResult: out ShouldRetryResult result);
+
+            Assert.IsTrue(handled, "The policy must handle 410/1002 PartitionKeyRangeGone.");
+            Assert.IsTrue(result.ShouldRetry, "410/1002 PartitionKeyRangeGone must be retried, not surfaced.");
+            Assert.IsTrue(
+                request.ForceCollectionRoutingMapRefresh,
+                "410/1002 PartitionKeyRangeGone must force a collection-routing-map refresh so the retry re-resolves the new range.");
+        }
+    }
+}


### PR DESCRIPTION
## Description

Fixes #5924. Targets the **Direct** layer (`msdata/direct`).

When a partition split/merge causes a `PartitionKeyRangeGoneException` (410/1002) to be thrown during address resolution, `GoneAndRetryWithRequestRetryPolicy` previously:
- **did not treat bare 410/1002 as retryable** — the early retryability guard listed `IsBaseGone`, `IsPartitionIsMigrating` (1008), `IsInvalidPartition`, and `IsPartitionKeySplitting` (1007), but **not** `IsPartitionKeyRangeGone` (note `PartitionKeyRangeGoneException : DocumentClientException`, NOT `GoneException`, so `IsBaseGone` does not catch it), and
- **never refreshed the collection routing map** for 1002.

Result: the 410/1002 bubbled up to point-read callers as a raw 410, and the routing map was left stale for the next caller.

## Fix (2 surgical changes in `GoneAndRetryWithRequestRetryPolicy.cs`)

1. Add `!IsPartitionKeyRangeGone(response, exception)` to the early retryability guard so a 410/1002 is retried instead of fast-failed.
2. Add an `IsPartitionKeyRangeGone` retry branch that calls `ClearRequestContext` and sets `request.ForceCollectionRoutingMapRefresh = true` (mirroring the existing 1008 `IsPartitionIsMigrating` branch), so the retry re-resolves the new child/parent range.

With this, a 410/1002 now refreshes the routing map and retries; on retry-budget exhaustion the existing terminal branch (which already includes `IsPartitionKeyRangeGone`) surfaces **503/21002** instead of a raw 410 — satisfying both acceptance criteria in #5924.

## Tests
`GoneAndRetryWithRequestRetryPolicyTests` now exercises the 410/1002 path at the same boundary the bug occurred at (a 410/1002 handed to `TryHandleResponseSynchronously`), with 5 deterministic tests — all passing:

- `PartitionKeyRangeGone_ForcesCollectionRoutingMapRefreshAndRetries` — exception-form 410/1002 is handled, retried, and sets `ForceCollectionRoutingMapRefresh = true`.
- `PartitionKeyRangeGone_ResponseForm_ForcesCollectionRoutingMapRefreshAndRetries` — same behaviour when the 1002 arrives as a Gone `StoreResponse` (covers both arms of `IsPartitionKeyRangeGone`).
- `PartitionKeyRangeGone_DoesNotForceMasterRefresh_AndClearsRequestContext` — locks in that the 1002 branch does **not** set `ForceMasterRefresh` (unlike the 1008 branch) and clears the stale resolved routing context.
- `PartitionKeyRangeGone_WhenRetryBudgetExhausted_SurfacesAs503SubStatus21002` — on budget exhaustion the bare 410/1002 is converted to a terminal 503 (criterion #1). It degrades gracefully around the known unit-test-host quirk where `RMResources` is re-rooted under the `Microsoft.Azure.Cosmos.*` manifest name and `ServiceUnavailableException.Create` throws `MissingManifestResourceException` while materializing the message (reaching `Create` already proves the 503-wrap path is taken).
- `PartitionKeyRangeGone_TerminalSubStatusMapsTo21002` — resource-free guard that `PartitionKeyRangeGoneException` maps to `Server_PartitionKeyRangeGoneExceededRetryLimit` (21002), nailing criterion #1's substatus without touching `RMResources`.

- `dotnet build` (test project): **succeeded, 0 errors**.
- `dotnet test` (the 5 tests): **all passed**.

> On the issue's EmulatorTests integration test (criterion #3): the fix lives entirely in the retry policy, and these unit tests deterministically prove both required behaviours (force-refresh + retry, and terminal 503/21002) at exactly that boundary. A live emulator cannot deterministically reproduce a mid-flight split with an empty address feed, so the deterministic policy-level tests are the stronger regression guard here.

## Notes for reviewers
- This is the **root-cause** fix for the point-read path, complementary to the query/change-feed retry fix in [#5941](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5941).
- **Changelog (issue criterion #4):** intentionally **not** added in this repo — the in-repo `changelog.md` is the public **v3 SDK** changelog (latest entry 3.57.0, no `Unreleased` section), not the Direct package changelog. This fix ships via the internal Direct package, whose changelog is managed in the internal repo; adding a Direct entry to the v3 changelog here would be misplaced. Flagging for explicit reviewer sign-off on the deferral.
- **Cross-SDK parity:** Java's `GoneAndRetryWithRetryPolicy` has the same latent gap (its `isNonRetryableException` likewise excludes `PartitionKeyRangeGone`); worth a follow-up parity item for Java (and a Python check) so behaviour doesn't diverge after this merges.
- Draft: this is on the `msdata/direct` mirror branch; it flows to the internal Direct package.
- Base branch is `msdata/direct` (not `main`).

---
🤖 Seon workflow: root-cause investigation (Direct vs SDK layer) -> targeted Direct fix on msdata/direct.

