### PR TITLE
Add WithRawJsonParameter method to QueryDefinition

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryDefinition.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/QueryDefinition.cs
@@ -148,6 +148,30 @@ namespace Microsoft.Azure.Cosmos
         }
 
         /// <summary>
+        /// Add a raw json string parameter to the SQL query.
+        /// </summary>
+        /// <param name="name">The name of the parameter.</param>
+        /// <param name="jsonString">The raw JSON string value for the parameter.</param>
+        /// <example>
+        /// <code language="c#">
+        /// <![CDATA[
+        /// QueryDefinition query = new QueryDefinition(
+        ///     "select * from t where t.Account = @account")
+        ///     .WithRawJsonParameter("@account", jsonValue);
+        /// ]]>
+        /// </code>
+        /// </example>
+        /// <returns>An instance of <see cref="QueryDefinition"/>.</returns>
+        public QueryDefinition WithRawJsonParameter(string name, string jsonString)
+        {
+            // pack it into an internal type for identification.
+            return this.WithParameter(name, new SerializedParameterValue
+            {
+                rawSerializedJsonValue = jsonString
+            });
+        }
+
+        /// <summary>
         /// Returns the names and values of parameters in this <see cref="QueryDefinition"/>.
         /// </summary>
         /// <returns>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -1654,6 +1654,242 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
