### PR TITLE
[Internal] Client Encryption: Adds compression envelope primitives

### DIFF
--- a/Microsoft.Azure.Cosmos.Encryption.Custom/src/Transformation/BrotliCompressorAdapter.cs
+++ b/Microsoft.Azure.Cosmos.Encryption.Custom/src/Transformation/BrotliCompressorAdapter.cs
@@ -1,0 +1,67 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+
+#if NET8_0_OR_GREATER
+namespace Microsoft.Azure.Cosmos.Encryption.Custom.Transformation
+{
+    using System;
+    using System.Buffers;
+    using System.IO;
+    using System.IO.Compression;
+
+    internal sealed class BrotliCompressorAdapter : ICompressionCodecAdapter
+    {
+        public int Compress(
+            ReadOnlySpan<byte> source,
+            CompressionLevelSetting level,
+            IBufferWriter<byte> destination)
+        {
+            Span<byte> target = destination.GetSpan(BrotliEncoder.GetMaxCompressedLength(source.Length));
+            if (!BrotliEncoder.TryCompress(
+                source,
+                target,
+                out int written,
+                ToQuality(level),
+                window: 22))
+            {
+                throw new InvalidDataException("Brotli compression failed.");
+            }
+
+            destination.Advance(written);
+            return written;
+        }
+
+        public int Decompress(
+            ReadOnlyMemory<byte> source,
+            Span<byte> destination)
+        {
+            using BrotliDecoder decoder = default;
+            OperationStatus status = decoder.Decompress(
+                source.Span,
+                destination,
+                out int bytesConsumed,
+                out int bytesWritten);
+            if (status != OperationStatus.Done ||
+                bytesConsumed != source.Length ||
+                bytesWritten != destination.Length)
+            {
+                throw new InvalidDataException("Brotli decompression failed.");
+            }
+
+            return bytesWritten;
+        }
+
+        internal static int ToQuality(CompressionLevelSetting level)
+        {
+            return level switch
+            {
+                CompressionLevelSetting.Fastest => 1,
+                CompressionLevelSetting.Balanced => 5,
+                CompressionLevelSetting.SmallestSize => 9,
+                _ => throw new ArgumentException("Unsupported compression level.", nameof(level)),
+            };
+        }
+    }
+}
+#endif

--- a/Microsoft.Azure.Cosmos.Encryption.Custom/src/Transformation/BufferWriterCopyingStream.cs
+++ b/Microsoft.Azure.Cosmos.Encryption.Custom/src/Transformation/BufferWriterCopyingStream.cs
@@ -1,0 +1,71 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+
+#if NET8_0_OR_GREATER
+namespace Microsoft.Azure.Cosmos.Encryption.Custom.Transformation
+{
+    using System;
+    using System.Buffers;
+    using System.IO;
+
+    internal sealed class BufferWriterCopyingStream : Stream
+    {
+        private readonly IBufferWriter<byte> writer;
+
+        public BufferWriterCopyingStream(IBufferWriter<byte> writer)
+        {
+            this.writer = writer ?? throw new ArgumentNullException(nameof(writer));
+        }
+
+        public override bool CanRead => false;
+
+        public override bool CanSeek => false;
+
+        public override bool CanWrite => true;
+
+        public override long Length => throw new NotSupportedException();
+
+        public override long Position
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public int BytesWritten { get; private set; }
+
+        public override void Flush()
+        {
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void SetLength(long value)
+        {
+            throw new NotSupportedException();
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            buffer.AsSpan(offset, count).CopyTo(this.writer.GetSpan(count));
+            this.writer.Advance(count);
+            this.BytesWritten += count;
+        }
+
+        public override void Write(ReadOnlySpan<byte> buffer)
+        {
+            buffer.CopyTo(this.writer.GetSpan(buffer.Length));
+            this.writer.Advance(buffer.Length);
+            this.BytesWritten += buffer.Length;
+        }
+    }
+}
+#endif

--- a/Microsoft.Azure.Cosmos.Encryption.Custom/src/Transformation/CompressionCodecId.cs
+++ b/Microsoft.Azure.Cosmos.Encryption.Custom/src/Transformation/CompressionCodecId.cs
@@ -1,0 +1,15 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+
+#if NET8_0_OR_GREATER
+namespace Microsoft.Azure.Cosmos.Encryption.Custom.Transformation
+{
+    internal enum CompressionCodecId : byte
+    {
+        Raw = 0,
+        Deflate = 1,
+        Brotli = 2,
+    }
+}
+#endif

--- a/Microsoft.Azure.Cosmos.Encryption.Custom/src/Transformation/CompressionHelper.cs
+++ b/Microsoft.Azure.Cosmos.Encryption.Custom/src/Transformation/CompressionHelper.cs
@@ -1,0 +1,71 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+
+#if NET8_0_OR_GREATER
+namespace Microsoft.Azure.Cosmos.Encryption.Custom.Transformation
+{
+    using System;
+
+    internal static class CompressionHelper
+    {
+        public static int GetBase64Length(int byteCount)
+        {
+            if (byteCount < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(byteCount));
+            }
+
+            return checked((byteCount + 2) / 3 * 4);
+        }
+
+        public static int GetStoredBase64Length(
+            int plaintextLength,
+            Func<int, int> getEncryptByteCount)
+        {
+            if (plaintextLength < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(plaintextLength));
+            }
+
+            if (getEncryptByteCount == null)
+            {
+                throw new ArgumentNullException(nameof(getEncryptByteCount));
+            }
+
+            int encryptedLength = getEncryptByteCount(plaintextLength);
+            if (encryptedLength < 0)
+            {
+                throw new InvalidOperationException("Encrypted byte count cannot be negative.");
+            }
+
+            return GetBase64Length(checked(1 + encryptedLength));
+        }
+
+        public static bool IsCompressedEnvelopeStrictlySmaller(
+            int rawLength,
+            int compressedLength,
+            Func<int, int> getEncryptByteCount)
+        {
+            if (rawLength < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(rawLength));
+            }
+
+            if (compressedLength < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(compressedLength));
+            }
+
+            int rawPlaintextLength = EnvelopeHeaderConstants.HeaderSize + rawLength;
+            int compressedPlaintextLength = EnvelopeHeaderConstants.HeaderSize +
+                UleB128.GetEncodedLength((uint)rawLength) +
+                UleB128.GetEncodedLength((uint)compressedLength) +
+                compressedLength;
+
+            return GetStoredBase64Length(compressedPlaintextLength, getEncryptByteCount) <
+                GetStoredBase64Length(rawPlaintextLength, getEncryptByteCount);
+        }
+    }
+}
+#endif

--- a/Microsoft.Azure.Cosmos.Encryption.Custom/src/Transformation/CompressionLevelSetting.cs
+++ b/Microsoft.Azure.Cosmos.Encryption.Custom/src/Transformation/CompressionLevelSetting.cs
@@ -1,0 +1,15 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+
+#if NET8_0_OR_GREATER
+namespace Microsoft.Azure.Cosmos.Encryption.Custom.Transformation
+{
+    internal enum CompressionLevelSetting : byte
+    {
+        Fastest = 0,
+        Balanced = 1,
+        SmallestSize = 2,
+    }
+}
+#endif

--- a/Microsoft.Azure.Cosmos.Encryption.Custom/src/Transformation/CompressionSettings.cs
+++ b/Microsoft.Azure.Cosmos.Encryption.Custom/src/Transformation/CompressionSettings.cs
@@ -1,0 +1,50 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+
+#if NET8_0_OR_GREATER
+namespace Microsoft.Azure.Cosmos.Encryption.Custom.Transformation
+{
+    using System;
+
+    internal readonly struct CompressionSettings
+    {
+        private const int MaximumContentLength = 64 * 1024 * 1024;
+
+        public CompressionSettings(
+            CompressionCodecId codec,
+            CompressionLevelSetting level,
+            int minimumContentLength)
+        {
+            if (codec != CompressionCodecId.Raw &&
+                codec != CompressionCodecId.Deflate &&
+                codec != CompressionCodecId.Brotli)
+            {
+                throw new ArgumentException("Unsupported compression codec.", nameof(codec));
+            }
+
+            if (level != CompressionLevelSetting.Fastest &&
+                level != CompressionLevelSetting.Balanced &&
+                level != CompressionLevelSetting.SmallestSize)
+            {
+                throw new ArgumentException("Unsupported compression level.", nameof(level));
+            }
+
+            if (minimumContentLength < 0 || minimumContentLength > MaximumContentLength)
+            {
+                throw new ArgumentOutOfRangeException(nameof(minimumContentLength));
+            }
+
+            this.Codec = codec;
+            this.Level = level;
+            this.MinimumContentLength = minimumContentLength;
+        }
+
+        public CompressionCodecId Codec { get; }
+
+        public CompressionLevelSetting Level { get; }
+
+        public int MinimumContentLength { get; }
+    }
+}
+#endif

--- a/Microsoft.Azure.Cosmos.Encryption.Custom/src/Transformation/DecodedEnvelope.cs
+++ b/Microsoft.Azure.Cosmos.Encryption.Custom/src/Transformation/DecodedEnvelope.cs
@@ -1,0 +1,27 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+
+#if NET8_0_OR_GREATER
+namespace Microsoft.Azure.Cosmos.Encryption.Custom.Transformation
+{
+    internal readonly struct DecodedEnvelope
+    {
+        public DecodedEnvelope(TypeMarker typeMarker, byte[] buffer, int offset, int length)
+        {
+            this.TypeMarker = typeMarker;
+            this.Buffer = buffer;
+            this.Offset = offset;
+            this.Length = length;
+        }
+
+        public TypeMarker TypeMarker { get; }
+
+        public byte[] Buffer { get; }
+
+        public int Offset { get; }
+
+        public int Length { get; }
+    }
+}
+#endif

