### PR TITLE
[Internal] Routing: Refactors partition-key resolution into a request-free shared core

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Routing/AddressResolver.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/AddressResolver.cs
@@ -679,6 +679,95 @@ namespace Microsoft.Azure.Cosmos
                 throw new InternalServerErrorException(string.Format(CultureInfo.InvariantCulture, "partition key is null '{0}'", partitionKeyString));
             }
 
+            // Delegate to the request-free core, then translate its result into the gateway's historical
+            // contract (return range / return null to refresh / throw on mismatch).
+            PartitionKeyRangeResolutionKind resolutionKind = AddressResolver.TryResolvePartitionKeyToRange(
+                partitionKey,
+                collection,
+                routingMap,
+                collectionCacheUptoDate,
+                out PartitionKeyRange range);
+
+            switch (resolutionKind)
+            {
+                case PartitionKeyRangeResolutionKind.Resolved:
+                    return range;
+
+                case PartitionKeyRangeResolutionKind.KeyMismatch:
+                    BadRequestException badRequestException = new BadRequestException(RMResources.PartitionKeyMismatch) { ResourceAddress = request.ResourceAddress };
+                    badRequestException.Headers[WFConstants.BackendHeaders.SubStatus] =
+                        ((uint)SubStatusCodes.PartitionKeyMismatch).ToString(CultureInfo.InvariantCulture);
+
+                    throw badRequestException;
+
+                case PartitionKeyRangeResolutionKind.NeedsRefresh:
+                default:
+                    return null;
+            }
+        }
+
+        /// <summary>
+        /// Outcome of mapping a partition key to a physical partition key range, independent of any
+        /// <see cref="DocumentServiceRequest"/>. Callers translate the outcome into their own contract
+        /// (e.g. the gateway throws / returns null; distributed transactions apply no session token).
+        /// </summary>
+        internal enum PartitionKeyRangeResolutionKind
+        {
+            /// <summary>
+            /// The key maps to exactly one range, returned via the out parameter.
+            /// </summary>
+            Resolved,
+
+            /// <summary>
+            /// The key could not be mapped with the currently cached routing/partition-key definition
+            /// and the caller should refresh its caches and retry (historically the gateway returned null).
+            /// </summary>
+            NeedsRefresh,
+
+            /// <summary>
+            /// The supplied key has a different number of components than the (up-to-date) partition-key
+            /// definition, so it is a genuine mismatch (historically the gateway threw a 400 PartitionKeyMismatch).
+            /// </summary>
+            KeyMismatch,
+        }
+
+        /// <summary>
+        /// Request-free core that maps a partition key to the owning <see cref="PartitionKeyRange"/> using
+        /// the collection's partition-key definition and routing map. This is the single source of truth for
+        /// the empty-or-full-key (component-count) guard, effective-key computation and
+        /// <see cref="CollectionRoutingMap.GetRangeByEffectivePartitionKey(string)"/> lookup that both the
+        /// gateway point-operation path and the distributed-transaction resolver rely on.
+        /// </summary>
+        /// <param name="partitionKey">The already-parsed partition key value.</param>
+        /// <param name="collection">The container properties supplying the partition-key definition.</param>
+        /// <param name="routingMap">The collection routing map used to locate the owning range.</param>
+        /// <param name="collectionCacheUptoDate">Whether the collection cache backing <paramref name="collection"/> is known to be up to date.</param>
+        /// <param name="range">The resolved range when the result is <see cref="PartitionKeyRangeResolutionKind.Resolved"/>; otherwise null.</param>
+        /// <returns>The classification describing how the key mapped.</returns>
+        internal static PartitionKeyRangeResolutionKind TryResolvePartitionKeyToRange(
+            PartitionKeyInternal partitionKey,
+            ContainerProperties collection,
+            CollectionRoutingMap routingMap,
+            bool collectionCacheUptoDate,
+            out PartitionKeyRange range)
+        {
+            range = null;
+
+            if (partitionKey == null)
+            {
+                throw new ArgumentNullException(nameof(partitionKey));
+            }
+
+            if (collection == null)
+            {
+                throw new ArgumentNullException(nameof(collection));
+            }
+
+            if (routingMap == null)
+            {
+                throw new ArgumentNullException(nameof(routingMap));
+            }
+
             if (partitionKey.Equals(PartitionKeyInternal.Empty) || partitionKey.Components.Count == collection.PartitionKey.Paths.Count)
             {
                 // Although we can compute effective partition key here, in general case this Gateway can have outdated
@@ -689,16 +778,18 @@ namespace Microsoft.Azure.Cosmos
                 string effectivePartitionKey = partitionKey.GetEffectivePartitionKeyString(collection.PartitionKey);
 
                 // There should be exactly one range which contains a partition key. Always.
-                return routingMap.GetRangeByEffectivePartitionKey(effectivePartitionKey);
+                range = routingMap.GetRangeByEffectivePartitionKey(effectivePartitionKey);
+
+                // A null here means the currently cached routing map has no owning range for the key;
+                // signal a refresh (the gateway historically returned null in this case).
+                return range != null
+                    ? PartitionKeyRangeResolutionKind.Resolved
+                    : PartitionKeyRangeResolutionKind.NeedsRefresh;
             }
 
             if (collectionCacheUptoDate)
             {
-                BadRequestException badRequestException = new BadRequestException(RMResources.PartitionKeyMismatch) { ResourceAddress = request.ResourceAddress };
-                badRequestException.Headers[WFConstants.BackendHeaders.SubStatus] =
-                    ((uint)SubStatusCodes.PartitionKeyMismatch).ToString(CultureInfo.InvariantCulture);
-
-                throw badRequestException;
+                return PartitionKeyRangeResolutionKind.KeyMismatch;
             }
 
             // Partition key supplied has different number paths than locally cached partition key definition.
@@ -718,7 +809,7 @@ namespace Microsoft.Azure.Cosmos
                 collection.PartitionKey.Paths.Count,
                 partitionKey.Components.Count);
 
