### PR TITLE
[Internal] Thin Client Integration: Refactors support for query plan in thinclient mode.

### DIFF
--- a/Microsoft.Azure.Cosmos/src/Query/v3Query/CosmosQueryClientCore.cs
+++ b/Microsoft.Azure.Cosmos/src/Query/v3Query/CosmosQueryClientCore.cs
@@ -209,25 +209,7 @@ namespace Microsoft.Azure.Cosmos
             {
                 // Syntax exception are argument exceptions and thrown to the user.
                 message.EnsureSuccessStatusCode();
-
-                bool responseCameViaThinClient = string.Equals(
-                    message.Headers?.Get(ThinClientConstants.RoutedViaProxy),
-                    "1",
-                    StringComparison.Ordinal);
-
-                if (responseCameViaThinClient)
-                {
-                    ContainerProperties containerProperties = await this.clientContext.GetCachedContainerPropertiesAsync(
-                        resourceUri, trace, cancellationToken);
-
-                    partitionedQueryExecutionInfo = ThinClientQueryPlanHelper.DeserializeQueryPlanResponse(
-                        message.Content,
-                        containerProperties.PartitionKey);
-                }
-                else
-                {
-                    partitionedQueryExecutionInfo = this.clientContext.SerializerCore.FromStream<PartitionedQueryExecutionInfo>(message.Content);
-                }
+                partitionedQueryExecutionInfo = this.clientContext.SerializerCore.FromStream<PartitionedQueryExecutionInfo>(message.Content);
             }
 
             return partitionedQueryExecutionInfo;

--- a/Microsoft.Azure.Cosmos/src/ThinClientStoreModel.cs
+++ b/Microsoft.Azure.Cosmos/src/ThinClientStoreModel.cs
@@ -122,8 +122,7 @@ namespace Microsoft.Azure.Cosmos
                 || request.OperationType == OperationType.Upsert
                 || request.OperationType == OperationType.Replace
                 || request.OperationType == OperationType.Delete