--- a/Microsoft.Azure.Cosmos.Encryption.Custom/src/Transformation/DecompressionBudget.cs
+++ b/Microsoft.Azure.Cosmos.Encryption.Custom/src/Transformation/DecompressionBudget.cs
@@ -1,0 +1,71 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+
+#if NET8_0_OR_GREATER
+namespace Microsoft.Azure.Cosmos.Encryption.Custom.Transformation
+{
+    using System;
+    using System.Threading;
+
+    internal sealed class DecompressionBudget
+    {
+        public const long DefaultLimitBytes = 64L * 1024 * 1024;
+
+        private readonly long limitBytes;
+        private long chargedBytes;
+
+        public DecompressionBudget()
+            : this(DefaultLimitBytes)
+        {
+        }
+
+        public DecompressionBudget(long limitBytes)
+        {
+            if (limitBytes < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(limitBytes));
+            }
+
+            this.limitBytes = limitBytes;
+        }
+
+        public long RemainingBytes
+        {
+            get
+            {
+                long remaining = this.limitBytes - Interlocked.Read(ref this.chargedBytes);
+                return remaining > 0 ? remaining : 0;
+            }
+        }
+
+        public bool TryCharge(long bytes)
+        {
+            if (bytes < 0)
+            {
+                throw new ArgumentOutOfRangeException(nameof(bytes));
+            }
+
+            while (true)
+            {
+                long current = Interlocked.Read(ref this.chargedBytes);
+                if (bytes > this.limitBytes - current)
+                {
+                    return false;
+                }
+
+                long next = current + bytes;
+                if (next < current)
+                {
+                    return false;
+                }
+
+                if (Interlocked.CompareExchange(ref this.chargedBytes, next, current) == current)
+                {
+                    return true;
+                }
+            }
+        }
+    }
+}
+#endif

--- a/Microsoft.Azure.Cosmos.Encryption.Custom/src/Transformation/DeflateCompressorAdapter.cs
+++ b/Microsoft.Azure.Cosmos.Encryption.Custom/src/Transformation/DeflateCompressorAdapter.cs
@@ -1,0 +1,90 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+
+#if NET8_0_OR_GREATER
+namespace Microsoft.Azure.Cosmos.Encryption.Custom.Transformation
+{
+    using System;
+    using System.Buffers;
+    using System.IO;
+    using System.IO.Compression;
+    using System.Runtime.InteropServices;
+
+    internal sealed class DeflateCompressorAdapter : ICompressionCodecAdapter
+    {
+        public int Compress(
+            ReadOnlySpan<byte> source,
+            CompressionLevelSetting level,
+            IBufferWriter<byte> destination)
+        {
+            BufferWriterCopyingStream sink = new (destination);
+            using (DeflateStream stream = new (
+                sink,
+                ToCompressionLevel(level),
+                leaveOpen: true))
+            {
+                stream.Write(source);
+            }
+
+            return sink.BytesWritten;
+        }
+
+        public int Decompress(
+            ReadOnlyMemory<byte> source,
+            Span<byte> destination)
+        {
+            if (!MemoryMarshal.TryGetArray(source, out ArraySegment<byte> sourceSegment))
+            {
+                throw new InvalidOperationException("Deflate input must be backed by an array.");
+            }
+
+            // Exact decompressed length and over-expansion are checked below. Exact compressed input
+            // consumption cannot be efficiently observed because .NET 8 DeflateStream buffers and reads ahead.
+            int total = 0;
+            using (MemoryStream input = new (
+                sourceSegment.Array,
+                sourceSegment.Offset,
+                sourceSegment.Count,
+                writable: false))
+            using (DeflateStream stream = new (input, CompressionMode.Decompress, leaveOpen: false))
+            {
+                while (total < destination.Length)
+                {
+                    int read = stream.Read(destination.Slice(total));
+                    if (read == 0)
+                    {
+                        break;
+                    }
+
+                    total += read;
+                }
+
+                Span<byte> overExpansionProbe = stackalloc byte[1];
+                if (stream.Read(overExpansionProbe) != 0)
+                {
+                    throw new InvalidDataException("Deflate decompressed more bytes than declared.");
+                }
+            }
+
+            if (total != destination.Length)
+            {
+                throw new InvalidDataException("Deflate decompressed length did not match the declared length.");
+            }
+
+            return total;
+        }
+
+        private static CompressionLevel ToCompressionLevel(CompressionLevelSetting level)
+        {
+            return level switch
+            {
+                CompressionLevelSetting.Fastest => CompressionLevel.Fastest,
+                CompressionLevelSetting.Balanced => CompressionLevel.Optimal,
+                CompressionLevelSetting.SmallestSize => CompressionLevel.SmallestSize,
+                _ => throw new ArgumentException("Unsupported compression level.", nameof(level)),
+            };
+        }
+    }
+}
+#endif

--- a/Microsoft.Azure.Cosmos.Encryption.Custom/src/Transformation/EnvelopeHeader.cs
+++ b/Microsoft.Azure.Cosmos.Encryption.Custom/src/Transformation/EnvelopeHeader.cs
@@ -1,0 +1,21 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+
+#if NET8_0_OR_GREATER
+namespace Microsoft.Azure.Cosmos.Encryption.Custom.Transformation
+{
+    internal readonly struct EnvelopeHeader
+    {
+        public EnvelopeHeader(byte innerType, CompressionCodecId codec)
+        {
+            this.InnerType = innerType;
+            this.Codec = codec;
+        }
+
+        public byte InnerType { get; }
+
+        public CompressionCodecId Codec { get; }
+    }
+}
+#endif

--- a/Microsoft.Azure.Cosmos.Encryption.Custom/src/Transformation/EnvelopeHeaderConstants.cs
+++ b/Microsoft.Azure.Cosmos.Encryption.Custom/src/Transformation/EnvelopeHeaderConstants.cs
@@ -1,0 +1,26 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+
+#if NET8_0_OR_GREATER
+namespace Microsoft.Azure.Cosmos.Encryption.Custom.Transformation
+{
+    using System;
+
+    internal static class EnvelopeHeaderConstants
+    {
+        private static readonly byte[] MagicBytes = { 0x43, 0x45, 0xC5, 0x01, 0x56, 0x34 };
+
+        public const byte EpochByte = 0x04;
+        public const int MagicLength = 6;
+        public const int FormatEpochOffset = MagicLength;
+        public const int InnerTypeOffset = FormatEpochOffset + 1;
+        public const int CodecOffset = InnerTypeOffset + 1;
+        public const int HeaderSize = CodecOffset + 1;
+        public const byte MinValidInnerTypeMarker = 2;
+        public const byte MaxValidInnerTypeMarker = 7;
+
+        public static ReadOnlySpan<byte> Magic => MagicBytes;
+    }
+}
+#endif

--- a/Microsoft.Azure.Cosmos.Encryption.Custom/src/Transformation/EnvelopeHeaderReader.cs
+++ b/Microsoft.Azure.Cosmos.Encryption.Custom/src/Transformation/EnvelopeHeaderReader.cs
@@ -1,0 +1,52 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+
+#if NET8_0_OR_GREATER
+namespace Microsoft.Azure.Cosmos.Encryption.Custom.Transformation
+{
+    using System;
+
+    internal static class EnvelopeHeaderReader
+    {
+        public static bool TryReadV4Header(
+            ReadOnlySpan<byte> plaintext,
+            out EnvelopeHeader header,
+            out int consumed)
+        {
+            header = default;
+            consumed = 0;
+
+            if (plaintext.Length < EnvelopeHeaderConstants.HeaderSize ||
+                !plaintext.StartsWith(EnvelopeHeaderConstants.Magic))
+            {
+                return false;
+            }
+
+            if (plaintext[EnvelopeHeaderConstants.FormatEpochOffset] != EnvelopeHeaderConstants.EpochByte)
+            {
+                return false;
+            }
+
+            byte innerType = plaintext[EnvelopeHeaderConstants.InnerTypeOffset];
+            if (innerType < EnvelopeHeaderConstants.MinValidInnerTypeMarker ||
+                innerType > EnvelopeHeaderConstants.MaxValidInnerTypeMarker)
+            {
+                return false;
+            }
+
+            byte codec = plaintext[EnvelopeHeaderConstants.CodecOffset];
+            if (codec != (byte)CompressionCodecId.Raw &&
+                codec != (byte)CompressionCodecId.Deflate &&
+                codec != (byte)CompressionCodecId.Brotli)
+            {
+                return false;
+            }
+
+            header = new EnvelopeHeader(innerType, (CompressionCodecId)codec);
+            consumed = EnvelopeHeaderConstants.HeaderSize;
+            return true;
+        }
+    }
+}
+#endif

--- a/Microsoft.Azure.Cosmos.Encryption.Custom/src/Transformation/EnvelopeHeaderWriter.cs
+++ b/Microsoft.Azure.Cosmos.Encryption.Custom/src/Transformation/EnvelopeHeaderWriter.cs
@@ -1,0 +1,39 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+
+#if NET8_0_OR_GREATER
+namespace Microsoft.Azure.Cosmos.Encryption.Custom.Transformation
+{
+    using System;
+
+    internal static class EnvelopeHeaderWriter
+    {
+        public static void Write(Span<byte> destination, byte innerType, CompressionCodecId codec)
+        {
+            if (destination.Length < EnvelopeHeaderConstants.HeaderSize)
+            {
+                throw new ArgumentException("Destination is too small.", nameof(destination));
+            }
+
+            if (innerType < EnvelopeHeaderConstants.MinValidInnerTypeMarker ||
+                innerType > EnvelopeHeaderConstants.MaxValidInnerTypeMarker)
+            {
+                throw new ArgumentOutOfRangeException(nameof(innerType));
+            }
+
+            if (codec != CompressionCodecId.Raw &&
+                codec != CompressionCodecId.Deflate &&
+                codec != CompressionCodecId.Brotli)
+            {
+                throw new ArgumentOutOfRangeException(nameof(codec));
+            }
+
+            EnvelopeHeaderConstants.Magic.CopyTo(destination);
+            destination[EnvelopeHeaderConstants.FormatEpochOffset] = EnvelopeHeaderConstants.EpochByte;
+            destination[EnvelopeHeaderConstants.InnerTypeOffset] = innerType;
+            destination[EnvelopeHeaderConstants.CodecOffset] = (byte)codec;
+        }
+    }
+}
+#endif

