### PR TITLE
[Internal] Routing: Refactors partition-move cache refresh into a shared primitive

### DIFF
--- a/Microsoft.Azure.Cosmos/src/GatewayStoreModel.cs
+++ b/Microsoft.Azure.Cosmos/src/GatewayStoreModel.cs
@@ -339,20 +339,12 @@ namespace Microsoft.Azure.Cosmos
             else
             {
                 this.sessionContainer.SetSessionToken(request, responseHeaders);
-                PartitionKeyRange detectedPartitionKeyRange = request.RequestContext.ResolvedPartitionKeyRange;
-                string partitionKeyRangeInResponse = responseHeaders[HttpConstants.HttpHeaders.PartitionKeyRangeId];
-                if (detectedPartitionKeyRange != null
-                    && !string.IsNullOrEmpty(partitionKeyRangeInResponse)
-                    && !string.IsNullOrEmpty(request.RequestContext.ResolvedCollectionRid)
-                    && !partitionKeyRangeInResponse.Equals(detectedPartitionKeyRange.Id, StringComparison.OrdinalIgnoreCase))
-                {
-                    // The request ended up being on a different partition unknown to the client, so we better refresh the caches
-                    await this.partitionKeyRangeCache.TryGetPartitionKeyRangeByIdAsync(
-                        request.RequestContext.ResolvedCollectionRid,
-                        partitionKeyRangeInResponse,
-                        NoOpTrace.Singleton,
-                        forceRefresh: true);
-                }
+                await PartitionKeyRangeCache.RefreshRoutingCacheIfPartitionMovedAsync(
+                    this.partitionKeyRangeCache,
+                    request.RequestContext.ResolvedCollectionRid,
+                    request.RequestContext.ResolvedPartitionKeyRange?.Id,
+                    responseHeaders[HttpConstants.HttpHeaders.PartitionKeyRangeId],
+                    NoOpTrace.Singleton);
             }
         }
 

--- a/Microsoft.Azure.Cosmos/src/Routing/PartitionKeyRangeCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/PartitionKeyRangeCache.cs
@@ -89,6 +89,61 @@ namespace Microsoft.Azure.Cosmos.Routing
             }
         }
 
