### PR TITLE
[Internal] DTS: Adds response reordering and fail-closed result handling

### DIFF
--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperationResult.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperationResult.cs
@@ -30,6 +30,7 @@ namespace Microsoft.Azure.Cosmos
         internal DistributedTransactionOperationResult(DistributedTransactionOperationResult other)
         {
             this.Index = other.Index;
+            this.HasIndex = other.HasIndex;
             this.StatusCode = other.StatusCode;
             this.SubStatusCode = other.SubStatusCode;
             this.ETag = other.ETag;
@@ -88,6 +89,12 @@ namespace Microsoft.Azure.Cosmos
         public virtual double RequestCharge { get; internal set; }
 
         internal virtual SubStatusCodes SubStatusCode { get; set; }
+
+        /// <summary>
+        /// Whether the server explicitly provided an <c>index</c>. A missing <c>index</c> defaults to 0
+        /// (indistinguishable from a real 0), so the reorder logic uses this flag to reject ambiguous responses.
+        /// </summary>
+        internal bool HasIndex { get; set; }
 
         internal virtual string SessionToken { get; set; }
 
@@ -159,6 +166,7 @@ namespace Microsoft.Azure.Cosmos
             if (TryGetInt32Property(json, DistributedTransactionSerializer.Index, out int index))
             {
                 result.Index = index;
+                result.HasIndex = true;
             }
 
             if (TryGetInt32Property(json, DistributedTransactionSerializer.StatusCode, out int statusCode))

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionResponse.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionResponse.cs
@@ -57,10 +57,15 @@ namespace Microsoft.Azure.Cosmos
         }
 
         /// <summary>
-        /// Gets the <see cref="DistributedTransactionOperationResult"/> at the specified index in the response.
+        /// Gets the <see cref="DistributedTransactionOperationResult"/> for the request operation at the specified index.
         /// </summary>
-        /// <param name="index">The zero-based index of the operation result to get.</param>
-        /// <returns>The <see cref="DistributedTransactionOperationResult"/> at the specified index.</returns>
+        /// <param name="index">The zero-based index of the request operation whose result to get.</param>
+        /// <returns>The <see cref="DistributedTransactionOperationResult"/> for the request operation at the specified index.</returns>
+        /// <remarks>
+        /// Results may arrive out of request order; the SDK reorders them by per-operation <c>index</c>,
+        /// so on a successful response <c>response[i]</c> is the i-th submitted operation. Payloads that
+        /// can't be mapped back (missing, duplicate, or out-of-range indices) fail closed (HTTP 500).
+        /// </remarks>
         public virtual DistributedTransactionOperationResult this[int index]
         {
             get
@@ -87,6 +92,8 @@ namespace Microsoft.Azure.Cosmos
         /// or <c>default(<typeparamref name="T"/>)</c> when the server did not return a body for that operation.
         /// </returns>
         /// <remarks>
+        /// <c>index</c> refers to the i-th operation submitted, regardless of the order the coordinator
+        /// returned results (see the indexer for reordering and fail-closed details).
         /// The underlying <see cref="DistributedTransactionOperationResult.ResourceStream"/> is left intact and
         /// remains readable after this call, so this method may be invoked multiple times (with the same or
         /// different <typeparamref name="T"/>) for the same index, and direct access via the indexer continues
@@ -273,6 +280,12 @@ namespace Microsoft.Azure.Cosmos
                         if (responseMessage.IsSuccessStatusCode)
                         {
                             SubStatusCodes wireSubStatusCode = responseMessage.Headers.SubStatusCode;
+
+                            // Preserve the envelope isRetriable/DiagnosticString before disposing: a wrong
+                            // result count is no more trustworthy than bad indices, and the retry signal is
+                            // independent of the unusable payload. Matches the two unmappable fail-closed paths.
+                            bool wireIsRetriable = response.IsRetriable;
+                            string wireDiagnosticString = response.DiagnosticString;
                             response.Dispose();
 
                             return new DistributedTransactionResponse(
@@ -282,7 +295,11 @@ namespace Microsoft.Azure.Cosmos
                                 responseMessage.Headers,
                                 serverRequest.Operations,
                                 serializer,
-                                idempotencyToken);
+                                idempotencyToken,
+                                wireIsRetriable)
+                            {
+                                DiagnosticString = wireDiagnosticString,
+                            };
                         }
 
                         response.CreateAndPopulateResults(serverRequest.Operations);
@@ -308,16 +325,26 @@ namespace Microsoft.Azure.Cosmos
                 return;
             }
 
-            if (disposing && this.results != null)
+            if (disposing)
             {
-                foreach (DistributedTransactionOperationResult result in this.results)
-                {
-                    result.ResourceStream?.Dispose();
-                }
+                DisposeResultStreams(this.results);
             }
 
             this.results = null;
             this.isDisposed = true;
+        }
+
+        private static void DisposeResultStreams(IEnumerable<DistributedTransactionOperationResult> results)
+        {
+            if (results == null)
+            {
+                return;
+            }
+
+            foreach (DistributedTransactionOperationResult result in results)
+            {
+                result.ResourceStream?.Dispose();
+            }
         }
 
         private static Guid GetIdempotencyTokenFromHeaders(Headers headers, Guid fallbackToken)
@@ -404,23 +431,61 @@ namespace Microsoft.Azure.Cosmos
                     catch (JsonException jsonEx)
                     {
                         DefaultTrace.TraceWarning(
-                            "DistributedTransactionResponse: per-operation parse failed; forcing isRetriable=false. {0}",
+                            "DistributedTransactionResponse: per-operation parse failed; discarding results. {0}",
                             jsonEx.Message);
 
-                        // Dispose any resource streams allocated for the partially-parsed operations
-                        // before discarding them.
-                        foreach (DistributedTransactionOperationResult partial in results)
-                        {
-                            partial.ResourceStream?.Dispose();
-                        }
-
+                        DisposeResultStreams(results);
                         results.Clear();
-                        isRetriable = false;
 
+                        // Preserve the coordinator's top-level isRetriable: it was parsed from the document
+                        // root before this loop and is independent of any single operationResponses element.
                         if (responseMessage.IsSuccessStatusCode)
                         {
-                            return CreateDeserializationFailureResponse(responseMessage, serverRequest, serializer, idempotencyToken);
+                            return CreateDeserializationFailureResponse(responseMessage, serverRequest, serializer, idempotencyToken, diagnosticString, isRetriable);
                         }
+                    }
+                }
+            }
+
+            // Reorder so response[i] maps to request operation i via the per-operation 'index' (wire order
+            // is not guaranteed). The indices must form a complete permutation of 0..n-1; otherwise the
+            // payload is uninterpretable and we fail closed rather than surface misaligned data.
+            if (results.Count > 0 && results.Count == serverRequest.Operations.Count)
+            {
+                DistributedTransactionOperationResult[] ordered = new DistributedTransactionOperationResult[results.Count];
+                bool canReorder = true;
+                foreach (DistributedTransactionOperationResult r in results)
+                {
+                    if (!r.HasIndex || r.Index < 0 || r.Index >= ordered.Length || ordered[r.Index] != null)
+                    {
+                        canReorder = false;
+                        break;
+                    }
+
+                    ordered[r.Index] = r;
+                }
+
+                if (canReorder)
+                {
+                    results.Clear();
+                    results.AddRange(ordered);
+                }
+                else
+                {
+                    DefaultTrace.TraceWarning(
+                        "DistributedTransactionResponse: operation indices are not a complete permutation of 0..{0}; response is not interpretable.",
+                        results.Count - 1);
+
+                    DisposeResultStreams(results);
+                    results.Clear();
+
+                    // isRetriable is independent of the operation indices, so preserve it: combined with the
+                    // idempotency token it lets the caller retry rather than fail terminally. On a success
+                    // status fail closed with 500; on an error status leave results empty so the
+                    // count-mismatch path pads with uniform error placeholders.
+                    if (responseMessage.IsSuccessStatusCode)
+                    {
+                        return CreateDeserializationFailureResponse(responseMessage, serverRequest, serializer, idempotencyToken, diagnosticString, isRetriable);
                     }
                 }
             }