--- a/Microsoft.Azure.Cosmos.Encryption.Custom/src/Transformation/ICompressionCodecAdapter.cs
+++ b/Microsoft.Azure.Cosmos.Encryption.Custom/src/Transformation/ICompressionCodecAdapter.cs
@@ -1,0 +1,23 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+
+#if NET8_0_OR_GREATER
+namespace Microsoft.Azure.Cosmos.Encryption.Custom.Transformation
+{
+    using System;
+    using System.Buffers;
+
+    internal interface ICompressionCodecAdapter
+    {
+        int Compress(
+            ReadOnlySpan<byte> source,
+            CompressionLevelSetting level,
+            IBufferWriter<byte> destination);
+
+        int Decompress(
+            ReadOnlyMemory<byte> source,
+            Span<byte> destination);
+    }
+}
+#endif

--- a/Microsoft.Azure.Cosmos.Encryption.Custom/src/Transformation/UleB128.cs
+++ b/Microsoft.Azure.Cosmos.Encryption.Custom/src/Transformation/UleB128.cs
@@ -1,0 +1,100 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+
+#if NET8_0_OR_GREATER
+namespace Microsoft.Azure.Cosmos.Encryption.Custom.Transformation
+{
+    using System;
+
+    internal static class UleB128
+    {
+        private const uint MaxValue = 0x0FFFFFFF;
+
+        public static int GetEncodedLength(uint value)
+        {
+            if (value > MaxValue)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value));
+            }
+
+            if (value < 0x80)
+            {
+                return 1;
+            }
+
+            if (value < 0x4000)
+            {
+                return 2;
+            }
+
+            if (value < 0x200000)
+            {
+                return 3;
+            }
+
+            return 4;
+        }
+
+        public static int Write(uint value, Span<byte> destination)
+        {
+            if (value > MaxValue)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value));
+            }
+
+            int length = GetEncodedLength(value);
+            if (destination.Length < length)
+            {
+                throw new ArgumentException("Destination is too small.", nameof(destination));
+            }
+
+            uint remaining = value;
+            for (int i = 0; i < length; i++)
+            {
+                byte valueByte = (byte)(remaining & 0x7F);
+                remaining >>= 7;
+                if (i < length - 1)
+                {
+                    valueByte |= 0x80;
+                }
+
+                destination[i] = valueByte;
+            }
+
+            return length;
+        }
+
+        public static bool TryRead(ReadOnlySpan<byte> source, out uint value, out int consumed)
+        {
+            value = 0;
+            consumed = 0;
+
+            uint result = 0;
+            for (int i = 0; i < 4; i++)
+            {
+                if (i >= source.Length)
+                {
+                    return false;
+                }
+
+                byte valueByte = source[i];
+                result |= (uint)(valueByte & 0x7F) << (7 * i);
+                if ((valueByte & 0x80) == 0)
+                {
+                    if (result > MaxValue || GetEncodedLength(result) != i + 1)
+                    {
+                        return false;
+                    }
+
+                    value = result;
+                    consumed = i + 1;
+                    return true;
+                }
+            }
+
+            return false;
+        }
+    }
+}
+#endif

--- a/Microsoft.Azure.Cosmos.Encryption.Custom/src/Transformation/V4CompressionEnvelope.cs
+++ b/Microsoft.Azure.Cosmos.Encryption.Custom/src/Transformation/V4CompressionEnvelope.cs
@@ -1,0 +1,262 @@
+// ------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+// ------------------------------------------------------------
+
+#if NET8_0_OR_GREATER
+namespace Microsoft.Azure.Cosmos.Encryption.Custom.Transformation
+{
+    using System;
+
+    internal static class V4CompressionEnvelope
+    {
+        private const int MaximumPayloadLength = 64 * 1024 * 1024;
+
+        private static readonly ICompressionCodecAdapter Deflate = new DeflateCompressorAdapter();
+        private static readonly ICompressionCodecAdapter Brotli = new BrotliCompressorAdapter();
+
+        public static bool IsStructurallyValidV4Envelope(ReadOnlySpan<byte> plaintext)
+        {
+            return TryParseFrame(plaintext, out _, out _, out _, out _);
+        }
+
+        public static (byte[] Buffer, int Length) Create(
+            ReadOnlySpan<byte> payload,
+            TypeMarker typeMarker,
+            CompressionSettings settings,
+            Func<int, int> getEncryptByteCount,
+            ArrayPoolManager pool)
+        {
+            if (getEncryptByteCount == null)
+            {
+                throw new ArgumentNullException(nameof(getEncryptByteCount));
+            }
+
+            if (pool == null)
+            {
+                throw new ArgumentNullException(nameof(pool));
+            }
+
+            if (payload.Length > MaximumPayloadLength)
+            {
+                throw new ArgumentOutOfRangeException(nameof(payload));
+            }
+
+            if (payload.IsEmpty ||
+                settings.Codec == CompressionCodecId.Raw ||
+                payload.Length < settings.MinimumContentLength)
+            {
+                return CreateRaw(payload, typeMarker, pool);
+            }
+
+            // Start at half the payload size, with a 256-byte floor and a 64 KiB cap on the initial
+            // pooled rent. The writer grows if the compressed output requires more space.
+            using RentArrayBufferWriter compressedWriter = new (
+                Math.Min(Math.Max(payload.Length / 2, 256), 64 * 1024));
+            ICompressionCodecAdapter adapter = GetAdapter(settings.Codec);
+            int compressedLength = adapter.Compress(payload, settings.Level, compressedWriter);
+            if (compressedLength != compressedWriter.BytesWritten)
+            {
+                throw new InvalidOperationException("Compression adapter returned an inconsistent byte count.");
+            }
+
+            if (!CompressionHelper.IsCompressedEnvelopeStrictlySmaller(
+                payload.Length,
+                compressedLength,
+                getEncryptByteCount))
+            {
+                return CreateRaw(payload, typeMarker, pool);
+            }
+
+            int rawLengthBytes = UleB128.GetEncodedLength((uint)payload.Length);
+            int compressedLengthBytes = UleB128.GetEncodedLength((uint)compressedLength);
+            int envelopeLength = checked(
+                EnvelopeHeaderConstants.HeaderSize +
+                rawLengthBytes +
+                compressedLengthBytes +
+                compressedLength);
+            byte[] envelope = pool.Rent(envelopeLength);
+            EnvelopeHeaderWriter.Write(envelope, (byte)typeMarker, settings.Codec);
+            int offset = EnvelopeHeaderConstants.HeaderSize;
+            offset += UleB128.Write((uint)payload.Length, envelope.AsSpan(offset));
+            offset += UleB128.Write((uint)compressedLength, envelope.AsSpan(offset));
+            compressedWriter.WrittenSpan.CopyTo(envelope.AsSpan(offset, compressedLength));
+            return (envelope, envelopeLength);
+        }
+
+        public static DecodedEnvelope Decode(
+            byte[] plaintext,
+            int plaintextLength,
+            byte outerTypeMarker,
+            DecompressionBudget budget,
+            ArrayPoolManager pool)
+        {
+            if (plaintext == null)
+            {
+                throw new ArgumentNullException(nameof(plaintext));
+            }
+
+            if (plaintextLength < 0 || plaintextLength > plaintext.Length)
+            {
+                throw new ArgumentOutOfRangeException(nameof(plaintextLength));
+            }
+
+            if (budget == null)
+            {
+                throw new ArgumentNullException(nameof(budget));
+            }
+
+            if (pool == null)
+            {
+                throw new ArgumentNullException(nameof(pool));
+            }
+
+            ReadOnlySpan<byte> envelope = plaintext.AsSpan(0, plaintextLength);
+            if (!TryParseFrame(
+                envelope,
+                out EnvelopeHeader header,
+                out int payloadOffset,
+                out int rawLength,
+                out int payloadLength))
+            {
+                throw new InvalidOperationException("Encrypted envelope failed integrity validation.");
+            }
+
+            if (header.InnerType != outerTypeMarker)
+            {
+                throw new InvalidOperationException(
+                    "Envelope inner type marker does not match the outer type marker.");
+            }
+
+            TypeMarker typeMarker = (TypeMarker)header.InnerType;
+            if (header.Codec == CompressionCodecId.Raw)
+            {
+                ChargeBudget(budget, rawLength);
+                return new DecodedEnvelope(typeMarker, plaintext, payloadOffset, rawLength);
+            }
+
+            ChargeBudget(budget, rawLength);
+            byte[] decoded = pool.Rent(rawLength);
+            ReadOnlyMemory<byte> compressedBody = new (
+                plaintext,
+                payloadOffset,
+                payloadLength);
+            int written = GetAdapter(header.Codec).Decompress(
+                compressedBody,
+                decoded.AsSpan(0, rawLength));
+            if (written != rawLength)
+            {
+                throw new InvalidOperationException(
+                    "Decompressed content did not match the declared length.");
+            }
+
+            return new DecodedEnvelope(typeMarker, decoded, 0, rawLength);
+        }
+
+        private static (byte[] Buffer, int Length) CreateRaw(
+            ReadOnlySpan<byte> payload,
+            TypeMarker typeMarker,
+            ArrayPoolManager pool)
+        {
+            int envelopeLength = checked(EnvelopeHeaderConstants.HeaderSize + payload.Length);
+            byte[] envelope = pool.Rent(envelopeLength);
+            EnvelopeHeaderWriter.Write(envelope, (byte)typeMarker, CompressionCodecId.Raw);
+            payload.CopyTo(envelope.AsSpan(EnvelopeHeaderConstants.HeaderSize, payload.Length));
+            return (envelope, envelopeLength);
+        }
+
+        private static ICompressionCodecAdapter GetAdapter(CompressionCodecId codec)
+        {
+            return codec switch
+            {
+                CompressionCodecId.Deflate => Deflate,
+                CompressionCodecId.Brotli => Brotli,
+                _ => throw new InvalidOperationException("Encrypted envelope failed integrity validation."),
+            };
+        }
+
+        private static bool TryParseFrame(
+            ReadOnlySpan<byte> plaintext,
+            out EnvelopeHeader header,
+            out int payloadOffset,
+            out int rawLength,
+            out int payloadLength)
+        {
+            header = default;
+            payloadOffset = 0;
+            rawLength = 0;
+            payloadLength = 0;
+
+            if (!EnvelopeHeaderReader.TryReadV4Header(plaintext, out header, out int bodyOffset))
+            {
+                return false;
+            }
+
+            TypeMarker typeMarker = (TypeMarker)header.InnerType;
+            if (header.Codec == CompressionCodecId.Raw)
+            {
+                int bodyLength = plaintext.Length - bodyOffset;
+                if (!IsPlausibleSerializedLength(typeMarker, bodyLength))
+                {
+                    return false;
+                }
+
+                payloadOffset = bodyOffset;
+                rawLength = bodyLength;
+                payloadLength = bodyLength;
+                return true;
+            }
+
+            ReadOnlySpan<byte> body = plaintext.Slice(bodyOffset);
+            if (!UleB128.TryRead(body, out uint rawLengthValue, out int rawLengthBytes) ||
+                !UleB128.TryRead(
+                    body.Slice(rawLengthBytes),
+                    out uint compressedLengthValue,
+                    out int compressedLengthBytes) ||
+                rawLengthValue == 0 ||
+                rawLengthValue > MaximumPayloadLength ||
+                compressedLengthValue == 0 ||
+                compressedLengthValue > MaximumPayloadLength ||
+                !IsPlausibleSerializedLength(typeMarker, (int)rawLengthValue))
+            {
+                return false;
+            }
+
+            int compressedOffset = rawLengthBytes + compressedLengthBytes;
+            if (body.Length - compressedOffset != (int)compressedLengthValue)
+            {
+                return false;
+            }
+
+            payloadOffset = bodyOffset + compressedOffset;
+            rawLength = (int)rawLengthValue;
+            payloadLength = (int)compressedLengthValue;
+            return true;
+        }
+
+        private static bool IsPlausibleSerializedLength(TypeMarker typeMarker, int length)
+        {
+            return typeMarker switch
+            {
+                TypeMarker.String => length >= 0 && length <= MaximumPayloadLength,
+                TypeMarker.Long or TypeMarker.Double or TypeMarker.Boolean => length == 8,
+                TypeMarker.Array or TypeMarker.Object => length >= 2 && length <= MaximumPayloadLength,
+                _ => false,
+            };
+        }
+
+        private static void ChargeBudget(DecompressionBudget budget, int length)
+        {
+            if (length < 0 || length > MaximumPayloadLength)
+            {
+                throw new InvalidOperationException("Encrypted envelope failed integrity validation.");
+            }
+
+            if (!budget.TryCharge(length))
+            {
+                throw new InvalidOperationException(
+                    "Aggregate decompressed content exceeds the request budget.");
+            }
+        }
+    }
+}
+#endif