+        /// <summary>
+        /// Force-refreshes the routing cache for a single collection when the partition key range the server
+        /// actually served differs from the range the client resolved for the request — i.e. the partition
+        /// moved (split/merge) to a range the client did not know about. If the ids match, or any input is
+        /// missing, this is a no-op.
+        /// </summary>
+        /// <remarks>
+        /// This is the shared move-detection primitive for both the point-operation capture path
+        /// (<see cref="GatewayStoreModel.CaptureSessionTokenAndHandleSplitAsync"/>) and the distributed-transaction
+        /// post-commit merge path, so the "did the partition move?" decision has exactly one definition instead of
+        /// two comment-synchronized copies. Callers own their own gating policy (which responses capture) and
+        /// failure policy (point ops let a refresh failure propagate for retry; DTX swallows it because the commit
+        /// already succeeded). <paramref name="refreshedRanges"/> is an optional per-pass dedupe set for callers
+        /// that process many operations at once (e.g. a distributed transaction with N sub-ops) so repeated moves
+        /// to the same range trigger a single refresh; it is only consulted after a move is confirmed.
+        /// </remarks>
+        public static Task RefreshRoutingCacheIfPartitionMovedAsync(
+            PartitionKeyRangeCache partitionKeyRangeCache,
+            string collectionResourceId,
+            string clientResolvedPartitionKeyRangeId,
+            string serverServedPartitionKeyRangeId,
+            ITrace trace,
+            HashSet<string> refreshedRanges = null)
+        {
+            if (partitionKeyRangeCache == null
+                || string.IsNullOrEmpty(collectionResourceId)
+                || string.IsNullOrEmpty(clientResolvedPartitionKeyRangeId)
+                || string.IsNullOrWhiteSpace(serverServedPartitionKeyRangeId)
+                || serverServedPartitionKeyRangeId.Equals(clientResolvedPartitionKeyRangeId, StringComparison.OrdinalIgnoreCase))
+            {
+                return Task.CompletedTask;
+            }
+
+            // Optional dedupe (only after a move is confirmed, so a non-moved op can't poison the key a
+            // later moved op needs): collapse repeated moves to the same range into a single refresh.
+            // The dedupe key uses the caller-supplied set's comparer; move detection above is
+            // OrdinalIgnoreCase, but partition key range ids are case-stable numeric strings so the two do
+            // not disagree in practice. Note the key is marked consumed here, before the refresh is issued:
+            // a future caller that both supplies a set and relies on retry-on-failure must account for a
+            // faulted refresh still having consumed the key (today's callers either pass no set — point ops —
+            // or swallow refresh failures — the distributed-transaction post-commit path).
+            if (refreshedRanges != null
+                && !refreshedRanges.Add(collectionResourceId + "|" + serverServedPartitionKeyRangeId))
+            {
+                return Task.CompletedTask;
+            }
+
+            // The request ended up on a different partition unknown to the client, so refresh the caches.
+            return partitionKeyRangeCache.TryGetPartitionKeyRangeByIdAsync(
+                collectionResourceId,
+                serverServedPartitionKeyRangeId,
+                trace ?? NoOpTrace.Singleton,
+                forceRefresh: true);
+        }
+
         public virtual async Task<PartitionKeyRange> TryGetPartitionKeyRangeByIdAsync(
             string collectionResourceId,
             string partitionKeyRangeId,

--- a/Microsoft.Azure.Cosmos/src/Routing/PartitionKeyRangeCache.cs
+++ b/Microsoft.Azure.Cosmos/src/Routing/PartitionKeyRangeCache.cs
@@ -96,42 +96,24 @@ namespace Microsoft.Azure.Cosmos.Routing
         /// missing, this is a no-op.
         /// </summary>
         /// <remarks>
-        /// This is the shared move-detection primitive for both the point-operation capture path
-        /// (<see cref="GatewayStoreModel.CaptureSessionTokenAndHandleSplitAsync"/>) and the distributed-transaction
-        /// post-commit merge path, so the "did the partition move?" decision has exactly one definition instead of
-        /// two comment-synchronized copies. Callers own their own gating policy (which responses capture) and
-        /// failure policy (point ops let a refresh failure propagate for retry; DTX swallows it because the commit
-        /// already succeeded). <paramref name="refreshedRanges"/> is an optional per-pass dedupe set for callers
-        /// that process many operations at once (e.g. a distributed transaction with N sub-ops) so repeated moves
-        /// to the same range trigger a single refresh; it is only consulted after a move is confirmed.
+        /// The method only detects the move and issues the refresh; the caller decides which responses to feed in
+        /// and how to handle a refresh failure. The returned task carries any failure so a caller can await and
+        /// retry, or ignore it. The method is stateless and safe to call concurrently. A caller that processes many
+        /// operations at once and wants repeated moves to the same range to refresh only once should dedupe the
+        /// distinct (collection, served range) pairs itself and call this once per distinct pair.
         /// </remarks>
         public static Task RefreshRoutingCacheIfPartitionMovedAsync(
             PartitionKeyRangeCache partitionKeyRangeCache,
             string collectionResourceId,
             string clientResolvedPartitionKeyRangeId,
             string serverServedPartitionKeyRangeId,
-            ITrace trace,
-            HashSet<string> refreshedRanges = null)
+            ITrace trace)
         {
             if (partitionKeyRangeCache == null
                 || string.IsNullOrEmpty(collectionResourceId)
                 || string.IsNullOrEmpty(clientResolvedPartitionKeyRangeId)
                 || string.IsNullOrWhiteSpace(serverServedPartitionKeyRangeId)
                 || serverServedPartitionKeyRangeId.Equals(clientResolvedPartitionKeyRangeId, StringComparison.OrdinalIgnoreCase))
-            {
-                return Task.CompletedTask;
-            }
-
-            // Optional dedupe (only after a move is confirmed, so a non-moved op can't poison the key a
-            // later moved op needs): collapse repeated moves to the same range into a single refresh.
-            // The dedupe key uses the caller-supplied set's comparer; move detection above is
-            // OrdinalIgnoreCase, but partition key range ids are case-stable numeric strings so the two do
-            // not disagree in practice. Note the key is marked consumed here, before the refresh is issued:
-            // a future caller that both supplies a set and relies on retry-on-failure must account for a
-            // faulted refresh still having consumed the key (today's callers either pass no set — point ops —
-            // or swallow refresh failures — the distributed-transaction post-commit path).
-            if (refreshedRanges != null
-                && !refreshedRanges.Add(collectionResourceId + "|" + serverServedPartitionKeyRangeId))
             {
                 return Task.CompletedTask;
             }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyRangeCacheTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyRangeCacheTest.cs
@@ -364,5 +364,144 @@ namespace Microsoft.Azure.Cosmos.Tests
                     $"Cold-start routing map should bake {expectedMaxComparerTypeName} when PartitionKeyRangeCache.useLengthAwareRangeComparer={useLengthAwareRangeComparer}.");
             }
         }
