### PR TITLE
CODEOWNERS: Adds FabianMeiswinkel as an owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -21,4 +21,4 @@ Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Contracts @kir
 Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetSDKAPI.json @Azure/azure-cosmosdb-lt
 Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetPreviewSDKAPI.json @Azure/azure-cosmosdb-lt
 Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetSDKTelemetryAPI.json @Azure/azure-cosmosdb-lt
-CODEOWNERS @Pilchie @kirankumarkolli @kushagraThapar @jeet1995 @kundadebdatta @xinlian12
+CODEOWNERS @Pilchie @kirankumarkolli @FabianMeiswinkel @kushagraThapar @jeet1995 @kundadebdatta @xinlian12


### PR DESCRIPTION
## Description

Adds Fabian (@FabianMeiswinkel) as a code owner so he has the same permissions as @Pilchie, @kirankumarkolli, @kushagraThapar, @jeet1995, @kundadebdatta, and @xinlian12.

Those six users are the owners of the `CODEOWNERS` file itself (last line of the file), which was the only entry where that group had ownership but @FabianMeiswinkel did not — the top-level `*` rule already includes him. This PR adds `@FabianMeiswinkel` to that `CODEOWNERS` entry, following the existing convention of placing him immediately after `@kirankumarkolli`.

## Type of change

- [x] This change requires no changelog entry (CI/repo configuration only — no shipped package source touched).

## No changelog entry required

This change only updates the `CODEOWNERS` file and has no customer-observable impact.