### PR TITLE
Routing: Fixes GetRangeByEffectivePartitionKey to honor the configured length-aware comparer

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Routing/CollectionRoutingMap.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/CollectionRoutingMap.cs
@@ -176,7 +176,7 @@ namespace Microsoft.Azure.Cosmos.Routing
 
             int index = this.orderedRanges.BinarySearch(
                 new Range<string>(effectivePartitionKeyValue, effectivePartitionKeyValue, true, true),
-                Range<string>.MinComparer.Instance);
+                this.comparers.MinComparer);
 
             if (index < 0)
             {

--- a/Microsoft.Azure.Cosmos/src/Routing/CollectionRoutingMap.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/CollectionRoutingMap.cs
@@ -174,6 +174,14 @@ namespace Microsoft.Azure.Cosmos.Routing
                 return this.orderedPartitionKeyRanges[0];
             }
 
+            // Search the ordinally-built orderedRanges with the configured (length-aware-by-default)
+            // comparer, mirroring GetOverlappingRanges. This is safe because partition key ranges form a
+            // contiguous hex-string space: (1) range boundaries with different significant prefixes keep the
+            // same relative order under both the ordinal and length-aware comparers, so the ordinal sort of
+            // orderedRanges is a valid precondition for the binary search; and (2) a short/partial EPK is
+            // intentionally treated as equal to its zero-padded boundary, which is exactly the disagreement
+            // with the previous ordinal comparer that this method must now resolve consistently with
+            // GetOverlappingRanges.
             int index = this.orderedRanges.BinarySearch(
                 new Range<string>(effectivePartitionKeyValue, effectivePartitionKeyValue, true, true),
                 this.comparers.MinComparer);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CollectionRoutingMapTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CollectionRoutingMapTest.cs
@@ -273,6 +273,71 @@ namespace Microsoft.Azure.Cosmos.Tests
             }
         }
 