+
+        /// <summary>
+        /// Server served a different range than the client resolved => the partition moved, so the routing
+        /// cache is force-refreshed for the served range exactly once.
+        /// </summary>
+        [TestMethod]
+        public async Task RefreshRoutingCacheIfPartitionMoved_ServerServedDifferentRange_ForceRefreshesOnce()
+        {
+            Mock<PartitionKeyRangeCache> cache = CreateRefreshableCacheMock();
+
+            await PartitionKeyRangeCache.RefreshRoutingCacheIfPartitionMovedAsync(
+                cache.Object,
+                collectionResourceId: "dbs/db/colls/coll",
+                clientResolvedPartitionKeyRangeId: "0",
+                serverServedPartitionKeyRangeId: "5",
+                trace: NoOpTrace.Singleton);
+
+            cache.Verify(
+                c => c.TryGetPartitionKeyRangeByIdAsync("dbs/db/colls/coll", "5", It.IsAny<ITrace>(), true),
+                Times.Once);
+        }
+
+        /// <summary>
+        /// Client and server ranges match (including case-insensitively) => the partition did not move, so no
+        /// refresh is issued.
+        /// </summary>
+        [TestMethod]
+        public async Task RefreshRoutingCacheIfPartitionMoved_SameRange_IsNoOp()
+        {
+            Mock<PartitionKeyRangeCache> cache = CreateRefreshableCacheMock();
+
+            await PartitionKeyRangeCache.RefreshRoutingCacheIfPartitionMovedAsync(cache.Object, "coll", "A", "A", NoOpTrace.Singleton);
+            await PartitionKeyRangeCache.RefreshRoutingCacheIfPartitionMovedAsync(cache.Object, "coll", "A", "a", NoOpTrace.Singleton);
+
+            cache.Verify(
+                c => c.TryGetPartitionKeyRangeByIdAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<ITrace>(), It.IsAny<bool>()),
+                Times.Never);
+        }
+
+        /// <summary>
+        /// A null cache, an empty collection id, an empty client range id, or a whitespace-only server range id
+        /// are all treated as absent inputs => no refresh and, importantly, no null-reference exception.
+        /// </summary>
+        [TestMethod]
+        public async Task RefreshRoutingCacheIfPartitionMoved_MissingInputs_IsNoOp()
+        {
+            Mock<PartitionKeyRangeCache> cache = CreateRefreshableCacheMock();
+
+            await PartitionKeyRangeCache.RefreshRoutingCacheIfPartitionMovedAsync(null, "coll", "0", "5", NoOpTrace.Singleton);
+            await PartitionKeyRangeCache.RefreshRoutingCacheIfPartitionMovedAsync(cache.Object, string.Empty, "0", "5", NoOpTrace.Singleton);
+            await PartitionKeyRangeCache.RefreshRoutingCacheIfPartitionMovedAsync(cache.Object, "coll", string.Empty, "5", NoOpTrace.Singleton);
+            await PartitionKeyRangeCache.RefreshRoutingCacheIfPartitionMovedAsync(cache.Object, "coll", "0", "   ", NoOpTrace.Singleton);
+
+            cache.Verify(
+                c => c.TryGetPartitionKeyRangeByIdAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<ITrace>(), It.IsAny<bool>()),
+                Times.Never);
+        }
+
+        /// <summary>
+        /// The optional dedupe set collapses repeated moves to the same (collection, range) into a single refresh
+        /// within one pass, while a distinct served range still refreshes.
+        /// </summary>
+        [TestMethod]
+        public async Task RefreshRoutingCacheIfPartitionMoved_DedupeSet_CollapsesRepeatedMovesToSameRange()
+        {
+            Mock<PartitionKeyRangeCache> cache = CreateRefreshableCacheMock();
+            HashSet<string> refreshedRanges = new HashSet<string>(StringComparer.Ordinal);
+
+            await PartitionKeyRangeCache.RefreshRoutingCacheIfPartitionMovedAsync(cache.Object, "coll", "0", "5", NoOpTrace.Singleton, refreshedRanges);
+            await PartitionKeyRangeCache.RefreshRoutingCacheIfPartitionMovedAsync(cache.Object, "coll", "1", "5", NoOpTrace.Singleton, refreshedRanges);
+            await PartitionKeyRangeCache.RefreshRoutingCacheIfPartitionMovedAsync(cache.Object, "coll", "2", "6", NoOpTrace.Singleton, refreshedRanges);
+
+            cache.Verify(c => c.TryGetPartitionKeyRangeByIdAsync("coll", "5", It.IsAny<ITrace>(), true), Times.Once);
+            cache.Verify(c => c.TryGetPartitionKeyRangeByIdAsync("coll", "6", It.IsAny<ITrace>(), true), Times.Once);
+        }
+
+        /// <summary>
+        /// The dedupe key is scoped per collection: the same served range id in two different collections must
+        /// each refresh, so the set must not suppress the second.
+        /// </summary>
+        [TestMethod]
+        public async Task RefreshRoutingCacheIfPartitionMoved_DedupeSet_DoesNotSuppressDistinctCollectionsSameRangeId()
+        {
+            Mock<PartitionKeyRangeCache> cache = CreateRefreshableCacheMock();
+            HashSet<string> refreshedRanges = new HashSet<string>(StringComparer.Ordinal);
+
+            await PartitionKeyRangeCache.RefreshRoutingCacheIfPartitionMovedAsync(cache.Object, "collA", "0", "5", NoOpTrace.Singleton, refreshedRanges);
+            await PartitionKeyRangeCache.RefreshRoutingCacheIfPartitionMovedAsync(cache.Object, "collB", "0", "5", NoOpTrace.Singleton, refreshedRanges);
+
+            cache.Verify(c => c.TryGetPartitionKeyRangeByIdAsync("collA", "5", It.IsAny<ITrace>(), true), Times.Once);
+            cache.Verify(c => c.TryGetPartitionKeyRangeByIdAsync("collB", "5", It.IsAny<ITrace>(), true), Times.Once);
+        }
+
+        /// <summary>
+        /// A refresh failure faults the returned task rather than being swallowed: the primitive returns the
+        /// un-awaited refresh task, which is the contract the point-op path relies on to retry an idempotent read.
+        /// </summary>
+        [TestMethod]
+        public async Task RefreshRoutingCacheIfPartitionMoved_RefreshFailure_FaultsReturnedTask()
+        {
+            Mock<PartitionKeyRangeCache> cache = new Mock<PartitionKeyRangeCache>(null, null, null, null, false, false, null);
+            cache
+                .Setup(c => c.TryGetPartitionKeyRangeByIdAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<ITrace>(), It.IsAny<bool>()))
+                .ThrowsAsync(new InvalidOperationException("refresh boom"));
+
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+                () => PartitionKeyRangeCache.RefreshRoutingCacheIfPartitionMovedAsync(
+                    cache.Object, "coll", "0", "5", NoOpTrace.Singleton));
+
+            cache.Verify(
+                c => c.TryGetPartitionKeyRangeByIdAsync("coll", "5", It.IsAny<ITrace>(), true),
+                Times.Once);
+        }
+
+        /// <summary>
+        /// With no dedupe set (the production point-op path passes none), two moves to the same range each
+        /// force-refresh — nothing collapses them.
+        /// </summary>
+        [TestMethod]
+        public async Task RefreshRoutingCacheIfPartitionMoved_NullDedupeSet_RepeatedSameRangeMovesRefreshEachTime()
+        {
+            Mock<PartitionKeyRangeCache> cache = CreateRefreshableCacheMock();
+
+            await PartitionKeyRangeCache.RefreshRoutingCacheIfPartitionMovedAsync(cache.Object, "coll", "0", "5", NoOpTrace.Singleton);
+            await PartitionKeyRangeCache.RefreshRoutingCacheIfPartitionMovedAsync(cache.Object, "coll", "1", "5", NoOpTrace.Singleton);
+
+            cache.Verify(
+                c => c.TryGetPartitionKeyRangeByIdAsync("coll", "5", It.IsAny<ITrace>(), true),
+                Times.Exactly(2));
+        }
+
+        private static Mock<PartitionKeyRangeCache> CreateRefreshableCacheMock()
+        {
+            Mock<PartitionKeyRangeCache> cache = new Mock<PartitionKeyRangeCache>(null, null, null, null, false, false, null);
+            cache
+                .Setup(c => c.TryGetPartitionKeyRangeByIdAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<ITrace>(), It.IsAny<bool>()))
+                .ReturnsAsync((PartitionKeyRange)null);
+            return cache;
+        }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyRangeCacheTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/PartitionKeyRangeCacheTest.cs
@@ -423,41 +423,6 @@ namespace Microsoft.Azure.Cosmos.Tests
         }
 
         /// <summary>
