### PR TITLE
[Internal] Query: Fixes preview build by restoring [Ignore] on emulator-dependent language test

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Fluent/ContainerSettingsTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Fluent/ContainerSettingsTests.cs
@@ -2046,6 +2046,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
         }
 
+        [Ignore("Marking as ignore until emulator is updated")]
         [TestMethod]
         [DataRow("en-US")]
         [DataRow("fr-FR")]


### PR DESCRIPTION
The [Ignore] attribute on TestFullTextSearchPolicyWithAllSupportedDefaultLanguages was accidentally removed in PR #5968. The CI emulator does not support all full-text languages yet, causing preview package build failures. This restores the attribute to unblock the release.