### PR TITLE
[Internal] Query: Fixes preview full-text emulator test gating

### DIFF
--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Fluent/ContainerSettingsTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/Fluent/ContainerSettingsTests.cs
@@ -963,6 +963,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
 #if PREVIEW
+        [Ignore("Requires an emulator with full-text analyzer configuration support")]
         [TestMethod]
         public async Task TestFullTextSearchPolicyStandardPackageWithQueryExecution()
         {
@@ -1051,6 +1052,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
         }
 
+        [Ignore("Requires an emulator with full-text analyzer configuration support")]
         [TestMethod]
         public async Task TestFullTextSearchPolicyStandardPackageWithStopWords()
         {
@@ -1124,6 +1126,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
         }
 
+        [Ignore("Requires an emulator with full-text analyzer configuration support")]
         [TestMethod]
         public async Task TestFullTextSearchPolicyStandardPackageUpdateContainer()
         {
@@ -1184,6 +1187,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
         }
 
+        [Ignore("Requires an emulator with full-text analyzer configuration support")]
         [TestMethod]
         public async Task TestFullTextSearchPolicyStandardPackagePerPathOverrides()
         {
@@ -1258,6 +1262,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
         }
 
+        [Ignore("Requires an emulator with full-text analyzer configuration support")]
         [TestMethod]
         public async Task TestFullTextSearchPolicyInvalidPackageReturnsError()
         {
@@ -1304,6 +1309,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
         }
 
+        [Ignore("Requires an emulator with full-text analyzer configuration support")]
         [TestMethod]
         public async Task TestFullTextSearchPolicyAllValidFilterTypes()
         {
@@ -1351,6 +1357,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
         }
 
+        [Ignore("Requires an emulator with full-text analyzer configuration support")]
         [TestMethod]
         public async Task TestFullTextSearchPolicyInvalidFilterReturnsError()
         {
@@ -1398,6 +1405,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
         }
 
+        [Ignore("Requires an emulator with full-text analyzer configuration support")]
         [TestMethod]
         public async Task TestFullTextSearchPolicyInvalidTokenizerReturnsError()
         {
@@ -1443,6 +1451,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
         }
 
+        [Ignore("Requires an emulator with full-text analyzer configuration support")]
         [TestMethod]
         public async Task TestFullTextSearchPolicyFiltersWithLegacyPackageReturnsError()
         {
@@ -1489,6 +1498,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
         }
 
+        [Ignore("Requires an emulator with full-text analyzer configuration support")]
         [TestMethod]
         public async Task TestFullTextSearchPolicyAllStopWordListKinds()
         {
@@ -1539,6 +1549,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
         }
 
+        [Ignore("Requires an emulator with full-text analyzer configuration support")]
         [TestMethod]
         public async Task TestFullTextSearchPolicyBothPackageTypesValid()
         {
@@ -2046,7 +2057,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             }
         }
 
-        [Ignore("Marking as ignore until emulator is updated")]
         [TestMethod]
         [DataRow("en-US")]
         [DataRow("fr-FR")]


### PR DESCRIPTION
## Description

Ports the validated release-branch fix from #6028 to `main`.

- Restores `TestFullTextSearchPolicyWithAllSupportedDefaultLanguages`, reverting the ignore added by #6027 because those seven data rows pass against the public emulator.
- Skips the exact 11 standard-package/analyzer-configuration integration tests that require newer emulator support.
- Keeps preview serialization and fluent-builder unit coverage enabled.

## Root cause

Preview builds activate the analyzer-configuration emulator tests introduced by #5968. The public emulator accepts but drops `package`, `defaultSpec`, tokenizer, filter, and stop-word fields and does not reject invalid analyzer values, causing the same 11 tests to fail deterministically.

See the merged release fix and detailed investigation in #6028.

## Validation

The targeted preview run discovered and skipped all 11 affected tests with no failures:

```text
Skipped! - Failed: 0, Passed: 0, Skipped: 11, Total: 11
```

The exact preview release path also passed in [build 62534](https://cosmos-db-sdk-public.visualstudio.com/4000bd49-81c3-47f2-94d8-d1392b95c228/_build/results?buildId=62534): 1,033 total, 963 passed, 70 skipped, and 0 failed.