### PR TITLE
[Internal] Query: Adds RegexReplace/RegexReplaceAll to SDK

### DIFF
--- a/Microsoft.Azure.Cosmos/src/SqlObjects/SqlFunctionCallScalarExpression.cs
+++ b/Microsoft.Azure.Cosmos/src/SqlObjects/SqlFunctionCallScalarExpression.cs
@@ -122,6 +122,8 @@ namespace Microsoft.Azure.Cosmos.SqlObjects
             { Names.RegexExtract, Identifiers.RegexExtract },
             { Names.RegexExtractAll, Identifiers.RegexExtractAll },
             { Names.RegexMatch, Identifiers.RegexMatch },
+            { Names.RegexReplace, Identifiers.RegexReplace },
+            { Names.RegexReplaceAll, Identifiers.RegexReplaceAll },
             { Names.Replace, Identifiers.Replace },
             { Names.Replicate, Identifiers.Replicate },
             { Names.Reverse, Identifiers.Reverse },
@@ -375,6 +377,8 @@ namespace Microsoft.Azure.Cosmos.SqlObjects
             public const string RegexExtract = "RegexExtract";
             public const string RegexExtractAll = "RegexExtractAll";
             public const string RegexMatch = "RegexMatch";
+            public const string RegexReplace = "RegexReplace";
+            public const string RegexReplaceAll = "RegexReplaceAll";
             public const string Replace = "REPLACE";
             public const string Replicate = "REPLICATE";
             public const string Reverse = "REVERSE";
@@ -557,6 +561,8 @@ namespace Microsoft.Azure.Cosmos.SqlObjects
             public static readonly SqlIdentifier RegexExtract = SqlIdentifier.Create(Names.RegexExtract);
             public static readonly SqlIdentifier RegexExtractAll = SqlIdentifier.Create(Names.RegexExtractAll);
             public static readonly SqlIdentifier RegexMatch = SqlIdentifier.Create(Names.RegexMatch);
+            public static readonly SqlIdentifier RegexReplace = SqlIdentifier.Create(Names.RegexReplace);
+            public static readonly SqlIdentifier RegexReplaceAll = SqlIdentifier.Create(Names.RegexReplaceAll);
             public static readonly SqlIdentifier Replace = SqlIdentifier.Create(Names.Replace);
             public static readonly SqlIdentifier Replicate = SqlIdentifier.Create(Names.Replicate);
             public static readonly SqlIdentifier Reverse = SqlIdentifier.Create(Names.Reverse);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BaselineTest/TestBaseline/SqlObjectVisitorBaselineTests.SqlFunctionCalls.xml
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/BaselineTest/TestBaseline/SqlObjectVisitorBaselineTests.SqlFunctionCalls.xml
@@ -3349,6 +3349,98 @@ RAND()
   </Result>
   <Result>
     <Input>