@@ -473,10 +538,17 @@ namespace Microsoft.Azure.Cosmos
         private void CreateAndPopulateResults(
             IReadOnlyList<DistributedTransactionOperation> operations)
         {
+            // Dispose previously-parsed streams before replacing the list (the count-mismatch error path
+            // reaches here with live results). Other paths already cleared results, so this is a no-op.
+            DisposeResultStreams(this.results);
+
             this.results = new List<DistributedTransactionOperationResult>(operations.Count);
 
             for (int i = 0; i < operations.Count; i++)
             {
+                // Leave per-op fields (SessionToken/PartitionKeyRangeId/ActivityId) null: this synthesized
+                // path only runs when per-op results are missing/unmappable. The envelope ActivityId remains
+                // on DistributedTransactionResponse.ActivityId.
                 this.results.Add(new DistributedTransactionOperationResult(this.StatusCode)
                 {
                     SubStatusCode = this.SubStatusCode,
@@ -488,11 +560,17 @@ namespace Microsoft.Azure.Cosmos
         /// Builds an InternalServerError response indicating the server replied with success but
         /// the SDK could not deserialize the response payload. Mirrors TransactionalBatch behavior.
         /// </summary>
+        /// <remarks>
+        /// <paramref name="diagnosticString"/> and the coordinator's <paramref name="isRetriable"/> verdict
+        /// are independent of the unreadable payload, so both are preserved on the failure response.
+        /// </remarks>
         private static DistributedTransactionResponse CreateDeserializationFailureResponse(
             ResponseMessage responseMessage,
             DistributedTransactionServerRequest serverRequest,
             CosmosSerializerCore serializer,
-            Guid idempotencyToken)
+            Guid idempotencyToken,
+            string diagnosticString = null,
+            bool isRetriable = false)
         {
             DistributedTransactionResponse failedResponse = new DistributedTransactionResponse(
                 HttpStatusCode.InternalServerError,
@@ -501,7 +579,11 @@ namespace Microsoft.Azure.Cosmos
                 responseMessage.Headers,
                 serverRequest.Operations,
                 serializer,
-                idempotencyToken);
+                idempotencyToken,
+                isRetriable)
+            {
+                DiagnosticString = diagnosticString,
+            };
 
             failedResponse.CreateAndPopulateResults(serverRequest.Operations);
             return failedResponse;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedReadTransactionCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedReadTransactionCoreTests.cs
@@ -510,6 +510,106 @@ namespace Microsoft.Azure.Cosmos.Tests
             Assert.AreEqual(OperationType.Read, capturedOperationType);
         }
 
+        [TestMethod]
+        [Description("Smoke test: a commit with 100+ read operations whose server operationResponses arrive " +
+                     "out-of-order is reordered by the SDK so response[i].Index == i for every operation.")]
+        public async Task CommitAsync_ManyOperations_OutOfOrderResponses_SortedByIndex()
+        {
+            const int OperationCount = 128;
+
+            // Server returns the per-operation responses in a deterministically-shuffled (out-of-order) sequence.
+            int[] shuffledIndices = BuildShuffledIndices(OperationCount, seed: 7);
+            Assert.IsTrue(
+                IsOutOfOrder(shuffledIndices),
+                "Wire order must be shuffled for this smoke test to be meaningful.");
+
+            string responseJson = BuildOperationResponsesJson(shuffledIndices, statusCode: (int)HttpStatusCode.OK);
+
+            Mock<CosmosClientContext> contextMock = this.BuildContextSetup();
+            contextMock
+                .Setup(c => c.ProcessResourceOperationStreamAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<ResourceType>(),
+                    It.IsAny<OperationType>(),
+                    It.IsAny<RequestOptions>(),
+                    It.IsAny<ContainerInternal>(),
+                    It.IsAny<CosmosPK?>(),
+                    It.IsAny<string>(),
+                    It.IsAny<Stream>(),
+                    It.IsAny<Action<RequestMessage>>(),
+                    It.IsAny<ITrace>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new MemoryStream(Encoding.UTF8.GetBytes(responseJson))
+                });
+
+            DistributedReadTransactionCore tx = new DistributedReadTransactionCore(contextMock.Object);
+            for (int i = 0; i < OperationCount; i++)
+            {
+                tx.ReadItem(BuildMockContainer(), new CosmosPK($"pk{i}"), $"id{i}");
+            }
+
+            DistributedTransactionResponse response = await tx.CommitTransactionAsync(CancellationToken.None);
+
+            Assert.IsTrue(response.IsSuccessStatusCode);
+            Assert.AreEqual(OperationCount, response.Count);
+            for (int i = 0; i < response.Count; i++)
+            {
+                Assert.AreEqual(i, response[i].Index,
+                    $"Response[{i}] must have Index {i} after SDK reordering.");
+                Assert.AreEqual(HttpStatusCode.OK, response[i].StatusCode);
+            }
+        }
+
+        [TestMethod]
+        [Description("Fail-closed: when the server response repeats an operation index (not a complete permutation " +
+                     "of 0..n-1), the SDK cannot map results back to requests and returns HTTP 500 instead of " +
+                     "surfacing misaligned data.")]
+        public async Task CommitAsync_DuplicateOperationIndex_FailsClosed()
+        {
+            // Three operations, but the response repeats index 1 and omits index 2 — an invalid permutation.
+            int[] indices = new[] { 0, 1, 1 };
+            string responseJson = BuildOperationResponsesJson(indices, statusCode: (int)HttpStatusCode.OK);
+
+            Mock<CosmosClientContext> contextMock = this.BuildContextSetup();
+            contextMock
+                .Setup(c => c.ProcessResourceOperationStreamAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<ResourceType>(),
+                    It.IsAny<OperationType>(),
+                    It.IsAny<RequestOptions>(),
+                    It.IsAny<ContainerInternal>(),
+                    It.IsAny<CosmosPK?>(),
+                    It.IsAny<string>(),
+                    It.IsAny<Stream>(),
+                    It.IsAny<Action<RequestMessage>>(),
+                    It.IsAny<ITrace>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new MemoryStream(Encoding.UTF8.GetBytes(responseJson))
+                });
+
+            DistributedTransactionResponse response = await new DistributedReadTransactionCore(contextMock.Object)
+                .ReadItem(BuildMockContainer(), new CosmosPK("pk0"), "id0")
+                .ReadItem(BuildMockContainer(), new CosmosPK("pk1"), "id1")
+                .ReadItem(BuildMockContainer(), new CosmosPK("pk2"), "id2")
+                .CommitTransactionAsync(CancellationToken.None);
+
+            Assert.AreEqual(HttpStatusCode.InternalServerError, response.StatusCode,
+                "A duplicate operation index must fail closed with HTTP 500.");
+            Assert.IsFalse(response.IsSuccessStatusCode);
+
+            // The unmappable payload is discarded and replaced with uniform fail-closed placeholders,
+            // one per submitted operation.
+            Assert.AreEqual(3, response.Count);
+            for (int i = 0; i < response.Count; i++)
+            {
+                Assert.AreEqual(HttpStatusCode.InternalServerError, response[i].StatusCode);
+            }
+        }
+
         #endregion
 
         /// <summary>
@@ -588,6 +688,61 @@ namespace Microsoft.Azure.Cosmos.Tests
             {
                 Content = new MemoryStream(Encoding.UTF8.GetBytes(json))
             };