-                || request.OperationType == OperationType.Query
-                || request.OperationType == OperationType.QueryPlan))
+                || request.OperationType == OperationType.Query))
             {
                 return true;
             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemThinClientTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemThinClientTests.cs
@@ -40,6 +40,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         [TestInitialize]
         public async Task TestInitAsync()
         {
+            Environment.SetEnvironmentVariable(ConfigurationManager.BypassQueryParsing, Boolean.TrueString);
             Environment.SetEnvironmentVariable(ConfigurationManager.ThinClientModeEnabled, "True");
             this.connectionString = Environment.GetEnvironmentVariable("COSMOSDB_THINCLIENT");
             if (string.IsNullOrEmpty(this.connectionString))
@@ -75,7 +76,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         public async Task TestCleanupAsync()
         {
             Environment.SetEnvironmentVariable(ConfigurationManager.ThinClientModeEnabled, "False");
-
+            Environment.SetEnvironmentVariable(ConfigurationManager.BypassQueryParsing, null);
             if (this.database != null)
             {
                 await this.database.DeleteAsync();
@@ -1588,14 +1589,26 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
         [TestMethod]
         [TestCategory("ThinClient")]
-        public async Task TestThinClientQueryPlanWithOrderBy()
+        public async Task TestQueryPlanWithOrderBy_GatewayMode()
         {
+            // Removing thinclient support for queryplan
+            Environment.SetEnvironmentVariable(ConfigurationManager.ThinClientModeEnabled, "False");
             List<TestObject> items = new List<TestObject>();
             string commonPk = "pk_orderby_test_" + Guid.NewGuid().ToString();
 
             try
             {
-                Environment.SetEnvironmentVariable(ConfigurationManager.BypassQueryParsing, Boolean.TrueString);
+                // Create a fresh client that honors the disabled ThinClient flag
+                using CosmosClient queryPlanClient = new CosmosClient(
+                    this.connectionString,
+                    new CosmosClientOptions()
+                    {
+                        ConnectionMode = ConnectionMode.Gateway,
+                        ApplicationPreferredRegions = PreferredRegions,
+                        Serializer = this.cosmosSystemTextJsonSerializer,
+                    });
+
+                Container queryPlanContainer = queryPlanClient.GetContainer(this.database.Id, this.container.Id);
 
                 for (int i = 0; i < 5; i++)
                 {
@@ -1614,7 +1627,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 string query = "SELECT * FROM c WHERE c.pk = @pk ORDER BY c.other DESC";
                 QueryDefinition queryDef = new QueryDefinition(query).WithParameter("@pk", commonPk);
 
-                FeedIterator<TestObject> iterator = this.container.GetItemQueryIterator<TestObject>(queryDef);
+                FeedIterator<TestObject> iterator = queryPlanContainer.GetItemQueryIterator<TestObject>(queryDef);
 
                 List<TestObject> results = new List<TestObject>();
                 int pageCount = 0;
@@ -1626,8 +1639,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     pageCount++;
 
                     string diagnostics = response.Diagnostics.ToString();
-                    Assert.IsTrue(diagnostics.Contains("|F4"), $"Page {pageCount}: Should use ThinClient");
-                    AssertExcludedRegionsNotInDiagnostics(diagnostics);
+                    Assert.IsFalse(diagnostics.Contains("ThinClientStoreModel"), $"Page {pageCount}: Should NOT use ThinClient");
                 }
 
                 Assert.AreEqual(5, results.Count, "Should return all 5 items");
@@ -1635,7 +1647,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
             finally
             {
-                Environment.SetEnvironmentVariable(ConfigurationManager.BypassQueryParsing, null);
 
                 foreach (TestObject item in items)
                 {
@@ -1650,14 +1661,26 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
         [TestMethod]
         [TestCategory("ThinClient")]
-        public async Task TestThinClientQueryPlanCrossPartitionWithFilter()
+        public async Task TestQueryPlanCrossPartitionWithFilter_GatewayMode()
         {
+            // Removing thinclient support for queryplan
+            Environment.SetEnvironmentVariable(ConfigurationManager.ThinClientModeEnabled, "False");
             List<TestObject> items = new List<TestObject>();
             string baseGuid = Guid.NewGuid().ToString();
 
             try
             {
-                Environment.SetEnvironmentVariable(ConfigurationManager.BypassQueryParsing, "True");
+                // Create a fresh client that honors the disabled ThinClient flag
+                using CosmosClient queryPlanClient = new CosmosClient(
+                    this.connectionString,
+                    new CosmosClientOptions()
+                    {
+                        ConnectionMode = ConnectionMode.Gateway,
+                        ApplicationPreferredRegions = PreferredRegions,
+                        Serializer = this.cosmosSystemTextJsonSerializer,
+                    });
+
+                Container queryPlanContainer = queryPlanClient.GetContainer(this.database.Id, this.container.Id);
 
                 string[] partitionKeys = {
                     $"pk_filter_1_{baseGuid}",
@@ -1683,7 +1706,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
                 string query = "SELECT * FROM c ORDER BY c._ts";
 
-                FeedIterator<TestObject> iterator = this.container.GetItemQueryIterator<TestObject>(query);
+                FeedIterator<TestObject> iterator = queryPlanContainer.GetItemQueryIterator<TestObject>(query);
 
                 List<TestObject> results = new List<TestObject>();
                 int pageCount = 0;
@@ -1695,8 +1718,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     pageCount++;
 
                     string diagnostics = response.Diagnostics.ToString();
-                    Assert.IsTrue(diagnostics.Contains("|F4"), $"Page {pageCount}: Should use ThinClient");
-                    AssertExcludedRegionsNotInDiagnostics(diagnostics);
+                    Assert.IsFalse(diagnostics.Contains("ThinClientStoreModel"), $"Page {pageCount}: Should NOT use ThinClient");
                 }
 
                 Assert.IsTrue(results.Count >= 9,
@@ -1717,7 +1739,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
             finally
             {
-                Environment.SetEnvironmentVariable(ConfigurationManager.BypassQueryParsing, null);
 
                 foreach (TestObject item in items)
                 {
@@ -1732,14 +1753,25 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
         [TestMethod]
         [TestCategory("ThinClient")]
-        public async Task TestThinClientQueryPlanMultiPartitionFanout()
+        public async Task TestQueryPlanMultiPartitionFanout_GatewayMode()
         {
+            Environment.SetEnvironmentVariable(ConfigurationManager.ThinClientModeEnabled, "False");
             List<TestObject> items = new List<TestObject>();
             string baseGuid = Guid.NewGuid().ToString();
 
             try
             {
-                Environment.SetEnvironmentVariable(ConfigurationManager.BypassQueryParsing, Boolean.TrueString);
+                // Create a fresh client that honors the disabled ThinClient flag
+                using CosmosClient queryPlanClient = new CosmosClient(
+                    this.connectionString,
+                    new CosmosClientOptions()
+                    {
+                        ConnectionMode = ConnectionMode.Gateway,
+                        ApplicationPreferredRegions = PreferredRegions,
+                        Serializer = this.cosmosSystemTextJsonSerializer,
+                    });
+
+                Container queryPlanContainer = queryPlanClient.GetContainer(this.database.Id, this.container.Id);
 
                 // Create items across many distinct partition keys to ensure multi-partition fanout
                 int partitionCount = 10;
@@ -1766,23 +1798,22 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 // Execute a cross-partition ORDER BY query (requires QueryPlan + fanout)
                 string query = "SELECT * FROM c WHERE STARTSWITH(c.other, 'Partition_') ORDER BY c.other ASC";
 
-                // Run query via ThinClient mode
-                FeedIterator<TestObject> thinClientIterator = this.container.GetItemQueryIterator<TestObject>(query);
+                // Run query via non-ThinClient mode
+                FeedIterator<TestObject> queryPlanIterator = queryPlanContainer.GetItemQueryIterator<TestObject>(query);
 
-                List<TestObject> thinClientResults = new List<TestObject>();
-                while (thinClientIterator.HasMoreResults)
+                List<TestObject> queryPlanResults = new List<TestObject>();
+                while (queryPlanIterator.HasMoreResults)
                 {
-                    FeedResponse<TestObject> response = await thinClientIterator.ReadNextAsync();
-                    thinClientResults.AddRange(response);
+                    FeedResponse<TestObject> response = await queryPlanIterator.ReadNextAsync();
+                    queryPlanResults.AddRange(response);
 
                     string diagnostics = response.Diagnostics.ToString();
-                    Assert.IsTrue(diagnostics.Contains("|F4"), "Should use ThinClient mode");
-                    AssertExcludedRegionsNotInDiagnostics(diagnostics);
+                    Assert.IsFalse(diagnostics.Contains("ThinClientStoreModel"), "Should NOT use ThinClient mode");
                 }
 
                 // Verify all items are returned
                 int foundCount = createdItems.Count(created =>
-                    thinClientResults.Any(r => r.Id == created.Id));
+                    queryPlanResults.Any(r => r.Id == created.Id));
                 Assert.AreEqual(totalExpected, foundCount,
                     $"Should find all {totalExpected} test items in fanout results, found {foundCount}");
 
@@ -1805,19 +1836,18 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     gatewayResults.AddRange(response);
                 }
 
-                // ThinClient and Gateway should return the same item count
-                Assert.AreEqual(gatewayResults.Count, thinClientResults.Count,
-                    $"ThinClient ({thinClientResults.Count}) and Gateway ({gatewayResults.Count}) should return the same number of items.");
+                // QueryPlan client and Gateway should return the same item count
+                Assert.AreEqual(gatewayResults.Count, queryPlanResults.Count,
+                    $"QueryPlan client ({queryPlanResults.Count}) and Gateway ({gatewayResults.Count}) should return the same number of items.");
 
                 // Verify both results contain the same item IDs
-                HashSet<string> thinClientIds = new HashSet<string>(thinClientResults.Select(r => r.Id));
+                HashSet<string> queryPlanIds = new HashSet<string>(queryPlanResults.Select(r => r.Id));
                 HashSet<string> gatewayIds = new HashSet<string>(gatewayResults.Select(r => r.Id));
-                Assert.IsTrue(thinClientIds.SetEquals(gatewayIds),
-                    "ThinClient and Gateway should return the same set of items.");
+                Assert.IsTrue(queryPlanIds.SetEquals(gatewayIds),
+                    "QueryPlan client and Gateway should return the same set of items.");
             }
             finally
             {
-                Environment.SetEnvironmentVariable(ConfigurationManager.BypassQueryParsing, null);
 
                 foreach (TestObject item in items)
                 {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ThinClientStoreClientTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ThinClientStoreClientTests.cs
@@ -1,4 +1,4 @@
-//------------------------------------------------------------
+﻿//------------------------------------------------------------
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 //------------------------------------------------------------
 
@@ -396,7 +396,6 @@ namespace Microsoft.Azure.Cosmos.Tests
             Assert.AreEqual("userAgentContainer", ex.ParamName);
             StringAssert.Contains(ex.Message, "UserAgentContainer cannot be null");
         }
-
 
         private ContainerProperties GetMockContainerProperties()
         {

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ThinClientStoreClientTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ThinClientStoreClientTests.cs
@@ -1,4 +1,4 @@
-﻿//------------------------------------------------------------
+//------------------------------------------------------------
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 //------------------------------------------------------------
 
@@ -14,7 +14,6 @@ namespace Microsoft.Azure.Cosmos.Tests
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.Azure.Cosmos.Query.Core.QueryPlan;
     using Microsoft.Azure.Cosmos.Routing;
     using Microsoft.Azure.Cosmos.Telemetry;
     using Microsoft.Azure.Cosmos.Tracing;
@@ -22,7 +21,6 @@ namespace Microsoft.Azure.Cosmos.Tests
     using Microsoft.Azure.Documents.Routing;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Moq;
-    using Newtonsoft.Json;
 
     [TestClass]
     public class ThinClientStoreClientTests
@@ -399,132 +397,6 @@ namespace Microsoft.Azure.Cosmos.Tests
             StringAssert.Contains(ex.Message, "UserAgentContainer cannot be null");
         }
 
-        #region ThinClientQueryPlanHelper Tests
-
-        private static readonly PartitionKeyDefinition HashPartitionKeyDefinition = new PartitionKeyDefinition()
-        {
-            Paths = new Collection<string>() { "/id" },
-            Kind = PartitionKind.Hash,
-        };
-
-        [TestMethod]
-        [DynamicData(nameof(GetQueryPlanJsonTestCases), DynamicDataSourceType.Method)]
-        public void DeserializeQueryPlanResponse_ConsistentWithQueryPartitionProvider(string queryPlanJson, string description)
-        {
-            // Deserialize via ThinClientQueryPlanHelper (stream-based, as used in thin client mode)
-            PartitionedQueryExecutionInfo thinClientResult;
-            using (Stream stream = new MemoryStream(Encoding.UTF8.GetBytes(queryPlanJson)))
-            {
-                thinClientResult = ThinClientQueryPlanHelper.DeserializeQueryPlanResponse(
-                    stream,
-                    HashPartitionKeyDefinition);
-            }
-
-            // Deserialize via QueryPartitionProvider (string-based, as used in gateway/service-interop mode)
-            QueryPartitionProvider queryPartitionProvider = new QueryPartitionProvider(
-                new Dictionary<string, object>() { { "maxSqlQueryInputLength", 524288 } });
-
-            PartitionedQueryExecutionInfoInternal queryInfoInternal =
-                JsonConvert.DeserializeObject<PartitionedQueryExecutionInfoInternal>(
-                    queryPlanJson,
-                    new JsonSerializerSettings { DateParseHandling = DateParseHandling.None, MaxDepth = 64 });
-
-            PartitionedQueryExecutionInfo providerResult = queryPartitionProvider.ConvertPartitionedQueryExecutionInfo(
-                queryInfoInternal,
-                HashPartitionKeyDefinition);
-
-            // Assert: Both paths must produce identical EPK ranges
-            Assert.AreEqual(providerResult.QueryRanges.Count, thinClientResult.QueryRanges.Count, description);
-            for (int i = 0; i < providerResult.QueryRanges.Count; i++)
-            {
-                Assert.AreEqual(providerResult.QueryRanges[i].Min, thinClientResult.QueryRanges[i].Min, $"{description} - range[{i}].Min");
-                Assert.AreEqual(providerResult.QueryRanges[i].Max, thinClientResult.QueryRanges[i].Max, $"{description} - range[{i}].Max");
-                Assert.AreEqual(providerResult.QueryRanges[i].IsMinInclusive, thinClientResult.QueryRanges[i].IsMinInclusive, $"{description} - range[{i}].IsMinInclusive");
-                Assert.AreEqual(providerResult.QueryRanges[i].IsMaxInclusive, thinClientResult.QueryRanges[i].IsMaxInclusive, $"{description} - range[{i}].IsMaxInclusive");
-            }
-        }
-
-        private static IEnumerable<object[]> GetQueryPlanJsonTestCases()
-        {
-            // Full range (cross-partition query)
-            yield return new object[]
-            {
-                @"{""queryInfo"":{""distinctType"":""None"",""top"":null,""offset"":null,""limit"":null,""orderBy"":[],""orderByExpressions"":[],""groupByExpressions"":[],""groupByAliases"":[],""aggregates"":[""CountIf""],""groupByAliasToAggregateType"":{},""rewrittenQuery"":""SELECT VALUE [{\""item\"": COUNTIF(c.valid)}]\nFROM c"",""hasSelectValue"":true,""dCountInfo"":null,""hasNonStreamingOrderBy"":false},""queryRanges"":[{""min"":[],""max"":""Infinity"",""isMinInclusive"":true,""isMaxInclusive"":false}]}",
-                "Full range with aggregate"
-            };
-
-            // Point query (single partition key)
-            yield return new object[]
-            {
-                @"{""queryInfo"":{""distinctType"":""None"",""top"":null,""offset"":null,""limit"":null,""orderBy"":[""Descending""],""orderByExpressions"":[],""groupByExpressions"":[],""groupByAliases"":[],""aggregates"":[],""groupByAliasToAggregateType"":{},""rewrittenQuery"":"""",""hasSelectValue"":false,""dCountInfo"":null,""hasNonStreamingOrderBy"":false},""queryRanges"":[{""min"":[""testValue""],""max"":[""testValue""],""isMinInclusive"":true,""isMaxInclusive"":true}]}",
-                "Point query with ORDER BY"
-            };
-
-            // HybridSearchQueryInfo
-            yield return new object[]
-            {
-                @"{""hybridSearchQueryInfo"":{""globalStatisticsQuery"":""SELECT COUNT(1) AS documentCount, [] AS fullTextStatistics\nFROM c"",""componentQueryInfos"":[],""componentWithoutPayloadQueryInfos"":[],""projectionQueryInfo"":null,""componentWeights"":null,""skip"":null,""take"":10,""requiresGlobalStatistics"":false},""queryRanges"":[{""min"":[],""max"":""Infinity"",""isMinInclusive"":true,""isMaxInclusive"":false}]}",
-                "HybridSearchQueryInfo"
-            };
-        }
-
-        [TestMethod]
-        public void DeserializeQueryPlanResponse_MultipleRanges_SortsOutput()
-        {
-            // Multiple ranges in deliberate reverse order to verify sorting
-            string queryPlanJson = @"{""queryInfo"":{""distinctType"":""None"",""top"":null,""offset"":null,""limit"":null,""orderBy"":[],""orderByExpressions"":[],""groupByExpressions"":[],""groupByAliases"":[],""aggregates"":[],""groupByAliasToAggregateType"":{},""rewrittenQuery"":"""",""hasSelectValue"":false,""dCountInfo"":null,""hasNonStreamingOrderBy"":false},""queryRanges"":[{""min"":[""zzz""],""max"":[""zzz""],""isMinInclusive"":true,""isMaxInclusive"":true},{""min"":[""aaa""],""max"":[""aaa""],""isMinInclusive"":true,""isMaxInclusive"":true},{""min"":[""mmm""],""max"":[""mmm""],""isMinInclusive"":true,""isMaxInclusive"":true}]}";
-
-            using Stream stream = new MemoryStream(Encoding.UTF8.GetBytes(queryPlanJson));
-
-            PartitionedQueryExecutionInfo result = ThinClientQueryPlanHelper.DeserializeQueryPlanResponse(
-                stream,
-                HashPartitionKeyDefinition);
-
-            Assert.AreEqual(3, result.QueryRanges.Count);
-            for (int i = 0; i < result.QueryRanges.Count - 1; i++)
-            {
-                Assert.IsTrue(
-                    string.Compare(result.QueryRanges[i].Min, result.QueryRanges[i + 1].Min, StringComparison.Ordinal) <= 0,
-                    $"Ranges should be sorted: range[{i}].Min='{result.QueryRanges[i].Min}' should be <= range[{i + 1}].Min='{result.QueryRanges[i + 1].Min}'");
-            }
-        }
-
-        [TestMethod]
-        public void DeserializeQueryPlanResponse_InvalidInputs_FailsFast()
-        {
-            Assert.ThrowsException<ArgumentNullException>(
-                () => ThinClientQueryPlanHelper.DeserializeQueryPlanResponse(null, HashPartitionKeyDefinition),
-                "Null stream should throw");
-
-            using (Stream validStream = new MemoryStream(Encoding.UTF8.GetBytes("{}")))
-            {
-                Assert.ThrowsException<ArgumentNullException>(
-                    () => ThinClientQueryPlanHelper.DeserializeQueryPlanResponse(validStream, null),
-                    "Null partitionKeyDefinition should throw");
-            }
-
-            using (Stream badJson = new MemoryStream(Encoding.UTF8.GetBytes("not valid json {{{")))
-            {
-                try
-                {
-                    ThinClientQueryPlanHelper.DeserializeQueryPlanResponse(badJson, HashPartitionKeyDefinition);
-                    Assert.Fail("Malformed JSON should throw");
-                }
-                catch (System.Text.Json.JsonException)
-                {
-                    // Expected - System.Text.Json throws JsonException or a derived type for malformed JSON
-                }
-            }
-
-            using (Stream nullJson = new MemoryStream(Encoding.UTF8.GetBytes("null")))
-            {
-                Assert.ThrowsException<FormatException>(
-                    () => ThinClientQueryPlanHelper.DeserializeQueryPlanResponse(nullJson, HashPartitionKeyDefinition),
-                    "JSON null should throw FormatException");
-            }
-        }
-
-        #endregion
 
         private ContainerProperties GetMockContainerProperties()
         {


### PR DESCRIPTION
# Pull Request Template

## Description

Reverting the thinclient support for queryplan operation. Post this change query plan will be supported via gateway mode instead of thinclient mode.
The queryplan change was introduced in this PR https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5614

## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber

## Changelog

- [ ] I have added a changelog entry under `### Unreleased` in `changelog.md`
  for the user-facing impact of this change.
- [X] No changelog entry is required because this PR is one of:
  documentation-only, test-only, CI / build-only, or a pure internal refactor
  with no observable customer impact.

If the second box is checked, briefly justify here:

>
