### PR TITLE
[Internal] DistributedTransaction: Adds cumulative delay budget to outer retry loop

### DIFF
--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionCommitter.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionCommitter.cs
@@ -20,7 +20,17 @@ namespace Microsoft.Azure.Cosmos
     {
         // Outer-loop retry parameters. The inner loop (ClientRetryPolicy) handles envelope failures with empty body;
         // the outer loop handles body-bearing semantic failures whose JSON body sets isRetriable: true.
+        //
+        // Hard ceiling on outer-loop wire requests. With non-trivial retryBaseDelay the cumulative
+        // MaxCumulativeRetryDelay budget will typically fire first; this cap only binds when delays
+        // are very small (e.g., zero in tests or hypothetical fast-server scenarios) — it guards
+        // against unbounded wire-request amplification when delays are degenerate.
         internal const int MaxIsRetriableRetryCount = 10;
+        // Default cumulative planned-delay budget. With default 1s base and maxExponent=5 (±25% jitter),
+        // the budget is the binding constraint (~4-5 retries) rather than the attempt-count cap (10).
+        // Mirrors ResourceThrottleRetryPolicy's cumulative cap pattern. Overridable via the internal
+        // constructor for tests that need to exercise the attempt-count cap with realistic delays.
+        internal static readonly TimeSpan MaxCumulativeRetryDelay = TimeSpan.FromSeconds(30);
         private const int RetryMaxExponent = 5; // ~32 s max base delay before jitter
         private static readonly TimeSpan DefaultRetryBaseDelay = TimeSpan.FromSeconds(1);
         private static readonly string ResourceUri = Paths.OperationsPathSegment + "/" + Paths.Operations_Dtc;
@@ -28,6 +38,7 @@ namespace Microsoft.Azure.Cosmos
         private readonly IReadOnlyList<DistributedTransactionOperation> operations;
         private readonly CosmosClientContext clientContext;
         private readonly TimeSpan retryBaseDelay;
+        private readonly TimeSpan maxCumulativeRetryDelay;
         private readonly Func<TimeSpan, CancellationToken, Task> delayProvider;
 
         public DistributedTransactionCommitter(
@@ -41,12 +52,14 @@ namespace Microsoft.Azure.Cosmos
             IReadOnlyList<DistributedTransactionOperation> operations,
             CosmosClientContext clientContext,
             TimeSpan retryBaseDelay,
-            Func<TimeSpan, CancellationToken, Task> delayProvider = null)
+            Func<TimeSpan, CancellationToken, Task> delayProvider = null,
+            TimeSpan? maxCumulativeRetryDelay = null)
         {
             this.operations = operations ?? throw new ArgumentNullException(nameof(operations));
             this.clientContext = clientContext ?? throw new ArgumentNullException(nameof(clientContext));
             this.retryBaseDelay = retryBaseDelay;
             this.delayProvider = delayProvider ?? Task.Delay;
+            this.maxCumulativeRetryDelay = maxCumulativeRetryDelay ?? DistributedTransactionCommitter.MaxCumulativeRetryDelay;
         }
 
         public async Task<DistributedTransactionResponse> CommitTransactionAsync(
@@ -84,6 +97,7 @@ namespace Microsoft.Azure.Cosmos
             CosmosTraceDiagnostics diagnostics = new CosmosTraceDiagnostics(parentTrace);
 
             int attempt = 0;
+            TimeSpan cumulativeRetryDelay = TimeSpan.Zero;
             while (true)
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -117,8 +131,23 @@ namespace Microsoft.Azure.Cosmos
                     ? serverHint
                     : computedDelay;
 
+                // Check cumulative delay budget before sleeping. If the next delay would
+                // exceed the budget, stop retrying — mirroring ResourceThrottleRetryPolicy.
+                cumulativeRetryDelay += delay;
+                if (cumulativeRetryDelay > this.maxCumulativeRetryDelay)
+                {
+                    DefaultTrace.TraceWarning(
+                        $"Distributed transaction isRetriable cumulative delay budget exceeded " +
+                            $"(cumulativeDelayMs={(int)cumulativeRetryDelay.TotalMilliseconds}, " +
+                            $"maxDelayMs={(int)this.maxCumulativeRetryDelay.TotalMilliseconds}, " +
+                            $"attempt={attempt}, StatusCode={response.StatusCode}, " +
+                            $"DiagnosticString={TruncateForLog(response.DiagnosticString)}). Returning last response.");
+                    response.Diagnostics = diagnostics;
+                    return response;
+                }
+
                 DefaultTrace.TraceWarning(
-                    $"Distributed transaction commit retriable (StatusCode={response.StatusCode}, IsRetriable={response.IsRetriable}, DiagnosticString={TruncateForLog(response.DiagnosticString)}, attempt {attempt + 1}, delayMs={(int)delay.TotalMilliseconds}). Retrying with idempotency token {serverRequest.IdempotencyToken}.");
+                    $"Distributed transaction commit retriable (StatusCode={response.StatusCode}, IsRetriable={response.IsRetriable}, DiagnosticString={TruncateForLog(response.DiagnosticString)}, attempt={attempt}, delayMs={(int)delay.TotalMilliseconds}, cumulativeDelayMs={(int)cumulativeRetryDelay.TotalMilliseconds}). Retrying with idempotency token {serverRequest.IdempotencyToken}.");
 
                 response.Dispose();
                 attempt++;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionCommitterTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionCommitterTests.cs
