### PR TITLE
[Internal] DTS: Adds ifMatch/ifNoneMatch conditional ETag wire contract for operations

### DIFF
--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperation.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperation.cs
@@ -58,9 +58,9 @@ namespace Microsoft.Azure.Cosmos
 
         internal string SessionToken { get; set; }
 
-        internal string ETag => this.OperationType == OperationType.Read
-            ? this.RequestOptions?.IfNoneMatchEtag
-            : this.RequestOptions?.IfMatchEtag;
+        internal string IfMatch => this.RequestOptions?.IfMatchEtag ?? null;
+
+        internal string IfNoneMatch => this.RequestOptions?.IfNoneMatchEtag ?? null;
 
         internal Stream ResourceStream { get; set; }
 

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperation.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperation.cs
@@ -58,9 +58,9 @@ namespace Microsoft.Azure.Cosmos
 
         internal string SessionToken { get; set; }
 
-        internal string IfMatch => this.RequestOptions?.IfMatchEtag ?? null;
+        internal string IfMatch => this.RequestOptions?.IfMatchEtag;
 
-        internal string IfNoneMatch => this.RequestOptions?.IfNoneMatchEtag ?? null;
+        internal string IfNoneMatch => this.RequestOptions?.IfNoneMatchEtag;
 
         internal Stream ResourceStream { get; set; }
 

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionSerializer.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionSerializer.cs
@@ -32,7 +32,8 @@ namespace Microsoft.Azure.Cosmos
         internal const string OperationResponses = "operationResponses";
         internal const string SessionToken = "sessionToken";
         internal const string PartitionKeyRangeId = "partitionKeyRangeId";
-        internal const string ETag = "ifMatch";
+        internal const string IfMatch = "ifMatch";
+        internal const string IfNoneMatch = "ifNoneMatch";
         internal const string ResponseETag = "Etag";
         internal const string OperationType = "operationType";
         internal const string ResourceType = "resourceType";
@@ -127,10 +128,16 @@ namespace Microsoft.Azure.Cosmos
                 jsonWriter.WriteString(SessionToken, operation.SessionToken);
             }
 
-            // etag
-            if (operation.ETag != null)
+            // ifMatch
+            if (operation.IfMatch != null)
             {
-                jsonWriter.WriteString(ETag, operation.ETag);
+                jsonWriter.WriteString(IfMatch, operation.IfMatch);
+            }
+
+            // ifNoneMatch
+            if (operation.IfNoneMatch != null)
+            {
+                jsonWriter.WriteString(IfNoneMatch, operation.IfNoneMatch);
             }
 
             // operationType (string)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/DistributedTransaction/DistributedTransactionConditionalE2ETests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/DistributedTransaction/DistributedTransactionConditionalE2ETests.cs
