### PR TITLE
Use Assembly.GetType instead of Type.GetType to avoid TypeResolve event in AppDomain-isolated hosts

### DIFF
--- a/Microsoft.Azure.Cosmos/src/HttpClient/CosmosHttpClientCore.cs
+++ b/Microsoft.Azure.Cosmos/src/HttpClient/CosmosHttpClientCore.cs
@@ -117,7 +117,7 @@ namespace Microsoft.Azure.Cosmos
             Func<X509Certificate2, X509Chain, SslPolicyErrors, bool> serverCertificateCustomValidationCallback)
         {
             // TODO: Remove type check and use #if NET6_0_OR_GREATER when multitargetting is possible
-            Type socketHandlerType = Type.GetType("System.Net.Http.SocketsHttpHandler, System.Net.Http");
+            Type socketHandlerType = typeof(HttpClient).Assembly.GetType("System.Net.Http.SocketsHttpHandler");
 
             if (socketHandlerType != null)
             {
@@ -140,7 +140,7 @@ namespace Microsoft.Azure.Cosmos
             Func<X509Certificate2, X509Chain, SslPolicyErrors, bool> serverCertificateCustomValidationCallback)
         {
             // TODO: Remove Reflection when multitargetting is possible
-            Type socketHandlerType = Type.GetType("System.Net.Http.SocketsHttpHandler, System.Net.Http");
+            Type socketHandlerType = typeof(HttpClient).Assembly.GetType("System.Net.Http.SocketsHttpHandler");
 
             object socketHttpHandler = Activator.CreateInstance(socketHandlerType);
 

--- a/changelog.md
+++ b/changelog.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Bugs Fixed
 
 - [6032](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/6032) ThinClient: Fixes clients using resource-token (permission-scoped) authorization failing or misrouting when thin client mode is enabled by default. Such clients now always route data-plane requests through the Gateway store model, since thin client mode does not support resource-token authorization. Clients using primary/secondary key or Microsoft Entra ID (AAD) authorization are unaffected.
+- [6025](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/6025) Fixed `RemotingException` in AppDomain-isolated test hosts by replacing `Type.GetType` with `Assembly.GetType` in `CosmosHttpClientCore.CreateHttpClientHandler` and `CreateSocketsHttpHandlerHelper`. `Type.GetType` fires `AppDomain.TypeResolve` when the type is not found on .NET Framework, which crashes if cross-domain `MarshalByRefObject` proxies have expired leases.
 
 #### Other Changes
 


### PR DESCRIPTION
## Changes

Replaces Type.GetType("System.Net.Http.SocketsHttpHandler, System.Net.Http") with 	ypeof(HttpClient).Assembly.GetType("System.Net.Http.SocketsHttpHandler") in two locations in CosmosHttpClientCore.cs:
- CreateHttpClientHandler (line ~120)
- CreateSocketsHttpHandlerHelper (line ~143)

## Why

Type.GetType(string) fires AppDomain.TypeResolve when the type isn't found (which is the case on .NET Framework since SocketsHttpHandler doesn't exist there). In AppDomain-isolated hosts (e.g. stest.console.exe /InIsolation with code coverage), cross-domain MarshalByRefObject proxies registered for TypeResolve can expire after 5 minutes, causing RemotingException on subsequent CosmosClient creation.

Assembly.GetType(string) performs a direct metadata lookup within the already-loaded assembly — no TypeResolve event, no cross-AppDomain calls, no lease expiry risk. It returns 
ull when the type doesn't exist, same as before.

## Behavioral equivalence

- On .NET Core/.NET 5+: Returns the SocketsHttpHandler type (same as before)
- On .NET Framework: Returns null (same as before, but without side effects)
- 	typeof(HttpClient).Assembly reliably references System.Net.Http.dll on all platforms

Fixes #6024