+        }
+
+        /// <summary>
+        /// Builds an <c>operationResponses</c> JSON envelope from an explicit, ordered list of
+        /// per-operation indices (the wire order), each assigned the supplied HTTP status code.
+        /// </summary>
+        private static string BuildOperationResponsesJson(IReadOnlyList<int> indices, int statusCode)
+        {
+            List<string> results = new List<string>(indices.Count);
+            foreach (int index in indices)
+            {
+                results.Add($@"{{""index"":{index},""statusCode"":{statusCode}}}");
+            }
+
+            return $@"{{""operationResponses"":[{string.Join(",", results)}]}}";
+        }
+
+        /// <summary>
+        /// Returns the indices <c>0..count-1</c> in a deterministically-shuffled order so the
+        /// produced wire order is reproducibly out-of-order across test runs.
+        /// </summary>
+        private static int[] BuildShuffledIndices(int count, int seed)
+        {
+            int[] indices = new int[count];
+            for (int i = 0; i < count; i++)
+            {
+                indices[i] = i;
+            }
+
+            Random rng = new Random(seed);
+            for (int i = count - 1; i > 0; i--)
+            {
+                int j = rng.Next(i + 1);
+                int temp = indices[i];
+                indices[i] = indices[j];
+                indices[j] = temp;
+            }
+
+            return indices;
+        }
+
+        /// <summary>
+        /// Returns <c>true</c> when at least one element is not already in its sorted position.
+        /// </summary>
+        private static bool IsOutOfOrder(IReadOnlyList<int> indices)
+        {
+            for (int i = 0; i < indices.Count; i++)
+            {
+                if (indices[i] != i)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionResponseTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionResponseTests.cs
@@ -260,6 +260,44 @@ namespace Microsoft.Azure.Cosmos.Tests
             }
         }
 
+        [TestMethod]
+        [Description("Synthesized placeholder results leave per-operation SessionToken, PartitionKeyRangeId and " +
+                     "ActivityId null because they cannot be reliably attributed to a specific operation in an " +
+                     "unmappable response; the envelope ActivityId remains available on the response itself.")]
+        public async Task FromResponseMessage_PaddedResults_LeavePerOpFieldsNull()
+        {
+            const string expectedActivityId = "11111111-2222-3333-4444-555555555555";
+
+            // 3 operations submitted but server returns only 1 result on an error status — padded path.
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 3);
+
+            string json = @"{""operationResponses"":[{""index"":0,""statusCode"":409}]}";
+            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.Conflict, json);
+            responseMessage.Headers.Add(HttpConstants.HttpHeaders.ActivityId, expectedActivityId);
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            Assert.AreEqual(3, response.Count);
+
+            // The envelope ActivityId is still available at the response level for diagnostics.
+            Assert.AreEqual(expectedActivityId, response.ActivityId);
+
+            for (int i = 0; i < response.Count; i++)
+            {
+                Assert.IsNull(response[i].ActivityId,
+                    $"Padded result[{i}] must not stamp a per-operation ActivityId; read response.ActivityId instead.");
+                Assert.IsNull(response[i].SessionToken,
+                    $"Padded result[{i}] must not fake a per-operation SessionToken from envelope context.");
+                Assert.IsNull(response[i].PartitionKeyRangeId,
+                    $"Padded result[{i}] must not fake a per-operation PartitionKeyRangeId from envelope context.");
+            }
+        }
+
         // MultiStatus promotion
 
         [TestMethod]
@@ -502,6 +540,715 @@ namespace Microsoft.Azure.Cosmos.Tests
                 CancellationToken.None);
 
             Assert.AreEqual(4, response.Count);