@@ -1,0 +1,562 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
+{
+    using System;
+    using System.Net;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using PartitionKey = Cosmos.PartitionKey;
+
+    /// <summary>
+    /// End-to-end tests for conditional ETag behavior (ifMatch / ifNoneMatch) in distributed
+    /// transactions, run against a live DTX-enabled account.
+    ///
+    /// These tests verify SDK-visible behavior for conditional ETags in distributed transactions:
+    ///
+    /// ┌────┬──────────────────────────────────────────────────────┬──────────────────────────────────────────┐
+    /// │ #  │ Scenario                                             │ Expected SDK Result                      │
+    /// ├────┼──────────────────────────────────────────────────────┼──────────────────────────────────────────┤
+    /// │ 1  │ Read 2 existing items, no conditionals               │ 200 [200, 200]                           │
+    /// │ 2  │ Read 2 items, one has matching IfNoneMatch           │ 207 [200, 304]                           │
+    /// │ 3  │ Read 1 item with stale IfNoneMatch (item changed)    │ 200 [200] — returns updated resource     │
+    /// │ 4  │ Read 2 items, both have matching IfNoneMatch         │ 207 [304, 304]                           │
+    /// │ 5  │ Read 2 items, one does not exist                     │ 404 [424, 404]                           │
+    /// │ 6  │ Write with stale IfMatch (conflict)                  │ 412/452 — precondition failed            │
+    /// │ 7  │ Write with current IfMatch (no conflict)             │ 200 [200] — item replaced successfully   │
+    /// │ 8  │ Read 1 item with matching IfNoneMatch (inspectable)  │ 304 — user can inspect StatusCode        │
+    /// │ 9  │ Read with both IfMatch+IfNoneMatch set               │ 304 — only IfNoneMatch honoured          │
+    /// │ 10 │ Write with both IfMatch+IfNoneMatch set              │ 200 — only IfMatch honoured              │
+    /// │ 11 │ Write with stale IfMatch + current IfNoneMatch       │ 412 — IfNoneMatch cannot rescue writes   │
+    /// └────┴──────────────────────────────────────────────────────┴──────────────────────────────────────────┘
+    ///
+    /// To run locally:
+    ///     set COSMOS_DTX_ENDPOINT=https://your-account.documents.azure.com:443/
+    ///     set COSMOS_DTX_KEY=your-master-key
+    ///     dotnet test --filter "FullyQualifiedName~DistributedTransactionConditionalE2ETests"
+    ///
+    /// Remove the [Ignore] attribute before running.
+    /// </summary>
+    [TestClass]
+    [DoNotParallelize]
+    [Ignore("DTX endpoint not yet available in emulator. Remove to run locally with env vars.")]
+    public class DistributedTransactionConditionalE2ETests
+    {
+        private const string DatabaseId = "DtxConditionalE2ETestDb";
+        private const string ContainerId = "DtxConditionalE2ETestContainer";
+        private const string PartitionKeyPath = "/pk";
+
+        private CosmosClient client;
+        private Container container;
+
+        [TestInitialize]
+        public async Task TestInitialize()
+        {
+            string endpoint = Environment.GetEnvironmentVariable("COSMOS_DTX_ENDPOINT");
+            string key = Environment.GetEnvironmentVariable("COSMOS_DTX_KEY");
+
+            if (string.IsNullOrWhiteSpace(endpoint) || string.IsNullOrWhiteSpace(key))
+            {
+                Assert.Fail(
+                    "COSMOS_DTX_ENDPOINT and COSMOS_DTX_KEY environment variables must be set.");
+            }
+
+            this.client = new CosmosClient(
+                endpoint,
+                key,
+                new CosmosClientOptions
+                {
+                    ConnectionMode = ConnectionMode.Gateway,
+                    ConsistencyLevel = ConsistencyLevel.Session
+                });
+
+            Database database = (await this.client.CreateDatabaseIfNotExistsAsync(DatabaseId)).Database;
+            ContainerResponse containerResponse = await database.CreateContainerIfNotExistsAsync(
+                new ContainerProperties(ContainerId, PartitionKeyPath));
+            this.container = containerResponse.Container;
+        }
+
+        [TestCleanup]
+        public async Task TestCleanup()
+        {
+            if (this.client != null)
+            {
+                try
+                {
+                    await this.client.GetDatabase(DatabaseId).DeleteAsync();
+                }
+                catch { /* ignore */ }
+
+                this.client.Dispose();
+            }
+        }
+
+        // ─── Phase 1→2 happy path: all 200s ────────────────────────────────────
+
+        /// <summary>
+        /// Contract row: Phase 1 all-200 → Phase 2 all-200 → SDK 200 [200, 200, …]
+        /// Verifies baseline read DTx behavior without conditional ETags.
+        /// </summary>
+        [TestMethod]
+        public async Task ReadDtx_AllItemsExist_NoConditional_Returns200()
+        {
+            string pk1 = $"read-200-a-{Guid.NewGuid():N}";
+            string pk2 = $"read-200-b-{Guid.NewGuid():N}";
+            string id1 = Guid.NewGuid().ToString();
+            string id2 = Guid.NewGuid().ToString();
+
+            await this.container.CreateItemAsync(new { id = id1, pk = pk1, value = "item1" }, new PartitionKey(pk1));
+            await this.container.CreateItemAsync(new { id = id2, pk = pk2, value = "item2" }, new PartitionKey(pk2));
+
+            DistributedTransactionResponse response = await this.client
+                .CreateDistributedReadTransaction()
+                .ReadItem(this.container, new PartitionKey(pk1), id1)
+                .ReadItem(this.container, new PartitionKey(pk2), id2)
+                .CommitTransactionAsync(CancellationToken.None);
+
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode,
+                $"Envelope should be 200 when all ops succeed. Got: {response.StatusCode}");
+            Assert.IsTrue(response.IsSuccessStatusCode);
+            Assert.AreEqual(2, response.Count);
+
+            for (int i = 0; i < response.Count; i++)
+            {
+                Assert.AreEqual(HttpStatusCode.OK, response[i].StatusCode,
+                    $"Op[{i}] should be 200.");
+                Assert.IsNotNull(response[i].ResourceStream,
+                    $"Op[{i}] should have a resource body.");
+                Assert.IsFalse(string.IsNullOrEmpty(response[i].ETag),
+                    $"Op[{i}] should have an ETag.");
+            }
+
+            response.Dispose();
+        }
+
+        // ─── Phase 2: 207 with [200, 304] — IfNoneMatch match ──────────────────
+
+        /// <summary>
+        /// Contract row: Phase 1 207 [200, 304] → proceed → Phase 2 207 [200, 304, 200, 200]
+        /// Verifies that a matching IfNoneMatchEtag produces a 304 on the matching op
+        /// and a 207 MultiStatus envelope (aligning with TransactionalBatch behavior).
+        /// </summary>
+        [TestMethod]
+        public async Task ReadDtx_MultiOp_OneMatchingIfNoneMatch_Returns207()
+        {
+            string pk1 = $"read-207-a-{Guid.NewGuid():N}";
+            string pk2 = $"read-207-b-{Guid.NewGuid():N}";
+            string id1 = Guid.NewGuid().ToString();
+            string id2 = Guid.NewGuid().ToString();
+
+            await this.container.CreateItemAsync(new { id = id1, pk = pk1, value = "item1" }, new PartitionKey(pk1));
+            var item2Response = await this.container.CreateItemAsync<object>(
+                new { id = id2, pk = pk2, value = "item2" }, new PartitionKey(pk2));
+            string item2ETag = item2Response.ETag;
+
+            DistributedTransactionResponse response = await this.client
+                .CreateDistributedReadTransaction()
+                .ReadItem(this.container, new PartitionKey(pk1), id1)
+                .ReadItem(this.container, new PartitionKey(pk2), id2,
+                    new DistributedTransactionRequestOptions { IfNoneMatchEtag = item2ETag })
+                .CommitTransactionAsync(CancellationToken.None);
+
+            // Envelope should be 207 MultiStatus when any op is non-2xx (304),
+            // aligning with TransactionalBatch behavior.
+            Assert.AreEqual((HttpStatusCode)207, response.StatusCode,
+                $"Envelope should be 207 (MultiStatus) when one op returns 304. Got: {response.StatusCode}");
+            Assert.AreEqual(2, response.Count);
+
+            Assert.AreEqual(HttpStatusCode.OK, response[0].StatusCode,
+                "Op[0] (no condition) should be 200.");
+            Assert.IsNotNull(response[0].ResourceStream,
+                "Op[0] should have a resource body.");
+
+            Assert.AreEqual(HttpStatusCode.NotModified, response[1].StatusCode,
+                "Op[1] (matching IfNoneMatchEtag) should be 304.");
+            Assert.IsFalse(response[1].IsSuccessStatusCode,
+                "304 is not in the 2xx range, IsSuccessStatusCode should be false.");
+
+            response.Dispose();
+        }
+
+        // ─── IfNoneMatch: stale ETag → 200 with updated resource ───────────────
+
+        /// <summary>
+        /// When IfNoneMatchEtag is stale (item was modified), the server returns 200
+        /// with the updated resource body and the new ETag.
+        /// </summary>
+        [TestMethod]
+        public async Task ReadDtx_WithStaleIfNoneMatch_Returns200WithUpdatedResource()
+        {
+            string pk = $"stale-etag-{Guid.NewGuid():N}";
+            string id = Guid.NewGuid().ToString();
+
+            var createResponse = await this.container.CreateItemAsync<object>(
+                new { id, pk, value = "original" }, new PartitionKey(pk));
+            string originalETag = createResponse.ETag;
+
+            // Replace the item so its ETag changes.
+            await this.container.ReplaceItemAsync(
+                new { id, pk, value = "updated" }, id, new PartitionKey(pk));
+
+            DistributedTransactionResponse response = await this.client
+                .CreateDistributedReadTransaction()
+                .ReadItem(this.container, new PartitionKey(pk), id,
+                    new DistributedTransactionRequestOptions { IfNoneMatchEtag = originalETag })
+                .CommitTransactionAsync(CancellationToken.None);
+
+            Assert.IsTrue(response.IsSuccessStatusCode,
+                $"Stale IfNoneMatch should return success. Got: {response.StatusCode}");
+            Assert.AreEqual(1, response.Count);
+
+            DistributedTransactionOperationResult op = response[0];
+            Assert.AreEqual(HttpStatusCode.OK, op.StatusCode,
+                "Stale IfNoneMatch should return 200 (item was modified).");
+            Assert.IsNotNull(op.ResourceStream,
+                "200 response must include the resource body.");
+            Assert.IsFalse(string.IsNullOrEmpty(op.ETag),
+                "200 response must include the new ETag.");
+            Assert.AreNotEqual(originalETag, op.ETag,
+                "The returned ETag should differ from the stale one.");
+
+            response.Dispose();
+        }
+
+        // ─── IfNoneMatch: all ops match → all 304s ─────────────────────────────
+
+        /// <summary>
+        /// When all operations have matching IfNoneMatchEtag, all return 304.
+        /// Documents the envelope status behavior when every op is 304.
+        /// </summary>
+        [TestMethod]
+        public async Task ReadDtx_AllOpsMatchingIfNoneMatch_AllReturn304()
+        {
+            string pk1 = $"all-304-a-{Guid.NewGuid():N}";
+            string pk2 = $"all-304-b-{Guid.NewGuid():N}";
+            string id1 = Guid.NewGuid().ToString();
+            string id2 = Guid.NewGuid().ToString();
+
+            var resp1 = await this.container.CreateItemAsync<object>(
+                new { id = id1, pk = pk1, value = "item1" }, new PartitionKey(pk1));
+            var resp2 = await this.container.CreateItemAsync<object>(
+                new { id = id2, pk = pk2, value = "item2" }, new PartitionKey(pk2));
+
+            DistributedTransactionResponse response = await this.client
+                .CreateDistributedReadTransaction()
+                .ReadItem(this.container, new PartitionKey(pk1), id1,
+                    new DistributedTransactionRequestOptions { IfNoneMatchEtag = resp1.ETag })
+                .ReadItem(this.container, new PartitionKey(pk2), id2,
+                    new DistributedTransactionRequestOptions { IfNoneMatchEtag = resp2.ETag })
+                .CommitTransactionAsync(CancellationToken.None);
+
+            Assert.AreEqual(2, response.Count);
+
+            for (int i = 0; i < response.Count; i++)
+            {
+                Assert.AreEqual(HttpStatusCode.NotModified, response[i].StatusCode,
+                    $"Op[{i}] with matching IfNoneMatchEtag should be 304.");
+                Assert.IsFalse(response[i].IsSuccessStatusCode,
+                    $"Op[{i}] 304 should report IsSuccessStatusCode == false.");
+            }
+
+            response.Dispose();
+        }
+
+        // ─── Phase 1 abort: non-existent item → 404 with FailedDependency ──────
+
+        /// <summary>
+        /// Contract row: Phase 1 207 [424, 404] → SDK 404 [424, 404, 424, 424]
+        /// When one item doesn't exist, the transaction aborts in phase 1.
+        /// The failing op gets 404, all other ops get 424 (FailedDependency).
+        /// </summary>
+        [TestMethod]
+        public async Task ReadDtx_NonExistentItem_Returns404WithFailedDependency()
+        {
+            string pk1 = $"exist-{Guid.NewGuid():N}";
+            string pk2 = $"noexist-{Guid.NewGuid():N}";
+            string id1 = Guid.NewGuid().ToString();
+            string nonExistentId = Guid.NewGuid().ToString();
+
+            await this.container.CreateItemAsync(
+                new { id = id1, pk = pk1, value = "exists" }, new PartitionKey(pk1));
+
+            DistributedTransactionResponse response = await this.client
+                .CreateDistributedReadTransaction()
+                .ReadItem(this.container, new PartitionKey(pk1), id1)
+                .ReadItem(this.container, new PartitionKey(pk2), nonExistentId)
+                .CommitTransactionAsync(CancellationToken.None);
+
+            Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode,
+                $"Envelope should be 404 when a phase 1 op returns 404. Got: {response.StatusCode}");
+            Assert.IsFalse(response.IsSuccessStatusCode);
+
+            // Per contract: the failing op gets 404, other ops get 424 (FailedDependency).
+            // The exact op ordering depends on batch grouping, so check for presence rather than index.
+            bool found404 = false;
+            bool found424 = false;
+            for (int i = 0; i < response.Count; i++)
+            {
+                if (response[i].StatusCode == HttpStatusCode.NotFound) found404 = true;
+                if ((int)response[i].StatusCode == 424) found424 = true;
+            }
+
+            Assert.IsTrue(found404, "At least one op should be 404 (NotFound).");
+            Assert.IsTrue(found424, "Non-failing ops should be 424 (FailedDependency).");
+
+            response.Dispose();
+        }
+
+        // ─── Write DTx: stale IfMatch → 412 ────────────────────────────────────
+
+        /// <summary>
+        /// Verifies that a write DTx with a stale IfMatchEtag returns 412 PreconditionFailed.
+        /// The 412 should be promoted as the envelope status code.
+        /// </summary>
+        [TestMethod]
+        public async Task WriteDtx_WithStaleIfMatch_Returns412()
+        {
+            string pk = $"stale-match-{Guid.NewGuid():N}";
+            string id = Guid.NewGuid().ToString();
+
+            var createResponse = await this.container.CreateItemAsync<object>(
+                new { id, pk, value = "original" }, new PartitionKey(pk));
+            string originalETag = createResponse.ETag;
+
+            // Replace the item so its ETag changes.
+            await this.container.ReplaceItemAsync(
+                new { id, pk, value = "replaced" }, id, new PartitionKey(pk));
+
+            DistributedTransactionResponse response = await this.client
+                .CreateDistributedWriteTransaction()
+                .ReplaceItem(this.container, new PartitionKey(pk), id,
+                    new { id, pk, value = "dtx-replace" },
+                    new DistributedTransactionRequestOptions { IfMatchEtag = originalETag })
+                .CommitTransactionAsync(CancellationToken.None);
+
+            Assert.AreEqual(HttpStatusCode.PreconditionFailed, response.StatusCode,
+                $"Envelope should be 412 with stale IfMatch. Got: {response.StatusCode}");
+            Assert.IsFalse(response.IsSuccessStatusCode);
+
+            if (response.Count > 0)
+            {
+                Assert.AreEqual(HttpStatusCode.PreconditionFailed, response[0].StatusCode,
+                    "Op[0] should be 412 (PreconditionFailed).");
+            }
+
+            response.Dispose();
+        }
+
+        // ─── Write DTx: current IfMatch → success ──────────────────────────────
+
+        /// <summary>
+        /// Verifies that a write DTx with a current (valid) IfMatchEtag succeeds.
+        /// </summary>
+        [TestMethod]
+        public async Task WriteDtx_WithCurrentIfMatch_Succeeds()
+        {
+            string pk = $"current-match-{Guid.NewGuid():N}";
+            string id = Guid.NewGuid().ToString();
+
+            var createResponse = await this.container.CreateItemAsync<object>(
+                new { id, pk, value = "original" }, new PartitionKey(pk));
+            string currentETag = createResponse.ETag;
+
+            DistributedTransactionResponse response = await this.client
+                .CreateDistributedWriteTransaction()
+                .ReplaceItem(this.container, new PartitionKey(pk), id,
+                    new { id, pk, value = "dtx-replaced" },
+                    new DistributedTransactionRequestOptions { IfMatchEtag = currentETag })
+                .CommitTransactionAsync(CancellationToken.None);
+
+            Assert.IsTrue(response.IsSuccessStatusCode,
+                $"Replace with current IfMatch should succeed. Got: {response.StatusCode}");
+            Assert.IsTrue(response.Count > 0);
+            Assert.IsTrue(response[0].IsSuccessStatusCode,
+                $"Op[0] should succeed. Got: {response[0].StatusCode}");
+
+            response.Dispose();
+        }
+
+        // ─── 304 inspectability ─────────────────────────────────────────────────
+
+        /// <summary>
+        /// Verifies that a 304 (NotModified) result from IfNoneMatch is fully inspectable
+        /// via the user-facing DistributedTransactionOperationResult API.
+        /// </summary>
+        [TestMethod]
+        public async Task ReadDtx_304IsUserInspectable()
+        {
+            string pk = $"inspect-304-{Guid.NewGuid():N}";
+            string id = Guid.NewGuid().ToString();
+
+            var createResponse = await this.container.CreateItemAsync<object>(
+                new { id, pk, value = "inspectable" }, new PartitionKey(pk));
+            string matchingETag = createResponse.ETag;
+
+            DistributedTransactionResponse response = await this.client
+                .CreateDistributedReadTransaction()
+                .ReadItem(this.container, new PartitionKey(pk), id,
+                    new DistributedTransactionRequestOptions { IfNoneMatchEtag = matchingETag })
+                .CommitTransactionAsync(CancellationToken.None);
+
+            Assert.IsTrue(response.Count > 0,
+                "Response should have at least one operation result.");
+
+            DistributedTransactionOperationResult op = response[0];
+
+            // StatusCode is inspectable.
+            Assert.AreEqual(HttpStatusCode.NotModified, op.StatusCode,
+                "User should see StatusCode == 304 (NotModified).");
+
+            // IsSuccessStatusCode correctly reflects 304 is not 2xx.
+            Assert.IsFalse(op.IsSuccessStatusCode,
+                "304 is not in the 2xx range; IsSuccessStatusCode must be false.");
+
+            // ResourceStream should be null on 304 (no body returned).
+            Assert.IsNull(op.ResourceStream,
+                "304 response should not have a resource body (ResourceStream should be null).");
+
+            // ETag should be present — the server returns the matching ETag.
+
+            // The result is accessible via the IReadOnlyList<> indexer.
+            DistributedTransactionOperationResult fromIndexer = response[0];
+            Assert.AreSame(op, fromIndexer,
+                "Indexer access should return the same result instance.");
+
+            response.Dispose();
+        }
+
+        // ─── Both IfMatch + IfNoneMatch set: only the relevant one is honoured ──
+
+        /// <summary>
+        /// When both IfMatchEtag and IfNoneMatchEtag are set on a READ operation,
+        /// only IfNoneMatch is honoured (IfMatch is ignored for reads).
+        /// Setting a stale IfMatch alongside a matching IfNoneMatch should still
+        /// produce 304 — proving IfMatch was not evaluated.
+        /// </summary>
+        [TestMethod]
+        public async Task ReadDtx_BothConditionalsSet_OnlyIfNoneMatchHonoured()
+        {
+            string pk = $"both-read-{Guid.NewGuid():N}";
+            string id = Guid.NewGuid().ToString();
+
+            var createResponse = await this.container.CreateItemAsync<object>(
+                new { id, pk, value = "dual-conditional" }, new PartitionKey(pk));
+            string currentETag = createResponse.ETag;
+
+            // Set IfNoneMatch to the current ETag (should trigger 304)
+            // Set IfMatch to a deliberately stale/bogus ETag (would fail if evaluated)
+            DistributedTransactionResponse response = await this.client
+                .CreateDistributedReadTransaction()
+                .ReadItem(this.container, new PartitionKey(pk), id,
+                    new DistributedTransactionRequestOptions
+                    {
+                        IfMatchEtag = "\"stale-bogus-etag\"",
+                        IfNoneMatchEtag = currentETag
+                    })
+                .CommitTransactionAsync(CancellationToken.None);
+
+            Assert.IsTrue(response.Count > 0);
+
+            // IfNoneMatch was honoured → 304. If IfMatch were honoured, we'd get 412.
+            Assert.AreEqual(HttpStatusCode.NotModified, response[0].StatusCode,
+                $"Read should honour IfNoneMatch (304), not IfMatch. Got: {response[0].StatusCode}");
+
+            response.Dispose();
+        }
+
+        /// <summary>
+        /// When both IfMatchEtag and IfNoneMatchEtag are set on a WRITE operation,
+        /// only IfMatch is honoured (IfNoneMatch is ignored for writes).
+        /// Setting a matching IfNoneMatch alongside a current IfMatch should still
+        /// succeed — proving IfNoneMatch was not evaluated for the write.
+        /// </summary>
+        [TestMethod]
+        public async Task WriteDtx_BothConditionalsSet_OnlyIfMatchHonoured()
+        {
+            string pk = $"both-write-{Guid.NewGuid():N}";
+            string id = Guid.NewGuid().ToString();
+
+            var createResponse = await this.container.CreateItemAsync<object>(
+                new { id, pk, value = "dual-conditional-write" }, new PartitionKey(pk));
+            string currentETag = createResponse.ETag;
+
+            // Set IfMatch to the current ETag (should succeed)
+            // Set IfNoneMatch to the current ETag (would trigger 304 if evaluated on reads)
+            DistributedTransactionResponse response = await this.client
+                .CreateDistributedWriteTransaction()
+                .ReplaceItem(this.container, new PartitionKey(pk), id,
+                    new { id, pk, value = "replaced-with-both" },
+                    new DistributedTransactionRequestOptions
+                    {
+                        IfMatchEtag = currentETag,
+                        IfNoneMatchEtag = currentETag
+                    })
+                .CommitTransactionAsync(CancellationToken.None);
+
+            // IfMatch was honoured (current → success). IfNoneMatch was ignored for writes.
+            Assert.IsTrue(response.IsSuccessStatusCode,
+                $"Write should honour IfMatch (success), ignoring IfNoneMatch. Got: {response.StatusCode}");
+            Assert.IsTrue(response.Count > 0);
+            Assert.IsTrue(response[0].IsSuccessStatusCode,
+                $"Op[0] should succeed. Got: {response[0].StatusCode}");
+
+            response.Dispose();
+        }
+
+        /// <summary>
+        /// When both IfMatchEtag (stale) and IfNoneMatchEtag (current/matching) are set
+        /// on a WRITE operation, the write should fail with 412 because IfMatch is the
+        /// only conditional evaluated for writes — and it's stale.
+        /// This proves IfNoneMatch cannot "rescue" a failing IfMatch on writes.
+        /// </summary>
+        [TestMethod]
+        public async Task WriteDtx_BothConditionalsSet_StaleIfMatch_Fails()
+        {
+            string pk = $"both-write-stale-{Guid.NewGuid():N}";
+            string id = Guid.NewGuid().ToString();
+
+            var createResponse = await this.container.CreateItemAsync<object>(
+                new { id, pk, value = "original" }, new PartitionKey(pk));
+            string originalETag = createResponse.ETag;
+
+            // Replace the item so its ETag changes, making originalETag stale.
+            await this.container.ReplaceItemAsync(
+                new { id, pk, value = "updated" }, id, new PartitionKey(pk));
+
+            // Set IfMatch to the stale ETag (should fail)
+            // Set IfNoneMatch to the stale ETag (would succeed on a read, but irrelevant for writes)
+            DistributedTransactionResponse response = await this.client
+                .CreateDistributedWriteTransaction()
+                .ReplaceItem(this.container, new PartitionKey(pk), id,
+                    new { id, pk, value = "should-not-write" },
+                    new DistributedTransactionRequestOptions
+                    {
+                        IfMatchEtag = originalETag,
+                        IfNoneMatchEtag = originalETag
+                    })
+                .CommitTransactionAsync(CancellationToken.None);
+
+            // IfMatch is stale → precondition failure. IfNoneMatch cannot rescue the write.
+            Assert.IsFalse(response.IsSuccessStatusCode,
+                $"Write with stale IfMatch should fail even with IfNoneMatch set. Got: {response.StatusCode}");
+
+            response.Dispose();
+        }
+
+        // ─── Helpers ────────────────────────────────────────────────────────────
+
+        private static string[] GetOpStatuses(DistributedTransactionResponse response)
+        {
+            string[] statuses = new string[response.Count];
+            for (int i = 0; i < response.Count; i++)
+            {
+                statuses[i] = $"{(int)response[i].StatusCode}";
+            }
+            return statuses;
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/DistributedTransaction/DistributedTransactionConditionalE2ETests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/DistributedTransaction/DistributedTransactionConditionalE2ETests.cs
@@ -16,24 +16,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
     /// End-to-end tests for conditional ETag behavior (ifMatch / ifNoneMatch) in distributed
     /// transactions, run against a live DTX-enabled account.
     ///
-    /// These tests verify SDK-visible behavior for conditional ETags in distributed transactions:
-    ///
-    /// ┌────┬──────────────────────────────────────────────────────┬──────────────────────────────────────────┐
-    /// │ #  │ Scenario                                             │ Expected SDK Result                      │
-    /// ├────┼──────────────────────────────────────────────────────┼──────────────────────────────────────────┤
-    /// │ 1  │ Read 2 existing items, no conditionals               │ 200 [200, 200]                           │
-    /// │ 2  │ Read 2 items, one has matching IfNoneMatch           │ 207 [200, 304]                           │
-    /// │ 3  │ Read 1 item with stale IfNoneMatch (item changed)    │ 200 [200] — returns updated resource     │
-    /// │ 4  │ Read 2 items, both have matching IfNoneMatch         │ 207 [304, 304]                           │
-    /// │ 5  │ Read 2 items, one does not exist                     │ 404 [424, 404]                           │
-    /// │ 6  │ Write with stale IfMatch (conflict)                  │ 412/452 — precondition failed            │
-    /// │ 7  │ Write with current IfMatch (no conflict)             │ 200 [200] — item replaced successfully   │
-    /// │ 8  │ Read 1 item with matching IfNoneMatch (inspectable)  │ 304 — user can inspect StatusCode        │
-    /// │ 9  │ Read with both IfMatch+IfNoneMatch set               │ 304 — only IfNoneMatch honoured          │
-    /// │ 10 │ Write with both IfMatch+IfNoneMatch set              │ 200 — only IfMatch honoured              │
-    /// │ 11 │ Write with stale IfMatch + current IfNoneMatch       │ 412 — IfNoneMatch cannot rescue writes   │
-    /// └────┴──────────────────────────────────────────────────────┴──────────────────────────────────────────┘
-    ///
     /// To run locally:
     ///     set COSMOS_DTX_ENDPOINT=https://your-account.documents.azure.com:443/
     ///     set COSMOS_DTX_KEY=your-master-key
@@ -95,11 +77,11 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
         }
 
