### PR TITLE
Thinclient integration: Fixes resource token auth for thinclient mode.

### DIFF
--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -18,6 +18,7 @@ namespace Microsoft.Azure.Cosmos
     using System.Threading;
     using System.Threading.Tasks;
     using global::Azure.Core;
+    using Microsoft.Azure.Cosmos.Authorization;
     using Microsoft.Azure.Cosmos.Common;
     using Microsoft.Azure.Cosmos.Core.Trace;
     using Microsoft.Azure.Cosmos.Query;
@@ -1164,8 +1165,27 @@ namespace Microsoft.Azure.Cosmos
             // traffic; whether a given request actually routes to the proxy is decided per request
             // by IsThinClientRoutable and the connectivity probe gate, so the SDK can switch between
             // the proxy and Gateway V1 mid-session without a restart.
-            this.isThinClientEnabled = this.isThinClientFeatureFlagEnabled && (this.ConnectionPolicy.ConnectionMode == ConnectionMode.Gateway) &&
-                (this.accountServiceConfiguration.AccountProperties?.ThinClientWritableLocationsInternal?.Count ?? 0) > 0;
+            //
+            // ThinClient mode does not support resource-token (permission-scoped) authorization. A client
+            // authenticated with a resource token must therefore always route through the Gateway store model.
+            // This init-time gate short-circuits the common case (a client constructed with a resource token):
+            // the ThinClient store model is not built and no connectivity-probe cycle is started. Credential
+            // rotation (an AzureKeyCredential key updated from a master key to a resource token mid-session) is
+            // additionally guarded live per request in GetStoreProxy. Master-key and AAD/token-credential
+            // clients are unaffected by either check.
+            bool isResourceTokenAuthorization = DocumentClient.IsResourceTokenAuthorization(this.cosmosAuthorization);
+
+            this.isThinClientEnabled = this.isThinClientFeatureFlagEnabled
+                && (this.ConnectionPolicy.ConnectionMode == ConnectionMode.Gateway)
+                && !isResourceTokenAuthorization
+                && (this.accountServiceConfiguration.AccountProperties?.ThinClientWritableLocationsInternal?.Count ?? 0) > 0;
+
+            if (this.isThinClientFeatureFlagEnabled && isResourceTokenAuthorization)
+            {
+                DefaultTrace.TraceInformation(
+                    "DocumentClient: ThinClient mode disabled because the client is using resource-token authorization, which ThinClient does not support. Data-plane requests will route through the Gateway store model.");
+            }
+
             if (this.isThinClientEnabled)
             {
                 // Wire the HTTP/2 http client for the connectivity probe and run an initial probe against the
@@ -6744,6 +6764,18 @@ namespace Microsoft.Azure.Cosmos
                     "Ensure all in-flight requests complete before disposing the client.");
             }
 
+            // ThinClient mode does not support resource-token (permission-scoped) authorization. When ThinClient
+            // is enabled but the client is currently authenticated with a resource token, route through the plain
+            // Gateway store model instead of the ThinClient store model. This is evaluated per request (the auth
+            // provider is refreshed by TransportHandler immediately before this call), so an AzureKeyCredential
+            // rotated to a resource token mid-session falls back to Gateway on the very next request without a
+            // client restart. Master-key and AAD/token-credential clients are unaffected.
+            if (this.isThinClientEnabled
+                && DocumentClient.IsResourceTokenAuthorization(this.cosmosAuthorization))
+            {
+                return this.GatewayStoreModel;
+            }
+
             // If a request is configured to always use Gateway mode(in some cases when targeting .NET Core)
             // we return the Gateway store model
             if (request.UseGatewayMode)
@@ -7038,6 +7070,25 @@ namespace Microsoft.Azure.Cosmos
 
             this.GlobalEndpointManager.OnEnablePartitionLevelFailoverConfigChanged += this.UpdatePartitionLevelFailoverConfigWithAccountRefresh;
             this.GlobalEndpointManager.InitializeAccountPropertiesAndStartBackgroundRefresh(accountProperties);
