### PR TITLE
[Internal] Query: Fixes preview full-text emulator test gating

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Fluent/ContainerSettingsTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Fluent/ContainerSettingsTests.cs
@@ -963,6 +963,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
 #if PREVIEW
+        [Ignore("Requires an emulator with full-text analyzer configuration support")]
         [TestMethod]
         public async Task TestFullTextSearchPolicyStandardPackageWithQueryExecution()
         {
@@ -1051,6 +1052,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
         }
 
+        [Ignore("Requires an emulator with full-text analyzer configuration support")]
         [TestMethod]
         public async Task TestFullTextSearchPolicyStandardPackageWithStopWords()
         {
@@ -1124,6 +1126,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
         }
 
+        [Ignore("Requires an emulator with full-text analyzer configuration support")]
         [TestMethod]
         public async Task TestFullTextSearchPolicyStandardPackageUpdateContainer()
         {
@@ -1184,6 +1187,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
         }
 
+        [Ignore("Requires an emulator with full-text analyzer configuration support")]
         [TestMethod]
         public async Task TestFullTextSearchPolicyStandardPackagePerPathOverrides()
         {
@@ -1258,6 +1262,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
         }
 
+        [Ignore("Requires an emulator with full-text analyzer configuration support")]
         [TestMethod]
         public async Task TestFullTextSearchPolicyInvalidPackageReturnsError()
         {
@@ -1304,6 +1309,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
         }
 
+        [Ignore("Requires an emulator with full-text analyzer configuration support")]
         [TestMethod]
         public async Task TestFullTextSearchPolicyAllValidFilterTypes()
         {
@@ -1351,6 +1357,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
         }
 
+        [Ignore("Requires an emulator with full-text analyzer configuration support")]
         [TestMethod]
         public async Task TestFullTextSearchPolicyInvalidFilterReturnsError()
         {
@@ -1398,6 +1405,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
         }
 
+        [Ignore("Requires an emulator with full-text analyzer configuration support")]
         [TestMethod]
         public async Task TestFullTextSearchPolicyInvalidTokenizerReturnsError()
         {
@@ -1443,6 +1451,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
         }
 
+        [Ignore("Requires an emulator with full-text analyzer configuration support")]
         [TestMethod]
         public async Task TestFullTextSearchPolicyFiltersWithLegacyPackageReturnsError()
         {
@@ -1489,6 +1498,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
         }
 
+        [Ignore("Requires an emulator with full-text analyzer configuration support")]
         [TestMethod]
         public async Task TestFullTextSearchPolicyAllStopWordListKinds()
         {
@@ -1539,6 +1549,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
         }
 
+        [Ignore("Requires an emulator with full-text analyzer configuration support")]
         [TestMethod]
         public async Task TestFullTextSearchPolicyBothPackageTypesValid()
         {
@@ -2046,7 +2057,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
         }
 
-        [Ignore("Marking as ignore until emulator is updated")]
         [TestMethod]
         [DataRow("en-US")]
         [DataRow("fr-FR")]


### PR DESCRIPTION
## Description

- Restores `TestFullTextSearchPolicyWithAllSupportedDefaultLanguages`, reverting the ignore added by #6027 because those seven data rows passed before that change.
- Skips the exact 11 standard-package/analyzer-configuration integration tests that require newer emulator support.
- Keeps the preview serialization and fluent-builder unit coverage enabled.

## Root cause

The `3.63.0-preview.0` release build enables `PREVIEW`, which activates the analyzer-configuration emulator tests introduced by #5968. The public emulator accepts but drops `package`, `defaultSpec`, tokenizer, filter, and stop-word fields and does not reject invalid analyzer values. The same 11 tests fail deterministically on every attempt, after which retrying the full suite exhausts the 60-minute job timeout.

- Initial failure: [build 62517](https://cosmos-db-sdk-public.visualstudio.com/cosmos-db-sdk-public/_build/results?buildId=62517)
- #6027 verification: [build 62532, log 158](https://cosmos-db-sdk-public.visualstudio.com/4000bd49-81c3-47f2-94d8-d1392b95c228/_apis/build/builds/62532/logs/158)

Build 62532 confirms that #6027 skipped seven passing language rows while leaving all 11 actual failures enabled. The failed-test set from log 158 exactly matches the 11 tests gated by this PR. Expected corrected totals are 1,033 total, 963 passed, 0 failed, and 70 skipped.

## Testing

Ran the 11 affected tests with `/p:IsPreview=true` and the release configuration. All 11 were discovered and skipped; 0 failed.

```text
Skipped! - Failed: 0, Passed: 0, Skipped: 11, Total: 11
```

End-to-end PR validation: [build 62533](https://cosmos-db-sdk-public.visualstudio.com/4000bd49-81c3-47f2-94d8-d1392b95c228/_build/results?buildId=62533).