-        // ─── Phase 1→2 happy path: all 200s ────────────────────────────────────
+        // ─── Baseline: all items exist, no conditionals ─────────────────────────
 
         /// <summary>
-        /// Contract row: Phase 1 all-200 → Phase 2 all-200 → SDK 200 [200, 200, …]
         /// Verifies baseline read DTx behavior without conditional ETags.
+        /// All items exist and no conditionals are set, so every op returns 200.
         /// </summary>
         [TestMethod]
         public async Task ReadDtx_AllItemsExist_NoConditional_Returns200()
@@ -136,10 +118,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             response.Dispose();
         }
 
-        // ─── Phase 2: 207 with [200, 304] — IfNoneMatch match ──────────────────
+        // ─── IfNoneMatch match on one op → 207 [200, 304] ────────────────────
 
         /// <summary>
-        /// Contract row: Phase 1 207 [200, 304] → proceed → Phase 2 207 [200, 304, 200, 200]
         /// Verifies that a matching IfNoneMatchEtag produces a 304 on the matching op
         /// and a 207 MultiStatus envelope (aligning with TransactionalBatch behavior).
         /// </summary>
@@ -265,11 +246,10 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             response.Dispose();
         }
 
-        // ─── Phase 1 abort: non-existent item → 404 with FailedDependency ──────
+        // ─── Non-existent item → 404 with FailedDependency ──────────────────
 
         /// <summary>