+        }
+
+        /// <summary>
+        /// Determines whether the supplied authorization provider represents resource-token
+        /// (permission-scoped) authorization. ThinClient mode does not support resource tokens, so a client
+        /// using this authorization type must always route through the Gateway store model. Returns true only
+        /// for resource-token providers; master-key and Microsoft Entra ID (AAD) token-credential providers
+        /// return false. The <see cref="AzureKeyCredentialAuthorizationTokenProvider"/> wrapper is unwrapped
+        /// to its current inner provider because the key it holds can itself be a resource token and can be
+        /// rotated at runtime.
+        /// </summary>
+        internal static bool IsResourceTokenAuthorization(AuthorizationTokenProvider authorizationTokenProvider)
+        {
+            if (authorizationTokenProvider is AzureKeyCredentialAuthorizationTokenProvider azureKeyCredentialAuthorizationTokenProvider)
+            {
+                return azureKeyCredentialAuthorizationTokenProvider.authorizationTokenProvider is AuthorizationTokenProviderResourceToken;
+            }
+
+            return authorizationTokenProvider is AuthorizationTokenProviderResourceToken;
         }
 
         internal string GetUserAgentFeatures()

--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -1180,7 +1180,8 @@ namespace Microsoft.Azure.Cosmos
                 && !isResourceTokenAuthorization
                 && (this.accountServiceConfiguration.AccountProperties?.ThinClientWritableLocationsInternal?.Count ?? 0) > 0;
 
-            if (this.isThinClientFeatureFlagEnabled && isResourceTokenAuthorization)
+            if (this.isThinClientFeatureFlagEnabled && isResourceTokenAuthorization
+                && (this.ConnectionPolicy.ConnectionMode == ConnectionMode.Gateway))
             {
                 DefaultTrace.TraceInformation(
                     "DocumentClient: ThinClient mode disabled because the client is using resource-token authorization, which ThinClient does not support. Data-plane requests will route through the Gateway store model.");

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemThinClientTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/CosmosItemThinClientTests.cs
@@ -233,6 +233,90 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
         [TestMethod]
         [TestCategory("ThinClient")]
+        public async Task ResourceTokenAuth_ThinClient_CreateAndReadItemAsync()
+        {
+            // Ensure thin-client mode is on for this test (TestInit already sets it, but be explicit).
+            Environment.SetEnvironmentVariable(ConfigurationManager.ThinClientModeEnabled, "True");
+
+            // 1) Using the key-based client from TestInit, create a User and a Permission
+            //    scoped to the test container with PermissionMode.All so we can write + read.
+            string userId = "thinclient-user-" + Guid.NewGuid();
+            UserResponse userResponse = await this.database.CreateUserAsync(userId);
+            Assert.AreEqual(HttpStatusCode.Created, userResponse.StatusCode);
+            User user = userResponse.User;
+
+            string permissionId = "thinclient-perm-" + Guid.NewGuid();
+            PermissionProperties permissionProperties = new PermissionProperties(
+                permissionId,
+                PermissionMode.All,
+                this.container);
+
+            PermissionResponse permissionResponse = await user.CreatePermissionAsync(permissionProperties);
+            Assert.AreEqual(HttpStatusCode.Created, permissionResponse.StatusCode);
+            string resourceToken = permissionResponse.Resource.Token;
+            Assert.IsFalse(string.IsNullOrEmpty(resourceToken), "Resource token should be issued by the service.");
+
+            // 2) Parse the AccountEndpoint out of the connection string so we can build a
+            //    resource-token-based client (the token overload does not accept a full
+            //    connection string).
+            string accountEndpoint = this.connectionString
+                .Split(';', StringSplitOptions.RemoveEmptyEntries)
+                .Select(part => part.Trim())
+                .First(part => part.StartsWith("AccountEndpoint=", StringComparison.OrdinalIgnoreCase))
+                ["AccountEndpoint=".Length..];
+
+            CosmosClientOptions tokenClientOptions = new CosmosClientOptions()
+            {
+                ConnectionMode = ConnectionMode.Gateway,
+                ApplicationPreferredRegions = PreferredRegions,
+                Serializer = this.cosmosSystemTextJsonSerializer,
+            };
+            tokenClientOptions.CustomHandlers.Add(new ExcludeRegionsInjectingHandler(ExcludeRegions));
+
+            // 3) Build a second CosmosClient authenticated only via the resource token,
+            //    with thin-client mode enabled, and exercise item CRUD through it.
+            using (CosmosClient tokenClient = new CosmosClient(accountEndpoint, resourceToken, tokenClientOptions))
+            {
+                Container tokenContainer = tokenClient.GetContainer(this.database.Id, this.container.Id);
+
+                string pk = "rt-pk-" + Guid.NewGuid();
+                TestObject warmUpItem = new TestObject
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    Pk = pk,
+                    Other = "ThinClient resource-token warm-up"
+                };
+
+                // Warm up the thin-client connectivity probe on the token-auth client.
+                await WarmUpThinClientProbeAsync(tokenContainer, warmUpItem);
+
+                // Create via resource-token + thin client.
+                TestObject item = new TestObject
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    Pk = pk,
+                    Other = "ThinClient resource-token item"
+                };
+
+                ItemResponse<TestObject> createResponse = await tokenContainer.CreateItemAsync(
+                    item,
+                    new PartitionKey(item.Pk));
+                Assert.AreEqual(HttpStatusCode.Created, createResponse.StatusCode);
+                AssertExcludedRegionsNotInDiagnostics(createResponse.Diagnostics.ToString());
+
+                // Read it back via resource-token + thin client.
+                ItemResponse<TestObject> readResponse = await tokenContainer.ReadItemAsync<TestObject>(
+                    item.Id,
+                    new PartitionKey(item.Pk));
+                Assert.AreEqual(HttpStatusCode.OK, readResponse.StatusCode);
+                Assert.AreEqual(item.Id, readResponse.Resource.Id);
+                Assert.AreEqual(item.Pk, readResponse.Resource.Pk);
+                AssertExcludedRegionsNotInDiagnostics(readResponse.Diagnostics.ToString());
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("ThinClient")]
         public async Task TestThinClientWithExecuteStoredProcedureAsync()
         {
             CosmosClient localClient = null;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientTests.cs
@@ -1,4 +1,4 @@
-﻿//------------------------------------------------------------
+//------------------------------------------------------------
 // Copyright (c) Microsoft Corporation.  All rights reserved.
 //------------------------------------------------------------
 
@@ -296,6 +296,68 @@ namespace Microsoft.Azure.Cosmos.Tests
                 AzureKeyCredentialAuthorizationTokenProvider tokenProvider = (AzureKeyCredentialAuthorizationTokenProvider)client.AuthorizationTokenProvider;
                 Assert.AreEqual(typeof(AuthorizationTokenProviderResourceToken), tokenProvider.authorizationTokenProvider.GetType());
             }