+        }
+
+        // Out-of-order reordering
+
+        [TestMethod]
+        [Description("When operationResponses arrive out-of-order, the SDK reorders them by index. " +
+                     "Each operation has a distinct StatusCode and ETag to verify correct mapping.")]
+        public async Task FromResponseMessage_OutOfOrderResults_SortedByIndex()
+        {
+            // 5 operations submitted with indices [0..4].
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 5);
+
+            // Wire order [3, 0, 4, 2, 1], each with a unique statusCode/etag, so we can verify
+            // correct mapping after reordering (response[i].Index == i with that index's fields).
+            string json = @"{""operationResponses"":["
+                + @"{""index"":3,""statusCode"":200,""etag"":""e3""},"
+                + @"{""index"":0,""statusCode"":201,""etag"":""e0""},"
+                + @"{""index"":4,""statusCode"":204,""etag"":""e4""},"
+                + @"{""index"":2,""statusCode"":200,""etag"":""e2""},"
+                + @"{""index"":1,""statusCode"":201,""etag"":""e1""}"
+                + @"]}";
+
+            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.OK, json);
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            Assert.IsTrue(response.IsSuccessStatusCode);
+            Assert.AreEqual(5, response.Count);
+
+            // After reordering, response[i].Index must equal i and the per-operation
+            // fields must match what was originally sent for that index.
+            Assert.AreEqual(0, response[0].Index);
+            Assert.AreEqual(HttpStatusCode.Created, response[0].StatusCode);
+            Assert.AreEqual("e0", response[0].ETag);
+
+            Assert.AreEqual(1, response[1].Index);
+            Assert.AreEqual(HttpStatusCode.Created, response[1].StatusCode);
+            Assert.AreEqual("e1", response[1].ETag);
+
+            Assert.AreEqual(2, response[2].Index);
+            Assert.AreEqual(HttpStatusCode.OK, response[2].StatusCode);
+            Assert.AreEqual("e2", response[2].ETag);
+
+            Assert.AreEqual(3, response[3].Index);
+            Assert.AreEqual(HttpStatusCode.OK, response[3].StatusCode);
+            Assert.AreEqual("e3", response[3].ETag);
+
+            Assert.AreEqual(4, response[4].Index);
+            Assert.AreEqual(HttpStatusCode.NoContent, response[4].StatusCode);
+            Assert.AreEqual("e4", response[4].ETag);
+        }
+
+        [TestMethod]
+        [Description("The coordinator does not guarantee response order, so an out-of-range index makes the " +
+                     "payload unmappable. On a success status the SDK must fail closed with 500 + deserialization " +
+                     "failure rather than surface positionally-misaligned data.")]
+        public async Task FromResponseMessage_OutOfRangeIndex_SuccessStatus_ReturnsInternalServerError()
+        {
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 3);
+
+            // 3 operations submitted, but one result claims index 7 (out of range for an array of size 3).
+            string json = @"{""operationResponses"":["
+                + @"{""index"":0,""statusCode"":201},"
+                + @"{""index"":7,""statusCode"":201},"
+                + @"{""index"":2,""statusCode"":201}"
+                + @"]}";
+            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.OK, json);
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            // Unmappable response: fail closed instead of returning wire order.
+            Assert.AreEqual(HttpStatusCode.InternalServerError, response.StatusCode);
+            Assert.IsFalse(response.IsSuccessStatusCode);
+            Assert.AreEqual(ClientResources.ServerResponseDeserializationFailure, response.ErrorMessage);
+        }
+
+        [TestMethod]
+        [Description("Duplicate operation indices (with a missing index) make the payload unmappable. On a success " +
+                     "status the SDK must fail closed with 500 + deserialization failure.")]
+        public async Task FromResponseMessage_DuplicateIndex_SuccessStatus_ReturnsInternalServerError()
+        {
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 3);
+
+            // 3 operations submitted, but index 1 appears twice and index 2 is missing.
+            string json = @"{""operationResponses"":["
+                + @"{""index"":0,""statusCode"":201},"
+                + @"{""index"":1,""statusCode"":201},"
+                + @"{""index"":1,""statusCode"":201}"
+                + @"]}";
+            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.OK, json);
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            Assert.AreEqual(HttpStatusCode.InternalServerError, response.StatusCode);
+            Assert.IsFalse(response.IsSuccessStatusCode);
+            Assert.AreEqual(ClientResources.ServerResponseDeserializationFailure, response.ErrorMessage);
+        }
+
+        [TestMethod]
+        [Description("When the server omits 'index' on every result, the defaulted indices all collide at 0 and the " +
+                     "payload is unmappable. The SDK must not trust the defaulted indices; on a success status it must " +
+                     "fail closed with 500 + deserialization failure.")]
+        public async Task FromResponseMessage_MissingIndexOnAllResults_SuccessStatus_ReturnsInternalServerError()
+        {
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 3);
+
+            // No 'index' on any result → each defaults to 0 → not a permutation of 0..2.
+            string json = @"{""operationResponses"":["
+                + @"{""statusCode"":200,""etag"":""a""},"
+                + @"{""statusCode"":201,""etag"":""b""},"
+                + @"{""statusCode"":204,""etag"":""c""}"
+                + @"]}";
+            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.OK, json);
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            Assert.AreEqual(HttpStatusCode.InternalServerError, response.StatusCode);
+            Assert.IsFalse(response.IsSuccessStatusCode);
+            Assert.AreEqual(ClientResources.ServerResponseDeserializationFailure, response.ErrorMessage);
+        }
+
+        [TestMethod]
+        [Description("When indices are not a clean permutation but the HTTP status is an error, results are discarded " +
+                     "and padded with uniform error placeholders rather than surfacing misaligned data.")]
+        public async Task FromResponseMessage_NonPermutationIndices_ErrorStatus_PopulatesResultsWithErrorStatus()
+        {
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 3);
+
+            // index 1 appears twice, index 2 missing — unmappable — on an error status.
+            // Use 500 as the representative error: an unmappable response is a server-side failure,
+            // so a 5xx is the honest fit. Unlike 409 (per-op document conflict), 503 (marks the
+            // endpoint unavailable / triggers failover), or 400 (implies a client-side error), 500
+            // carries no special handling and keeps the focus on the unmappable-response path.
+            string json = @"{""operationResponses"":["
+                + @"{""index"":0,""statusCode"":500},"
+                + @"{""index"":1,""statusCode"":500},"
+                + @"{""index"":1,""statusCode"":500}"
+                + @"]}";
+            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.InternalServerError, json);
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            Assert.AreEqual(HttpStatusCode.InternalServerError, response.StatusCode);
+            Assert.AreEqual(3, response.Count);
+
+            // The envelope is a (non-success) 500, so this must take the error discard-and-pad branch,
+            // NOT the success fail-closed branch — which would also yield a 500 but stamp the
+            // deserialization-failure message. Asserting the message distinguishes the two branches,
+            // since the synthesized 500 status alone collides with this envelope's 500.
+            Assert.AreNotEqual(ClientResources.ServerResponseDeserializationFailure, response.ErrorMessage,
+                "A 500 error envelope must be padded via the error path, not rerouted through the success fail-closed branch.");
+
+            for (int i = 0; i < response.Count; i++)
+            {
+                Assert.AreEqual(HttpStatusCode.InternalServerError, response[i].StatusCode);
+            }
+        }
+
+        [TestMethod]
+        [Description("A 207 MultiStatus response is a success status, so malformed indices make it unmappable. The SDK " +
+                     "must fail closed with 500 + deserialization failure rather than run MultiStatus promotion over " +
+                     "positionally-misaligned per-operation data.")]
+        public async Task FromResponseMessage_NonPermutationIndices_MultiStatus_ReturnsInternalServerError()
+        {
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 3);
+
+            // index 1 appears twice, index 2 missing — unmappable — on a 207 MultiStatus (a success status).
+            // One operation reports 409, which promotion would normally surface; fail-closed must take precedence.
+            // A diagnosticString is present and must survive onto the synthesized 500 so the failure is debuggable.
+            string json = @"{""diagnosticString"":""coordinator-trace-xyz"",""operationResponses"":["
+                + @"{""index"":0,""statusCode"":201},"
+                + @"{""index"":1,""statusCode"":409},"
+                + @"{""index"":1,""statusCode"":201}"
+                + @"]}";
+            ResponseMessage responseMessage = BuildResponseMessage((HttpStatusCode)StatusCodes.MultiStatus, json);
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            Assert.AreEqual(HttpStatusCode.InternalServerError, response.StatusCode);
+            Assert.IsFalse(response.IsSuccessStatusCode);
+            Assert.AreEqual(ClientResources.ServerResponseDeserializationFailure, response.ErrorMessage);
+            Assert.AreEqual("coordinator-trace-xyz", response.DiagnosticString,
+                "The coordinator's diagnosticString must be preserved on the fail-closed 500 response.");
+        }
+
+        [TestMethod]
+        [Description("A 207 MultiStatus response with a VALID but out-of-order index permutation must first be " +
+                     "reordered, then have the lowest-index operation failure promoted to the overall status. " +
+                     "Reordering must not suppress promotion.")]
+        public async Task FromResponseMessage_ValidOutOfOrderIndices_MultiStatus_ReordersThenPromotes()
+        {
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 3);
+
+            // Wire order [2,0,1] is a valid permutation. Operation 1 (request order) is the failure (409);
+            // operation 2 also fails but with a later status (503). After reordering, promotion must scan in
+            // request order and surface operation 1's 409, not operation 2's 503 and not a fail-closed 500.
+            string json = @"{""operationResponses"":["
+                + @"{""index"":2,""statusCode"":503},"
+                + @"{""index"":0,""statusCode"":201},"
+                + @"{""index"":1,""statusCode"":409}"
+                + @"]}";
+            ResponseMessage responseMessage = BuildResponseMessage((HttpStatusCode)StatusCodes.MultiStatus, json);
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            Assert.AreEqual(HttpStatusCode.Conflict, response.StatusCode,
+                "Out-of-order 207 must be reordered, then promote the lowest-index failure (operation 1 → 409).");
+            Assert.IsFalse(response.IsSuccessStatusCode);
+            Assert.AreEqual(3, response.Count);
+            // Results are in request order after reordering.
+            Assert.AreEqual(0, response[0].Index);
+            Assert.AreEqual(1, response[1].Index);
+            Assert.AreEqual(HttpStatusCode.Conflict, response[1].StatusCode);
+            Assert.AreEqual(2, response[2].Index);
+            Assert.AreEqual(HttpStatusCode.ServiceUnavailable, response[2].StatusCode);
+        }
+
+        [TestMethod]
+        [Description("Even a single-operation transaction requires an explicit 'index' on its result. When the server " +
+                     "omits it, the defaulted index cannot be trusted, so on a success status the SDK fails closed " +
+                     "with 500 + deserialization failure rather than assuming positional alignment.")]
+        public async Task FromResponseMessage_SingleOperation_MissingIndex_SuccessStatus_ReturnsInternalServerError()
+        {
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
+
+            // Single operation, but the result omits 'index' → index defaults to 0 with HasIndex == false.
+            string json = @"{""operationResponses"":[{""statusCode"":201,""etag"":""e0""}]}";
+            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.OK, json);
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            Assert.AreEqual(HttpStatusCode.InternalServerError, response.StatusCode);
+            Assert.IsFalse(response.IsSuccessStatusCode);
+            Assert.AreEqual(ClientResources.ServerResponseDeserializationFailure, response.ErrorMessage);
+        }
+
+        [TestMethod]
+        [Description("The coordinator's top-level 'isRetriable' signal is independent of the per-operation indices. " +
+                     "When the payload is unmappable on a success status, the SDK fails closed with 500 but must " +
+                     "preserve isRetriable so the caller can safely retry under the idempotency token.")]
+        public async Task FromResponseMessage_NonPermutationIndices_SuccessStatus_PreservesIsRetriable()
+        {
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 3);
+
+            // index 1 appears twice, index 2 missing → unmappable. Coordinator marked the response retriable.
+            string json = @"{""isRetriable"":true,""operationResponses"":["
+                + @"{""index"":0,""statusCode"":201},"
+                + @"{""index"":1,""statusCode"":201},"
+                + @"{""index"":1,""statusCode"":201}"
+                + @"]}";
+            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.OK, json);
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            Assert.AreEqual(HttpStatusCode.InternalServerError, response.StatusCode);
+            Assert.IsFalse(response.IsSuccessStatusCode);
+            Assert.AreEqual(ClientResources.ServerResponseDeserializationFailure, response.ErrorMessage);
+            Assert.IsTrue(response.IsRetriable,
+                "The coordinator's isRetriable signal must survive onto the fail-closed 500 response.");
+        }
+
+        [TestMethod]
+        [Description("A per-operation element that fails to parse discards the results, but the coordinator's " +
+                     "top-level isRetriable verdict was parsed from the document root before the per-op loop and is " +
+                     "independent of it. On an error status the padded response must preserve isRetriable so the " +
+                     "committer can still retry under the idempotency token.")]
+        public async Task FromResponseMessage_PerOpParseFailure_ErrorStatus_PreservesIsRetriable()
+        {
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 3);
+
+            // Top-level isRetriable=true; one operation element has a wrong-type 'index' → per-op parse failure.
+            string json = @"{""isRetriable"":true,""operationResponses"":["
+                + @"{""index"":0,""statusCode"":201},"
+                + @"{""index"":""abc"",""statusCode"":201},"
+                + @"{""index"":2,""statusCode"":201}"
+                + @"]}";
+            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.ServiceUnavailable, json);
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            Assert.AreEqual(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+            Assert.AreEqual(3, response.Count);
+            Assert.IsTrue(response.IsRetriable,
+                "A per-op parse failure must not suppress the envelope-level isRetriable on an error status.");
+        }
+
+        [TestMethod]
+        [Description("On a success status a per-operation parse failure fails closed with 500, but must still " +
+                     "preserve the envelope-level isRetriable (symmetric with the unmappable-reorder path) so the " +
+                     "synthesized failure remains retriable under the idempotency token.")]
+        public async Task FromResponseMessage_PerOpParseFailure_SuccessStatus_PreservesIsRetriable()
+        {
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 2);
+
+            // Top-level isRetriable=true; a wrong-type 'index' triggers the per-op parse-failure path on a 200.
+            string json = @"{""isRetriable"":true,""operationResponses"":["
+                + @"{""index"":0,""statusCode"":201},"
+                + @"{""index"":""abc"",""statusCode"":201}"
+                + @"]}";
+            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.OK, json);
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            Assert.AreEqual(HttpStatusCode.InternalServerError, response.StatusCode);
+            Assert.AreEqual(ClientResources.ServerResponseDeserializationFailure, response.ErrorMessage);
+            Assert.IsTrue(response.IsRetriable,
+                "A per-op parse failure on a success status must preserve the envelope-level isRetriable on the fail-closed 500.");
+        }
+
+        [TestMethod]
+        [Description("On a success status a result-count mismatch (valid indices, wrong count) fails closed with 500. " +
+                     "The envelope-level isRetriable is independent of the unusable payload, so it must survive onto " +
+                     "the synthesized 500 — symmetric with the unmappable-index and per-op-parse-failure paths.")]
+        public async Task FromResponseMessage_CountMismatch_SuccessStatus_PreservesIsRetriable()
+        {
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 3);
+
+            // Three operations, but only two well-formed results → count mismatch skips reorder and fails closed.
+            string json = @"{""isRetriable"":true,""operationResponses"":["
+                + @"{""index"":0,""statusCode"":201},"
+                + @"{""index"":1,""statusCode"":201}"
+                + @"]}";
+            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.OK, json);
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            Assert.AreEqual(HttpStatusCode.InternalServerError, response.StatusCode);
+            Assert.IsFalse(response.IsSuccessStatusCode);
+            Assert.AreEqual(ClientResources.InvalidServerResponse, response.ErrorMessage);
+            Assert.IsTrue(response.IsRetriable,
+                "The envelope-level isRetriable must survive onto the count-mismatch fail-closed 500.");
+        }
+
+        [TestMethod]
+        [Description("A negative 'index' is out of range for the reorder array, so the payload is unmappable. " +
+                     "On a success status the SDK must fail closed with 500 + deserialization failure.")]
+        public async Task FromResponseMessage_NegativeIndex_SuccessStatus_ReturnsInternalServerError()
+        {
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 3);
+
+            // One result claims index -1, which can never be part of a 0..n-1 permutation.
+            string json = @"{""operationResponses"":["
+                + @"{""index"":0,""statusCode"":201},"
+                + @"{""index"":-1,""statusCode"":201},"
+                + @"{""index"":2,""statusCode"":201}"
+                + @"]}";
+            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.OK, json);
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            Assert.AreEqual(HttpStatusCode.InternalServerError, response.StatusCode);
+            Assert.IsFalse(response.IsSuccessStatusCode);
+            Assert.AreEqual(ClientResources.ServerResponseDeserializationFailure, response.ErrorMessage);
+        }
+
+        [TestMethod]
+        [Description("A valid but out-of-order index permutation on a plain (non-207) error status must still be " +
+                     "reordered into request order. Reordering is independent of MultiStatus promotion, so the " +
+                     "overall error status is preserved and response[i].Index == i.")]
+        public async Task FromResponseMessage_ValidOutOfOrderIndices_ErrorStatus_ReordersAndPreservesStatus()
+        {
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 3);
+
+            // Wire order [2,0,1] is a valid permutation; the overall HTTP status is a plain 409 (not 207).
+            string json = @"{""operationResponses"":["
+                + @"{""index"":2,""statusCode"":503},"
+                + @"{""index"":0,""statusCode"":201},"
+                + @"{""index"":1,""statusCode"":409}"
+                + @"]}";
+            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.Conflict, json);
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            // A plain error status carries no MultiStatus promotion, so the wire status is preserved as-is.
+            Assert.AreEqual(HttpStatusCode.Conflict, response.StatusCode);
+            Assert.IsFalse(response.IsSuccessStatusCode);
+            Assert.AreEqual(3, response.Count);
+
+            // Results must be reordered into request order regardless of the overall status.
+            Assert.AreEqual(0, response[0].Index);
+            Assert.AreEqual(HttpStatusCode.Created, response[0].StatusCode);
+            Assert.AreEqual(1, response[1].Index);
+            Assert.AreEqual(HttpStatusCode.Conflict, response[1].StatusCode);
+            Assert.AreEqual(2, response[2].Index);
+            Assert.AreEqual(HttpStatusCode.ServiceUnavailable, response[2].StatusCode);
+        }
+
+        [TestMethod]
+        [Description("When result count is fewer than the operation count, reordering is skipped (it requires a " +
+                     "count match) and the count-mismatch path takes over. On a success status that yields a 500 " +
+                     "InvalidServerResponse, not the unmappable-permutation deserialization failure.")]
+        public async Task FromResponseMessage_ValidIndices_CountMismatch_SuccessStatus_ReturnsInternalServerError()
+        {
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 5);
+
+            // Only 4 results returned for a 5-operation request; indices 0..3 are individually valid.
+            string json = @"{""operationResponses"":["
+                + @"{""index"":0,""statusCode"":201},"
+                + @"{""index"":1,""statusCode"":201},"
+                + @"{""index"":2,""statusCode"":201},"
+                + @"{""index"":3,""statusCode"":201}"
+                + @"]}";
+            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.OK, json);
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            Assert.AreEqual(HttpStatusCode.InternalServerError, response.StatusCode);
+            Assert.IsFalse(response.IsSuccessStatusCode);
+            Assert.AreEqual(ClientResources.InvalidServerResponse, response.ErrorMessage);
+        }
+
+        // Index validation / count mismatch — error-status and count-greater variants
+
+        [DataTestMethod]
+        [Description("An out-of-range index makes the payload unmappable. On an error status the SDK discards the " +
+                     "misaligned results and pads with uniform placeholders carrying the envelope error status, " +
+                     "regardless of the per-operation status codes on the wire.")]
+        [DataRow(409, DisplayName = "409 Conflict")]
+        [DataRow(429, DisplayName = "429 TooManyRequests")]
+        [DataRow(503, DisplayName = "503 ServiceUnavailable")]
+        public async Task FromResponseMessage_OutOfRangeIndex_ErrorStatus_PadsResults(int errorStatusCode)
+        {
+            HttpStatusCode status = (HttpStatusCode)errorStatusCode;
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 3);
+
+            // index 7 is out of range for an array of size 3 — unmappable.
+            string json = @"{""operationResponses"":["
+                + @"{""index"":0,""statusCode"":201},"
+                + @"{""index"":7,""statusCode"":201},"
+                + @"{""index"":2,""statusCode"":201}"
+                + @"]}";
+            ResponseMessage responseMessage = BuildResponseMessage(status, json);
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            Assert.AreEqual(status, response.StatusCode);
+            Assert.AreEqual(3, response.Count, "Count must equal the number of submitted operations.");
+            for (int i = 0; i < response.Count; i++)
+            {
+                Assert.AreEqual(status, response[i].StatusCode,
+                    $"Padded result[{i}] must carry the envelope error status, not the wire per-op status.");
+            }
+        }
+
+        [DataTestMethod]
+        [Description("Missing 'index' on every result defaults all indices to 0 (not a permutation). On an error " +
+                     "status the SDK discards them and pads with uniform placeholders carrying the envelope status.")]
+        [DataRow(409, DisplayName = "409 Conflict")]
+        [DataRow(429, DisplayName = "429 TooManyRequests")]
+        [DataRow(503, DisplayName = "503 ServiceUnavailable")]
+        public async Task FromResponseMessage_MissingIndex_ErrorStatus_PadsResults(int errorStatusCode)
+        {
+            HttpStatusCode status = (HttpStatusCode)errorStatusCode;
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 3);
+
+            // No 'index' on any result → all default to 0 → not a permutation of 0..2.
+            string json = @"{""operationResponses"":["
+                + @"{""statusCode"":201},"
+                + @"{""statusCode"":201},"
+                + @"{""statusCode"":201}"
+                + @"]}";
+            ResponseMessage responseMessage = BuildResponseMessage(status, json);
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            Assert.AreEqual(status, response.StatusCode);
+            Assert.AreEqual(3, response.Count);
+            for (int i = 0; i < response.Count; i++)
+            {
+                Assert.AreEqual(status, response[i].StatusCode);
+            }
+        }
+
+        [DataTestMethod]
+        [Description("A malformed 'index' (wrong JSON type or explicit null) fails per-operation parsing. On an error " +
+                     "status the parsed results are discarded and the count-mismatch path pads with uniform " +
+                     "placeholders carrying the envelope status (no fail-closed 500, which is reserved for success).")]
+        [DataRow(@"{""index"":""abc"",""statusCode"":201}", 409, DisplayName = "wrong-type index + 409")]
+        [DataRow(@"{""index"":null,""statusCode"":201}", 503, DisplayName = "null index + 503")]
+        public async Task FromResponseMessage_MalformedIndex_ErrorStatus_PadsResults(string firstElement, int errorStatusCode)
+        {
+            HttpStatusCode status = (HttpStatusCode)errorStatusCode;
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 3);
+
+            string json = @"{""operationResponses"":["
+                + firstElement + @","
+                + @"{""index"":1,""statusCode"":201},"
+                + @"{""index"":2,""statusCode"":201}"
+                + @"]}";
+            ResponseMessage responseMessage = BuildResponseMessage(status, json);
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            Assert.AreEqual(status, response.StatusCode);
+            Assert.IsFalse(response.IsSuccessStatusCode);
+            Assert.AreEqual(3, response.Count);
+            for (int i = 0; i < response.Count; i++)
+            {
+                Assert.AreEqual(status, response[i].StatusCode);
+            }
+        }
+
+        [TestMethod]
+        [Description("An explicit 'index':null is a malformed (non-number) index that fails parsing. On a success " +
+                     "status the SDK must fail closed with 500 + deserialization failure.")]
+        public async Task FromResponseMessage_NullIndex_SuccessStatus_ReturnsInternalServerError()
+        {
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
+
+            string json = @"{""operationResponses"":[{""index"":null,""statusCode"":201}]}";
+            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.OK, json);
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            Assert.AreEqual(HttpStatusCode.InternalServerError, response.StatusCode);
+            Assert.IsFalse(response.IsSuccessStatusCode);
+            Assert.AreEqual(ClientResources.ServerResponseDeserializationFailure, response.ErrorMessage);
+        }
+
+        [TestMethod]
+        [Description("When the server returns MORE results than submitted operations, reordering is skipped (it " +
+                     "requires a count match) and the count-mismatch path takes over. On a success status that yields " +
+                     "a 500 InvalidServerResponse.")]
+        public async Task FromResponseMessage_MoreResultsThanOperations_SuccessStatus_ReturnsInternalServerError()
+        {
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 2);
+
+            // 3 results returned for a 2-operation request; indices 0..2 are individually valid.
+            string json = @"{""operationResponses"":["
+                + @"{""index"":0,""statusCode"":201},"
+                + @"{""index"":1,""statusCode"":201},"
+                + @"{""index"":2,""statusCode"":201}"
+                + @"]}";
+            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.OK, json);
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            Assert.AreEqual(HttpStatusCode.InternalServerError, response.StatusCode);
+            Assert.IsFalse(response.IsSuccessStatusCode);
+            Assert.AreEqual(ClientResources.InvalidServerResponse, response.ErrorMessage);
+        }
+
+        [DataTestMethod]
+        [Description("When the server returns MORE results than submitted operations on an error status, the extra " +
+                     "results are dropped and the response is padded down to exactly the operation count with " +
+                     "placeholders carrying the envelope status.")]
+        [DataRow(409, DisplayName = "409 Conflict")]
+        [DataRow(412, DisplayName = "412 PreconditionFailed")]
+        public async Task FromResponseMessage_MoreResultsThanOperations_ErrorStatus_PadsToOperationCount(int errorStatusCode)
+        {
+            HttpStatusCode status = (HttpStatusCode)errorStatusCode;
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 2);
+
+            // 3 results returned for a 2-operation request.
+            string json = @"{""operationResponses"":["
+                + @"{""index"":0,""statusCode"":201},"
+                + @"{""index"":1,""statusCode"":201},"
+                + @"{""index"":2,""statusCode"":201}"
+                + @"]}";
+            ResponseMessage responseMessage = BuildResponseMessage(status, json);
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            Assert.AreEqual(status, response.StatusCode);
+            Assert.AreEqual(2, response.Count, "Count must be padded down to exactly the operation count.");
+            for (int i = 0; i < response.Count; i++)
+            {
+                Assert.AreEqual(status, response[i].StatusCode);
+            }
+        }
+
+        [TestMethod]
+        [Description("Exercises the error-status count-mismatch padding path while parsed results hold resource " +
+                     "streams (the branch where the leak-fix disposal runs). Verifies it pads to exactly the " +
+                     "operation count and the synthesized placeholders carry no stream. Observable disposal of the " +
+                     "discarded results is covered separately by Dispose_WithResourceBody_DisposesResourceStreams.")]
+        public async Task FromResponseMessage_CountMismatch_ErrorStatus_WithResourceBody_PadsWithoutStreams()
+        {
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 2);
+
+            // 3 results (each carrying a resourceBody → a ResourceStream) for a 2-operation request, on an
+            // error status. The parsed results are discarded and their streams disposed before padding.
+            string json = @"{""operationResponses"":["
+                + @"{""index"":0,""statusCode"":201,""resourceBody"":{""id"":""a"",""value"":1}},"
+                + @"{""index"":1,""statusCode"":201,""resourceBody"":{""id"":""b"",""value"":2}},"
+                + @"{""index"":2,""statusCode"":201,""resourceBody"":{""id"":""c"",""value"":3}}"
+                + @"]}";
+            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.Conflict, json);
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            Assert.AreEqual(HttpStatusCode.Conflict, response.StatusCode);
+            Assert.AreEqual(2, response.Count, "Count must be padded down to exactly the operation count.");
+            for (int i = 0; i < response.Count; i++)
+            {
+                Assert.AreEqual(HttpStatusCode.Conflict, response[i].StatusCode);
+                Assert.IsNull(response[i].ResourceStream,
+                    "Synthesized placeholders must not carry a resource stream from the discarded results.");
+            }
         }
 
         // Operation result property deserialization