-        /// Contract row: Phase 1 207 [424, 404] → SDK 404 [424, 404, 424, 424]
-        /// When one item doesn't exist, the transaction aborts in phase 1.
+        /// When one item doesn't exist, the transaction aborts.
         /// The failing op gets 404, all other ops get 424 (FailedDependency).
         /// </summary>
         [TestMethod]
@@ -290,7 +270,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 .CommitTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode,
-                $"Envelope should be 404 when a phase 1 op returns 404. Got: {response.StatusCode}");
+                $"Envelope should be 404 when a read op targets a non-existent item. Got: {response.StatusCode}");
             Assert.IsFalse(response.IsSuccessStatusCode);
 
             // Per contract: the failing op gets 404, other ops get 424 (FailedDependency).

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/DistributedTransaction/DistributedTransactionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/DistributedTransaction/DistributedTransactionTests.cs
@@ -434,7 +434,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     (DistributedTransactionSerializer.Id, JsonValueKind.String),
                     (DistributedTransactionSerializer.ResourceBody, JsonValueKind.Object),
                     (DistributedTransactionSerializer.SessionToken, JsonValueKind.String),
-                    (DistributedTransactionSerializer.ETag, JsonValueKind.String),
+                    (DistributedTransactionSerializer.IfMatch, JsonValueKind.String),
+                    (DistributedTransactionSerializer.IfNoneMatch, JsonValueKind.String),
                 };
 
                 foreach ((string property, JsonValueKind expectedKind) in optionalFields)