+      <Description>RegexReplace</Description>
+      <SqlObject><![CDATA[{
+  "Name": {
+    "Value": "RegexReplace"
+  },
+  "Arguments": [
+    {
+      "Literal": {
+        "Value": "Hell1 World"
+      }
+    },
+    {
+      "Literal": {
+        "Value": "\\d"
+      }
+    },
+    {
+      "Literal": {
+        "Value": "o"
+      }
+    },
+    {
+      "Literal": {
+        "Value": "imsx"
+      }
+    }
+  ],
+  "IsUdf": false
+}]]></SqlObject>
+    </Input>
+    <Output>
+      <TextOutput><![CDATA[RegexReplace("Hell1 World", "\\d", "o", "imsx")]]></TextOutput>
+      <PrettyPrint><![CDATA[
+RegexReplace(
+    "Hell1 World", 
+    "\\d", 
+    "o", 
+    "imsx"
+)
+]]></PrettyPrint>
+      <HashCode>653884473</HashCode>
+      <ObfusctedQuery><![CDATA[RegexReplace("str1__11", "str2", "o", "str3")]]></ObfusctedQuery>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
+      <Description>RegexReplaceAll</Description>
+      <SqlObject><![CDATA[{
+  "Name": {
+    "Value": "RegexReplaceAll"
+  },
+  "Arguments": [
+    {
+      "Literal": {
+        "Value": "Adam12Bella14David16Eric18"
+      }
+    },
+    {
+      "Literal": {
+        "Value": "[a-z]+"
+      }
+    },
+    {
+      "Literal": {
+        "Value": "Id: "
+      }
+    },
+    {
+      "Literal": {
+        "Value": "imsx"
+      }
+    }
+  ],
+  "IsUdf": false
+}]]></SqlObject>
+    </Input>
+    <Output>
+      <TextOutput><![CDATA[RegexReplaceAll("Adam12Bella14David16Eric18", "[a-z]+", "Id: ", "imsx")]]></TextOutput>
+      <PrettyPrint><![CDATA[
+RegexReplaceAll(
+    "Adam12Bella14David16Eric18", 
+    "[a-z]+", 
+    "Id: ", 
+    "imsx"
+)
+]]></PrettyPrint>
+      <HashCode>-687090482</HashCode>
+      <ObfusctedQuery><![CDATA[RegexReplaceAll("str1__26", "str2", "str3", "str4")]]></ObfusctedQuery>
+    </Output>
+  </Result>
+  <Result>
+    <Input>
       <Description>REPLACE</Description>
       <SqlObject><![CDATA[{
   "Name": {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/SqlObjects/SqlObjectVisitorBaselineTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/SqlObjects/SqlObjectVisitorBaselineTests.cs
@@ -886,6 +886,22 @@ namespace Microsoft.Azure.Cosmos.Test.SqlObjects
                 SqlFunctionCallScalarExpression.CreateBuiltin(
                     SqlFunctionCallScalarExpression.Identifiers.Rand)),
                 new SqlObjectVisitorInput(
+                SqlFunctionCallScalarExpression.Names.RegexReplace,
+                SqlFunctionCallScalarExpression.CreateBuiltin(
+                    SqlFunctionCallScalarExpression.Identifiers.RegexReplace,
+                    SqlLiteralScalarExpression.Create(SqlStringLiteral.Create("Hell1 World")),
+                    SqlLiteralScalarExpression.Create(SqlStringLiteral.Create("\\d")),
+                    SqlLiteralScalarExpression.Create(SqlStringLiteral.Create("o")),
+                    SqlLiteralScalarExpression.Create(SqlStringLiteral.Create("imsx")))),
+                new SqlObjectVisitorInput(
+                SqlFunctionCallScalarExpression.Names.RegexReplaceAll,
+                SqlFunctionCallScalarExpression.CreateBuiltin(
+                    SqlFunctionCallScalarExpression.Identifiers.RegexReplaceAll,
+                    SqlLiteralScalarExpression.Create(SqlStringLiteral.Create("Adam12Bella14David16Eric18")),
+                    SqlLiteralScalarExpression.Create(SqlStringLiteral.Create("[a-z]+")),
+                    SqlLiteralScalarExpression.Create(SqlStringLiteral.Create("Id: ")),
+                    SqlLiteralScalarExpression.Create(SqlStringLiteral.Create("imsx")))),
+                new SqlObjectVisitorInput(
                 SqlFunctionCallScalarExpression.Names.Replace,
                 SqlFunctionCallScalarExpression.CreateBuiltin(
                     SqlFunctionCallScalarExpression.Identifiers.Replace,


### PR DESCRIPTION
# RegexReplace / RegexReplaceAll

## RegexReplace
In a specified input string, replaces the first string that matches a regular expression pattern with a specified replacement string.
### Syntax
`RegexReplace(<main_string_expr>, <pattern_string_expr>, <replacement_string_expr> [, <modifier_string_expr>])`

### Examples

```
RegexReplace("Hello World", "o", "0") = "Hell0 World"
RegexReplace("foo bar baz", "\s+", "-") = "foo-bar baz"
RegexReplace("2023-01-15 2024-02-17", "(\d{4})-(\d{2})-(\d{2})", "$2/$3/$1") = "01/15/2023 2024-02-17"
RegexReplace("Hello World", "O", "0", "i") = "Hell0 World"
```

## RegexReplaceAll
In a specified input string, replace all strings that match a regular expression pattern with a specified replacement string.
### Syntax
`RegexReplaceAll(<main_string_expr>, <pattern_string_expr>, <replacement_string_expr> [, <modifier_string_expr>])`

### Examples

```
RegexReplaceAll("Hello World", "o", "0") = "Hell0 W0rld"
RegexReplaceAll("foo bar baz", "\s+", "-") = "foo-bar-baz"
RegexReplaceAll("2023-01-15 2024-02-17", "(\d{4})-(\d{2})-(\d{2})", "$2/$3/$1") = "01/15/2023 02/17/2024"
RegexReplaceAll("Hello World", "O", "0", "i") = "Hell0 W0rld"
```

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber

## Changelog

- [ ] I have added a changelog entry under `### Unreleased` in `changelog.md`
  for the user-facing impact of this change.
- [ ] No changelog entry is required because this PR is one of:
  documentation-only, test-only, CI / build-only, or a pure internal refactor
  with no observable customer impact.

If the second box is checked, briefly justify here:

>