--- a/Microsoft.Azure.Cosmos.Encryption.Custom/tests/Microsoft.Azure.Cosmos.Encryption.Custom.Tests/Transformation/CompressionEnvelopeNet6ContractTests.cs
+++ b/Microsoft.Azure.Cosmos.Encryption.Custom/tests/Microsoft.Azure.Cosmos.Encryption.Custom.Tests/Transformation/CompressionEnvelopeNet6ContractTests.cs
@@ -1,0 +1,46 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+#if !NET8_0_OR_GREATER
+namespace Microsoft.Azure.Cosmos.Encryption.Tests.Transformation
+{
+    using System.Reflection;
+    using Microsoft.Azure.Cosmos.Encryption.Custom;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class CompressionEnvelopeNet6ContractTests
+    {
+        [TestMethod]
+        public void CompressionEnvelopePrimitives_AreAbsent()
+        {
+            Assembly assembly = typeof(EncryptionOptions).Assembly;
+            string[] typeNames =
+            {
+                "Microsoft.Azure.Cosmos.Encryption.Custom.Transformation.BrotliCompressorAdapter",
+                "Microsoft.Azure.Cosmos.Encryption.Custom.Transformation.BufferWriterCopyingStream",
+                "Microsoft.Azure.Cosmos.Encryption.Custom.Transformation.CompressionCodecId",
+                "Microsoft.Azure.Cosmos.Encryption.Custom.Transformation.CompressionHelper",
+                "Microsoft.Azure.Cosmos.Encryption.Custom.Transformation.CompressionLevelSetting",
+                "Microsoft.Azure.Cosmos.Encryption.Custom.Transformation.CompressionSettings",
+                "Microsoft.Azure.Cosmos.Encryption.Custom.Transformation.DecodedEnvelope",
+                "Microsoft.Azure.Cosmos.Encryption.Custom.Transformation.DecompressionBudget",
+                "Microsoft.Azure.Cosmos.Encryption.Custom.Transformation.DeflateCompressorAdapter",
+                "Microsoft.Azure.Cosmos.Encryption.Custom.Transformation.EnvelopeHeader",
+                "Microsoft.Azure.Cosmos.Encryption.Custom.Transformation.EnvelopeHeaderConstants",
+                "Microsoft.Azure.Cosmos.Encryption.Custom.Transformation.EnvelopeHeaderReader",
+                "Microsoft.Azure.Cosmos.Encryption.Custom.Transformation.EnvelopeHeaderWriter",
+                "Microsoft.Azure.Cosmos.Encryption.Custom.Transformation.ICompressionCodecAdapter",
+                "Microsoft.Azure.Cosmos.Encryption.Custom.Transformation.UleB128",
+                "Microsoft.Azure.Cosmos.Encryption.Custom.Transformation.V4CompressionEnvelope",
+            };
+
+            foreach (string typeName in typeNames)
+            {
+                Assert.IsNull(assembly.GetType(typeName), typeName);
+            }
+        }
+    }
+}
+#endif