@@ -451,7 +452,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         // ETag conditions
 
         [TestMethod]
-        [Description("A replace operation with IfMatchEtag set serializes the etag field to the request.")]
+        [Description("A replace operation with IfMatchEtag set serializes the ifMatch field to the request.")]
         public async Task ReplaceItem_WithIfMatchEtag_EtagSerializedToRequest()
         {
             ToDoActivity doc = ToDoActivity.CreateRandomToDoActivity();
@@ -476,14 +477,14 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             JsonElement operation = requestJson.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
             Assert.IsTrue(operation.TryGetProperty(DistributedTransactionSerializer.Id, out JsonElement idElement), "id field should be present for replace operation");
             Assert.AreEqual(doc.id, idElement.GetString());
-            Assert.IsTrue(operation.TryGetProperty(DistributedTransactionSerializer.ETag, out JsonElement etagElement), "etag field should be present when IfMatchEtag is set");
+            Assert.IsTrue(operation.TryGetProperty(DistributedTransactionSerializer.IfMatch, out JsonElement etagElement), "ifMatch field should be present when IfMatchEtag is set");
             Assert.AreEqual(expectedEtag, etagElement.GetString());
 
             response.Dispose();
         }
 
         [TestMethod]
-        [Description("A delete operation with IfMatchEtag set serializes the etag field to the request.")]
+        [Description("A delete operation with IfMatchEtag set serializes the ifMatch field to the request.")]
         public async Task DeleteItem_WithIfMatchEtag_EtagSerializedToRequest()
         {
             string expectedEtag = "\"test-etag-delete\"";
@@ -506,14 +507,14 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             JsonElement operation = requestJson.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
             Assert.IsTrue(operation.TryGetProperty(DistributedTransactionSerializer.Id, out JsonElement idElement), "id field should be present for delete operation");
             Assert.AreEqual("delete-id", idElement.GetString());
-            Assert.IsTrue(operation.TryGetProperty(DistributedTransactionSerializer.ETag, out JsonElement etagElement), "etag field should be present when IfMatchEtag is set");
+            Assert.IsTrue(operation.TryGetProperty(DistributedTransactionSerializer.IfMatch, out JsonElement etagElement), "ifMatch field should be present when IfMatchEtag is set");
             Assert.AreEqual(expectedEtag, etagElement.GetString());
 
             response.Dispose();
         }
 
         [TestMethod]