@@ -769,6 +769,110 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             }
         }
 
+        [TestMethod]
+        [Description("Verifies that the outer retry loop stops when the cumulative delay budget (MaxCumulativeRetryDelay) is exceeded, even if attempt count has not been reached.")]
+        public async Task CommitTransaction_ExhaustsCumulativeDelayBudget_ReturnsLastResponse()
+        {
+            int callCount = 0;
+            List<TimeSpan> capturedDelays = new List<TimeSpan>();
+            Mock<CosmosClientContext> mockContext = this.CreateMockClientContext();
+            this.SetupProcessResourceOperation(
+                mockContext,
+                () =>
+                {
+                    callCount++;
+                    return Task.FromResult(CreateRetriableErrorResponseMessage());
+                });
+
+            Func<TimeSpan, CancellationToken, Task> captureDelay = (delay, _) =>
+            {
+                capturedDelays.Add(delay);
+                return Task.CompletedTask;
+            };
+
+            // Use a large base delay (15s) so the cumulative budget (30s) is exceeded after 2-3 retries,
+            // well before the attempt count cap (10).
+            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
+                CreateTestOperations(),
+                mockContext.Object,
+                retryBaseDelay: TimeSpan.FromSeconds(15),
+                delayProvider: captureDelay);
+
+            using (DistributedTransactionResponse response = await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None))
+            {
+                // With 15s base delay and exponential backoff (±25% jitter):
+                //   attempt 0 delay = 15s * 2^0 * jitter ≈ 11.25–18.75s (cumulative ≈ 11.25–18.75s, under 30s budget)
+                //   attempt 1 delay = 15s * 2^1 * jitter ≈ 22.5–37.5s  (cumulative ≈ 33.75–56.25s, exceeds 30s budget)
+                // So the loop should make exactly 2 calls and sleep exactly once before the budget stops it.
+                Assert.AreEqual(2, callCount,
+                    $"Expected exactly 2 calls (initial + 1 retry) before cumulative delay budget is exceeded. Got {callCount}.");
+                Assert.AreEqual(1, capturedDelays.Count,
+                    $"Expected exactly 1 delay to be slept before the budget-exceeding second delay triggers early exit. Got {capturedDelays.Count}.");
+
+                // The single slept delay must be under the budget (it passed the check).
+                Assert.IsTrue(capturedDelays[0] <= DistributedTransactionCommitter.MaxCumulativeRetryDelay,
+                    $"The slept delay ({capturedDelays[0].TotalMilliseconds}ms) must be within budget since it passed the check.");
+                // The slept delay must be substantial (15s base * 0.75 jitter minimum = 11.25s).
+                Assert.IsTrue(capturedDelays[0] >= TimeSpan.FromSeconds(11),
+                    $"Delay should reflect 15s base with jitter, but was only {capturedDelays[0].TotalMilliseconds}ms.");
+
+                Assert.IsFalse(response.IsSuccessStatusCode,
+                    "The returned response must be the last non-success response.");
+                Assert.IsNotNull(response.Diagnostics,
+                    "Diagnostics must not be null when the cumulative delay budget is exhausted.");
+            }
+        }
+
+        [TestMethod]
+        [Description("Verifies that large server RetryAfter headers exhaust the cumulative delay budget after only a few attempts, " +
+                     "even though the attempt count cap (10) is far from reached.")]
+        public async Task CommitTransaction_ServerRetryAfterDominates_ExhaustsCumulativeDelayBudgetEarly()
+        {
+            int callCount = 0;
+            List<TimeSpan> capturedDelays = new List<TimeSpan>();
+            Mock<CosmosClientContext> mockContext = this.CreateMockClientContext();
+            this.SetupProcessResourceOperation(
+                mockContext,
+                () =>
+                {
+                    callCount++;
+                    // Server returns RetryAfter=25s on every retriable response
+                    ResponseMessage msg = CreateRetriableErrorResponseMessage();
+                    msg.Headers.RetryAfter = TimeSpan.FromSeconds(25);
+                    return Task.FromResult(msg);
+                });
+
+            Func<TimeSpan, CancellationToken, Task> captureDelay = (delay, _) =>
+            {
+                capturedDelays.Add(delay);
+                return Task.CompletedTask;
+            };
+
+            // Use small base delay so server RetryAfter dominates the delay selection.
+            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
+                CreateTestOperations(),
+                mockContext.Object,
+                retryBaseDelay: TimeSpan.FromMilliseconds(100),
+                delayProvider: captureDelay);
+
+            using (DistributedTransactionResponse response = await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None))
+            {
+                // With 25s server hint per attempt: attempt 0 delay=25s (cumulative=25s OK), attempt 1 delay=25s (cumulative=50s > 30s budget).
+                // So only 1 retry should succeed before budget exhaustion stops the loop.
+                Assert.AreEqual(1, capturedDelays.Count,
+                    $"Expected exactly 1 retry before the cumulative budget (30s) is exceeded by the second 25s RetryAfter. Got {capturedDelays.Count}.");
+                Assert.AreEqual(2, callCount,
+                    "Expected 2 total calls: initial attempt + 1 retry before budget exhaustion on the second delay computation.");
+                Assert.IsFalse(response.IsSuccessStatusCode);
+                Assert.IsTrue(response.IsRetriable);
+                Assert.IsNotNull(response.Diagnostics);
+
+                // Verify the captured delay used the server hint (25s) not the computed backoff
+                Assert.IsTrue(capturedDelays[0] >= TimeSpan.FromSeconds(24),
+                    $"Delay should reflect server RetryAfter (~25s), but was {capturedDelays[0].TotalMilliseconds}ms.");
+            }
+        }
+
         [DataTestMethod]
         [Description("Verifies that a CosmosException thrown from the pipeline propagates immediately without triggering the outer retry loop, regardless of status code. Status-code-based retries (e.g. 408, 449/5352) are handled by ClientRetryPolicy inside the pipeline; the outer loop only handles the isRetriable JSON body flag.")]
         [DataRow((int)HttpStatusCode.RequestTimeout, DisplayName = "408 RequestTimeout — propagates")]