--- a/Microsoft.Azure.Cosmos.Encryption.Custom/tests/Microsoft.Azure.Cosmos.Encryption.Custom.Tests/Transformation/CompressionEnvelopePrimitivesTests.cs
+++ b/Microsoft.Azure.Cosmos.Encryption.Custom/tests/Microsoft.Azure.Cosmos.Encryption.Custom.Tests/Transformation/CompressionEnvelopePrimitivesTests.cs
@@ -1,0 +1,320 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+#if NET8_0_OR_GREATER
+namespace Microsoft.Azure.Cosmos.Encryption.Tests.Transformation
+{
+    using System;
+    using System.Buffers;
+    using System.IO;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using Microsoft.Azure.Cosmos.Encryption.Custom.Transformation;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class CompressionEnvelopePrimitivesTests
+    {
+        [TestMethod]
+        public void EnvelopeHeader_WritesExactBytesAndRejectsTamper()
+        {
+            Assert.AreEqual(6, EnvelopeHeaderConstants.MagicLength);
+            Assert.AreEqual(6, EnvelopeHeaderConstants.FormatEpochOffset);
+            Assert.AreEqual(7, EnvelopeHeaderConstants.InnerTypeOffset);
+            Assert.AreEqual(8, EnvelopeHeaderConstants.CodecOffset);
+            Assert.AreEqual(9, EnvelopeHeaderConstants.HeaderSize);
+            Span<byte> buffer = stackalloc byte[EnvelopeHeaderConstants.HeaderSize];
+            EnvelopeHeaderWriter.Write(buffer, 7, CompressionCodecId.Brotli);
+
+            CollectionAssert.AreEqual(
+                new byte[] { 0x43, 0x45, 0xC5, 0x01, 0x56, 0x34, 0x04, 0x07, 0x02 },
+                buffer.ToArray());
+
+            Assert.IsTrue(EnvelopeHeaderReader.TryReadV4Header(buffer, out EnvelopeHeader header, out int consumed));
+            Assert.AreEqual(EnvelopeHeaderConstants.HeaderSize, consumed);
+            Assert.AreEqual(7, header.InnerType);
+            Assert.AreEqual(CompressionCodecId.Brotli, header.Codec);
+
+            byte[] nullMarker = buffer.ToArray();
+            nullMarker[EnvelopeHeaderConstants.InnerTypeOffset] = (byte)TypeMarker.Null;
+            Assert.IsFalse(EnvelopeHeaderReader.TryReadV4Header(nullMarker, out _, out _));
+
+            for (int i = 0; i < EnvelopeHeaderConstants.HeaderSize; i++)
+            {
+                byte[] tampered = buffer.ToArray();
+                tampered[i] ^= 0x7F;
+                Assert.IsFalse(
+                    EnvelopeHeaderReader.TryReadV4Header(tampered, out _, out _),
+                    $"Tamper at offset {i} should fail.");
+            }
+        }
+
+        [TestMethod]
+        public void EnvelopeHeader_RejectsInvalidArgumentsAndUnknownCodec()
+        {
+            Assert.ThrowsException<ArgumentException>(() => EnvelopeHeaderWriter.Write(
+                new byte[EnvelopeHeaderConstants.HeaderSize - 1],
+                (byte)TypeMarker.String,
+                CompressionCodecId.Raw));
+
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => EnvelopeHeaderWriter.Write(
+                new byte[EnvelopeHeaderConstants.HeaderSize],
+                0,
+                CompressionCodecId.Raw));
+
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => EnvelopeHeaderWriter.Write(
+                new byte[EnvelopeHeaderConstants.HeaderSize],
+                (byte)TypeMarker.Null,
+                CompressionCodecId.Raw));
+
+            byte[] headerBuffer = new byte[EnvelopeHeaderConstants.HeaderSize];
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => EnvelopeHeaderWriter.Write(
+                headerBuffer,
+                (byte)TypeMarker.String,
+                (CompressionCodecId)3));
+
+            EnvelopeHeaderWriter.Write(headerBuffer, (byte)TypeMarker.String, CompressionCodecId.Raw);
+            headerBuffer[EnvelopeHeaderConstants.CodecOffset] = 3;
+            Assert.IsFalse(EnvelopeHeaderReader.TryReadV4Header(headerBuffer, out _, out _));
+        }
+
+        [TestMethod]
+        public void CompressionCodecIds_AreStable()
+        {
+            Assert.AreEqual(0, (byte)CompressionCodecId.Raw);
+            Assert.AreEqual(1, (byte)CompressionCodecId.Deflate);
+            Assert.AreEqual(2, (byte)CompressionCodecId.Brotli);
+            Assert.IsFalse(Enum.IsDefined(typeof(CompressionCodecId), (byte)3));
+        }
+
+        [TestMethod]
+        public void UleB128_UsesCanonicalShortestEncoding()
+        {
+            byte[] scratch = new byte[4];
+            for (int value = 0; value < 100000; value++)
+            {
+                int written = UleB128.Write((uint)value, scratch);
+                Assert.IsTrue(UleB128.TryRead(scratch.AsSpan(0, written), out uint decoded, out int consumed));
+                Assert.AreEqual((uint)value, decoded);
+                Assert.AreEqual(written, consumed);
+                Assert.AreEqual(written, UleB128.GetEncodedLength((uint)value));
+            }
+
+            foreach (uint value in new uint[] { 0x0FFFFFFF, 64 * 1024 * 1024 })
+            {
+                int written = UleB128.Write(value, scratch);
+                Assert.IsTrue(UleB128.TryRead(scratch.AsSpan(0, written), out uint decoded, out int consumed));
+                Assert.AreEqual(value, decoded);
+                Assert.AreEqual(written, consumed);
+            }
+        }
+
+        [TestMethod]
+        public void UleB128_RejectsMalformedAndNonCanonicalEncoding()
+        {
+            Assert.IsFalse(UleB128.TryRead(new byte[] { 0x80 }, out _, out _));
+            Assert.IsFalse(UleB128.TryRead(new byte[] { 0x80, 0x00 }, out _, out _));
+            Assert.IsFalse(UleB128.TryRead(new byte[] { 0xAA, 0x80, 0x00 }, out _, out _));
+            Assert.IsFalse(UleB128.TryRead(new byte[] { 0x80, 0x80, 0x80, 0x80 }, out _, out _));
+            Assert.IsFalse(UleB128.TryRead(new byte[] { 0x80, 0x80, 0x80, 0x80, 0x00 }, out _, out _));
+            Assert.ThrowsException<ArgumentException>(() => UleB128.Write(0x80, new byte[1]));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => UleB128.GetEncodedLength(0x10000000));
+        }
+
+        [TestMethod]
+        public void CompressionHelper_UsesExactEncryptedBase64BreakEven()
+        {
+            Func<int, int> encryptedBytes = plaintextLength => 49 + ((plaintextLength / 16) + 1) * 16;
+
+            Assert.AreEqual(368, CompressionHelper.GetStoredBase64Length(209, encryptedBytes));
+            Assert.AreEqual(260, CompressionHelper.GetStoredBase64Length(132, encryptedBytes));
+            Assert.AreEqual(216, CompressionHelper.GetStoredBase64Length(109, encryptedBytes));
+            Assert.AreEqual(216, CompressionHelper.GetStoredBase64Length(110, encryptedBytes));
+
+            Assert.IsFalse(CompressionHelper.IsCompressedEnvelopeStrictlySmaller(100, 99, encryptedBytes));
+            Assert.IsTrue(CompressionHelper.IsCompressedEnvelopeStrictlySmaller(1024, 780, encryptedBytes));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => CompressionHelper.GetBase64Length(-1));
+            Assert.ThrowsException<OverflowException>(() => CompressionHelper.GetBase64Length(int.MaxValue));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => CompressionHelper.GetStoredBase64Length(-1, encryptedBytes));
+            Assert.ThrowsException<InvalidOperationException>(() => CompressionHelper.GetStoredBase64Length(1, _ => -1));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => CompressionHelper.IsCompressedEnvelopeStrictlySmaller(-1, 1, encryptedBytes));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => CompressionHelper.IsCompressedEnvelopeStrictlySmaller(1, -1, encryptedBytes));
+        }
+
+        [TestMethod]
+        public void DecompressionBudget_ChargesAtomicallyAndValidatesLimits()
+        {
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => new DecompressionBudget(-1));
+
+            DecompressionBudget budget = new (10);
+            Assert.IsTrue(budget.TryCharge(6));
+            Assert.AreEqual(4, budget.RemainingBytes);
+            Assert.IsFalse(budget.TryCharge(5));
+            Assert.IsTrue(budget.TryCharge(4));
+            Assert.AreEqual(0, budget.RemainingBytes);
+            Assert.IsTrue(budget.TryCharge(0));
+            Assert.IsFalse(budget.TryCharge(1));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => budget.TryCharge(-1));
+
+            DecompressionBudget overflow = new (long.MaxValue);
+            Assert.IsTrue(overflow.TryCharge(long.MaxValue - 1));
+            Assert.IsFalse(overflow.TryCharge(2));
+        }
+
+        [TestMethod]
+        public void DecompressionBudget_IsConcurrencySafe()
+        {
+            DecompressionBudget budget = new (1000);
+
+            Parallel.ForEach(Enumerable.Range(0, 10000), _ => budget.TryCharge(1));
+
+            Assert.AreEqual(0, budget.RemainingBytes);
+            Assert.IsFalse(budget.TryCharge(1));
+        }
+
+        [TestMethod]
+        public void CodecImplementationTypes_AreAvailableOnlyOnNet8()
+        {
+            Type deflate = typeof(CompressionCodecId).Assembly.GetType(
+                "Microsoft.Azure.Cosmos.Encryption.Custom.Transformation.DeflateCompressorAdapter");
+            Type brotli = typeof(CompressionCodecId).Assembly.GetType(
+                "Microsoft.Azure.Cosmos.Encryption.Custom.Transformation.BrotliCompressorAdapter");
+
+            Assert.IsNotNull(deflate);
+            Assert.IsNotNull(brotli);
+        }
+
+        [DataTestMethod]
+        [DataRow((byte)CompressionLevelSetting.Fastest, 1)]
+        [DataRow((byte)CompressionLevelSetting.Balanced, 5)]
+        [DataRow((byte)CompressionLevelSetting.SmallestSize, 9)]
+        public void BrotliCompressorAdapter_MapsInternalLevels(byte levelValue, int expectedQuality)
+        {
+            Assert.AreEqual(
+                expectedQuality,
+                BrotliCompressorAdapter.ToQuality((CompressionLevelSetting)levelValue));
+        }
+
+        [TestMethod]
+        public void BrotliCompressorAdapter_RejectsUnsupportedLevel()
+        {
+            Assert.ThrowsException<ArgumentException>(() =>
+                BrotliCompressorAdapter.ToQuality((CompressionLevelSetting)255));
+        }
+
+        [TestMethod]
+        public void CodecAdapters_RoundTripAndEnforceDestinationSize()
+        {
+            byte[] source = Encoding.UTF8.GetBytes(new string('x', 8192));
+
+            AssertRoundTrip(new DeflateCompressorAdapter(), source);
+            AssertRoundTrip(new BrotliCompressorAdapter(), source);
+
+            AssertRejectsInvalidCompressedInput(new DeflateCompressorAdapter(), source);
+            AssertRejectsInvalidCompressedInput(new BrotliCompressorAdapter(), source);
+
+            using NonArrayMemoryOwner owner = new (new byte[] { 1, 2, 3 });
+            Assert.ThrowsException<InvalidOperationException>(() =>
+                new DeflateCompressorAdapter().Decompress(owner.Memory, new byte[1]));
+        }
+
+        [TestMethod]
+        public void BufferWriterCopyingStream_CountsOnlySuccessfulWrites()
+        {
+            ArrayBufferWriter<byte> destination = new ();
+            BufferWriterCopyingStream stream = new (destination);
+            byte[] first = { 1, 2, 3, 4 };
+
+            stream.Write(first, 1, 2);
+            stream.Write(new byte[] { 4, 5, 6 }.AsSpan());
+
+            Assert.AreEqual(5, stream.BytesWritten);
+            CollectionAssert.AreEqual(new byte[] { 2, 3, 4, 5, 6 }, destination.WrittenSpan.ToArray());
+
+            BufferWriterCopyingStream failingStream = new (new ThrowingAdvanceBufferWriter());
+            Assert.ThrowsException<InvalidOperationException>(() =>
+                failingStream.Write(new byte[] { 7, 8 }, 0, 2));
+            Assert.AreEqual(0, failingStream.BytesWritten);
+        }
+
+        private static void AssertRoundTrip(ICompressionCodecAdapter adapter, byte[] source)
+        {
+            byte[] compressed = Compress(adapter, source);
+
+            byte[] decompressed = new byte[source.Length];
+            int written = adapter.Decompress(compressed, decompressed);
+            Assert.AreEqual(source.Length, written);
+            CollectionAssert.AreEqual(source, decompressed);
+        }
+
+        private static void AssertRejectsInvalidCompressedInput(ICompressionCodecAdapter adapter, byte[] source)
+        {
+            byte[] compressed = Compress(adapter, source);
+
+            Assert.ThrowsException<InvalidDataException>(() => adapter.Decompress(new byte[] { 1, 2, 3 }, new byte[source.Length]));
+            Assert.ThrowsException<InvalidDataException>(() => adapter.Decompress(compressed.AsMemory(0, compressed.Length / 2), new byte[source.Length]));
+            Assert.ThrowsException<InvalidDataException>(() => adapter.Decompress(compressed, new byte[source.Length + 1]));
+            Assert.ThrowsException<InvalidDataException>(() => adapter.Decompress(compressed, new byte[source.Length - 1]));
+        }
+
+        private static byte[] Compress(ICompressionCodecAdapter adapter, byte[] source)
+        {
+            ArrayBufferWriter<byte> compressed = new ();
+            int written = adapter.Compress(source, CompressionLevelSetting.Balanced, compressed);
+            Assert.AreEqual(compressed.WrittenCount, written);
+            Assert.IsTrue(compressed.WrittenCount < source.Length);
+            return compressed.WrittenSpan.ToArray();
+        }
+
+        private sealed class NonArrayMemoryOwner : MemoryManager<byte>
+        {
+            private readonly byte[] buffer;
+
+            public NonArrayMemoryOwner(byte[] buffer)
+            {
+                this.buffer = buffer;
+            }
+
+            public override Span<byte> GetSpan()
+            {
+                return this.buffer;
+            }
+
+            public override MemoryHandle Pin(int elementIndex = 0)
+            {
+                throw new NotSupportedException();
+            }
+
+            public override void Unpin()
+            {
+            }
+
+            protected override void Dispose(bool disposing)
+            {
+            }
+        }
+
+        private sealed class ThrowingAdvanceBufferWriter : IBufferWriter<byte>
+        {
+            private readonly byte[] buffer = new byte[16];
+
+            public void Advance(int count)
+            {
+                throw new InvalidOperationException("Advance failed.");
+            }
+
+            public Memory<byte> GetMemory(int sizeHint = 0)
+            {
+                return this.buffer;
+            }
+
+            public Span<byte> GetSpan(int sizeHint = 0)
+            {
+                return this.buffer;
+            }
+        }
+    }
+}
+#endif