@@ -1068,7 +1815,34 @@ namespace Microsoft.Azure.Cosmos.Tests
             Assert.AreEqual(0, enumerated, "Enumeration after disposal must yield no items without throwing.");
         }
 
-        // GetOperationResultAtIndex<T>
+        [TestMethod]
+        [Description("Dispose() must release the resource streams it owns. This observes the shared disposal helper " +
+                     "(also used by the count-mismatch leak-fix path) through the public Dispose() API: a parsed " +
+                     "ResourceStream must be unusable (CanRead == false) after Dispose().")]
+        public async Task Dispose_WithResourceBody_DisposesResourceStreams()
+        {
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
+
+            string json = @"{""operationResponses"":[{""index"":0,""statusCode"":201,""resourceBody"":{""id"":""a"",""value"":1}}]}";
+            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.OK, json);
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            Stream resourceStream = response[0].ResourceStream;
+            Assert.IsNotNull(resourceStream, "The parsed result must carry a resource stream to dispose.");
+            Assert.IsTrue(resourceStream.CanRead, "The stream must be readable before disposal.");
+
+            response.Dispose();
+
+            Assert.IsFalse(resourceStream.CanRead, "Dispose() must dispose the owned resource stream.");
+        }
+
+
 
         [TestMethod]
         [Description("GetOperationResultAtIndex<T> deserializes the resource body into the requested type.")]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedWriteTransactionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedWriteTransactionTests.cs