-            return null;
+            return PartitionKeyRangeResolutionKind.NeedsRefresh;
         }
 
         public Task UpdateAsync(ServerKey serverKey, CancellationToken cancellationToken = default)

--- a/Microsoft.Azure.Cosmos/src/Routing/AddressResolver.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/AddressResolver.cs
@@ -700,7 +700,7 @@ namespace Microsoft.Azure.Cosmos
 
                     throw badRequestException;
 
-                case PartitionKeyRangeResolutionKind.NeedsRefresh:
+                case PartitionKeyRangeResolutionKind.StaleMetadata:
                 default:
                     return null;
             }
@@ -756,10 +756,10 @@ namespace Microsoft.Azure.Cosmos
                 range = routingMap.GetRangeByEffectivePartitionKey(effectivePartitionKey);
 
                 // A null here means the currently cached routing map has no owning range for the key;
-                // signal a refresh (the gateway historically returned null in this case).
+                // treat the cached metadata as possibly stale (the gateway historically returned null here).
                 return range != null
                     ? PartitionKeyRangeResolutionKind.Resolved
-                    : PartitionKeyRangeResolutionKind.NeedsRefresh;
+                    : PartitionKeyRangeResolutionKind.StaleMetadata;
             }
 
             if (collectionCacheUptoDate)
@@ -784,7 +784,7 @@ namespace Microsoft.Azure.Cosmos
                 collection.PartitionKey.Paths.Count,
                 partitionKey.Components.Count);
 
-            return PartitionKeyRangeResolutionKind.NeedsRefresh;
+            return PartitionKeyRangeResolutionKind.StaleMetadata;
         }
 
         public Task UpdateAsync(ServerKey serverKey, CancellationToken cancellationToken = default)

--- a/Microsoft.Azure.Cosmos/src/Routing/AddressResolver.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/AddressResolver.cs
@@ -707,31 +707,6 @@ namespace Microsoft.Azure.Cosmos
         }
 
         /// <summary>
