### PR TITLE
[Internal] Query: Fixes preview build by restoring [Ignore] on emulat…

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Fluent/ContainerSettingsTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Fluent/ContainerSettingsTests.cs
@@ -2046,6 +2046,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
         }
 
+        [Ignore("Marking as ignore until emulator is updated")]
         [TestMethod]
         [DataRow("en-US")]
         [DataRow("fr-FR")]


### PR DESCRIPTION
## Description

Cherry-picking this PR https://github.com/Azure/azure-cosmos-dotnet-v3/pull/6026 to fix preview emulator tests in preview release CI for 3.63.0-preview.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber

## Changelog

- [ ] I have added a changelog entry under `### Unreleased` in `changelog.md`
  for the user-facing impact of this change.
- [X] No changelog entry is required because this PR is one of:
  documentation-only, test-only, CI / build-only, or a pure internal refactor
  with no observable customer impact.

If the second box is checked, briefly justify here:

>