-        /// The optional dedupe set collapses repeated moves to the same (collection, range) into a single refresh
-        /// within one pass, while a distinct served range still refreshes.
-        /// </summary>
-        [TestMethod]
-        public async Task RefreshRoutingCacheIfPartitionMoved_DedupeSet_CollapsesRepeatedMovesToSameRange()
-        {
-            Mock<PartitionKeyRangeCache> cache = CreateRefreshableCacheMock();
-            HashSet<string> refreshedRanges = new HashSet<string>(StringComparer.Ordinal);
-
-            await PartitionKeyRangeCache.RefreshRoutingCacheIfPartitionMovedAsync(cache.Object, "coll", "0", "5", NoOpTrace.Singleton, refreshedRanges);
-            await PartitionKeyRangeCache.RefreshRoutingCacheIfPartitionMovedAsync(cache.Object, "coll", "1", "5", NoOpTrace.Singleton, refreshedRanges);
-            await PartitionKeyRangeCache.RefreshRoutingCacheIfPartitionMovedAsync(cache.Object, "coll", "2", "6", NoOpTrace.Singleton, refreshedRanges);
-
-            cache.Verify(c => c.TryGetPartitionKeyRangeByIdAsync("coll", "5", It.IsAny<ITrace>(), true), Times.Once);
-            cache.Verify(c => c.TryGetPartitionKeyRangeByIdAsync("coll", "6", It.IsAny<ITrace>(), true), Times.Once);
-        }
-
-        /// <summary>
-        /// The dedupe key is scoped per collection: the same served range id in two different collections must
-        /// each refresh, so the set must not suppress the second.
-        /// </summary>
-        [TestMethod]
-        public async Task RefreshRoutingCacheIfPartitionMoved_DedupeSet_DoesNotSuppressDistinctCollectionsSameRangeId()
-        {
-            Mock<PartitionKeyRangeCache> cache = CreateRefreshableCacheMock();
-            HashSet<string> refreshedRanges = new HashSet<string>(StringComparer.Ordinal);
-
-            await PartitionKeyRangeCache.RefreshRoutingCacheIfPartitionMovedAsync(cache.Object, "collA", "0", "5", NoOpTrace.Singleton, refreshedRanges);
-            await PartitionKeyRangeCache.RefreshRoutingCacheIfPartitionMovedAsync(cache.Object, "collB", "0", "5", NoOpTrace.Singleton, refreshedRanges);
-
-            cache.Verify(c => c.TryGetPartitionKeyRangeByIdAsync("collA", "5", It.IsAny<ITrace>(), true), Times.Once);
-            cache.Verify(c => c.TryGetPartitionKeyRangeByIdAsync("collB", "5", It.IsAny<ITrace>(), true), Times.Once);
-        }
-
-        /// <summary>
         /// A refresh failure faults the returned task rather than being swallowed: the primitive returns the
         /// un-awaited refresh task, which is the contract the point-op path relies on to retry an idempotent read.
         /// </summary>