+        }
+
+        // ThinClient does not support resource-token authorization, so DocumentClient.IsResourceTokenAuthorization
+        // is the gate that keeps such clients on the Gateway store model. A master key must return false; a
+        // resource token must return true.
+        [DataTestMethod]
+        [DataRow(false, DisplayName = "MasterKey")]
+        [DataRow(true, DisplayName = "ResourceToken")]
+        public void IsResourceTokenAuthorization_DirectProvider(bool isResourceToken)
+        {
+            AuthorizationTokenProvider provider = AuthorizationTokenProvider.CreateWithResourceTokenOrAuthKey(
+                isResourceToken ? CosmosClientTests.NewRamdonResourceToken() : CosmosClientTests.NewRamdonMasterKey());
+
+            Assert.IsInstanceOfType(
+                provider,
+                isResourceToken ? typeof(AuthorizationTokenProviderResourceToken) : typeof(AuthorizationTokenProviderMasterKey));
+            Assert.AreEqual(isResourceToken, DocumentClient.IsResourceTokenAuthorization(provider));
+        }
+
+        [TestMethod]
+        public async Task IsResourceTokenAuthorization_AzureKeyCredentialRotation_TracksCurrentKey()
+        {
+            // Start with a master key: thin-client-eligible.
+            AzureKeyCredential credential = new AzureKeyCredential(CosmosClientTests.NewRamdonMasterKey());
+            AzureKeyCredentialAuthorizationTokenProvider provider = new AzureKeyCredentialAuthorizationTokenProvider(credential);
+            Assert.IsFalse(DocumentClient.IsResourceTokenAuthorization(provider), "A master key must not be treated as a resource token.");
+
+            // Rotate to a resource token at runtime. The request pipeline refreshes the wrapper's inner provider
+            // before dispatch; here a public authorization call (the same trigger the pipeline uses) forces it.
+            credential.Update(CosmosClientTests.NewRamdonResourceToken());
+            await provider.AddAuthorizationHeaderAsync(
+                new StoreResponseNameValueCollection(),
+                new Uri(CosmosClientTests.AccountEndpoint),
+                "GET",
+                Microsoft.Azure.Documents.AuthorizationTokenType.PrimaryMasterKey);
+            Assert.IsTrue(DocumentClient.IsResourceTokenAuthorization(provider), "After rotating to a resource token the wrapper must report resource-token authorization.");
+
+            // Rotate back to a master key: thin-client eligibility is restored.
+            credential.Update(CosmosClientTests.NewRamdonMasterKey());
+            await provider.AddAuthorizationHeaderAsync(
+                new StoreResponseNameValueCollection(),
+                new Uri(CosmosClientTests.AccountEndpoint),
+                "GET",
+                Microsoft.Azure.Documents.AuthorizationTokenType.PrimaryMasterKey);
+            Assert.IsFalse(DocumentClient.IsResourceTokenAuthorization(provider), "After rotating back to a master key the wrapper must no longer report resource-token authorization.");
+        }
+
+        [TestMethod]
+        public void IsResourceTokenAuthorization_TokenCredential_ReturnsFalse()
+        {
+            Mock<TokenCredential> mockTokenCredential = new Mock<TokenCredential>();
+            mockTokenCredential
+                .Setup(x => x.GetTokenAsync(It.IsAny<TokenRequestContext>(), It.IsAny<CancellationToken>()))
+                .Returns(new ValueTask<AccessToken>(new AccessToken("token", DateTimeOffset.UtcNow.AddHours(1))));
+
+            AuthorizationTokenProvider tokenCredentialProvider = new AuthorizationTokenProviderTokenCredential(
+                tokenCredential: mockTokenCredential.Object,
+                accountEndpoint: new Uri(CosmosClientTests.AccountEndpoint),
+                backgroundTokenCredentialRefreshInterval: null,
+                tokenToAuthorizationHeader: (token) => token);
+
+            Assert.IsFalse(DocumentClient.IsResourceTokenAuthorization(tokenCredentialProvider));
         }
 
         [TestMethod]