-        [Description("A patch operation with IfMatchEtag set serializes the etag field to the request.")]
+        [Description("A patch operation with IfMatchEtag set serializes the ifMatch field to the request.")]
         public async Task PatchItem_WithIfMatchEtag_EtagSerializedToRequest()
         {
             string expectedEtag = "\"test-etag-patch\"";
@@ -538,7 +539,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             JsonElement operation = requestJson.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
             Assert.IsTrue(operation.TryGetProperty(DistributedTransactionSerializer.Id, out JsonElement idElement), "id field should be present for patch operation");
             Assert.AreEqual("patch-id", idElement.GetString());
-            Assert.IsTrue(operation.TryGetProperty(DistributedTransactionSerializer.ETag, out JsonElement etagElement), "etag field should be present when IfMatchEtag is set");
+            Assert.IsTrue(operation.TryGetProperty(DistributedTransactionSerializer.IfMatch, out JsonElement etagElement), "ifMatch field should be present when IfMatchEtag is set");
             Assert.AreEqual(expectedEtag, etagElement.GetString());
 
             response.Dispose();
@@ -580,7 +581,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        [Description("Operations without IfMatchEtag set do not include an etag field in the serialized request.")]
+        [Description("Operations without conditional ETags set do not include ifMatch or ifNoneMatch fields in the serialized request.")]
         public async Task Operations_WithoutIfMatchEtag_NoEtagFieldSerialized()
         {
             ToDoActivity createDoc = ToDoActivity.CreateRandomToDoActivity();
@@ -600,7 +601,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             JsonElement ops = requestJson.RootElement.GetProperty(DistributedTransactionSerializer.Operations);
             foreach (JsonElement operation in ops.EnumerateArray())
             {
-                Assert.IsFalse(operation.TryGetProperty(DistributedTransactionSerializer.ETag, out _), "etag field should not be present when IfMatchEtag is not set");
+                Assert.IsFalse(operation.TryGetProperty(DistributedTransactionSerializer.IfMatch, out _), "ifMatch field should not be present when IfMatchEtag is not set");
+                Assert.IsFalse(operation.TryGetProperty(DistributedTransactionSerializer.IfNoneMatch, out _), "ifNoneMatch field should not be present when IfNoneMatchEtag is not set");
             }
 
             response.Dispose();

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionSerializerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionSerializerTests.cs
@@ -327,7 +327,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         // IfNoneMatchEtag for ReadItem
 
         [TestMethod]
-        [Description("ReadItem with IfNoneMatchEtag set must serialize an 'etag' field in the operation JSON.")]
+        [Description("ReadItem with IfNoneMatchEtag set must serialize an 'ifNoneMatch' field in the operation JSON.")]
         public async Task ReadItem_WithIfNoneMatchEtag_SerializesEtagField()
         {
             const string etag = "\"test-etag\"";
@@ -340,13 +340,15 @@ namespace Microsoft.Azure.Cosmos.Tests
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
             JsonElement op = doc.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
 
-            Assert.IsTrue(op.TryGetProperty(DistributedTransactionSerializer.ETag, out JsonElement etagElement),
-                "Read operation with IfNoneMatchEtag must include an 'etag' field.");
+            Assert.IsTrue(op.TryGetProperty(DistributedTransactionSerializer.IfNoneMatch, out JsonElement etagElement),
+                "Read operation with IfNoneMatchEtag must include an 'ifNoneMatch' field.");
             Assert.AreEqual(etag, etagElement.GetString());
+            Assert.IsFalse(op.TryGetProperty(DistributedTransactionSerializer.IfMatch, out _),
+                "Read operation with only IfNoneMatchEtag must not include an 'ifMatch' field.");
         }
 
         [TestMethod]
-        [Description("ReadItem without any etag option must not include an 'etag' field in the serialized JSON.")]
+        [Description("ReadItem without any etag options must not include either conditional field in the serialized JSON.")]
         public async Task ReadItem_WithoutEtag_DoesNotIncludeEtagField()
         {
             string capturedJson = await this.CaptureReadCommitBodyAsync(tx =>
@@ -355,13 +357,15 @@ namespace Microsoft.Azure.Cosmos.Tests
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
             JsonElement op = doc.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
 
-            Assert.IsFalse(op.TryGetProperty(DistributedTransactionSerializer.ETag, out _),
-                "Read operation without etag options must NOT include an 'etag' field.");
+            Assert.IsFalse(op.TryGetProperty(DistributedTransactionSerializer.IfMatch, out _),
+                "Read operation without etag options must NOT include an 'ifMatch' field.");
+            Assert.IsFalse(op.TryGetProperty(DistributedTransactionSerializer.IfNoneMatch, out _),
+                "Read operation without etag options must NOT include an 'ifNoneMatch' field.");
         }
 
         [TestMethod]
-        [Description("ReadItem with IfMatchEtag (write-side etag) must NOT serialize an 'etag' field; reads use IfNoneMatchEtag only.")]
-        public async Task ReadItem_WithIfMatchEtag_DoesNotSerializeEtagField()
+        [Description("ReadItem with IfMatchEtag set must serialize an 'ifMatch' field in the operation JSON.")]
+        public async Task ReadItem_WithIfMatchEtag_SerializesIfMatchField()
         {
             const string etag = "\"write-etag\"";
             const string itemId = "read-ifmatch-id";
@@ -373,14 +377,17 @@ namespace Microsoft.Azure.Cosmos.Tests
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
             JsonElement op = doc.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
 
-            Assert.IsFalse(op.TryGetProperty(DistributedTransactionSerializer.ETag, out _),
-                "Read operation must not use IfMatchEtag; only IfNoneMatchEtag is serialized for reads.");
+            Assert.IsTrue(op.TryGetProperty(DistributedTransactionSerializer.IfMatch, out JsonElement etagElement),
+                "Read operation with IfMatchEtag must include an 'ifMatch' field.");
+            Assert.AreEqual(etag, etagElement.GetString());
+            Assert.IsFalse(op.TryGetProperty(DistributedTransactionSerializer.IfNoneMatch, out _),
+                "Read operation with only IfMatchEtag must not include an 'ifNoneMatch' field.");
         }
 
         // IfMatchEtag
 
         [TestMethod]
-        [Description("ReplaceItem with IfMatchEtag set must serialize an 'etag' field in the operation JSON.")]
+        [Description("ReplaceItem with IfMatchEtag set must serialize an 'ifMatch' field in the operation JSON.")]
         public async Task ReplaceItem_WithIfMatchEtag_SerializesEtagField()
         {
             const string etag = "\"test-etag\"";
@@ -393,13 +400,15 @@ namespace Microsoft.Azure.Cosmos.Tests
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
             JsonElement op = doc.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
 
-            Assert.IsTrue(op.TryGetProperty(DistributedTransactionSerializer.ETag, out JsonElement etagElement),
-                "Replace operation with IfMatchEtag must include an 'etag' field.");
+            Assert.IsTrue(op.TryGetProperty(DistributedTransactionSerializer.IfMatch, out JsonElement etagElement),
+                "Replace operation with IfMatchEtag must include an 'ifMatch' field.");
             Assert.AreEqual(etag, etagElement.GetString());
+            Assert.IsFalse(op.TryGetProperty(DistributedTransactionSerializer.IfNoneMatch, out _),
+                "Replace operation with only IfMatchEtag must not include an 'ifNoneMatch' field.");
         }
 
         [TestMethod]
-        [Description("DeleteItem with IfMatchEtag set must serialize an 'etag' field in the operation JSON.")]
+        [Description("DeleteItem with IfMatchEtag set must serialize an 'ifMatch' field in the operation JSON.")]
         public async Task DeleteItem_WithIfMatchEtag_SerializesEtagField()
         {
             const string etag = "\"test-etag\"";
@@ -412,13 +421,15 @@ namespace Microsoft.Azure.Cosmos.Tests
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
             JsonElement op = doc.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
 
-            Assert.IsTrue(op.TryGetProperty(DistributedTransactionSerializer.ETag, out JsonElement etagElement),
-                "Delete operation with IfMatchEtag must include an 'etag' field.");
+            Assert.IsTrue(op.TryGetProperty(DistributedTransactionSerializer.IfMatch, out JsonElement etagElement),
+                "Delete operation with IfMatchEtag must include an 'ifMatch' field.");
             Assert.AreEqual(etag, etagElement.GetString());
+            Assert.IsFalse(op.TryGetProperty(DistributedTransactionSerializer.IfNoneMatch, out _),
+                "Delete operation with only IfMatchEtag must not include an 'ifNoneMatch' field.");
         }
 
         [TestMethod]
-        [Description("PatchItem with IfMatchEtag set must serialize an 'etag' field in the operation JSON.")]
+        [Description("PatchItem with IfMatchEtag set must serialize an 'ifMatch' field in the operation JSON.")]
         public async Task PatchItem_WithIfMatchEtag_SerializesEtagField()
         {
             const string etag = "\"test-etag\"";
@@ -432,14 +443,16 @@ namespace Microsoft.Azure.Cosmos.Tests
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
             JsonElement op = doc.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
 
-            Assert.IsTrue(op.TryGetProperty(DistributedTransactionSerializer.ETag, out JsonElement etagElement),
-                "Patch operation with IfMatchEtag must include an 'etag' field.");
+            Assert.IsTrue(op.TryGetProperty(DistributedTransactionSerializer.IfMatch, out JsonElement etagElement),
+                "Patch operation with IfMatchEtag must include an 'ifMatch' field.");
             Assert.AreEqual(etag, etagElement.GetString());
+            Assert.IsFalse(op.TryGetProperty(DistributedTransactionSerializer.IfNoneMatch, out _),
+                "Patch operation with only IfMatchEtag must not include an 'ifNoneMatch' field.");
         }
 
         [TestMethod]
-        [Description("Operations without IfMatchEtag must not include an 'etag' field in the serialized JSON for any operation.")]
-        public async Task Operations_WithoutIfMatchEtag_DoNotIncludeEtagField()
+        [Description("Operations without conditional ETags must not include 'ifMatch' or 'ifNoneMatch' fields in serialized JSON.")]
+        public async Task Operations_WithoutConditionalEtags_DoNotIncludeConditionalFields()
         {
             string capturedJson = await this.CaptureCommitBodyAsync(tx =>
                 tx.CreateItem(BuildMockContainer(), new PartitionKey("pk"), "create-no-etag", new TestItem("create-no-etag"))
@@ -451,9 +464,59 @@ namespace Microsoft.Azure.Cosmos.Tests
 
             for (int i = 0; i < ops.GetArrayLength(); i++)
             {
-                Assert.IsFalse(ops[i].TryGetProperty(DistributedTransactionSerializer.ETag, out _),
-                    $"Operation[{i}] without IfMatchEtag must NOT include an 'etag' field.");
+                Assert.IsFalse(ops[i].TryGetProperty(DistributedTransactionSerializer.IfMatch, out _),
+                    $"Operation[{i}] without conditional etags must NOT include an 'ifMatch' field.");
+                Assert.IsFalse(ops[i].TryGetProperty(DistributedTransactionSerializer.IfNoneMatch, out _),
+                    $"Operation[{i}] without conditional etags must NOT include an 'ifNoneMatch' field.");
             }
+        }
+
+        [TestMethod]
+        [Description("An operation with both IfMatchEtag and IfNoneMatchEtag must serialize both wire fields.")]
+        public async Task ReadItem_WithBothConditionalEtags_SerializesBothFields()
+        {
+            const string ifMatch = "\"if-match-etag\"";
+            const string ifNoneMatch = "\"if-none-match-etag\"";
+
+            string capturedJson = await this.CaptureReadCommitBodyAsync(tx =>
+                tx.ReadItem(BuildMockContainer(), new PartitionKey("pk"), "read-both-etags",
+                    new DistributedTransactionRequestOptions
+                    {
+                        IfMatchEtag = ifMatch,
+                        IfNoneMatchEtag = ifNoneMatch
+                    }));
+
+            using JsonDocument doc = JsonDocument.Parse(capturedJson);
+            JsonElement op = doc.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
+
+            Assert.IsTrue(op.TryGetProperty(DistributedTransactionSerializer.IfMatch, out JsonElement ifMatchElement),
+                "Read operation with IfMatchEtag must include an 'ifMatch' field.");
+            Assert.AreEqual(ifMatch, ifMatchElement.GetString());
+
+            Assert.IsTrue(op.TryGetProperty(DistributedTransactionSerializer.IfNoneMatch, out JsonElement ifNoneMatchElement),
+                "Read operation with IfNoneMatchEtag must include an 'ifNoneMatch' field.");
+            Assert.AreEqual(ifNoneMatch, ifNoneMatchElement.GetString());
+        }
+
+        [TestMethod]
+        [Description("A write operation (ReplaceItem) with IfNoneMatchEtag set must serialize an 'ifNoneMatch' field in the operation JSON.")]
+        public async Task ReplaceItem_WithIfNoneMatchEtag_SerializesIfNoneMatchField()
+        {
+            const string etag = "\"test-etag\"";
+            const string itemId = "etag-replace-ifnonematch-id";
+
+            string capturedJson = await this.CaptureCommitBodyAsync(tx =>
+                tx.ReplaceItem(BuildMockContainer(), new PartitionKey("pk"), itemId, new TestItem(itemId),
+                    new DistributedTransactionRequestOptions { IfNoneMatchEtag = etag }));
+
+            using JsonDocument doc = JsonDocument.Parse(capturedJson);
+            JsonElement op = doc.RootElement.GetProperty(DistributedTransactionSerializer.Operations)[0];
+
+            Assert.IsTrue(op.TryGetProperty(DistributedTransactionSerializer.IfNoneMatch, out JsonElement etagElement),
+                "Replace operation with IfNoneMatchEtag must include an 'ifNoneMatch' field.");
+            Assert.AreEqual(etag, etagElement.GetString());
+            Assert.IsFalse(op.TryGetProperty(DistributedTransactionSerializer.IfMatch, out _),
+                "Replace operation with only IfNoneMatchEtag must not include an 'ifMatch' field.");
         }
 
         [TestMethod]

--- a/changelog.md
+++ b/changelog.md
@@ -30,7 +30,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Other Changes
 
-- DistributedTransaction (Preview): Changes per-operation conditional ETag serialization to emit separate `ifMatch` and `ifNoneMatch` fields in the request body (instead of a single combined field), so both `IfMatchEtag` and `IfNoneMatchEtag` request options are honored independently for each operation.
 - [5916](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5916) Direct: Moves the `OpenTcpConnectionTimeout` negative-value warning trace from `CosmosClientOptions` to `DocumentClient`. The warning is now emitted once per client construction (instead of once per property assignment) and is gated on `ConnectionMode == Direct`, so it no longer false-positives when a negative value is later overwritten with a non-negative one or when running in Gateway mode where the timeout is not consumed.
 ### <a name="3.62.0-preview.0"/> [3.62.0-preview.0](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.62.0-preview.0) - 2026-6-1
 

--- a/changelog.md
+++ b/changelog.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Other Changes
 
+- DistributedTransaction (Preview): Changes per-operation conditional ETag serialization to emit separate `ifMatch` and `ifNoneMatch` fields in the request body (instead of a single combined field), so both `IfMatchEtag` and `IfNoneMatchEtag` request options are honored independently for each operation.
 - [5916](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5916) Direct: Moves the `OpenTcpConnectionTimeout` negative-value warning trace from `CosmosClientOptions` to `DocumentClient`. The warning is now emitted once per client construction (instead of once per property assignment) and is gated on `ConnectionMode == Direct`, so it no longer false-positives when a negative value is later overwritten with a non-negative one or when running in Gateway mode where the timeout is not consumed.
 ### <a name="3.62.0-preview.0"/> [3.62.0-preview.0](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.62.0-preview.0) - 2026-6-1
 


### PR DESCRIPTION
## Description

Updates the DistributedTransaction (preview) request wire contract so each operation serializes **two independent conditional-ETag fields** — `ifMatch` and `ifNoneMatch` — sourced separately from `IfMatchEtag` and `IfNoneMatchEtag` request options. Previously the serializer emitted a single combined field whose value was switched on operation type (reads used `IfNoneMatchEtag`, writes used `IfMatchEtag`), which dropped the other option.

This brings the field names in line with the existing TransactionalBatch wire contract (`ifMatch` / `ifNoneMatch`).

### Changes

- `DistributedTransactionOperation` now exposes `IfMatch` and `IfNoneMatch` (replacing the single `ETag` property).
- `DistributedTransactionSerializer` writes `ifMatch` from `IfMatch` and `ifNoneMatch` from `IfNoneMatch`, each only when set.
- Unit tests (`DistributedTransactionSerializerTests`) and emulator tests (`DistributedTransactionTests`) updated to the new field names, with added coverage for:
  - write-side `IfNoneMatchEtag` → `ifNoneMatch`
  - both conditionals set → both fields emitted
  - absence of each field when the corresponding option is unset

### Behavioral note

Unlike GA TransactionalBatch (which writes the two ETags mutually exclusively), this serializer emits both fields independently when both options are set. This is intentional and covered by a test; confirming the server contract accepts both simultaneously is recommended.

## Test Coverage

### Unit Tests — Serializer (`DistributedTransactionSerializerTests`)

#### ifMatch / ifNoneMatch wire serialization (modified + new)

| Test | Verifies |
| --- | --- |
| `ReadItem_WithIfNoneMatchEtag_SerializesEtagField` | Read op with IfNoneMatchEtag emits `ifNoneMatch` field |
| `ReadItem_WithIfMatchEtag_SerializesIfMatchField` | Read op with IfMatchEtag emits `ifMatch` field |
| `ReadItem_WithoutEtag_DoesNotIncludeEtagField` | Read op without conditionals omits both fields |
| `ReadItem_WithBothConditionalEtags_SerializesBothFields` | Both IfMatchEtag + IfNoneMatchEtag → both fields emitted |
| `ReplaceItem_WithIfMatchEtag_SerializesEtagField` | Replace with IfMatchEtag emits `ifMatch`, omits `ifNoneMatch` |
| `ReplaceItem_WithIfNoneMatchEtag_SerializesIfNoneMatchField` | Replace with IfNoneMatchEtag emits `ifNoneMatch`, omits `ifMatch` |
| `DeleteItem_WithIfMatchEtag_SerializesEtagField` | Delete with IfMatchEtag emits `ifMatch`, omits `ifNoneMatch` |
| `PatchItem_WithIfMatchEtag_SerializesEtagField` | Patch with IfMatchEtag emits `ifMatch`, omits `ifNoneMatch` |
| `Operations_WithoutConditionalEtags_DoNotIncludeConditionalFields` | All op types without conditionals omit both fields |

### Emulator Tests — Serialization (`DistributedTransactionTests`, modified)

| Test | Verifies |
| --- | --- |
| `ReplaceItem_WithIfMatchEtag_EtagSerializedToRequest` | Replace → captured JSON contains `ifMatch` field |
| `DeleteItem_WithIfMatchEtag_EtagSerializedToRequest` | Delete → captured JSON contains `ifMatch` field |
| `PatchItem_WithIfMatchEtag_EtagSerializedToRequest` | Patch → captured JSON contains `ifMatch` field |
| `Operations_WithoutIfMatchEtag_NoEtagFieldSerialized` | No conditionals → neither field present |
| `SerializedRequest_OptionalFieldsHaveCorrectTypes` | Optional fields include `ifMatch` + `ifNoneMatch` |

### E2E Tests — Conditional ETag behavior (`DistributedTransactionConditionalE2ETests`, new, `[Ignore]`)

#### Read DTx — IfNoneMatch

| Test | Verifies |
| --- | --- |
| `ReadDtx_AllItemsExist_NoConditional_Returns200` | Baseline: no conditionals → 200 [200, 200] |
| `ReadDtx_MultiOp_OneMatchingIfNoneMatch_Returns207` | One matching IfNoneMatch → 207 [200, 304] |
| `ReadDtx_WithStaleIfNoneMatch_Returns200WithUpdatedResource` | Stale IfNoneMatch → 200 with updated body + new ETag |
| `ReadDtx_AllOpsMatchingIfNoneMatch_AllReturn304` | All ops match → all 304 |
| `ReadDtx_NonExistentItem_Returns404WithFailedDependency` | Non-existent item → 404, others get 424 |

#### Read DTx — 304 inspectability

| Test | Verifies |
| --- | --- |
| `ReadDtx_304IsUserInspectable` | 304: StatusCode, IsSuccessStatusCode=false, ResourceStream=null, indexer access |

#### Write DTx — IfMatch

| Test | Verifies |
| --- | --- |
| `WriteDtx_WithStaleIfMatch_Returns412` | Stale IfMatch → 412 PreconditionFailed |
| `WriteDtx_WithCurrentIfMatch_Succeeds` | Current IfMatch → 200 success |

#### Both conditionals set

| Test | Verifies |
| --- | --- |
| `ReadDtx_BothConditionalsSet_OnlyIfNoneMatchHonoured` | Read: IfNoneMatch honoured, IfMatch ignored → 304 |
| `WriteDtx_BothConditionalsSet_OnlyIfMatchHonoured` | Write: IfMatch honoured, IfNoneMatch ignored → 200 |
| `WriteDtx_BothConditionalsSet_StaleIfMatch_Fails` | Stale IfMatch + current IfNoneMatch → failure |

## Type of change

- [x] This change requires a documentation update — changelog entry added under `### Unreleased` → `Other Changes`.

## Closing issues

N/A