-        /// Outcome of mapping a partition key to a physical partition key range, independent of any
-        /// <see cref="DocumentServiceRequest"/>. Callers translate the outcome into their own contract
-        /// (e.g. the gateway throws / returns null; distributed transactions apply no session token).
-        /// </summary>
-        internal enum PartitionKeyRangeResolutionKind
-        {
-            /// <summary>
-            /// The key maps to exactly one range, returned via the out parameter.
-            /// </summary>
-            Resolved,
-
-            /// <summary>
-            /// The key could not be mapped with the currently cached routing/partition-key definition
-            /// and the caller should refresh its caches and retry (historically the gateway returned null).
-            /// </summary>
-            NeedsRefresh,
-
-            /// <summary>
-            /// The supplied key has a different number of components than the (up-to-date) partition-key
-            /// definition, so it is a genuine mismatch (historically the gateway threw a 400 PartitionKeyMismatch).
-            /// </summary>
-            KeyMismatch,
-        }
-
-        /// <summary>
         /// Request-free core that maps a partition key to the owning <see cref="PartitionKeyRange"/> using
         /// the collection's partition-key definition and routing map. This is the single source of truth for
         /// the empty-or-full-key (component-count) guard, effective-key computation and

--- a/Microsoft.Azure.Cosmos/src/Routing/PartitionKeyRangeResolutionKind.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/PartitionKeyRangeResolutionKind.cs
@@ -18,10 +18,12 @@ namespace Microsoft.Azure.Cosmos
         Resolved,
 
         /// <summary>
-        /// The key could not be mapped with the currently cached routing/partition-key definition
-        /// and the caller should refresh its caches and retry (historically the gateway returned null).
+        /// The key could not be mapped because the currently cached routing/partition-key definition
+        /// may be stale — unlike <see cref="KeyMismatch"/>, this is not a definite mismatch. Each caller
+        /// picks its own reaction (the gateway refreshes its caches and retries — historically returning
+        /// null; distributed transactions apply no session token and degrade to eventual consistency).
         /// </summary>
-        NeedsRefresh,
+        StaleMetadata,
 
         /// <summary>
         /// The supplied key has a different number of components than the (up-to-date) partition-key

--- a/Microsoft.Azure.Cosmos/src/Routing/PartitionKeyRangeResolutionKind.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/PartitionKeyRangeResolutionKind.cs
@@ -1,0 +1,32 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+namespace Microsoft.Azure.Cosmos
+{
+    using Microsoft.Azure.Documents;
+
+    /// <summary>
+    /// Outcome of mapping a partition key to a physical partition key range, independent of any
+    /// <see cref="DocumentServiceRequest"/>. Callers translate the outcome into their own contract
+    /// (e.g. the gateway throws / returns null; distributed transactions apply no session token).
+    /// </summary>
+    internal enum PartitionKeyRangeResolutionKind
+    {
+        /// <summary>
+        /// The key maps to exactly one range, returned via the out parameter.
+        /// </summary>
+        Resolved,
+
+        /// <summary>
+        /// The key could not be mapped with the currently cached routing/partition-key definition
+        /// and the caller should refresh its caches and retry (historically the gateway returned null).
+        /// </summary>
+        NeedsRefresh,
+
+        /// <summary>
+        /// The supplied key has a different number of components than the (up-to-date) partition-key
+        /// definition, so it is a genuine mismatch (historically the gateway threw a 400 PartitionKeyMismatch).
+        /// </summary>
+        KeyMismatch,
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Routing/AddressResolverPartitionKeyResolutionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Routing/AddressResolverPartitionKeyResolutionTests.cs
@@ -103,7 +103,7 @@ namespace Microsoft.Azure.Cosmos.Tests.Routing
         }
 
         [TestMethod]
-        public void U31_PartialHierarchicalPrefix_StaleCache_NeedsRefresh()
+        public void U31_PartialHierarchicalPrefix_StaleCache_StaleMetadata()
         {
             ContainerProperties collection = HierarchicalContainer();
             CollectionRoutingMap routingMap = SingleRangeRoutingMap();
@@ -117,15 +117,15 @@ namespace Microsoft.Azure.Cosmos.Tests.Routing
                 collectionCacheUptoDate: false,
                 out PartitionKeyRange range);
 
-            Assert.AreEqual(PartitionKeyRangeResolutionKind.NeedsRefresh, kind);
+            Assert.AreEqual(PartitionKeyRangeResolutionKind.StaleMetadata, kind);
             Assert.IsNull(range);
         }
 
         [TestMethod]