--- a/Microsoft.Azure.Cosmos.Encryption.Custom/tests/Microsoft.Azure.Cosmos.Encryption.Custom.Tests/Transformation/V4CompressionEnvelopeTests.cs
+++ b/Microsoft.Azure.Cosmos.Encryption.Custom/tests/Microsoft.Azure.Cosmos.Encryption.Custom.Tests/Transformation/V4CompressionEnvelopeTests.cs
@@ -1,0 +1,583 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+#if NET8_0_OR_GREATER
+namespace Microsoft.Azure.Cosmos.Encryption.Tests.Transformation
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Reflection;
+    using System.Text;
+    using Microsoft.Azure.Cosmos.Encryption.Custom;
+    using Microsoft.Azure.Cosmos.Encryption.Custom.Transformation;
+    using Microsoft.Data.Encryption.Cryptography.Serializers;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class V4CompressionEnvelopeTests
+    {
+        private static readonly Func<int, int> EncryptByteCount =
+            length => 49 + (((length / 16) + 1) * 16);
+
+        [DataTestMethod]
+        [DataRow((byte)CompressionCodecId.Raw)]
+        [DataRow((byte)CompressionCodecId.Deflate)]
+        [DataRow((byte)CompressionCodecId.Brotli)]
+        public void CreateAndDecode_RoundTrips(byte codecValue)
+        {
+            CompressionCodecId codec = (CompressionCodecId)codecValue;
+            byte[] payload = Encoding.UTF8.GetBytes(new string('a', 4096));
+            CompressionSettings settings = new (
+                codec,
+                CompressionLevelSetting.Balanced,
+                minimumContentLength: 0);
+
+            using ArrayPoolManager pool = new ();
+            (byte[] envelope, int envelopeLength) = V4CompressionEnvelope.Create(
+                payload,
+                TypeMarker.String,
+                settings,
+                EncryptByteCount,
+                pool);
+
+            DecodedEnvelope decoded = V4CompressionEnvelope.Decode(
+                envelope,
+                envelopeLength,
+                (byte)TypeMarker.String,
+                new DecompressionBudget(),
+                pool);
+
+            Assert.AreEqual(TypeMarker.String, decoded.TypeMarker);
+            CollectionAssert.AreEqual(payload, decoded.Buffer.AsSpan(decoded.Offset, decoded.Length).ToArray());
+        }
+
+        [TestMethod]
+        public void CreateAndDecode_AllEmittedTypeMarkersRoundTrip()
+        {
+            using ArrayPoolManager pool = new ();
+            CompressionSettings settings = new (
+                CompressionCodecId.Raw,
+                CompressionLevelSetting.Balanced,
+                minimumContentLength: 0);
+
+            foreach ((TypeMarker TypeMarker, byte[] Payload) value in new[]
+            {
+                (TypeMarker.String, Encoding.UTF8.GetBytes("value")),
+                (TypeMarker.Double, new byte[8]),
+                (TypeMarker.Long, new byte[8]),
+                (TypeMarker.Boolean, new byte[8]),
+                (TypeMarker.Array, Encoding.UTF8.GetBytes("[]")),
+                (TypeMarker.Object, Encoding.UTF8.GetBytes("{}")),
+            })
+            {
+                (byte[] envelope, int envelopeLength) = V4CompressionEnvelope.Create(
+                    value.Payload,
+                    value.TypeMarker,
+                    settings,
+                    EncryptByteCount,
+                    pool);
+
+                DecodedEnvelope decoded = V4CompressionEnvelope.Decode(
+                    envelope,
+                    envelopeLength,
+                    (byte)value.TypeMarker,
+                    new DecompressionBudget(),
+                    pool);
+
+                Assert.AreEqual(value.TypeMarker, decoded.TypeMarker);
+                CollectionAssert.AreEqual(
+                    value.Payload,
+                    decoded.Buffer.AsSpan(decoded.Offset, decoded.Length).ToArray());
+            }
+        }
+
+        [TestMethod]
+        public void Create_UsesRawForEmptyBelowThresholdAndNonBeneficialCompression()
+        {
+            using ArrayPoolManager pool = new ();
+
+            AssertRaw(
+                V4CompressionEnvelope.Create(
+                    ReadOnlySpan<byte>.Empty,
+                    TypeMarker.String,
+                    new CompressionSettings(CompressionCodecId.Deflate, CompressionLevelSetting.Fastest, 0),
+                    EncryptByteCount,
+                    pool));
+
+            AssertRaw(
+                V4CompressionEnvelope.Create(
+                    Encoding.UTF8.GetBytes(new string('a', 255)),
+                    TypeMarker.String,
+                    new CompressionSettings(CompressionCodecId.Deflate, CompressionLevelSetting.Fastest, 256),
+                    EncryptByteCount,
+                    pool));
+
+            byte[] random = new byte[300];
+            new Random(42).NextBytes(random);
+            AssertRaw(
+                V4CompressionEnvelope.Create(
+                    random,
+                    TypeMarker.String,
+                    new CompressionSettings(CompressionCodecId.Brotli, CompressionLevelSetting.Balanced, 0),
+                    EncryptByteCount,
+                    pool));
+        }
+
+        [TestMethod]
+        public void CompressionSettings_RejectsInvalidValues()
+        {
+            Assert.ThrowsException<ArgumentException>(() => new CompressionSettings(
+                (CompressionCodecId)3,
+                CompressionLevelSetting.Balanced,
+                0));
+            Assert.ThrowsException<ArgumentException>(() => new CompressionSettings(
+                CompressionCodecId.Deflate,
+                (CompressionLevelSetting)255,
+                0));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => new CompressionSettings(
+                CompressionCodecId.Deflate,
+                CompressionLevelSetting.Balanced,
+                -1));
+            Assert.ThrowsException<ArgumentOutOfRangeException>(() => new CompressionSettings(
+                CompressionCodecId.Deflate,
+                CompressionLevelSetting.Balanced,
+                (64 * 1024 * 1024) + 1));
+        }
+
+        [TestMethod]
+        public void Decode_RejectsOuterTypeMismatchUnknownCodecAndTrailingBytes()
+        {
+            byte[] payload = Encoding.UTF8.GetBytes(new string('b', 1024));
+            using ArrayPoolManager pool = new ();
+            (byte[] envelope, int envelopeLength) = V4CompressionEnvelope.Create(
+                payload,
+                TypeMarker.String,
+                new CompressionSettings(CompressionCodecId.Brotli, CompressionLevelSetting.Balanced, 0),
+                EncryptByteCount,
+                pool);
+
+            InvalidOperationException mismatch = Assert.ThrowsException<InvalidOperationException>(() =>
+                V4CompressionEnvelope.Decode(
+                    envelope,
+                    envelopeLength,
+                    (byte)TypeMarker.Long,
+                    new DecompressionBudget(),
+                    pool));
+            Assert.AreEqual(
+                "Envelope inner type marker does not match the outer type marker.",
+                mismatch.Message);
+
+            byte[] unknownCodec = new byte[EnvelopeHeaderConstants.HeaderSize + 1];
+            EnvelopeHeaderWriter.Write(unknownCodec, (byte)TypeMarker.String, CompressionCodecId.Raw);
+            unknownCodec[EnvelopeHeaderConstants.CodecOffset] = 3;
+            unknownCodec[EnvelopeHeaderConstants.HeaderSize] = 1;
+            Assert.ThrowsException<InvalidOperationException>(() => V4CompressionEnvelope.Decode(
+                unknownCodec,
+                unknownCodec.Length,
+                (byte)TypeMarker.String,
+                new DecompressionBudget(),
+                pool));
+
+            byte[] withTrailingByte = new byte[envelopeLength + 1];
+            envelope.AsSpan(0, envelopeLength).CopyTo(withTrailingByte);
+            Assert.ThrowsException<InvalidOperationException>(() => V4CompressionEnvelope.Decode(
+                withTrailingByte,
+                withTrailingByte.Length,
+                (byte)TypeMarker.String,
+                new DecompressionBudget(),
+                pool));
+        }
+
+        [TestMethod]
+        public void Decode_RejectsMalformedLengthsCorruptPayloadAndBudgetOverflow()
+        {
+            using ArrayPoolManager pool = new ();
+
+            AssertInvalid(CreateEnvelope(CompressionCodecId.Deflate, new byte[] { 0x80, 0x00 }, new byte[] { 1 }, new byte[] { 1 }), pool);
+            AssertInvalid(CreateEnvelope(CompressionCodecId.Deflate, new byte[] { 1 }, new byte[] { 0x80 }, new byte[] { 1 }), pool);
+            AssertInvalid(CreateEnvelope(CompressionCodecId.Deflate, 0, 1, new byte[] { 1 }), pool);
+            AssertInvalid(CreateEnvelope(CompressionCodecId.Deflate, (64 * 1024 * 1024) + 1U, 1, new byte[] { 1 }), pool);
+            AssertInvalid(CreateEnvelope(CompressionCodecId.Deflate, 1, 0, Array.Empty<byte>()), pool);
+            AssertInvalid(CreateEnvelope(CompressionCodecId.Deflate, 1, (64 * 1024 * 1024) + 1U, new byte[] { 1 }), pool);
+            AssertInvalid(CreateEnvelope(CompressionCodecId.Deflate, 1, 2, new byte[] { 1 }), pool);
+
+            Assert.ThrowsException<InvalidDataException>(() => V4CompressionEnvelope.Decode(
+                CreateEnvelope(CompressionCodecId.Deflate, 4, 3, new byte[] { 1, 2, 3 }),
+                EnvelopeHeaderConstants.HeaderSize + 2 + 3,
+                (byte)TypeMarker.String,
+                new DecompressionBudget(),
+                pool));
+
+            byte[] raw = CreateRawEnvelope(new byte[] { 1, 2 }, TypeMarker.String);
+            Assert.ThrowsException<InvalidOperationException>(() => V4CompressionEnvelope.Decode(
+                raw,
+                raw.Length,
+                (byte)TypeMarker.String,
+                new DecompressionBudget(1),
+                pool));
+        }
+
+        [TestMethod]
+        public void Decode_CompressedPayloadChargesBudgetBeforeDecompression()
+        {
+            byte[] envelope = CreateEnvelope(
+                CompressionCodecId.Deflate,
+                rawLength: 1024,
+                compressedLength: 3,
+                compressedBody: new byte[] { 1, 2, 3 });
+            using ArrayPoolManager pool = new ();
+
+            Assert.ThrowsException<InvalidDataException>(() => V4CompressionEnvelope.Decode(
+                envelope,
+                envelope.Length,
+                (byte)TypeMarker.String,
+                new DecompressionBudget(),
+                pool));
+
+            using ArrayPoolManager budgetPool = new ();
+            InvalidOperationException exception = Assert.ThrowsException<InvalidOperationException>(() =>
+                V4CompressionEnvelope.Decode(
+                    envelope,
+                    envelope.Length,
+                    (byte)TypeMarker.String,
+                    new DecompressionBudget(1023),
+                    budgetPool));
+
+            Assert.AreEqual(
+                "Aggregate decompressed content exceeds the request budget.",
+                exception.Message);
+            Assert.AreEqual(0, GetRentCount(budgetPool));
+        }
+
+        [TestMethod]
+        public void StructuralProbe_RawLengthMatrixUsesAuthenticatedInnerType()
+        {
+            foreach ((TypeMarker TypeMarker, int RawLength) valid in new[]
+            {
+                (TypeMarker.String, 0),
+                (TypeMarker.String, 1),
+                (TypeMarker.Long, 8),
+                (TypeMarker.Double, 8),
+                (TypeMarker.Boolean, 8),
+                (TypeMarker.Array, 2),
+                (TypeMarker.Object, 2),
+            })
+            {
+                Assert.IsTrue(V4CompressionEnvelope.IsStructurallyValidV4Envelope(
+                    CreateRawEnvelope(new byte[valid.RawLength], valid.TypeMarker)));
+            }
+
+            foreach ((TypeMarker TypeMarker, int RawLength) invalid in new[]
+            {
+                (TypeMarker.Long, 7),
+                (TypeMarker.Long, 9),
+                (TypeMarker.Double, 7),
+                (TypeMarker.Double, 9),
+                (TypeMarker.Boolean, 7),
+                (TypeMarker.Boolean, 9),
+                (TypeMarker.Array, 0),
+                (TypeMarker.Array, 1),
+                (TypeMarker.Object, 0),
+                (TypeMarker.Object, 1),
+            })
+            {
+                Assert.IsFalse(V4CompressionEnvelope.IsStructurallyValidV4Envelope(
+                    CreateRawEnvelope(new byte[invalid.RawLength], invalid.TypeMarker)));
+            }
+
+            byte[] nullEnvelope = CreateRawEnvelope(Array.Empty<byte>(), TypeMarker.String);
+            nullEnvelope[EnvelopeHeaderConstants.InnerTypeOffset] = (byte)TypeMarker.Null;
+            AssertRejectedByAllReaders(nullEnvelope, (byte)TypeMarker.Null);
+
+            byte[] oversizedString = new byte[
+                EnvelopeHeaderConstants.HeaderSize +
+                (64 * 1024 * 1024) +
+                1];
+            EnvelopeHeaderWriter.Write(
+                oversizedString,
+                (byte)TypeMarker.String,
+                CompressionCodecId.Raw);
+            Assert.IsFalse(V4CompressionEnvelope.IsStructurallyValidV4Envelope(
+                oversizedString));
+
+            byte hypotheticalOuterTypeMarker = (byte)TypeMarker.Long;
+            Assert.AreNotEqual((byte)TypeMarker.String, hypotheticalOuterTypeMarker);
+            Assert.IsTrue(V4CompressionEnvelope.IsStructurallyValidV4Envelope(
+                CreateRawEnvelope(new byte[1], TypeMarker.String)));
+        }
+
+        [TestMethod]
+        public void StructuralProbe_CompressedCanonicalFramingMatrix()
+        {
+            foreach (CompressionCodecId codec in new[] { CompressionCodecId.Deflate, CompressionCodecId.Brotli })
+            {
+                foreach ((TypeMarker TypeMarker, uint RawLength) valid in new[]
+                {
+                    (TypeMarker.String, 1U),
+                    (TypeMarker.Long, 8U),
+                    (TypeMarker.Double, 8U),
+                    (TypeMarker.Boolean, 8U),
+                    (TypeMarker.Array, 2U),
+                    (TypeMarker.Object, 2U),
+                })
+                {
+                    Assert.IsTrue(V4CompressionEnvelope.IsStructurallyValidV4Envelope(
+                        CreateEnvelope(
+                            codec,
+                            valid.RawLength,
+                            1,
+                            new byte[] { 0x01 },
+                            valid.TypeMarker)));
+                }
+
+                foreach (byte[] invalid in new[]
+                {
+                    CreateEnvelope(codec, 0, 1, new byte[] { 0x01 }),
+                    CreateEnvelope(codec, 1, 0, Array.Empty<byte>()),
+                    CreateEnvelope(
+                        codec,
+                        (64 * 1024 * 1024) + 1U,
+                        1,
+                        new byte[] { 0x01 }),
+                    CreateEnvelope(
+                        codec,
+                        new byte[] { 0x81, 0x00 },
+                        new byte[] { 0x01 },
+                        new byte[] { 0x01 }),
+                    CreateEnvelope(
+                        codec,
+                        new byte[] { 0x01 },
+                        new byte[] { 0x81, 0x00 },
+                        new byte[] { 0x01 }),
+                    CreateEnvelope(
+                        codec,
+                        new byte[] { 0x80 },
+                        Array.Empty<byte>(),
+                        Array.Empty<byte>()),
+                    CreateEnvelope(
+                        codec,
+                        new byte[] { 0x01 },
+                        new byte[] { 0x80 },
+                        Array.Empty<byte>()),
+                    CreateEnvelope(
+                        codec,
+                        new byte[] { 0x01 },
+                        Encode((64 * 1024 * 1024) + 1U),
+                        new byte[] { 0x01 }),
+                    CreateEnvelope(codec, 7, 1, new byte[] { 0x01 }, TypeMarker.Long),
+                    CreateEnvelope(
+                        codec,
+                        new byte[] { 0x01 },
+                        new byte[] { 0x02 },
+                        new byte[] { 0x01 }),
+                    CreateEnvelope(
+                        codec,
+                        new byte[] { 0x01 },
+                        new byte[] { 0x01 },
+                        new byte[] { 0x01, 0x02 }),
+                })
+                {
+                    Assert.IsFalse(V4CompressionEnvelope.IsStructurallyValidV4Envelope(invalid));
+                }
+            }
+
+            for (int length = 0; length < EnvelopeHeaderConstants.HeaderSize; length++)
+            {
+                Assert.IsFalse(V4CompressionEnvelope.IsStructurallyValidV4Envelope(
+                    new byte[length]));
+            }
+        }
+
+        [TestMethod]
+        public void StructuralProbe_RejectsLegacyLongAndDoubleEightByteCollisions()
+        {
+            Assert.IsFalse(V4CompressionEnvelope.IsStructurallyValidV4Envelope(
+                new byte[] { 0x43, 0x45, 0xC5, 0x01, 0x04, 0x04, 0x00, 0x00 }));
+            Assert.IsFalse(V4CompressionEnvelope.IsStructurallyValidV4Envelope(
+                new byte[] { 0x43, 0x45, 0xC5, 0x01, 0x04, 0x03, 0x00, 0x00 }));
+            Assert.IsFalse(
+                V4CompressionEnvelope.IsStructurallyValidV4Envelope(
+                    new byte[] { 0x43, 0x45, 0xC5, 0x01, 0x04, 0x02, 0x00, (byte)'x' }),
+                "The malformed old seven-byte header must be rejected.");
+        }
+
+        [TestMethod]
+        public void MalformedOldSevenByteHeaders_AreRejectedByHeaderReaderStructuralProbeAndDecode()
+        {
+            AssertRejectedByAllReaders(
+                new byte[] { 0x43, 0x45, 0xC5, 0x01, 0x04, 0x02, 0x00, 0x56, 0x34, 0x78 },
+                (byte)TypeMarker.String);
+
+            for (byte innerType = EnvelopeHeaderConstants.MinValidInnerTypeMarker;
+                innerType <= EnvelopeHeaderConstants.MaxValidInnerTypeMarker;
+                innerType++)
+            {
+                for (byte codec = (byte)CompressionCodecId.Raw;
+                    codec <= (byte)CompressionCodecId.Brotli;
+                    codec++)
+                {
+                    AssertRejectedByAllReaders(
+                        new byte[] { 0x43, 0x45, 0xC5, 0x01, 0x04, innerType, codec, 0xAA, 0xBB, 0xCC },
+                        innerType);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void StructuralProbe_NeverThrowsOrAllocatesForMalformedInput()
+        {
+            byte[] valid = CreateEnvelope(
+                CompressionCodecId.Deflate,
+                1,
+                1,
+                new byte[] { 0x01 });
+            for (int length = 0; length <= valid.Length; length++)
+            {
+                _ = V4CompressionEnvelope.IsStructurallyValidV4Envelope(
+                    valid.AsSpan(0, length));
+            }
+
+            Random random = new (42);
+            for (int length = 0; length < 256; length++)
+            {
+                byte[] malformed = new byte[length];
+                random.NextBytes(malformed);
+                _ = V4CompressionEnvelope.IsStructurallyValidV4Envelope(malformed);
+            }
+
+            _ = V4CompressionEnvelope.IsStructurallyValidV4Envelope(valid);
+            long allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+            bool allValid = true;
+            for (int i = 0; i < 1000; i++)
+            {
+                allValid &= V4CompressionEnvelope.IsStructurallyValidV4Envelope(valid);
+            }
+
+            long allocated = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
+            Assert.IsTrue(allValid);
+            Assert.AreEqual(0L, allocated);
+        }
+
+        [TestMethod]
+        public void StructuralParser_RejectsImplausibleRawFrameInProbeAndDecode()
+        {
+            byte[] invalid = CreateRawEnvelope(new byte[1], TypeMarker.Boolean);
+            Assert.IsFalse(V4CompressionEnvelope.IsStructurallyValidV4Envelope(invalid));
+
+            using ArrayPoolManager pool = new ();
+            InvalidOperationException exception = Assert.ThrowsException<InvalidOperationException>(() =>
+                V4CompressionEnvelope.Decode(
+                    invalid,
+                    invalid.Length,
+                    (byte)TypeMarker.Boolean,
+                    new DecompressionBudget(),
+                    pool));
+            Assert.AreEqual(
+                "Encrypted envelope failed integrity validation.",
+                exception.Message);
+        }
+
+        [TestMethod]
+        public void StructuralProbe_BooleanLengthMatchesSqlSerializer()
+        {
+            SqlBitSerializer serializer = new ();
+            byte[] buffer = new byte[serializer.GetSerializedMaxByteCount()];
+
+            Assert.AreEqual(8, serializer.Serialize(true, buffer));
+            Assert.AreEqual(8, serializer.Serialize(false, buffer));
+            Assert.IsTrue(V4CompressionEnvelope.IsStructurallyValidV4Envelope(
+                CreateRawEnvelope(buffer, TypeMarker.Boolean)));
+        }
+
+        private static void AssertRaw((byte[] Buffer, int Length) envelope)
+        {
+            Assert.IsTrue(EnvelopeHeaderReader.TryReadV4Header(
+                envelope.Buffer.AsSpan(0, envelope.Length),
+                out EnvelopeHeader header,
+                out _));
+            Assert.AreEqual(CompressionCodecId.Raw, header.Codec);
+        }
+
+        private static byte[] CreateRawEnvelope(byte[] body, TypeMarker typeMarker)
+        {
+            byte[] envelope = new byte[EnvelopeHeaderConstants.HeaderSize + body.Length];
+            EnvelopeHeaderWriter.Write(envelope, (byte)typeMarker, CompressionCodecId.Raw);
+            body.CopyTo(envelope, EnvelopeHeaderConstants.HeaderSize);
+            return envelope;
+        }
+
+        private static byte[] CreateEnvelope(
+            CompressionCodecId codec,
+            uint rawLength,
+            uint compressedLength,
+            byte[] compressedBody,
+            TypeMarker typeMarker = TypeMarker.String)
+        {
+            return CreateEnvelope(codec, Encode(rawLength), Encode(compressedLength), compressedBody, typeMarker);
+        }
+
+        private static byte[] CreateEnvelope(
+            CompressionCodecId codec,
+            byte[] rawLengthBytes,
+            byte[] compressedLengthBytes,
+            byte[] compressedBody,
+            TypeMarker typeMarker = TypeMarker.String)
+        {
+            byte[] envelope = new byte[
+                EnvelopeHeaderConstants.HeaderSize +
+                rawLengthBytes.Length +
+                compressedLengthBytes.Length +
+                compressedBody.Length];
+            EnvelopeHeaderWriter.Write(envelope, (byte)typeMarker, codec);
+            int offset = EnvelopeHeaderConstants.HeaderSize;
+            rawLengthBytes.CopyTo(envelope, offset);
+            offset += rawLengthBytes.Length;
+            compressedLengthBytes.CopyTo(envelope, offset);
+            offset += compressedLengthBytes.Length;
+            compressedBody.CopyTo(envelope, offset);
+            return envelope;
+        }
+
+        private static byte[] Encode(uint value)
+        {
+            byte[] buffer = new byte[4];
+            int length = UleB128.Write(value, buffer);
+            return buffer.AsSpan(0, length).ToArray();
+        }
+
+        private static int GetRentCount(ArrayPoolManager pool)
+        {
+            FieldInfo rentedBuffers = typeof(ArrayPoolManager<byte>).GetField(
+                "rentedBuffers",
+                BindingFlags.Instance | BindingFlags.NonPublic);
+            return ((List<byte[]>)rentedBuffers.GetValue(pool)).Count;
+        }
+
+        private static void AssertRejectedByAllReaders(byte[] envelope, byte outerType)
+        {
+            Assert.IsFalse(EnvelopeHeaderReader.TryReadV4Header(envelope, out _, out _));
+            Assert.IsFalse(V4CompressionEnvelope.IsStructurallyValidV4Envelope(envelope));
+
+            using ArrayPoolManager pool = new ();
+            Assert.ThrowsException<InvalidOperationException>(() => V4CompressionEnvelope.Decode(
+                envelope,
+                envelope.Length,
+                outerType,
+                new DecompressionBudget(),
+                pool));
+        }
+
+        private static void AssertInvalid(byte[] envelope, ArrayPoolManager pool)
+        {
+            Assert.ThrowsException<InvalidOperationException>(() => V4CompressionEnvelope.Decode(
+                envelope,
+                envelope.Length,
+                (byte)TypeMarker.String,
+                new DecompressionBudget(),
+                pool));
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Description

Adds the internal, .NET 8-only compression-envelope primitives for
`Microsoft.Azure.Cosmos.Encryption.Custom`.

This is the first pull request in the compression work and intentionally does
not connect these primitives to any production encryption or decryption path.
Splitting the foundation allows the wire framing, malformed-input handling,
codec behavior, and resource limits to be reviewed before introducing public
API or request-path integration.

### Included

- Fixed 9-byte format-4 envelope header.
- Raw, Deflate, and Brotli codecs.
- Canonical, 4-byte-maximum unsigned little-endian base-128 (ULEB128) length
  encoding.
- Structural envelope validation without decompression.
- Inner type-marker framing designed to be authenticated by later Microsoft
  Data Encryption (MDE) integration.
- Aggregate 64 MiB decompression budgeting.
- Pooled-buffer ownership and clearing.
- Exact encrypted Base64-size comparison before retaining compression.
- Focused primitive, malformed-input, codec, and target-framework tests.

### Not included

- Public compression API.
- Encryption metadata dispatch.
- Production reader or writer integration.
- Per-request configuration or Auto policy.
- End-to-end benchmarks.
- Emission or consumption of format-4 payloads by existing SDK paths.

### Wire format

```text
Magic[6] | Epoch[1] | InnerType[1] | Codec[1] | Body
```

The envelope is designed to be placed inside MDE-authenticated ciphertext by a
follow-up pull request. This pull request alone does not emit or consume the new
format.

### Dependencies

No new package dependencies.

## Type of change

- [x] Internal implementation groundwork with no customer-observable behavior.

## Closing issues

No GitHub issue is closed by this foundation pull request.

## Validation

- .NET 8 non-contract tests: 730 passed.
- .NET 6 non-contract tests: 417 passed.
- Contract tests: 1 passed on .NET 8 and 1 passed on .NET 6.
- Source and test projects built for all target frameworks.

The .NET 6 count is lower because that run exercises the package's
netstandard2.0 asset, where the .NET 8-only compression primitives and their
tests are intentionally absent.

## Follow-up work

1. Add format-4 reader integration and decompression-budget propagation.
2. Add the public per-request API, writer integration, Auto policy, API
   contracts, changelog entry, and benchmarks.

## Changelog

- [ ] I have added a changelog entry under `### Unreleased` in `changelog.md`
  for the user-facing impact of this change.
- [x] No changelog entry is required because this pull request is one of:
  documentation-only, test-only, CI / build-only, or a pure internal refactor
  with no observable customer impact.

If the second box is checked, briefly justify here:

> Every added type is internal and compiled only for .NET 8. No current
> production path references these primitives, emits or consumes format 4, or
> changes public API, runtime behavior, allocations, return values, or errors.
> The customer-facing changelog entry will be added with the pull request that
> enables request-time compression.