@@ -1086,11 +1190,15 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                 return Task.CompletedTask;
             };
 
+            // Override the cumulative delay budget so the 7-retry exponential backoff (worst case
+            // cumulative ~95s with 1s base) can complete and we exercise the full backoff curve
+            // including delays beyond the maxExponent cap.
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
                 CreateTestOperations(),
                 mockContext.Object,
                 retryBaseDelay: baseDelay,
-                delayProvider: captureDelay);
+                delayProvider: captureDelay,
+                maxCumulativeRetryDelay: TimeSpan.FromMinutes(5));
 
             using (DistributedTransactionResponse response = await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None))
             {

--- a/changelog.md
+++ b/changelog.md
@@ -30,7 +30,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Other Changes
 
-- [5961](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5961) DistributedTransaction (Preview): Adds a 30-second cumulative delay budget to the outer commit retry loop, capping maximum retry duration under default settings.
 - [5916](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5916) Direct: Moves the `OpenTcpConnectionTimeout` negative-value warning trace from `CosmosClientOptions` to `DocumentClient`. The warning is now emitted once per client construction (instead of once per property assignment) and is gated on `ConnectionMode == Direct`, so it no longer false-positives when a negative value is later overwritten with a non-negative one or when running in Gateway mode where the timeout is not consumed.
 ### <a name="3.62.0-preview.0"/> [3.62.0-preview.0](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.62.0-preview.0) - 2026-6-1
 

--- a/changelog.md
+++ b/changelog.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Other Changes
 
+- [5961](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5961) DistributedTransaction (Preview): Adds a 30-second cumulative delay budget to the outer commit retry loop, capping maximum retry duration under default settings.
 - [5916](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5916) Direct: Moves the `OpenTcpConnectionTimeout` negative-value warning trace from `CosmosClientOptions` to `DocumentClient`. The warning is now emitted once per client construction (instead of once per property assignment) and is gated on `ConnectionMode == Direct`, so it no longer false-positives when a negative value is later overwritten with a non-negative one or when running in Gateway mode where the timeout is not consumed.
 ### <a name="3.62.0-preview.0"/> [3.62.0-preview.0](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.62.0-preview.0) - 2026-6-1
 


### PR DESCRIPTION
## Summary

Adds a `MaxCumulativeRetryDelay` (30 seconds) check to the `DistributedTransactionCommitter` outer retry loop, mirroring the existing `ResourceThrottleRetryPolicy` cumulative delay pattern used by non-DTX flows.

## Motivation

Previously, the outer retry loop was bounded only by attempt count (`MaxIsRetriableRetryCount = 10`). With the default exponential backoff (1s base, max exponent 5, ±25% jitter), the worst-case cumulative delay could reach ~4 minutes — far longer than is reasonable for a caller to wait.

The cumulative delay budget provides a hard time-based cap that:
- Prevents unbounded retry duration when server `RetryAfter` headers are large
- Matches the pattern already established by `ResourceThrottleRetryPolicy`
- Is the binding constraint under default settings (~4-5 retries) while the attempt-count cap (10) only fires when delays are very small

## Changes

- **`DistributedTransactionCommitter.cs`**: Added `MaxCumulativeRetryDelay` constant (30s) and cumulative delay tracking in the retry loop. Enhanced trace logs to include `cumulativeDelayMs`.
- **`DistributedTransactionCommitterTests.cs`**: Added tests for cumulative budget exhaustion and server RetryAfter-dominated budget exhaustion. Updated the existing exponential backoff test to override the budget so it can still exercise the full backoff curve.

## Testing

- All 47 `DistributedTransactionCommitterTests` pass
- Build succeeds with 0 warnings/errors