-        public void U31_NoOwningRange_NeedsRefresh_Unreachable_Documented()
+        public void U31_NoOwningRange_StaleMetadata_Unreachable_Documented()
         {
-            // U3.1 lists "key with no owning range => NeedsRefresh". That branch maps a null
-            // GetRangeByEffectivePartitionKey result to NeedsRefresh, but it is defensive-only: a
+            // U3.1 lists "key with no owning range => StaleMetadata". That branch maps a null
+            // GetRangeByEffectivePartitionKey result to StaleMetadata, but it is defensive-only: a
             // *complete* CollectionRoutingMap always returns a containing range for an in-bounds key, and
             // the class is sealed with a non-virtual lookup, so no real map or mock can yield a null range.
             // This test documents that unreachability; the full key below therefore resolves.

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Routing/AddressResolverPartitionKeyResolutionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Routing/AddressResolverPartitionKeyResolutionTests.cs
@@ -1,0 +1,269 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Tests.Routing
+{
+    using System;
+    using System.Collections.ObjectModel;
+    using System.Globalization;
+    using Microsoft.Azure.Cosmos.Routing;
+    using Microsoft.Azure.Documents;
+    using Microsoft.Azure.Documents.Collections;
+    using Microsoft.Azure.Documents.Routing;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    /// <summary>
+    /// Unit tests for the shared, request-free partition-key -> range core
+    /// (<see cref="AddressResolver.TryResolvePartitionKeyToRange"/>) and the gateway wrapper
+    /// (<see cref="AddressResolver.TryResolveServerPartitionByPartitionKey"/>) that translates the core's
+    /// result back into the gateway's historical throw/return-null contract.
+    /// </summary>
+    [TestClass]
+    public class AddressResolverPartitionKeyResolutionTests
+    {
+        private const string CollectionRid = "OVJwAA==";
+        private const string DocumentPath = "dbs/OVJwAA==/colls/OVJwAOcMtA0=/docs/OVJwAOcMtA0BAAAAAAAAAA==/";
+
+        // ---------- U3.1: TryResolvePartitionKeyToRange matrix ----------
+
+        [TestMethod]
+        public void U31_FullKey_Resolves_ToOwningRange()
+        {
+            ContainerProperties collection = SinglePathContainer();
+            CollectionRoutingMap routingMap = SingleRangeRoutingMap();
+            PartitionKeyInternal fullKey = PartitionKeyInternal.FromJsonString("[\"a\"]");
+
+            AddressResolver.PartitionKeyRangeResolutionKind kind = AddressResolver.TryResolvePartitionKeyToRange(
+                fullKey,
+                collection,
+                routingMap,
+                collectionCacheUptoDate: true,
+                out PartitionKeyRange range);
+
+            Assert.AreEqual(AddressResolver.PartitionKeyRangeResolutionKind.Resolved, kind);
+            Assert.IsNotNull(range);
+            Assert.AreEqual("0", range.Id);
+        }
+
+        [TestMethod]
+        public void U31_EmptyKey_Resolves()
+        {
+            ContainerProperties collection = SinglePathContainer();
+            CollectionRoutingMap routingMap = SingleRangeRoutingMap();
+
+            AddressResolver.PartitionKeyRangeResolutionKind kind = AddressResolver.TryResolvePartitionKeyToRange(
+                PartitionKeyInternal.Empty,
+                collection,
+                routingMap,
+                collectionCacheUptoDate: true,
+                out PartitionKeyRange range);
+
+            Assert.AreEqual(AddressResolver.PartitionKeyRangeResolutionKind.Resolved, kind);
+            Assert.IsNotNull(range);
+            Assert.AreEqual("0", range.Id);
+        }
+
+        [TestMethod]
+        public void U31_FullHierarchicalKey_Resolves()
+        {
+            ContainerProperties collection = HierarchicalContainer();
+            CollectionRoutingMap routingMap = SingleRangeRoutingMap();
+            PartitionKeyInternal fullKey = PartitionKeyInternal.FromJsonString("[\"a\",\"b\"]");
+
+            AddressResolver.PartitionKeyRangeResolutionKind kind = AddressResolver.TryResolvePartitionKeyToRange(
+                fullKey,
+                collection,
+                routingMap,
+                collectionCacheUptoDate: true,
+                out PartitionKeyRange range);
+
+            Assert.AreEqual(AddressResolver.PartitionKeyRangeResolutionKind.Resolved, kind);
+            Assert.IsNotNull(range);
+        }
+
+        [TestMethod]
+        public void U31_PartialHierarchicalPrefix_CacheUpToDate_IsKeyMismatch()
+        {
+            ContainerProperties collection = HierarchicalContainer();
+            CollectionRoutingMap routingMap = SingleRangeRoutingMap();
+
+            // Only the first of two defined paths supplied -> component count mismatch.
+            PartitionKeyInternal partialKey = PartitionKeyInternal.FromJsonString("[\"a\"]");
+
+            AddressResolver.PartitionKeyRangeResolutionKind kind = AddressResolver.TryResolvePartitionKeyToRange(
+                partialKey,
+                collection,
+                routingMap,
+                collectionCacheUptoDate: true,
+                out PartitionKeyRange range);
+
+            Assert.AreEqual(AddressResolver.PartitionKeyRangeResolutionKind.KeyMismatch, kind);
+            Assert.IsNull(range);
+        }
+
+        [TestMethod]
+        public void U31_PartialHierarchicalPrefix_StaleCache_NeedsRefresh()
+        {
+            ContainerProperties collection = HierarchicalContainer();
+            CollectionRoutingMap routingMap = SingleRangeRoutingMap();
+
+            PartitionKeyInternal partialKey = PartitionKeyInternal.FromJsonString("[\"a\"]");
+
+            AddressResolver.PartitionKeyRangeResolutionKind kind = AddressResolver.TryResolvePartitionKeyToRange(
+                partialKey,
+                collection,
+                routingMap,
+                collectionCacheUptoDate: false,
+                out PartitionKeyRange range);
+
+            Assert.AreEqual(AddressResolver.PartitionKeyRangeResolutionKind.NeedsRefresh, kind);
+            Assert.IsNull(range);
+        }
+
+        [TestMethod]
+        public void U31_NoOwningRange_NeedsRefresh_Unreachable_Documented()
+        {
+            // U3.1 lists "key with no owning range => NeedsRefresh". That branch maps a null
+            // GetRangeByEffectivePartitionKey result to NeedsRefresh, but it is defensive-only: a
+            // *complete* CollectionRoutingMap always returns a containing range for an in-bounds key, and
+            // the class is sealed with a non-virtual lookup, so no real map or mock can yield a null range.
+            // This test documents that unreachability; the full key below therefore resolves.
+            ContainerProperties collection = SinglePathContainer();
+            CollectionRoutingMap routingMap = SingleRangeRoutingMap();
+
+            AddressResolver.PartitionKeyRangeResolutionKind kind = AddressResolver.TryResolvePartitionKeyToRange(
+                PartitionKeyInternal.FromJsonString("[\"a\"]"),
+                collection,
+                routingMap,
+                collectionCacheUptoDate: true,
+                out PartitionKeyRange range);
+
+            Assert.AreEqual(AddressResolver.PartitionKeyRangeResolutionKind.Resolved, kind);
+            Assert.IsNotNull(range);
+        }
+
+        [TestMethod]
+        public void U31_NullArguments_Throw()
+        {
+            ContainerProperties collection = SinglePathContainer();
+            CollectionRoutingMap routingMap = SingleRangeRoutingMap();
+            PartitionKeyInternal key = PartitionKeyInternal.FromJsonString("[\"a\"]");
+
+            Assert.ThrowsException<ArgumentNullException>(() =>
+                AddressResolver.TryResolvePartitionKeyToRange(null, collection, routingMap, true, out _));
+            Assert.ThrowsException<ArgumentNullException>(() =>
+                AddressResolver.TryResolvePartitionKeyToRange(key, null, routingMap, true, out _));
+            Assert.ThrowsException<ArgumentNullException>(() =>
+                AddressResolver.TryResolvePartitionKeyToRange(key, collection, null, true, out _));
+        }
+
+        // ---------- R3.2: gateway wrapper translation ----------
+
+        [TestMethod]
+        public void R32_Wrapper_FullKey_ReturnsRange()
+        {
+            using DocumentServiceRequest request = CreateDocumentRequest();
+
+            PartitionKeyRange range = AddressResolver.TryResolveServerPartitionByPartitionKey(
+                request,
+                partitionKeyString: "[\"a\"]",
+                collectionCacheUptoDate: true,
+                collection: SinglePathContainer(),
+                routingMap: SingleRangeRoutingMap());
+
+            Assert.IsNotNull(range);
+            Assert.AreEqual("0", range.Id);
+        }
+
+        [TestMethod]
+        public void R32_Wrapper_KeyMismatch_Throws_PartitionKeyMismatch_With_ResourceAddress()
+        {
+            using DocumentServiceRequest request = CreateDocumentRequest();
+
+            BadRequestException exception = Assert.ThrowsException<BadRequestException>(() =>
+                AddressResolver.TryResolveServerPartitionByPartitionKey(
+                    request,
+                    partitionKeyString: "[\"a\"]", // one component against a two-path definition
+                    collectionCacheUptoDate: true,
+                    collection: HierarchicalContainer(),
+                    routingMap: SingleRangeRoutingMap()));
+
+            Assert.AreEqual(
+                ((uint)SubStatusCodes.PartitionKeyMismatch).ToString(CultureInfo.InvariantCulture),
+                exception.Headers[WFConstants.BackendHeaders.SubStatus]);
+            Assert.AreEqual(request.ResourceAddress, exception.ResourceAddress);
+        }
+
+        [TestMethod]
+        public void R32_Wrapper_StaleCachePartialKey_ReturnsNull()
+        {
+            using DocumentServiceRequest request = CreateDocumentRequest();
+
+            PartitionKeyRange range = AddressResolver.TryResolveServerPartitionByPartitionKey(
+                request,
+                partitionKeyString: "[\"a\"]",
+                collectionCacheUptoDate: false,
+                collection: HierarchicalContainer(),
+                routingMap: SingleRangeRoutingMap());
+
+            Assert.IsNull(range);
+        }
+
+        // ---------- helpers ----------
+
+        private static DocumentServiceRequest CreateDocumentRequest()
+        {
+            return DocumentServiceRequest.Create(
+                OperationType.Read,
+                ResourceType.Document,
+                DocumentPath,
+                AuthorizationTokenType.PrimaryMasterKey,
+                new DictionaryNameValueCollection());
+        }
+
+        private static ContainerProperties SinglePathContainer()
+        {
+            return new ContainerProperties()
+            {
+                Id = "id",
+                PartitionKey = new PartitionKeyDefinition()
+                {
+                    Kind = PartitionKind.Hash,
+                    Paths = new Collection<string>() { "/path1" },
+                    Version = PartitionKeyDefinitionVersion.V2,
+                },
+            };
+        }
+
+        private static ContainerProperties HierarchicalContainer()
+        {
+            return new ContainerProperties()
+            {
+                Id = "id",
+                PartitionKey = new PartitionKeyDefinition()
+                {
+                    Kind = PartitionKind.MultiHash,
+                    Paths = new Collection<string>() { "/path1", "/path2" },
+                    Version = PartitionKeyDefinitionVersion.V2,
+                },
+            };
+        }
+
+        private static CollectionRoutingMap SingleRangeRoutingMap()
+        {
+            CollectionRoutingMap routingMap = CollectionRoutingMap.TryCreateCompleteRoutingMap(
+                new[]
+                {
+                    Tuple.Create(
+                        new PartitionKeyRange { Id = "0", MinInclusive = string.Empty, MaxExclusive = "FF" },
+                        (ServiceIdentity)null),
+                },
+                CollectionRid,
+                useLengthAwareRangeComparer: false);
+
+            Assert.IsNotNull(routingMap);
+            return routingMap;
+        }
+    }
+}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Routing/AddressResolverPartitionKeyResolutionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Routing/AddressResolverPartitionKeyResolutionTests.cs
@@ -34,14 +34,14 @@ namespace Microsoft.Azure.Cosmos.Tests.Routing
             CollectionRoutingMap routingMap = SingleRangeRoutingMap();
             PartitionKeyInternal fullKey = PartitionKeyInternal.FromJsonString("[\"a\"]");
 
-            AddressResolver.PartitionKeyRangeResolutionKind kind = AddressResolver.TryResolvePartitionKeyToRange(
+            PartitionKeyRangeResolutionKind kind = AddressResolver.TryResolvePartitionKeyToRange(
                 fullKey,
                 collection,
                 routingMap,
                 collectionCacheUptoDate: true,
                 out PartitionKeyRange range);
 
-            Assert.AreEqual(AddressResolver.PartitionKeyRangeResolutionKind.Resolved, kind);
+            Assert.AreEqual(PartitionKeyRangeResolutionKind.Resolved, kind);
             Assert.IsNotNull(range);
             Assert.AreEqual("0", range.Id);
         }
@@ -52,14 +52,14 @@ namespace Microsoft.Azure.Cosmos.Tests.Routing
             ContainerProperties collection = SinglePathContainer();
             CollectionRoutingMap routingMap = SingleRangeRoutingMap();
 
-            AddressResolver.PartitionKeyRangeResolutionKind kind = AddressResolver.TryResolvePartitionKeyToRange(
+            PartitionKeyRangeResolutionKind kind = AddressResolver.TryResolvePartitionKeyToRange(
                 PartitionKeyInternal.Empty,
                 collection,
                 routingMap,
                 collectionCacheUptoDate: true,
                 out PartitionKeyRange range);
 
-            Assert.AreEqual(AddressResolver.PartitionKeyRangeResolutionKind.Resolved, kind);
+            Assert.AreEqual(PartitionKeyRangeResolutionKind.Resolved, kind);
             Assert.IsNotNull(range);
             Assert.AreEqual("0", range.Id);
         }
@@ -71,14 +71,14 @@ namespace Microsoft.Azure.Cosmos.Tests.Routing
             CollectionRoutingMap routingMap = SingleRangeRoutingMap();
             PartitionKeyInternal fullKey = PartitionKeyInternal.FromJsonString("[\"a\",\"b\"]");
 
-            AddressResolver.PartitionKeyRangeResolutionKind kind = AddressResolver.TryResolvePartitionKeyToRange(
+            PartitionKeyRangeResolutionKind kind = AddressResolver.TryResolvePartitionKeyToRange(
                 fullKey,
                 collection,
                 routingMap,
                 collectionCacheUptoDate: true,
                 out PartitionKeyRange range);
 
-            Assert.AreEqual(AddressResolver.PartitionKeyRangeResolutionKind.Resolved, kind);
+            Assert.AreEqual(PartitionKeyRangeResolutionKind.Resolved, kind);
             Assert.IsNotNull(range);
         }
 
@@ -91,14 +91,14 @@ namespace Microsoft.Azure.Cosmos.Tests.Routing
             // Only the first of two defined paths supplied -> component count mismatch.
             PartitionKeyInternal partialKey = PartitionKeyInternal.FromJsonString("[\"a\"]");
 
-            AddressResolver.PartitionKeyRangeResolutionKind kind = AddressResolver.TryResolvePartitionKeyToRange(
+            PartitionKeyRangeResolutionKind kind = AddressResolver.TryResolvePartitionKeyToRange(
                 partialKey,
                 collection,
                 routingMap,
                 collectionCacheUptoDate: true,
                 out PartitionKeyRange range);
 
-            Assert.AreEqual(AddressResolver.PartitionKeyRangeResolutionKind.KeyMismatch, kind);
+            Assert.AreEqual(PartitionKeyRangeResolutionKind.KeyMismatch, kind);
             Assert.IsNull(range);
         }
 
@@ -110,14 +110,14 @@ namespace Microsoft.Azure.Cosmos.Tests.Routing
 
             PartitionKeyInternal partialKey = PartitionKeyInternal.FromJsonString("[\"a\"]");
 
-            AddressResolver.PartitionKeyRangeResolutionKind kind = AddressResolver.TryResolvePartitionKeyToRange(
+            PartitionKeyRangeResolutionKind kind = AddressResolver.TryResolvePartitionKeyToRange(
                 partialKey,
                 collection,
                 routingMap,
                 collectionCacheUptoDate: false,
                 out PartitionKeyRange range);
 
-            Assert.AreEqual(AddressResolver.PartitionKeyRangeResolutionKind.NeedsRefresh, kind);
+            Assert.AreEqual(PartitionKeyRangeResolutionKind.NeedsRefresh, kind);
             Assert.IsNull(range);
         }
 
@@ -132,14 +132,14 @@ namespace Microsoft.Azure.Cosmos.Tests.Routing
             ContainerProperties collection = SinglePathContainer();
             CollectionRoutingMap routingMap = SingleRangeRoutingMap();
 
-            AddressResolver.PartitionKeyRangeResolutionKind kind = AddressResolver.TryResolvePartitionKeyToRange(
+            PartitionKeyRangeResolutionKind kind = AddressResolver.TryResolvePartitionKeyToRange(
                 PartitionKeyInternal.FromJsonString("[\"a\"]"),
                 collection,
                 routingMap,
                 collectionCacheUptoDate: true,
                 out PartitionKeyRange range);
 
-            Assert.AreEqual(AddressResolver.PartitionKeyRangeResolutionKind.Resolved, kind);
+            Assert.AreEqual(PartitionKeyRangeResolutionKind.Resolved, kind);
             Assert.IsNotNull(range);
         }
 


### PR DESCRIPTION
## Why

`AddressResolver.TryResolveServerPartitionByPartitionKey` (the gateway point-operation hot path) owns the canonical logic for mapping a partition key to its owning `PartitionKeyRange`: the empty-or-full-key **component-count guard**, effective-key computation, and `GetRangeByEffectivePartitionKey` lookup. Other code paths (notably the distributed-transaction session-token resolver) need the *same* mapping, and re-implementing it has already caused drift once — the DTX component-count guard was missing until it was added later to match this method. Duplicated resolution logic will drift again.

This PR extracts a **request-free shared core** so the two paths can't diverge, without changing any observable gateway behavior.

## What

- New `internal enum PartitionKeyRangeResolutionKind { Resolved, NeedsRefresh, KeyMismatch }`.
- New `internal static PartitionKeyRangeResolutionKind TryResolvePartitionKeyToRange(PartitionKeyInternal, ContainerProperties, CollectionRoutingMap, bool collectionCacheUptoDate, out PartitionKeyRange)` — the single source of truth for the component-count guard + effective-key + range lookup. It **returns** a classification instead of throwing / returning `null`.
- `TryResolveServerPartitionByPartitionKey` keeps all its `DocumentServiceRequest` handling (null-checks, JSON parse, `ResourceAddress` decoration) and **translates the core result byte-for-byte**:
  - `Resolved` → return the range
  - `KeyMismatch` → throw `BadRequestException(RMResources.PartitionKeyMismatch)` with the `PartitionKeyMismatch` substatus + `ResourceAddress`
  - `NeedsRefresh` → return `null`

All three existing call sites are unchanged, and the gateway's throw/return-null contract is preserved exactly.

## Follow-up (separate PR / branch)

The distributed-transaction resolver hookup — calling this shared core and deleting its private inline component-count guard — lands on the DTX session-token branch during its post-merge rebase, so this risky gateway-hot-path change ships isolated.

## Tests

New `AddressResolverPartitionKeyResolutionTests`:
- Core matrix: full key ⇒ `Resolved`+range; empty key ⇒ `Resolved`; partial (hierarchical prefix) + cache up-to-date ⇒ `KeyMismatch`; partial + stale ⇒ `NeedsRefresh`; null-arg guards throw.
- Gateway wrapper: `KeyMismatch` ⇒ throws `BadRequestException` with `PartitionKeyMismatch` substatus + `ResourceAddress`; stale partial key ⇒ `null`; full key ⇒ range.

Local validation (net6.0): src Release build clean; test project Debug build clean; **239/239** tests pass across the `AddressResolver`, `DistributedTransaction`, `SessionContainer`, and `GatewayStoreModel` filters (10 new + 229 pre-existing regression).

## Changelog

No entry required — pure internal refactor with gateway behavior preserved byte-for-byte and no customer-observable change (per the repo changelog classifier).