+        // Regression for GetRangeByEffectivePartitionKey honoring the configured length-aware comparer.
+        // Previously the point lookup hard-coded the ordinal Range<string>.MinComparer.Instance while its
+        // sibling GetOverlappingRanges used the configured comparer, so the two disagreed for a short/partial
+        // EPK sitting on a zero-padded range boundary.
+        // The 32-char EPK "06AB34CFE4E482236BCACBBF50E234AB" equals (length-aware) range "2"'s zero-padded
+        // MinInclusive "06AB34CFE4E482236BCACBBF50E234AB00000000000000000000000000000000".
+        // Length-aware -> "2" (matches GetOverlappingRanges scenario 1.1); ordinal lands one bucket low at "1".
+        [TestMethod]
+        public void TestGetRangeByEffectivePartitionKeyUsesLengthAwareComparer()
+        {
+            CollectionRoutingMap routingMap = this.GenerateRoutingMap(isFullySpecified: false, useLengthAwareComparer: true);
+
+            string id = routingMap.GetRangeByEffectivePartitionKey("06AB34CFE4E482236BCACBBF50E234AB").Id;
+
+            Assert.AreEqual("2", id, "Length-aware point lookup must select the partition that owns the zero-padded boundary EPK.");
+        }
+
+        // The point lookup must agree with its sibling GetOverlappingRanges for the boundary EPK.
+        [TestMethod]
+        public void TestGetRangeByEffectivePartitionKeyAgreesWithGetOverlappingRanges()
+        {
+            CollectionRoutingMap routingMap = this.GenerateRoutingMap(isFullySpecified: false, useLengthAwareComparer: true);
+
+            const string boundaryEpk = "06AB34CFE4E482236BCACBBF50E234AB";
+
+            PartitionKeyRange pointLookup = routingMap.GetRangeByEffectivePartitionKey(boundaryEpk);
+
+            IReadOnlyList<PartitionKeyRange> overlapping = routingMap.GetOverlappingRanges(
+                new Range<string>(boundaryEpk, boundaryEpk + "FF", true, false));
+
+            Assert.AreEqual(1, overlapping.Count);
+            Assert.AreEqual("2", pointLookup.Id);
+            Assert.AreEqual(pointLookup.Id, overlapping[0].Id, "GetRangeByEffectivePartitionKey must agree with GetOverlappingRanges on the boundary EPK.");
+        }
+
+        // Legacy/ordinal path must be preserved when length-aware comparison is disabled: the same boundary
+        // EPK lands in range "1" under ordinal comparison (the historical behavior).
+        [TestMethod]
+        public void TestGetRangeByEffectivePartitionKeyLegacyComparerUnchanged()
+        {
+            CollectionRoutingMap routingMap = this.GenerateRoutingMap(isFullySpecified: false, useLengthAwareComparer: false);
+
+            string id = routingMap.GetRangeByEffectivePartitionKey("06AB34CFE4E482236BCACBBF50E234AB").Id;
+
+            Assert.AreEqual("1", id, "With the length-aware comparer disabled the ordinal/legacy behavior must be preserved.");
+        }
+
+        // Fully specified (64-char) EPKs are unaffected by the fix: current synchronous callers pass full-length
+        // EPKs, for which ordinal and length-aware comparison are equivalent. The same partition must be selected
+        // regardless of which comparer is configured.
+        [TestMethod]
+        public void TestGetRangeByEffectivePartitionKeyFullEpkUnaffected()
+        {
+            const string fullEpk = "0800000000000000000000000000000000000000000000000000000000000000";
+
+            CollectionRoutingMap lengthAwareMap = this.GenerateRoutingMap(isFullySpecified: false, useLengthAwareComparer: true);
+            CollectionRoutingMap legacyMap = this.GenerateRoutingMap(isFullySpecified: false, useLengthAwareComparer: false);
+
+            string lengthAwareId = lengthAwareMap.GetRangeByEffectivePartitionKey(fullEpk).Id;
+            string legacyId = legacyMap.GetRangeByEffectivePartitionKey(fullEpk).Id;
+
+            Assert.AreEqual("2", lengthAwareId);
+            Assert.AreEqual(legacyId, lengthAwareId, "A full-length EPK must map to the same partition under both comparers.");
+        }
+
         private CollectionRoutingMap GenerateRoutingMap(bool isFullySpecified, bool useLengthAwareComparer)
         {
             IEnumerable<Tuple<PartitionKeyRange, ServiceIdentity>> partitionKeyRangeTuples = new[]

--- a/changelog.md
+++ b/changelog.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Other Changes
 
+- [5956](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5956) Routing: Fixes `CollectionRoutingMap.GetRangeByEffectivePartitionKey` to use the configured (length-aware-by-default) comparer instead of a hard-coded ordinal comparer, so it agrees with `GetOverlappingRanges` for a short/partial effective partition key on a zero-padded range boundary. This is a defense-in-depth correctness fix; current SDK callers pass full-length effective partition keys, for which the ordinal and length-aware comparers are equivalent, so there is no behavior change for existing workloads.
+
 ### <a name="3.62.0-preview.0"/> [3.62.0-preview.0](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.62.0-preview.0) - 2026-6-1
 
 #### Features Added


### PR DESCRIPTION
## Summary

`CollectionRoutingMap.GetRangeByEffectivePartitionKey` hard-coded the **ordinal** `Range<string>.MinComparer.Instance` for its binary search, while its sibling `GetOverlappingRanges` uses the **configured** comparer (`this.comparers`, set via `RangeComparerProvider.GetComparers(useLengthAwareRangeComparer)`). Length-aware comparison is the GA default (`ConfigurationManager.IsLengthAwareRangeComparatorEnabled() == true` for non-INTERNAL builds — PRs #5260 / #5866). As a result, the two methods that both answer *"which partition owns this EPK?"* could disagree for a short/partial EPK that sits on a zero-padded range boundary.

### Fix
One line in `Microsoft.Azure.Cosmos/src/Routing/CollectionRoutingMap.cs`:

```diff
 int index = this.orderedRanges.BinarySearch(
     new Range<string>(effectivePartitionKeyValue, effectivePartitionKeyValue, true, true),
-    Range<string>.MinComparer.Instance);
+    this.comparers.MinComparer);
```

This mirrors the #5260 change that switched `GetOverlappingRanges` to `this.comparers` (the ordinal sort of `orderedRanges` is preserved; the binary-search precondition is the same one accepted there). When `useLengthAwareRangeComparer == false`, `this.comparers.MinComparer` resolves to the legacy ordinal comparer, so the legacy path is unchanged.

## Honest / masked-impact note (why this is a latent fix)

All **current** synchronous callers — `AddressResolver`, `BatchExecUtils`/`BatchAsyncContainerExecutor`, `ReadManyQueryHelper` — pass **full-length** EPKs, for which ordinal and length-aware comparison are equivalent. So this is a **latent correctness / defense-in-depth** fix, **not** a confirmed live customer regression today. It prevents a wrong-partition result if any future caller passes a short/partial EPK to the point lookup.

## Verified reproduction (test fails pre-fix)

Using the existing length-aware routing map (`GenerateRoutingMap(useLengthAwareComparer: true)`), whose range "1"/"2" boundary is the zero-padded `06AB34CFE4E482236BCACBBF50E234AB00000000000000000000000000000000`:

```csharp
map.GetRangeByEffectivePartitionKey("06AB34CFE4E482236BCACBBF50E234AB").Id
```

- **Pre-fix (ordinal):** returns `"1"` (lands one bucket low).
- **Post-fix (length-aware):** returns `"2"` — matching `GetOverlappingRanges` (existing scenario 1.1).

Confirmed by temporarily reverting the fix and running the new tests: `TestGetRangeByEffectivePartitionKeyUsesLengthAwareComparer` and `TestGetRangeByEffectivePartitionKeyAgreesWithGetOverlappingRanges` both fail with `Expected:<2>. Actual:<1>`; they pass after the fix.

## Tests added (`CollectionRoutingMapTest.cs`, reusing `GenerateRoutingMap`)

1. **Length-aware point lookup (regression):** boundary EPK → `"2"`.
2. **Agreement with sibling:** point lookup agrees with `GetOverlappingRanges` on the boundary EPK.
3. **Legacy/ordinal unchanged:** with `useLengthAwareComparer: false`, boundary EPK → `"1"` (historical behavior preserved).
4. **Full-EPK callers unaffected:** a fully specified 64-char EPK maps to the same partition under both comparers.
5. Existing `TestCollectionRoutingMap`, `TestCollectionRoutingMapWithLengthAwareRangeComparators`, and `TestLegacyComparatorsUsedWhenLengthAwareComparatorFlagIsFalse` remain green.

**Result:** `dotnet test --filter "FullyQualifiedName~CollectionRoutingMap"` → Passed: 14, Failed: 0.

## Changelog

Applied the repo changelog classifier: the diff touches shipped `src/**`, but live impact is masked today (current callers pass full EPKs, where ordinal == length-aware), so there is no guaranteed customer-observable change on upgrade. This is the ambiguous defense-in-depth case, so per the classifier's "default to an Other Changes entry and explain" rule, an entry is added under **#### Other Changes** rather than silently omitted.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>