+        public async Task QueryRawJsonValueTest()
+        {
+            DateTime createDateTime = DateTime.UtcNow;
+
+            static string ToJsonString(Stream stream)
+            {
+                using (stream)
+                using (StreamReader streamReader = new StreamReader(stream, Encoding.UTF8))
+                {
+                    return streamReader.ReadToEnd();
+                }
+            }
+
+            dynamic testItem1 = new
+            {
+                id = "testItem1",
+                cost = (double?)null,
+                totalCost = 98.2789,
+                pk = "MyCustomStatus",
+                taskNum = 4909,
+                createdDateTime = createDateTime,
+                statusCode = HttpStatusCode.Accepted,
+                itemIds = new int[] { 1, 5, 10 },
+                itemcode = new byte?[5] { 0x16, (byte)'\0', 0x3, null, (byte)'}' },
+            };
+
+            dynamic testItem2 = new
+            {
+                id = "testItem2",
+                cost = (double?)null,
+                totalCost = 98.2789,
+                pk = "MyCustomStatus",
+                taskNum = 4909,
+                createdDateTime = createDateTime,
+                statusCode = HttpStatusCode.Accepted,
+                itemIds = new int[] { 1, 5, 10 },
+                itemcode = new byte?[5] { 0x16, (byte)'\0', 0x3, null, (byte)'}' },
+            };
+
+            //with Custom Serializer.
+            JsonSerializerSettings jsonSerializerSettings = new JsonSerializerSettings()
+            {
+                Converters = new List<JsonConverter>() { new CosmosSerializerHelper.FormatNumbersAsTextConverter() }
+            };
+
+            int toStreamCount = 0;
+            int fromStreamCount = 0;
+            CosmosSerializerHelper cosmosSerializerHelper = new CosmosSerializerHelper(
+                jsonSerializerSettings,
+                toStreamCallBack: (itemValue) =>
+                {
+                    Type itemType = itemValue?.GetType();
+                    if (itemValue == null
+                        || itemType == typeof(int)
+                        || itemType == typeof(double)
+                        || itemType == typeof(string)
+                        || itemType == typeof(DateTime)
+                        || itemType == typeof(HttpStatusCode)
+                        || itemType == typeof(int[])
+                        || itemType == typeof(byte))
+                    {
+                        toStreamCount++;
+                    }
+                },
+                fromStreamCallback: (item) => fromStreamCount++);
+
+            CosmosClientOptions options = new CosmosClientOptions()
+            {
+                Serializer = cosmosSerializerHelper
+            };
+
+            CosmosClient clientSerializer = TestCommon.CreateCosmosClient(options);
+            Container containerSerializer = clientSerializer.GetContainer(this.database.Id, this.Container.Id);
+
+            List<QueryDefinition> queryDefinitions = new List<QueryDefinition>()
+            {
+                new QueryDefinition("select * from t where t.pk = @pk" )
+                .WithRawJsonParameter("@pk", ToJsonString(cosmosSerializerHelper.ToStream<dynamic>(testItem1.pk))),
+                new QueryDefinition("select * from t where t.cost = @cost" )
+                .WithRawJsonParameter("@cost", ToJsonString(cosmosSerializerHelper.ToStream<dynamic>(testItem1.cost))),
+                new QueryDefinition("select * from t where t.taskNum = @taskNum" )
+                .WithRawJsonParameter("@taskNum", ToJsonString(cosmosSerializerHelper.ToStream<dynamic>(testItem1.taskNum))),
+                new QueryDefinition("select * from t where t.totalCost = @totalCost" )
+                .WithRawJsonParameter("@totalCost", ToJsonString(cosmosSerializerHelper.ToStream<dynamic>(testItem1.totalCost))),
+                new QueryDefinition("select * from t where t.createdDateTime = @createdDateTime" )
+                .WithRawJsonParameter("@createdDateTime", ToJsonString(cosmosSerializerHelper.ToStream<dynamic>(testItem1.createdDateTime))),
+                new QueryDefinition("select * from t where t.statusCode = @statusCode" )
+                .WithRawJsonParameter("@statusCode", ToJsonString(cosmosSerializerHelper.ToStream<dynamic>(testItem1.statusCode))),
+                new QueryDefinition("select * from t where t.itemIds = @itemIds" )
+                .WithRawJsonParameter("@itemIds", ToJsonString(cosmosSerializerHelper.ToStream<dynamic>(testItem1.itemIds))),
+                new QueryDefinition("select * from t where t.itemcode = @itemcode" )
+                .WithRawJsonParameter("@itemcode", ToJsonString(cosmosSerializerHelper.ToStream<dynamic>(testItem1.itemcode))),
+                new QueryDefinition("select * from t where t.pk = @pk and t.cost = @cost" )
+                    .WithRawJsonParameter("@pk", ToJsonString(cosmosSerializerHelper.ToStream<dynamic>(testItem1.pk)))
+                    .WithRawJsonParameter("@cost", ToJsonString(cosmosSerializerHelper.ToStream<dynamic>(testItem1.cost))),
+            };
+
+            try
+            {
+                await containerSerializer.CreateItemAsync<dynamic>(testItem1);
+                await containerSerializer.CreateItemAsync<dynamic>(testItem2);
+            }
+            catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.Conflict)
+            {
+                // Ignore conflicts since the object already exists
+            }
+
+            foreach (QueryDefinition queryDefinition in queryDefinitions)
+            {
+                toStreamCount = 0;
+                fromStreamCount = 0;
+
+                List<dynamic> allItems = new List<dynamic>();
+                int pageCount = 0;
+                using (FeedIterator<dynamic> feedIterator = containerSerializer.GetItemQueryIterator<dynamic>(
+                    queryDefinition: queryDefinition))
+                {
+                    while (feedIterator.HasMoreResults)
+                    {
+                        // Only need once to verify correct serialization of the query definition
+                        FeedResponse<dynamic> response = await feedIterator.ReadNextAsync(this.cancellationToken);
+                        string diagnosticString = response.Diagnostics.ToString();
+                        Assert.IsTrue(diagnosticString.Contains("Query Response Serialization"));
+                        Assert.AreEqual(response.Count, response.Count());
+                        allItems.AddRange(response);
+                        pageCount++;
+                    }
+                }
+
+                Assert.AreEqual(2, allItems.Count, $"missing query results. Only found: {allItems.Count} items for query:{queryDefinition.ToSqlQuerySpec().QueryText}");
+
+                // There should be no call to custom serializer since the parameter values are already serialized.
+                Assert.AreEqual(0, toStreamCount, $"missing to stream call. Expected: 0 , Actual: {toStreamCount} for query:{queryDefinition.ToSqlQuerySpec().QueryText}");
+                Assert.AreEqual(pageCount, fromStreamCount);
+            }
+
+            // get result across pages,multiple requests by setting MaxItemCount to 1.
+            foreach (QueryDefinition queryDefinition in queryDefinitions)
+            {
+                toStreamCount = 0;
+                fromStreamCount = 0;
+
+                List<dynamic> allItems = new List<dynamic>();
+                int pageCount = 0;
+                using (FeedIterator<dynamic> feedIterator = containerSerializer.GetItemQueryIterator<dynamic>(
+                    queryDefinition: queryDefinition,
+                    requestOptions: new QueryRequestOptions { MaxItemCount = 1 }))
+                {
+                    while (feedIterator.HasMoreResults)
+                    {
+                        // Only need once to verify correct serialization of the query definition
+                        FeedResponse<dynamic> response = await feedIterator.ReadNextAsync(this.cancellationToken);
+                        Assert.AreEqual(response.Count, response.Count());
+                        allItems.AddRange(response);
+                        pageCount++;
+                    }
+                }
+
+                Assert.AreEqual(2, allItems.Count, $"missing query results. Only found: {allItems.Count} items for query:{queryDefinition.ToSqlQuerySpec().QueryText}");
+
+                // There should be no call to custom serializer since the parameter values are already serialized.
+                Assert.AreEqual(0, toStreamCount, $"missing to stream call. Expected: 0 , Actual: {toStreamCount} for query:{queryDefinition.ToSqlQuerySpec().QueryText}");
+                Assert.AreEqual(pageCount, fromStreamCount);
+            }
+
+
+            // Standard Cosmos Serializer Used
+
+            CosmosClient clientStandardSerializer = TestCommon.CreateCosmosClient(useCustomSeralizer: false);
+            Container containerStandardSerializer = clientStandardSerializer.GetContainer(this.database.Id, this.Container.Id);
+
+            testItem1 = ToDoActivity.CreateRandomToDoActivity();
+            testItem1.pk = "myPk";
+            await containerStandardSerializer.CreateItemAsync(testItem1, new Cosmos.PartitionKey(testItem1.pk));
+
+            testItem2 = ToDoActivity.CreateRandomToDoActivity();
+            testItem2.pk = "myPk";
+            await containerStandardSerializer.CreateItemAsync(testItem2, new Cosmos.PartitionKey(testItem2.pk));
+            CosmosSerializer cosmosSerializer = containerStandardSerializer.Database.Client.ClientOptions.Serializer;
+
+            queryDefinitions = new List<QueryDefinition>()
+            {
+                new QueryDefinition("select * from t where t.pk = @pk" )
+                .WithRawJsonParameter("@pk", ToJsonString(cosmosSerializer.ToStream(testItem1.pk))),
+                new QueryDefinition("select * from t where t.cost = @cost" )
+                .WithRawJsonParameter("@cost", ToJsonString(cosmosSerializer.ToStream(testItem1.cost))),
+                new QueryDefinition("select * from t where t.taskNum = @taskNum" )
+                .WithRawJsonParameter("@taskNum", ToJsonString(cosmosSerializer.ToStream(testItem1.taskNum))),
+                new QueryDefinition("select * from t where t.CamelCase = @CamelCase" )
+                .WithRawJsonParameter("@CamelCase", ToJsonString(cosmosSerializer.ToStream(testItem1.CamelCase))),
+                new QueryDefinition("select * from t where t.valid = @valid" )
+                .WithRawJsonParameter("@valid", ToJsonString(cosmosSerializer.ToStream(testItem1.valid))),
+                new QueryDefinition("select * from t where t.description = @description" )
+                .WithRawJsonParameter("@description", ToJsonString(cosmosSerializer.ToStream(testItem1.description))),
+                new QueryDefinition("select * from t where t.pk = @pk and t.cost = @cost" )
+                    .WithRawJsonParameter("@pk", ToJsonString(cosmosSerializer.ToStream(testItem1.pk)))
+                    .WithRawJsonParameter("@cost", ToJsonString(cosmosSerializer.ToStream(testItem1.cost))),
+            };
+
+            foreach (QueryDefinition queryDefinition in queryDefinitions)
+            {
+                List<ToDoActivity> allItems = new List<ToDoActivity>();
+                int pageCount = 0;
+                using (FeedIterator<ToDoActivity> feedIterator = containerStandardSerializer.GetItemQueryIterator<ToDoActivity>(
+                    queryDefinition: queryDefinition))
+                {
+                    while (feedIterator.HasMoreResults)
+                    {
+                        // Only need once to verify correct serialization of the query definition
+                        FeedResponse<ToDoActivity> response = await feedIterator.ReadNextAsync(this.cancellationToken);
+                        Assert.AreEqual(response.Count, response.Count());
+                        allItems.AddRange(response);
+                        pageCount++;
+                    }
+                }
+
+                Assert.AreEqual(2, allItems.Count, $"missing query results. Only found: {allItems.Count} items for query:{queryDefinition.ToSqlQuerySpec().QueryText}");
+                if (queryDefinition.QueryText.Contains("pk"))
+                {
+                    Assert.AreEqual(1, pageCount);
+                }
+                else
+                {
+                    Assert.AreEqual(3, pageCount);
+                }
+
+
+
+                IReadOnlyList<(string Name, object Value)> parameters1 = queryDefinition.GetQueryParameters();
+                IReadOnlyList<(string Name, object Value)> parameters2 = queryDefinition.GetQueryParameters();
+
+                Assert.AreSame(parameters1, parameters2);
+            }
+        }
+
+        [TestMethod]
         public async Task ItemIterator()
         {
             IList<ToDoActivity> deleteList = await ToDoActivity.CreateRandomItems(this.Container, 3, randomPartitionKey: true);

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -1729,27 +1729,27 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Container containerSerializer = clientSerializer.GetContainer(this.database.Id, this.Container.Id);
 
             List<QueryDefinition> queryDefinitions = new List<QueryDefinition>()
-            {
-                new QueryDefinition("select * from t where t.pk = @pk" )
-                .WithRawJsonParameter("@pk", ToJsonString(cosmosSerializerHelper.ToStream<dynamic>(testItem1.pk))),
-                new QueryDefinition("select * from t where t.cost = @cost" )
-                .WithRawJsonParameter("@cost", ToJsonString(cosmosSerializerHelper.ToStream<dynamic>(testItem1.cost))),
-                new QueryDefinition("select * from t where t.taskNum = @taskNum" )
-                .WithRawJsonParameter("@taskNum", ToJsonString(cosmosSerializerHelper.ToStream<dynamic>(testItem1.taskNum))),
-                new QueryDefinition("select * from t where t.totalCost = @totalCost" )
-                .WithRawJsonParameter("@totalCost", ToJsonString(cosmosSerializerHelper.ToStream<dynamic>(testItem1.totalCost))),
-                new QueryDefinition("select * from t where t.createdDateTime = @createdDateTime" )
-                .WithRawJsonParameter("@createdDateTime", ToJsonString(cosmosSerializerHelper.ToStream<dynamic>(testItem1.createdDateTime))),
-                new QueryDefinition("select * from t where t.statusCode = @statusCode" )
-                .WithRawJsonParameter("@statusCode", ToJsonString(cosmosSerializerHelper.ToStream<dynamic>(testItem1.statusCode))),
-                new QueryDefinition("select * from t where t.itemIds = @itemIds" )
-                .WithRawJsonParameter("@itemIds", ToJsonString(cosmosSerializerHelper.ToStream<dynamic>(testItem1.itemIds))),
-                new QueryDefinition("select * from t where t.itemcode = @itemcode" )
-                .WithRawJsonParameter("@itemcode", ToJsonString(cosmosSerializerHelper.ToStream<dynamic>(testItem1.itemcode))),
-                new QueryDefinition("select * from t where t.pk = @pk and t.cost = @cost" )
-                    .WithRawJsonParameter("@pk", ToJsonString(cosmosSerializerHelper.ToStream<dynamic>(testItem1.pk)))
-                    .WithRawJsonParameter("@cost", ToJsonString(cosmosSerializerHelper.ToStream<dynamic>(testItem1.cost))),
-            };
+    {
+        new QueryDefinition("select * from t where t.pk = @pk" )
+        .WithRawJsonParameter("@pk", ToJsonString(cosmosSerializerHelper.ToStream<dynamic>(testItem1.pk))),
+        new QueryDefinition("select * from t where t.cost = @cost" )
+        .WithRawJsonParameter("@cost", ToJsonString(cosmosSerializerHelper.ToStream<dynamic>(testItem1.cost))),
+        new QueryDefinition("select * from t where t.taskNum = @taskNum" )
+        .WithRawJsonParameter("@taskNum", ToJsonString(cosmosSerializerHelper.ToStream<dynamic>(testItem1.taskNum))),
+        new QueryDefinition("select * from t where t.totalCost = @totalCost" )
+        .WithRawJsonParameter("@totalCost", ToJsonString(cosmosSerializerHelper.ToStream<dynamic>(testItem1.totalCost))),
+        new QueryDefinition("select * from t where t.createdDateTime = @createdDateTime" )
+        .WithRawJsonParameter("@createdDateTime", ToJsonString(cosmosSerializerHelper.ToStream<dynamic>(testItem1.createdDateTime))),
+        new QueryDefinition("select * from t where t.statusCode = @statusCode" )
+        .WithRawJsonParameter("@statusCode", ToJsonString(cosmosSerializerHelper.ToStream<dynamic>(testItem1.statusCode))),
+        new QueryDefinition("select * from t where t.itemIds = @itemIds" )
+        .WithRawJsonParameter("@itemIds", ToJsonString(cosmosSerializerHelper.ToStream<dynamic>(testItem1.itemIds))),
+        new QueryDefinition("select * from t where t.itemcode = @itemcode" )
+        .WithRawJsonParameter("@itemcode", ToJsonString(cosmosSerializerHelper.ToStream<dynamic>(testItem1.itemcode))),
+        new QueryDefinition("select * from t where t.pk = @pk and t.cost = @cost" )
+            .WithRawJsonParameter("@pk", ToJsonString(cosmosSerializerHelper.ToStream<dynamic>(testItem1.pk)))
+            .WithRawJsonParameter("@cost", ToJsonString(cosmosSerializerHelper.ToStream<dynamic>(testItem1.cost))),
+    };
 
             try
             {
@@ -1835,23 +1835,23 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             CosmosSerializer cosmosSerializer = containerStandardSerializer.Database.Client.ClientOptions.Serializer;
 
             queryDefinitions = new List<QueryDefinition>()
-            {
-                new QueryDefinition("select * from t where t.pk = @pk" )
-                .WithRawJsonParameter("@pk", ToJsonString(cosmosSerializer.ToStream(testItem1.pk))),
-                new QueryDefinition("select * from t where t.cost = @cost" )
-                .WithRawJsonParameter("@cost", ToJsonString(cosmosSerializer.ToStream(testItem1.cost))),
-                new QueryDefinition("select * from t where t.taskNum = @taskNum" )
-                .WithRawJsonParameter("@taskNum", ToJsonString(cosmosSerializer.ToStream(testItem1.taskNum))),
-                new QueryDefinition("select * from t where t.CamelCase = @CamelCase" )
-                .WithRawJsonParameter("@CamelCase", ToJsonString(cosmosSerializer.ToStream(testItem1.CamelCase))),
-                new QueryDefinition("select * from t where t.valid = @valid" )
-                .WithRawJsonParameter("@valid", ToJsonString(cosmosSerializer.ToStream(testItem1.valid))),
-                new QueryDefinition("select * from t where t.description = @description" )
-                .WithRawJsonParameter("@description", ToJsonString(cosmosSerializer.ToStream(testItem1.description))),
-                new QueryDefinition("select * from t where t.pk = @pk and t.cost = @cost" )
-                    .WithRawJsonParameter("@pk", ToJsonString(cosmosSerializer.ToStream(testItem1.pk)))
-                    .WithRawJsonParameter("@cost", ToJsonString(cosmosSerializer.ToStream(testItem1.cost))),
-            };
+    {
+        new QueryDefinition("select * from t where t.pk = @pk" )
+        .WithRawJsonParameter("@pk", ToJsonString(cosmosSerializer.ToStream(testItem1.pk))),
+        new QueryDefinition("select * from t where t.cost = @cost" )
+        .WithRawJsonParameter("@cost", ToJsonString(cosmosSerializer.ToStream(testItem1.cost))),
+        new QueryDefinition("select * from t where t.taskNum = @taskNum" )
+        .WithRawJsonParameter("@taskNum", ToJsonString(cosmosSerializer.ToStream(testItem1.taskNum))),
+        new QueryDefinition("select * from t where t.CamelCase = @CamelCase" )
+        .WithRawJsonParameter("@CamelCase", ToJsonString(cosmosSerializer.ToStream(testItem1.CamelCase))),
+        new QueryDefinition("select * from t where t.valid = @valid" )
+        .WithRawJsonParameter("@valid", ToJsonString(cosmosSerializer.ToStream(testItem1.valid))),
+        new QueryDefinition("select * from t where t.description = @description" )
+        .WithRawJsonParameter("@description", ToJsonString(cosmosSerializer.ToStream(testItem1.description))),
+        new QueryDefinition("select * from t where t.pk = @pk and t.cost = @cost" )
+            .WithRawJsonParameter("@pk", ToJsonString(cosmosSerializer.ToStream(testItem1.pk)))
+            .WithRawJsonParameter("@cost", ToJsonString(cosmosSerializer.ToStream(testItem1.cost))),
+    };
 
             foreach (QueryDefinition queryDefinition in queryDefinitions)
             {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemTests.cs
@@ -1729,27 +1729,27 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Container containerSerializer = clientSerializer.GetContainer(this.database.Id, this.Container.Id);
 
             List<QueryDefinition> queryDefinitions = new List<QueryDefinition>()
-    {
-        new QueryDefinition("select * from t where t.pk = @pk" )
-        .WithRawJsonParameter("@pk", ToJsonString(cosmosSerializerHelper.ToStream<dynamic>(testItem1.pk))),
-        new QueryDefinition("select * from t where t.cost = @cost" )
-        .WithRawJsonParameter("@cost", ToJsonString(cosmosSerializerHelper.ToStream<dynamic>(testItem1.cost))),
-        new QueryDefinition("select * from t where t.taskNum = @taskNum" )
-        .WithRawJsonParameter("@taskNum", ToJsonString(cosmosSerializerHelper.ToStream<dynamic>(testItem1.taskNum))),
-        new QueryDefinition("select * from t where t.totalCost = @totalCost" )
-        .WithRawJsonParameter("@totalCost", ToJsonString(cosmosSerializerHelper.ToStream<dynamic>(testItem1.totalCost))),
-        new QueryDefinition("select * from t where t.createdDateTime = @createdDateTime" )
-        .WithRawJsonParameter("@createdDateTime", ToJsonString(cosmosSerializerHelper.ToStream<dynamic>(testItem1.createdDateTime))),
-        new QueryDefinition("select * from t where t.statusCode = @statusCode" )
-        .WithRawJsonParameter("@statusCode", ToJsonString(cosmosSerializerHelper.ToStream<dynamic>(testItem1.statusCode))),
-        new QueryDefinition("select * from t where t.itemIds = @itemIds" )
-        .WithRawJsonParameter("@itemIds", ToJsonString(cosmosSerializerHelper.ToStream<dynamic>(testItem1.itemIds))),
-        new QueryDefinition("select * from t where t.itemcode = @itemcode" )
-        .WithRawJsonParameter("@itemcode", ToJsonString(cosmosSerializerHelper.ToStream<dynamic>(testItem1.itemcode))),
-        new QueryDefinition("select * from t where t.pk = @pk and t.cost = @cost" )
-            .WithRawJsonParameter("@pk", ToJsonString(cosmosSerializerHelper.ToStream<dynamic>(testItem1.pk)))
-            .WithRawJsonParameter("@cost", ToJsonString(cosmosSerializerHelper.ToStream<dynamic>(testItem1.cost))),
-    };
+            {
+                new QueryDefinition("select * from t where t.pk = @pk" )
+                .WithRawJsonParameter("@pk", ToJsonString(cosmosSerializerHelper.ToStream<dynamic>(testItem1.pk))),
+                new QueryDefinition("select * from t where t.cost = @cost" )
+                .WithRawJsonParameter("@cost", ToJsonString(cosmosSerializerHelper.ToStream<dynamic>(testItem1.cost))),
+                new QueryDefinition("select * from t where t.taskNum = @taskNum" )
+                .WithRawJsonParameter("@taskNum", ToJsonString(cosmosSerializerHelper.ToStream<dynamic>(testItem1.taskNum))),
+                new QueryDefinition("select * from t where t.totalCost = @totalCost" )
+                .WithRawJsonParameter("@totalCost", ToJsonString(cosmosSerializerHelper.ToStream<dynamic>(testItem1.totalCost))),
+                new QueryDefinition("select * from t where t.createdDateTime = @createdDateTime" )
+                .WithRawJsonParameter("@createdDateTime", ToJsonString(cosmosSerializerHelper.ToStream<dynamic>(testItem1.createdDateTime))),
+                new QueryDefinition("select * from t where t.statusCode = @statusCode" )
+                .WithRawJsonParameter("@statusCode", ToJsonString(cosmosSerializerHelper.ToStream<dynamic>(testItem1.statusCode))),
+                new QueryDefinition("select * from t where t.itemIds = @itemIds" )
+                .WithRawJsonParameter("@itemIds", ToJsonString(cosmosSerializerHelper.ToStream<dynamic>(testItem1.itemIds))),
+                new QueryDefinition("select * from t where t.itemcode = @itemcode" )
+                .WithRawJsonParameter("@itemcode", ToJsonString(cosmosSerializerHelper.ToStream<dynamic>(testItem1.itemcode))),
+                new QueryDefinition("select * from t where t.pk = @pk and t.cost = @cost" )
+                    .WithRawJsonParameter("@pk", ToJsonString(cosmosSerializerHelper.ToStream<dynamic>(testItem1.pk)))
+                    .WithRawJsonParameter("@cost", ToJsonString(cosmosSerializerHelper.ToStream<dynamic>(testItem1.cost))),
+            };
 
             try
             {
@@ -1835,23 +1835,23 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             CosmosSerializer cosmosSerializer = containerStandardSerializer.Database.Client.ClientOptions.Serializer;
 
             queryDefinitions = new List<QueryDefinition>()
-    {
-        new QueryDefinition("select * from t where t.pk = @pk" )
-        .WithRawJsonParameter("@pk", ToJsonString(cosmosSerializer.ToStream(testItem1.pk))),
-        new QueryDefinition("select * from t where t.cost = @cost" )
-        .WithRawJsonParameter("@cost", ToJsonString(cosmosSerializer.ToStream(testItem1.cost))),
-        new QueryDefinition("select * from t where t.taskNum = @taskNum" )
-        .WithRawJsonParameter("@taskNum", ToJsonString(cosmosSerializer.ToStream(testItem1.taskNum))),
-        new QueryDefinition("select * from t where t.CamelCase = @CamelCase" )
-        .WithRawJsonParameter("@CamelCase", ToJsonString(cosmosSerializer.ToStream(testItem1.CamelCase))),
-        new QueryDefinition("select * from t where t.valid = @valid" )
-        .WithRawJsonParameter("@valid", ToJsonString(cosmosSerializer.ToStream(testItem1.valid))),
-        new QueryDefinition("select * from t where t.description = @description" )
-        .WithRawJsonParameter("@description", ToJsonString(cosmosSerializer.ToStream(testItem1.description))),
-        new QueryDefinition("select * from t where t.pk = @pk and t.cost = @cost" )
-            .WithRawJsonParameter("@pk", ToJsonString(cosmosSerializer.ToStream(testItem1.pk)))
-            .WithRawJsonParameter("@cost", ToJsonString(cosmosSerializer.ToStream(testItem1.cost))),
-    };
+            {
+                new QueryDefinition("select * from t where t.pk = @pk" )
+                .WithRawJsonParameter("@pk", ToJsonString(cosmosSerializer.ToStream(testItem1.pk))),
+                new QueryDefinition("select * from t where t.cost = @cost" )
+                .WithRawJsonParameter("@cost", ToJsonString(cosmosSerializer.ToStream(testItem1.cost))),
+                new QueryDefinition("select * from t where t.taskNum = @taskNum" )
+                .WithRawJsonParameter("@taskNum", ToJsonString(cosmosSerializer.ToStream(testItem1.taskNum))),
+                new QueryDefinition("select * from t where t.CamelCase = @CamelCase" )
+                .WithRawJsonParameter("@CamelCase", ToJsonString(cosmosSerializer.ToStream(testItem1.CamelCase))),
+                new QueryDefinition("select * from t where t.valid = @valid" )
+                .WithRawJsonParameter("@valid", ToJsonString(cosmosSerializer.ToStream(testItem1.valid))),
+                new QueryDefinition("select * from t where t.description = @description" )
+                .WithRawJsonParameter("@description", ToJsonString(cosmosSerializer.ToStream(testItem1.description))),
+                new QueryDefinition("select * from t where t.pk = @pk and t.cost = @cost" )
+                    .WithRawJsonParameter("@pk", ToJsonString(cosmosSerializer.ToStream(testItem1.pk)))
+                    .WithRawJsonParameter("@cost", ToJsonString(cosmosSerializer.ToStream(testItem1.cost))),
+            };
 
             foreach (QueryDefinition queryDefinition in queryDefinitions)
             {

--- a/changelog.md
+++ b/changelog.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [5829](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5829) Routing: Adds Gateway Account Property Flag for Dynamic Hedging Control. Introduces a Gateway-controlled `disableCrossRegionalHedging` account property that lets operators dynamically disable PPAF cross-region hedging (and any customer-configured `AvailabilityStrategy`) without rolling back PPAF entirely. The SDK reconciles `ConnectionPolicy.AvailabilityStrategy` against the Gateway-supplied flag on each account-properties refresh; toggling the flag back to `false` restores the customer-configured strategy or rebuilds the SDK default.
 - [5648](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5648) Hub Region Caching: Caches discovered hub region per partition on successful response during 403/3 discovery chain, enabling subsequent requests to skip the discovery and route directly to the cached hub.
 - [#5549](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5549) Adds AAD token revocation (CAE / Emergency) transparent retry handling
+- [6010](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/6010) Query: Adds `QueryDefinition.WithRawJsonParameter` to pass pre-serialized JSON query parameter values without serializing them again, preventing double encoding when callers already have raw JSON parameter payloads.
 
 #### Breaking Changes
 


### PR DESCRIPTION
 to prevent double encoding for raw json strings

# Pull Request Template

## Description

Adds `QueryDefinition.WithRawJsonParameter(string name, string jsonString)` to allow callers to pass pre-serialized JSON parameter values into SQL queries without the SDK serializing them again. This prevents double encoding for raw JSON strings and matches the existing internal serialized-parameter path used by stream parameters.

Example:

```csharp
QueryDefinition query = new QueryDefinition(
    "select * from t where t.pk = @pk")
    .WithRawJsonParameter("@pk", "\"myPk\"");
```

## Type of change

New feature (non-breaking change which adds functionality)

## Changelog

- [x] I have added a changelog entry under `### Unreleased` in `changelog.md`
  for the user-facing impact of this change.
- [ ] No changelog entry is required because this PR is one of:
  documentation-only, test-only, CI / build-only, or a pure internal refactor
  with no observable customer impact.
