### PR TITLE
[Internal] Tests: Fixes MultiRegion test setup to seed existing-but-unseeded databases

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/MultiRegionSetupHelpers.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Utils/MultiRegionSetupHelpers.cs
@@ -4,7 +4,6 @@
 
 namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 {
-    using System.Collections.Generic;
     using System.IO;
     using System.Net;
     using System.Text.Json;
@@ -29,41 +28,66 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 throughput: 400);
             database = db.Database;
 
-            if (db.StatusCode == HttpStatusCode.Created)
+            // Ensure the containers exist regardless of whether the database was just created or
+            // already existed. Relying solely on db.StatusCode == Created caused tests to fail with
+            // a 404 on warm-up reads when the database existed but had never been seeded (for example
+            // on a fresh account where a prior run created the database but failed before seeding).
+            ContainerResponse containerResponse = await database.CreateContainerIfNotExistsAsync(
+                id: MultiRegionSetupHelpers.containerName,
+                partitionKeyPath: "/pk",
+                throughput: 400);
+            container = containerResponse.Container;
+
+            ContainerResponse changeFeedContainerResponse = await database.CreateContainerIfNotExistsAsync(
+                id: MultiRegionSetupHelpers.changeFeedContainerName,
+                partitionKeyPath: "/partitionKey",
+                throughput: 400);
+            changeFeedContainer = changeFeedContainerResponse.Container;
+
+            // Seed the documents the tests warm up against. Upsert makes this idempotent so an
+            // existing-but-unseeded container is repaired instead of silently skipped.
+            bool seeded = await MultiRegionSetupHelpers.EnsureSeedItemsAsync(container);
+
+            if (db.StatusCode == HttpStatusCode.Created
+                || containerResponse.StatusCode == HttpStatusCode.Created
+                || changeFeedContainerResponse.StatusCode == HttpStatusCode.Created
+                || seeded)
             {
-                container = await database.CreateContainerIfNotExistsAsync(
-                    id: MultiRegionSetupHelpers.containerName,
-                    partitionKeyPath: "/pk",
-                    throughput: 400);
-                changeFeedContainer = await database.CreateContainerIfNotExistsAsync(
-                    id: MultiRegionSetupHelpers.changeFeedContainerName,
-                    partitionKeyPath: "/partitionKey",
-                    throughput: 400);
-
-                List<Task> tasks = new List<Task>()
-                {
-                    container.CreateItemAsync<CosmosIntegrationTestObject>(
-                        new CosmosIntegrationTestObject { Id = "testId", Pk = "pk" }),
-                    container.CreateItemAsync<CosmosIntegrationTestObject>(
-                        new CosmosIntegrationTestObject { Id = "testId2", Pk = "pk2" }),
-                    container.CreateItemAsync<CosmosIntegrationTestObject>(
-                        new CosmosIntegrationTestObject { Id = "testId3", Pk = "pk3" }),
-                    container.CreateItemAsync<CosmosIntegrationTestObject>(
-                        new CosmosIntegrationTestObject { Id = "testId4", Pk = "pk4" })
-                };
-
-                await Task.WhenAll(tasks);
-
                 //Must Ensure the data is replicated to all regions
                 await Task.Delay(60000);
-
-                return (database, container, changeFeedContainer);
             }
 
-            container = database.GetContainer(MultiRegionSetupHelpers.containerName);
-            changeFeedContainer = database.GetContainer(MultiRegionSetupHelpers.changeFeedContainerName);
-
             return (database, container, changeFeedContainer);
+        }
+
+        private static async Task<bool> EnsureSeedItemsAsync(Container container)
+        {
+            (string id, string pk)[] seedItems = new[]
+            {
+                ("testId", "pk"),
+                ("testId2", "pk2"),
+                ("testId3", "pk3"),
+                ("testId4", "pk4")
+            };
+
+            bool createdAny = false;
+            foreach ((string id, string pk) in seedItems)
+            {
+                using (ResponseMessage response = await container.ReadItemStreamAsync(id, new PartitionKey(pk)))
+                {
+                    if (response.StatusCode == HttpStatusCode.OK)
+                    {
+                        continue;
+                    }
+                }
+
+                await container.UpsertItemAsync<CosmosIntegrationTestObject>(
+                    new CosmosIntegrationTestObject { Id = id, Pk = pk },
+                    new PartitionKey(pk));
+                createdAny = true;
+            }
+
+            return createdAny;
         }
 
         internal class CosmosIntegrationTestObject


### PR DESCRIPTION
## Description

Investigated #5949 — `CosmosAvailabilityStrategyTests` hedging datarows failing consistently in CI across all PRs and main.

### Root cause (infrastructure, not SDK code)
Reproduced live against a multi-region account. The failures are **not** a code regression in the hedging/availability-strategy path. Two infra factors:

1. **Account firewall** rejected the runner's public-internet egress IP (`403 — blocked by your Cosmos DB account firewall settings`). Fixed by allowing the corp/runner IP ranges on the account.
2. **Missing seed data** combined with a non-idempotent test setup helper.

`MultiRegionSetupHelpers.GetOrCreateMultiRegionDatabaseAndContainers` only seeded the warm-up documents (`testId`/`pk`, …) **when the database was freshly `Created`**. On a fresh or partially-provisioned account where the database already existed but had never been seeded (e.g. a prior run created the DB but failed before seeding), seeding was silently skipped and every test row failed with a `404 NotFound` on the warm-up read at `CosmosAvailabilityStrategyTests.cs:605`.

### Fix
Make the setup idempotent:
- Always `CreateContainerIfNotExists` for both containers regardless of DB create status.
- Upsert the four seed documents if missing (`EnsureSeedItemsAsync`).
- Only perform the 60s cross-region replication wait when something was actually created.

### Validation
After allowing the firewall range and applying this fix, the full `ReadSessionNotAvailable` set (Read / SinglePartitionQuery / CrossPartitionQuery / ReadMany / ChangeFeed × preferred-region modes) passes:

```
Passed! - Failed: 0, Passed: 10, Skipped: 0, Total: 10 - Microsoft.Azure.Cosmos.EmulatorTests.dll (net6.0)
```

This confirms there is **no SDK regression** — the hedging assertions are reached and green once the account is reachable and seeded. (The earlier #5648 hypothesis on the issue is ruled out for the reproducible path.)

## Type of change
- [x] Bug fix (non-breaking change which fixes test setup robustness)

## Changelog
No changelog entry required — change is test-only (`Microsoft.Azure.Cosmos.EmulatorTests` util), not under shipped package source.

Closes #5949