@@ -479,11 +444,10 @@ namespace Microsoft.Azure.Cosmos.Tests
         }
 
         /// <summary>
-        /// With no dedupe set (the production point-op path passes none), two moves to the same range each
-        /// force-refresh — nothing collapses them.
+        /// The primitive is stateless, so two moves to the same range each force-refresh — nothing collapses them.
         /// </summary>
         [TestMethod]
-        public async Task RefreshRoutingCacheIfPartitionMoved_NullDedupeSet_RepeatedSameRangeMovesRefreshEachTime()
+        public async Task RefreshRoutingCacheIfPartitionMoved_RepeatedSameRangeMovesRefreshEachTime()
         {
             Mock<PartitionKeyRangeCache> cache = CreateRefreshableCacheMock();
 


### PR DESCRIPTION
## Summary

Extracts the duplicated "partition moved -> force-refresh routing cache" detection into a single shared primitive, `PartitionKeyRangeCache.RefreshRoutingCacheIfPartitionMovedAsync`, so the gateway point-op path and the upcoming distributed-transaction (DTX) post-commit path share one definition instead of two comment-enforced mirrors.

The primitive:
- Guards out no-op cases (null cache, empty collection rid, empty client range id, whitespace server range id, ids equal under `OrdinalIgnoreCase`).
- Optionally dedupes repeated moves to the same range via a caller-supplied set (consulted only after a move is confirmed).
- Returns the un-awaited refresh task, so callers can choose to let a refresh failure propagate (point ops, for idempotent retry) or swallow it (DTX).

The point-op call site in `GatewayStoreModel` now delegates to this primitive.

## Notes for reviewers

**`refreshedRanges` param has no production caller on this branch.** The optional dedupe set is exercised here by tests only — the point-op path calls the primitive passing no set. Its production consumer is the DTX post-commit merge path, which lands in the immediately-following DTX PR.

**Not a byte-for-byte refactor — two intentional, benign guard tightenings vs. the old inline point-op code:**
- The client-range guard moved from object-null (`detectedPartitionKeyRange != null`) to id-empty (`IsNullOrEmpty(ResolvedPartitionKeyRange?.Id)`).
- The server-range check moved from `IsNullOrEmpty` to `IsNullOrWhiteSpace`.

Both make a spurious force-refresh less likely and won't occur in practice.

## Testing

Added focused unit tests in `PartitionKeyRangeCacheTest.cs` covering: move detected/not-detected, each guard, dedupe collapse, null-set repeated-move double refresh, and refresh-failure propagation (returned task faults). 41 tests pass.

## Changelog

No entry required — pure internal refactor with no customer-observable change.