@@ -410,6 +410,106 @@ namespace Microsoft.Azure.Cosmos.Tests
         }
 
         [TestMethod]
+        [Description("Smoke test: a commit with 100+ write operations whose server operationResponses arrive " +
+                     "out-of-order is reordered by the SDK so response[i].Index == i for every operation.")]
+        public async Task CommitAsync_ManyOperations_OutOfOrderResponses_SortedByIndex()
+        {
+            const int OperationCount = 128;
+
+            // Server returns the per-operation responses in a deterministically-shuffled (out-of-order) sequence.
+            int[] shuffledIndices = BuildShuffledIndices(OperationCount, seed: 7);
+            Assert.IsTrue(
+                IsOutOfOrder(shuffledIndices),
+                "Wire order must be shuffled for this smoke test to be meaningful.");
+
+            string responseJson = BuildOperationResponsesJson(shuffledIndices, statusCode: (int)HttpStatusCode.Created);
+
+            Mock<CosmosClientContext> contextMock = this.BuildContextSetup();
+            contextMock
+                .Setup(c => c.ProcessResourceOperationStreamAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<ResourceType>(),
+                    It.IsAny<OperationType>(),
+                    It.IsAny<RequestOptions>(),
+                    It.IsAny<ContainerInternal>(),
+                    It.IsAny<PartitionKey?>(),
+                    It.IsAny<string>(),
+                    It.IsAny<Stream>(),
+                    It.IsAny<Action<RequestMessage>>(),
+                    It.IsAny<ITrace>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new MemoryStream(Encoding.UTF8.GetBytes(responseJson))
+                });
+
+            DistributedWriteTransactionCore tx = new DistributedWriteTransactionCore(contextMock.Object);
+            for (int i = 0; i < OperationCount; i++)
+            {
+                tx.CreateItem(BuildMockContainer(), new PartitionKey($"pk{i}"), $"id{i}", new TestItem($"id{i}"));
+            }
+
+            DistributedTransactionResponse response = await tx.CommitTransactionAsync(CancellationToken.None);
+
+            Assert.IsTrue(response.IsSuccessStatusCode);
+            Assert.AreEqual(OperationCount, response.Count);
+            for (int i = 0; i < response.Count; i++)
+            {
+                Assert.AreEqual(i, response[i].Index,
+                    $"Response[{i}] must have Index {i} after SDK reordering.");
+                Assert.AreEqual(HttpStatusCode.Created, response[i].StatusCode);
+            }
+        }
+
+        [TestMethod]
+        [Description("Fail-closed: when the server response repeats an operation index (not a complete permutation " +
+                     "of 0..n-1), the SDK cannot map results back to requests and returns HTTP 500 instead of " +
+                     "surfacing misaligned data.")]
+        public async Task CommitAsync_DuplicateOperationIndex_FailsClosed()
+        {
+            // Three operations, but the response repeats index 1 and omits index 2 — an invalid permutation.
+            int[] indices = new[] { 0, 1, 1 };
+            string responseJson = BuildOperationResponsesJson(indices, statusCode: (int)HttpStatusCode.Created);
+
+            Mock<CosmosClientContext> contextMock = this.BuildContextSetup();
+            contextMock
+                .Setup(c => c.ProcessResourceOperationStreamAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<ResourceType>(),
+                    It.IsAny<OperationType>(),
+                    It.IsAny<RequestOptions>(),
+                    It.IsAny<ContainerInternal>(),
+                    It.IsAny<PartitionKey?>(),
+                    It.IsAny<string>(),
+                    It.IsAny<Stream>(),
+                    It.IsAny<Action<RequestMessage>>(),
+                    It.IsAny<ITrace>(),
+                    It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new ResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new MemoryStream(Encoding.UTF8.GetBytes(responseJson))
+                });
+
+            DistributedTransactionResponse response = await new DistributedWriteTransactionCore(contextMock.Object)
+                .CreateItem(BuildMockContainer(), new PartitionKey("pk0"), "id0", new TestItem("id0"))
+                .CreateItem(BuildMockContainer(), new PartitionKey("pk1"), "id1", new TestItem("id1"))
+                .CreateItem(BuildMockContainer(), new PartitionKey("pk2"), "id2", new TestItem("id2"))
+                .CommitTransactionAsync(CancellationToken.None);
+
+            Assert.AreEqual(HttpStatusCode.InternalServerError, response.StatusCode,
+                "A duplicate operation index must fail closed with HTTP 500.");
+            Assert.IsFalse(response.IsSuccessStatusCode);
+
+            // The unmappable payload is discarded and replaced with uniform fail-closed placeholders,
+            // one per submitted operation.
+            Assert.AreEqual(3, response.Count);
+            for (int i = 0; i < response.Count; i++)
+            {
+                Assert.AreEqual(HttpStatusCode.InternalServerError, response[i].StatusCode);
+            }
+        }
+
+        [TestMethod]
         public async Task CommitAsync_AllFiveOperationTypes_AreIncluded()
         {
             string capturedJson = null;
@@ -912,6 +1012,61 @@ namespace Microsoft.Azure.Cosmos.Tests
             {
                 Content = new MemoryStream(Encoding.UTF8.GetBytes(json))
             };
+        }
+
+        /// <summary>
+        /// Builds an <c>operationResponses</c> JSON envelope from an explicit, ordered list of
+        /// per-operation indices (the wire order), each assigned the supplied HTTP status code.
+        /// </summary>
+        private static string BuildOperationResponsesJson(IReadOnlyList<int> indices, int statusCode)
+        {
+            List<string> results = new List<string>(indices.Count);
+            foreach (int index in indices)
+            {
+                results.Add($@"{{""index"":{index},""statusCode"":{statusCode}}}");
+            }
+
+            return $@"{{""operationResponses"":[{string.Join(",", results)}]}}";
+        }
+
+        /// <summary>
+        /// Returns the indices <c>0..count-1</c> in a deterministically-shuffled order so the
+        /// produced wire order is reproducibly out-of-order across test runs.
+        /// </summary>
+        private static int[] BuildShuffledIndices(int count, int seed)
+        {
+            int[] indices = new int[count];
+            for (int i = 0; i < count; i++)
+            {
+                indices[i] = i;
+            }
+
+            Random rng = new Random(seed);
+            for (int i = count - 1; i > 0; i--)
+            {
+                int j = rng.Next(i + 1);
+                int temp = indices[i];
+                indices[i] = indices[j];
+                indices[j] = temp;
+            }
+
+            return indices;
+        }
+
+        /// <summary>
+        /// Returns <c>true</c> when at least one element is not already in its sorted position.
+        /// </summary>
+        private static bool IsOutOfOrder(IReadOnlyList<int> indices)
+        {
+            for (int i = 0; i < indices.Count; i++)
+            {
+                if (indices[i] != i)
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private sealed class TestItem

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedWriteTransactionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedWriteTransactionTests.cs
@@ -347,6 +347,69 @@ namespace Microsoft.Azure.Cosmos.Tests
         }
 
         [TestMethod]
+        [Description("When server operationResponses arrive out-of-order, the SDK reorders them by index so response[i].Index == i.")]
+        public async Task CommitAsync_OutOfOrderOperationResponses_SortedByIndex()
+        {
+            string capturedRequestJson = null;
+
+            // Wire response has indices in order [3,4,1,2,0] — deliberately shuffled.
+            const string mockResponseJson =
+                @"{""operationResponses"":[{""index"":3,""statusCode"":201},{""index"":4,""statusCode"":201},{""index"":1,""statusCode"":201},{""index"":2,""statusCode"":201},{""index"":0,""statusCode"":201}]}";
+
+            Mock<CosmosClientContext> contextMock = this.BuildContextSetup();
+            contextMock
+                .Setup(c => c.ProcessResourceOperationStreamAsync(
+                    It.IsAny<string>(),
+                    It.IsAny<ResourceType>(),
+                    It.IsAny<OperationType>(),
+                    It.IsAny<RequestOptions>(),
+                    It.IsAny<ContainerInternal>(),
+                    It.IsAny<PartitionKey?>(),
+                    It.IsAny<string>(),
+                    It.IsAny<Stream>(),
+                    It.IsAny<Action<RequestMessage>>(),
+                    It.IsAny<ITrace>(),
+                    It.IsAny<CancellationToken>()))
+                .Returns<string, ResourceType, OperationType, RequestOptions, ContainerInternal, PartitionKey?, string, Stream, Action<RequestMessage>, ITrace, CancellationToken>(
+                    (uri, resType, opType, opts, container, pk, itemId, stream, enricher, trace, ct) =>
+                    {
+                        using MemoryStream ms = new MemoryStream();
+                        stream.CopyTo(ms);
+                        capturedRequestJson = Encoding.UTF8.GetString(ms.ToArray());
+                        return Task.FromResult(new ResponseMessage(HttpStatusCode.OK)
+                        {
+                            Content = new MemoryStream(Encoding.UTF8.GetBytes(mockResponseJson))
+                        });
+                    });
+
+            DistributedTransactionResponse response = await new DistributedWriteTransactionCore(contextMock.Object)
+                .CreateItem(BuildMockContainer(), new PartitionKey("pk0"), "id0", new TestItem("id0"))
+                .ReplaceItem(BuildMockContainer(), new PartitionKey("pk1"), "id1", new TestItem("id1"))
+                .DeleteItem(BuildMockContainer(), new PartitionKey("pk2"), "id2")
+                .PatchItem(BuildMockContainer(), new PartitionKey("pk3"), "id3", new[] { PatchOperation.Add("/value", "v3") })
+                .UpsertItem(BuildMockContainer(), new PartitionKey("pk4"), "id4", new TestItem("id4"))
+                .CommitTransactionAsync(CancellationToken.None);
+
+            // Verify request indices are 0-based and ordered.
+            using JsonDocument requestDoc = JsonDocument.Parse(capturedRequestJson);
+            JsonElement requestOps = requestDoc.RootElement.GetProperty("operations");
+            Assert.AreEqual(5, requestOps.GetArrayLength());
+            for (int i = 0; i < 5; i++)
+            {
+                Assert.AreEqual(i, requestOps[i].GetProperty("index").GetInt32());
+            }
+
+            // After SDK reordering, response[i].Index must equal i.
+            Assert.AreEqual(5, response.Count);
+            for (int i = 0; i < response.Count; i++)
+            {
+                Assert.AreEqual(i, response[i].Index,
+                    $"Response[{i}] must have Index {i} after SDK reordering.");
+                Assert.AreEqual(HttpStatusCode.Created, response[i].StatusCode);
+            }
+        }
+
+        [TestMethod]
         public async Task CommitAsync_AllFiveOperationTypes_AreIncluded()
         {
             string capturedJson = null;


### PR DESCRIPTION
## Description

Distributed transaction (DTX) responses do not guarantee that per-operation results come back in the same order the operations were sent, and a malformed or short payload could otherwise surface misaligned results to the caller. This change makes DTX response parsing order-safe and fail-closed.

**What it does:**

- **Reorders by server `index`.** Each per-operation result carries the original request `index`; results are placed back into request order rather than trusting wire order. The indices must form a complete permutation of `0..n-1`. A new `HasIndex` flag distinguishes a real server `index:0` from a defaulted/omitted one so an ambiguous payload is never mis-mapped.
- **Fails closed on unmappable payloads.** Bad/duplicate/missing indices, per-operation parse failures, and result-count mismatches are treated as uninterpretable: on a success status the response is downgraded to `500 InternalServerError`; on an error status the SDK synthesizes uniform error placeholders so the caller always gets exactly `Operations.Count` results.
- **Fixes a resource-stream leak.** Discarded parsed results' `ResourceStream`s are now disposed before the result list is replaced. The four disposal sites share a single null-safe `DisposeResultStreams` helper (also used by `Dispose()`).
- **Preserves envelope-level signals across reconstruction.** The coordinator's root-level `isRetriable` verdict and `diagnosticString` are independent of the per-operation payload, so they are now carried onto every synthesized fail-closed response. Previously the count-mismatch path dropped them, which could turn a coordinator-signalled "safe to retry" into a terminal failure; all three fail-closed paths are now consistent.

**Worth a careful look:** the `isRetriable` preservation is the most behaviorally significant piece. The retry it enables is safe because it is guarded by the idempotency token; suppressing the signal was strictly worse than keeping it.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Closing issues

N/A

## Changelog

- [ ] I have added a changelog entry under `### Unreleased` in `changelog.md`
  for the user-facing impact of this change.
- [x] No changelog entry is required because this PR is one of:
  documentation-only, test-only, CI / build-only, or a pure internal refactor
  with no observable customer impact.

If the second box is checked, briefly justify here:

> All changes are confined to the `PREVIEW`-gated DistributedTransaction feature, which is internal/preview and not reachable in a customer's default configuration. No customer-observable impact in any shipped default-config path.