--- a/changelog.md
+++ b/changelog.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Bugs Fixed
 
+- [6032](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/6032) ThinClient: Fixes clients using resource-token (permission-scoped) authorization failing or misrouting when thin client mode is enabled by default. Such clients now always route data-plane requests through the Gateway store model, since thin client mode does not support resource-token authorization. Clients using primary/secondary key or Microsoft Entra ID (AAD) authorization are unaffected.
+
 #### Other Changes
 
 - [5991](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5991) TargetReplicaSetSize : Updated address cache logic to use partition-specific target replica set size when available, falling back to the user replication policy value.

--- a/changelog.md
+++ b/changelog.md
@@ -36,6 +36,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Breaking Changes
 
+- [5970](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5970) Thin Client: Starting with this release, thin client mode is enabled by default. Accounts and workloads that authenticate with resource tokens are not supported in thin client mode, so customers relying on resource token authentication will experience a breaking change on upgrade. To continue using resource token authentication, opt out of thin client mode by setting the environment variable `AZURE_COSMOS_THIN_CLIENT_ENABLED=false`.
+
 #### Bugs Fixed
 
 - [5989](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5989) Distributed Transactions (preview): Fixes a bodyless `429`/`3200` (RUBudgetExceeded) response on a distributed-transaction commit or read being surfaced to the caller without any retry. The empty response body was misdetected as a semantic per-operation result and deferred to the transaction's outer retry loop, which could not act on it, so the request was never re-sent. Such a throttled response is now retried honoring the server's `x-ms-retry-after-ms` header and the customer-configured rate-limit retry options (`CosmosClientOptions.MaxRetryAttemptsOnRateLimitedRequests` and `MaxRetryWaitTimeOnRateLimitedRequests`, defaults 9 attempts / 30 seconds cumulative), so a coordinator returning large retry-after values cannot stall a commit indefinitely.
@@ -53,6 +55,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [#5549](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5549) Adds AAD token revocation (CAE / Emergency) transparent retry handling
 
 #### Breaking Changes
+
+- [5970](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5970) Thin Client: Starting with this release, thin client mode is enabled by default. Accounts and workloads that authenticate with resource tokens are not supported in thin client mode, so customers relying on resource token authentication will experience a breaking change on upgrade. To continue using resource token authentication, opt out of thin client mode by setting the environment variable `AZURE_COSMOS_THIN_CLIENT_ENABLED=false`.
 
 #### Bugs Fixed
 


### PR DESCRIPTION
# Pull Request Template

## Description

Resource-token clients now always route data-plane requests through the Gateway store model instead of ThinClient (which doesn't support resource tokens), evaluated live per request so  AzureKeyCredential  rotations are handled without a restart. Adds a changelog note that thin client mode is on by default from 3.62.0 and 3.63.0-preview.0 (via #5970). This breaks customers using resource token auth, since thin client mode does not support resource tokens. They can opt out with AZURE_COSMOS_THIN_CLIENT_ENABLED=false.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber

## Changelog

- [X] I have added a changelog entry under `### Unreleased` in `changelog.md`
  for the user-facing impact of this change.
- [] No changelog entry is required because this PR is one of:
  documentation-only, test-only, CI / build-only, or a pure internal refactor
  with no observable customer impact.

If the second box is checked, briefly justify here:

>
