### PR TITLE
[Internal] FaultInjection: Refactors documentation for accuracy and completeness

### DIFF
--- a/Microsoft.Azure.Cosmos/FaultInjection/DEVELOPMENT.md
+++ b/Microsoft.Azure.Cosmos/FaultInjection/DEVELOPMENT.md
@@ -1,0 +1,247 @@
+# Fault Injection — Development & Maintenance Guide
+
+This guide is for **contributors and maintainers** of the
+`Microsoft.Azure.Cosmos.FaultInjection` library. If you are a *consumer* of the
+package (writing tests against your own app), start with [README.md](./README.md)
+instead.
+
+- [Project layout](#project-layout)
+- [How it plugs into the SDK](#how-it-plugs-into-the-sdk)
+- [Building](#building)
+- [Running the tests](#running-the-tests)
+- [Working on / maintaining the project](#working-on--maintaining-the-project)
+- [Adding a new fault type](#adding-a-new-fault-type)
+- [Changelog rules](#changelog-rules)
+- [Release process](#release-process)
+- [Common issues & troubleshooting](#common-issues--troubleshooting)
+
+---
+
+## Project layout
+
+Everything lives under `Microsoft.Azure.Cosmos/FaultInjection/`:
+
+```
+FaultInjection/
+├── README.md                     # Consumer-facing usage guide
+├── DEVELOPMENT.md                # This file
+├── changelog.md                  # Package release notes
+├── LICENSE
+├── src/
+│   ├── FaultInjection.csproj      # The shipped package project (targets net6)
+│   ├── FaultInjection.sln
+│   ├── stylecop.json              # StyleCop config (enforced; warnings are errors)
+│   ├── FaultInjector.cs           # Public entry point passed to the CosmosClient
+│   ├── FaultInjection*Builder.cs  # Public fluent builders (rule/condition/result/endpoint)
+│   ├── FaultInjection*Type.cs     # Public enums (server error, connection error, operation, connection)
+│   └── implementation/            # Internal wiring (interceptor rules, stores, processors)
+│       ├── FaultInjectionRuleProcessor.cs
+│       ├── FaultInjectionRuleStore.cs
+│       ├── FaultInjectionServerErrorResultInternal.cs
+│       ├── FaultInjectionConnectionErrorRule.cs
+│       ├── FaultInjectionApplicationContext.cs
+│       └── ...
+└── tests/
+    ├── FaultInjectionTests.csproj
+    ├── FaultInjectionUnitTests.cs            # Builder tests (no account)
+    ├── FaultInjectionBuilderValidationTests.cs # Builder validation (no account)
+    ├── FaultInjectionDirectModeTests.cs      # Integration (live account)
+    ├── FaultInjectionGatewayModeTests.cs     # Integration (live account)
+    ├── FaultInjectionMetadataTests.cs        # Integration (live account)
+    ├── FaultInjectionProxyTests.cs           # Integration (ThinClient proxy)
+    └── Utils/TestCommon.cs                   # Shared setup + env-var helpers
+```
+
+The **public surface** is the set of `FaultInjection*` types directly under `src/`.
+The `src/implementation/` folder contains the internal classes that translate a
+public `FaultInjectionRule` into the `IChaosInterceptor` the SDK understands.
+
+## How it plugs into the SDK
+
+The main SDK (`Microsoft.Azure.Cosmos`) exposes internal hook points that this
+library implements:
+
+- `Microsoft.Azure.Cosmos/src/FaultInjection/IFaultInjector.cs` — the public
+  interface `FaultInjector` implements.
+- `Microsoft.Azure.Cosmos/src/FaultInjection/IChaosInterceptorFactory.cs` — the
+  internal factory the SDK calls to build the interceptor.
+- `CosmosClientOptions.FaultInjector` (public) → sets the internal
+  `CosmosClientOptions.ChaosInterceptorFactory`.
+- `CosmosClientBuilder.WithFaultInjection(IFaultInjector)` (public) → same wiring
+  through the fluent builder.
+
+At runtime, `FaultInjector.GetChaosInterceptorFactory()` returns a
+`ChaosInterceptorFactory` (backed by `Microsoft.Azure.Documents.FaultInjection`)
+that the SDK invokes on every request to decide whether/how to inject a fault.
+
+By default `FaultInjection.csproj` builds with `SdkProjectRef=True`, which uses a
+**`ProjectReference`** to `..\..\src\Microsoft.Azure.Cosmos.csproj` (so you build
+against your local SDK changes). When packaging, that switches to a
+**`PackageReference`** on the published `Microsoft.Azure.Cosmos` version
+(`$(ClientOfficialVersion)` from the root `Directory.Build.props`).
+
+## Building
+
+From the repo root:
+
+```bash
+# Build just the fault injection library
+dotnet build Microsoft.Azure.Cosmos/FaultInjection/src/FaultInjection.csproj -c Release
+
+# Or open the focused solution
+#   Microsoft.Azure.Cosmos/FaultInjection/src/FaultInjection.sln
+```
+
+Notes:
+
+- The project targets **`net6`**, has `Nullable` enabled, and sets
+  **`TreatWarningsAsErrors=true`** with StyleCop analyzers — a stray warning will
+  fail the build. Keep XML docs on public members.
+- Release builds are **delay-signed** with `35MSSharedLib1024.snk`; local dev
+  builds do not require the private key.
+
+## Running the tests
+
+The test project (`FaultInjection/tests/FaultInjectionTests.csproj`) contains
+**both** pure unit tests and **live-account integration tests**. Despite the
+`IsEmulatorTest`/`EmulatorFlavor` MSBuild flags on the project, the integration
+tests run against a **real, multi-region Cosmos DB account** (multi-region is
+required to exercise region-scoped and failover faults), not the emulator.
+
+| Test class | Needs a live account? | Environment variable |
+| ---------- | --------------------- | -------------------- |
+| `FaultInjectionUnitTests` | No | — |
+| `FaultInjectionBuilderValidationTests` | No | — |
+| `FaultInjectionDirectModeTests` | Yes (multi-region) | `COSMOSDB_MULTI_REGION` |
+| `FaultInjectionGatewayModeTests` | Yes (multi-region) | `COSMOSDB_MULTI_REGION` |
+| `FaultInjectionMetadataTests` | Yes (multi-region) | `COSMOSDB_MULTI_REGION` |
+| `FaultInjectionProxyTests` | Yes (ThinClient proxy) | `COSMOSDB_THIN_CLIENT` |
+
+`COSMOSDB_MULTI_REGION` and `COSMOSDB_THIN_CLIENT` are **connection strings**.
+The integration tests create (if missing) a `faultInjectionDatabase` with
+`faultInjectionContainer` / `faultInjectionContainerHTP` on the target account
+and reuse them across runs to reduce replication-lag flakiness.
+
+### Run only the tests that need no account
+
+```bash
+dotnet test Microsoft.Azure.Cosmos/FaultInjection/tests/FaultInjectionTests.csproj \
+  --filter "FullyQualifiedName~FaultInjectionUnitTests|FullyQualifiedName~FaultInjectionBuilderValidationTests"
+```
+
+### Run the full suite (integration)
+
+```powershell
+$env:COSMOSDB_MULTI_REGION = "<multi-region account connection string>"
+$env:COSMOSDB_THIN_CLIENT  = "<thin client / proxy connection string>"   # only for proxy tests
+
+dotnet test Microsoft.Azure.Cosmos/FaultInjection/tests/FaultInjectionTests.csproj -c Release
+```
+
+If a required variable is missing, the affected tests fail fast with
+`Set environment variable COSMOSDB_MULTI_REGION to run the tests` (or the
+`COSMOSDB_THIN_CLIENT` equivalent) rather than silently passing.
+
+### How CI runs them
+
+`azure-pipelines-faultinjection.yml` runs the integration tests on the internal
+`OneES` pool with the `COSMOSDB_MULTI_REGION` secret wired in, using
+`dotnet test` over `Microsoft.Azure.Cosmos/FaultInjection/tests/*.csproj`.
+
+## Working on / maintaining the project
+
+- **Public API changes** must keep the fluent-builder style consistent
+  (`WithXxx(...)` returns the builder; a terminal `Build()` produces the immutable
+  result/rule). Validate arguments in the builder (`ArgumentOutOfRangeException`,
+  `InvalidOperationException`) close to where they're set.
+- **Mode restrictions** are enforced in `FaultInjectionRuleBuilder.Build()`
+  (`ValidateDirectConnection` / `ValidateGatewayConnection`). Update these when a
+  new fault type is only valid for one connection mode or for metadata operations.
+- Keep the **README tables** (server error types, connection error types,
+  operation types, properties) in sync with the enums and builders — they are the
+  primary consumer reference and drift easily.
+- Every public member needs an XML doc comment (StyleCop + warnings-as-errors).
+
+## Adding a new fault type
+
+Rough checklist for adding a new server error type (connection error types are
+analogous):
+
+1. Add the value + XML doc (status code) to
+   `src/FaultInjectionServerErrorType.cs`.
+2. Map it to the actual injected error in the internal implementation
+   (`src/implementation/FaultInjectionServerErrorResultInternal.cs` and the
+   rule processor).
+3. If the fault only applies to Direct **or** Gateway mode, or to (or excludes)
+   metadata operations, update the validation in
+   `src/FaultInjectionRuleBuilder.cs`.
+4. Add unit coverage in `FaultInjectionBuilderValidationTests.cs` and, if it
+   needs a live account, integration coverage in the relevant `*ModeTests.cs`.
+5. Add the row to the server-error table in [README.md](./README.md).
+6. Add a changelog entry (see below).
+
+## Changelog rules
+
+The package has its **own** changelog:
+[`Microsoft.Azure.Cosmos/FaultInjection/changelog.md`](./changelog.md). Any PR
+that touches `Microsoft.Azure.Cosmos/FaultInjection/src/**` must add a bullet
+under the `### Unreleased` section, in one of `Features Added` /
+`Breaking Changes` / `Bugs Fixed` / `Other Changes`, written in customer-facing
+language and linking the PR. This mirrors the main-SDK rules in the repo-root
+[CONTRIBUTING.md](../../CONTRIBUTING.md). Docs/test/CI-only changes do not require
+an entry.
+
+PR titles still follow the repo regex, e.g.
+`FaultInjection: Adds ServiceUnavailable injection for Gateway mode`.
+
+## Release process
+
+The package version is centrally managed in the **root**
+[`Directory.Build.props`](../../Directory.Build.props):
+
+```xml
+<FaultInjectionVersion>1.0.0</FaultInjectionVersion>
+<FaultInjectionSuffixVersion>beta.1</FaultInjectionSuffixVersion>
+```
+
+These combine into the NuGet version (e.g. `1.0.0-beta.1`). High-level steps:
+
+1. **Bump the version** — update `FaultInjectionVersion` and/or
+   `FaultInjectionSuffixVersion` in the root `Directory.Build.props`.
+2. **Finalize the changelog** — move the `### Unreleased` bullets under a new
+   version heading with the release date and a NuGet link, matching the existing
+   entries in `changelog.md`.
+3. **Run the release pipeline** `azure-pipelines-faultinjection.yml` (it is
+   manually triggered — `trigger: none` / `pr: none`). It:
+   - runs static analysis (`templates/static-tools.yml`),
+   - runs the integration tests on `OneES` with `COSMOSDB_MULTI_REGION`,
+   - packs the NuGet + symbols package and stages artifacts via
+     `templates/fault-injection-nuget-pack.yml`, publishing to the
+     `azuresdkpartnerdrops` blob under
+     `cosmosdb/faultInjection/<BlobVersion>` (set the `BlobVersion` variable).
+4. Push the resulting `.nupkg` to NuGet.org through the standard partner-drop
+   release flow.
+
+> **Canonical runbook:** the detailed, step-by-step release procedure lives in
+> the `cosmos-release-dotnet-faultinjection` skill in the
+> [cosmos-sdk-copilot-toolkit](https://github.com/Azure/cosmos-sdk-copilot-toolkit).
+> In the Copilot CLI you can just describe the task naturally (e.g. "release
+> fault injection beta") and the routing agent loads that skill. Prefer the skill
+> over hand-running the steps above so the version bump, changelog, pipeline, and
+> blob drop stay consistent.
+
+## Common issues & troubleshooting
+
+| Symptom | Cause / fix |
+| ------- | ----------- |
+| Test fails with `Set environment variable COSMOSDB_MULTI_REGION to run the tests` | An integration test ran without a live multi-region account. Set the `COSMOSDB_MULTI_REGION` connection string (or filter to the unit tests). |
+| Proxy test fails with `Set environment variable COSMOSDB_THIN_CLIENT` | `FaultInjectionProxyTests` needs a ThinClient/proxy connection string in `COSMOSDB_THIN_CLIENT`. |
+| `InvalidOperationException: Delay is not applicable for server error type ...` | `WithDelay` was called for a non-delay error type. It is only valid for `SendDelay`, `ResponseDelay`, and `ConnectionDelay`. |
+| `ArgumentNullException: Argument 'delay' required for server error type ...` on `Build()` | A delay error type (`SendDelay`/`ResponseDelay`/`ConnectionDelay`) was built without calling `WithDelay(...)`. |
+| `ArgumentException: Gone error type is not supported for Gateway connection type.` | `Gone` is Direct-mode only. Use a Direct-mode condition or a different error type for Gateway. |
+| `ArgumentException: DatabaseAccountNotFound error type is not supported for Direct connection type.` | `DatabaseAccountNotFound` is Gateway-mode only. |
+| `ArgumentException: <Type> is not supported for metadata requests.` | Only a subset of server errors is valid for metadata operations in Gateway mode (see README). |
+| `ArgumentOutOfRangeException` on `WithInjectionRate` / `WithThreshold` | Rate/threshold must be within `(0, 1]`. |
+| `ArgumentOutOfRangeException` on `WithHitLimit` / `WithInterval` | `HitLimit` must be `> 0`; connection-error `Interval` must be greater than zero. |
+| Build fails on a warning | The project uses `TreatWarningsAsErrors=true` with StyleCop. Fix the warning or add the required XML doc comment. |
+| Faults never fire | Confirm the `FaultInjector` was actually wired in (`WithFaultInjection(...)` on the builder, or `CosmosClientOptions.FaultInjector = ...`), the rule is enabled and its `Duration`/`StartDelay`/`HitLimit` window is active, and the `FaultInjectionCondition` (operation/connection/region/endpoint) matches the requests you are issuing. Use `FaultInjector.GetApplicationContext()` / `GetFaultInjectionRuleId(activityId)` to confirm which rules were applied. |

--- a/Microsoft.Azure.Cosmos/FaultInjection/README.md
+++ b/Microsoft.Azure.Cosmos/FaultInjection/README.md
@@ -2,6 +2,22 @@
 
 The Azure Cosmos DB .NET SDK Fault Injection Library allows you to simulate network issues in the Azure Cosmos DB .NET SDK. This library is useful for testing the SDK's behavior when there are network issues. Additionally, this library can help you test your own retry policies. Note that this library is not intended for use in production environments and should only be used for testing purposes. This **library** is currently in preview, and breaking changes may occur.
 
+> **Contributing / maintaining this library?** See [DEVELOPMENT.md](./DEVELOPMENT.md) for how to build the project, run its integration tests inside this repository, cut a release, and troubleshoot common issues.
+
+## Installation
+
+The library ships as the [`Microsoft.Azure.Cosmos.FaultInjection`](https://www.nuget.org/packages/Microsoft.Azure.Cosmos.FaultInjection) NuGet package. Because it is currently in beta, install it with the `--prerelease` flag (or pin an explicit prerelease version):
+
+```bash
+# Latest prerelease
+dotnet add package Microsoft.Azure.Cosmos.FaultInjection --prerelease
+
+# Or pin an explicit version
+dotnet add package Microsoft.Azure.Cosmos.FaultInjection --version 1.0.0-beta.1
+```
+
+The package brings in a compatible `Microsoft.Azure.Cosmos` SDK version as a dependency. It targets `net6.0`.
+
 ## Key Concepts
 
 ### `FaultInjectionRule`
@@ -32,6 +48,12 @@ This result will return a server error to the customer: `FaultInjectionServerErr
 | `ResponseDelay`         | n/a          | Will inject a delay to the request after a response is received from the backend before returning the result. |
 | `ConnectionDelay`       | n/a          | Used to simulate high channel acquisition.                                  |
 | `ServiceUnavailable`    | 503:0        | The service is currently unavailable.                                       |
+| `DatabaseAccountNotFound`| 403:1008    | The database account was not found. Gateway mode only (rejected for Direct connection type). |
+| `LeaseNotFound`         | 410:1022     | The lease required to serve the request was not found.                      |
+| `Unauthorized`          | 401:0        | The request is not authorized.                                              |
+| `AadTokenRevoked`       | 401:5013     | The Microsoft Entra ID (AAD) token has been revoked.                        |
+
+> **Mode applicability:** `Gone` is only injected on **Direct** mode calls and is rejected when the rule targets the `Gateway` connection type. `DatabaseAccountNotFound` is the inverse — it is only valid for **Gateway** mode. See the validation in `FaultInjectionRuleBuilder`.
 
 ##### `FaultInjectionConnectionErrorResult`
 
@@ -44,13 +66,21 @@ This result will return a connection error to the customer: `FaultInjectionConne
 
 ##### Other `FaultInjectionResult` Properties
 
-When creating a `FaultInjectionResult`, you can also specify the following properties:
+When creating a **server error** `FaultInjectionResult` (via `FaultInjectionServerErrorResultBuilder`), you can also specify the following properties:
 
-| Property       | Description |
-| -------------- | ----------- |
-| `Times`        | This allows you to specify how many times to inject the fault for a single operation. By default, there is no limit. |
-| `Delay`        | This allows you to specify how long to delay the fault injection. Only applicable for `SendDelay`, `ResponseDelay`, and `ConnectionDelay` error types. |
-| `InjectionRate`| This allows you to specify how often the rule is applied when applicable to an operation. By default, the rate is 100%. |
+| Property       | Builder method | Description |
+| -------------- | -------------- | ----------- |
+| `Times`        | `WithTimes(int)` | Specifies how many times to inject the fault for a single operation (retries within one logical operation). By default, there is no limit. |
+| `Delay`        | `WithDelay(TimeSpan)` | Specifies how long to delay the fault injection. Only applicable for `SendDelay`, `ResponseDelay`, and `ConnectionDelay` error types (and required for them). |
+| `InjectionRate`| `WithInjectionRate(double)` | Specifies how often the rule is applied when applicable to an operation, in the range `(0, 1]`. By default, the rate is 100% (`1.0`). |
+| `SuppressServiceRequest` | `WithSuppressServiceRequest(bool)` | When `true`, the real request is never sent to the backend and the injected fault is returned immediately. When `false`, the request is still sent (useful for delay-style faults). |
+
+When creating a **connection error** `FaultInjectionResult` (via `FaultInjectionConnectionErrorResultBuilder`), the following properties apply instead:
+
+| Property    | Builder method | Description |
+| ----------- | -------------- | ----------- |
+| `Interval`  | `WithInterval(TimeSpan)` | How often the connection error is injected. Must be greater than zero. |
+| `Threshold` | `WithThreshold(double)` | The percentage of established connections impacted by the fault, in the range `(0, 1]`. Default is `1.0` (100%). |
 
 #### `FaultInjectionCondition`
 
@@ -78,7 +108,14 @@ The `FaultInjectionOperationType` specifies the type of operation that the fault
 | `PatchItem` |
 | `Batch` |
 | `ReadFeed` |
+| `MetadataContainer` |
+| `MetadataDatabaseAccount` |
+| `MetadataPartitionKeyRange` |
+| `MetadataRefreshAddresses` |
+| `MetadataQueryPlan` |
 | `All` |
+
+> The `Metadata*` operation types target the SDK's control-plane / metadata requests (container, database-account, partition-key-range, address refresh, and query-plan calls). In Gateway mode, metadata requests only support a subset of server error types (`TooManyRequests`, `ResponseDelay`, `SendDelay`, `DatabaseAccountNotFound`, `ServiceUnavailable`, `InternalServerError`, `LeaseNotFound`, `Unauthorized`, `AadTokenRevoked`).
 
 ##### `FaultInjectionConnectionType`
 
@@ -97,23 +134,36 @@ The `Gateway` connection type also supports connection to the `ThinProxy`.
 
 When creating a `FaultInjectionRule`, you can also specify the following properties:
 
-| Property       | Description |
-| -------------- | ----------- |
-| `Duration`     | This allows you to specify how long a rule is valid for. |
-| `StartDelay`   | This allows you to specify how long to wait before starting to inject faults. |
-| `HitLimit`     | This allows you to specify how many times to inject faults. |
+| Property       | Builder method | Description |
+| -------------- | -------------- | ----------- |
+| `Duration`     | `WithDuration(TimeSpan)` | How long the rule is valid for. The duration is measured from the time the rule is created. By default, the rule is effective until the application ends. |
+| `StartDelay`   | `WithStartDelay(TimeSpan)` | How long to wait after rule creation before the rule starts injecting faults. |
+| `HitLimit`     | `WithHitLimit(int)` | The maximum number of times the rule can be applied across all operations. Must be greater than 0. |
+| `IsEnabled`    | `IsEnabled(bool)` | Whether the rule is enabled. A disabled rule is never applied. Rules are enabled by default and can be toggled multiple times. |
 
 
 ### `FaultInjector`
 
 The `FaultInjector` is a class that allows you to inject faults into the Azure Cosmos DB .NET SDK. The `FaultInjector` is created with a list of `FaultInjectionRule`s. Once created, the `FaultInjector` can be passed to the `CosmosClient` constructor to enable fault injection.
 
-After conductiong the tests, you can use the `FaultInjector` to get the `FaultInjectionApplicationContext` which allows you to get the following: 
+After conducting the tests, you can use the `FaultInjector` to get the `FaultInjectionApplicationContext`, which allows you to get the following:
 
 - Given a rule id, get the time and activity id of all requests that were affected by the rule.
 - Given an activity id, get the rule id that affected the request.
 
 This can be useful for debugging and understanding which rules are affecting which requests.
+
+```c#
+FaultInjector faultInjector = new FaultInjector(rules);
+
+// ... run your workload against a client configured with faultInjector ...
+
+// Get the rule id that affected a specific request (by activity id)
+string? ruleId = faultInjector.GetFaultInjectionRuleId(activityId);
+
+// Get the full application context to inspect every rule hit
+FaultInjectionApplicationContext? context = faultInjector.GetApplicationContext();
+```
 
 ## Examples
 
@@ -153,7 +203,7 @@ FaultInjectionRule rule = new FaultInjectionRuleBuilder(
 
 ### Server Return Gone
 
-This rule will return a 410 Gone error for all operations. Note that because when the server returns a 410 Gone error, it will apply to all operations, the `FaultInjectionCondition` will be ignored.
+This rule will return a 410 Gone error for read item operations. `Gone` is a Direct-mode error; a rule using the `Gone` result is rejected if it targets the `Gateway` connection type.
 
 ```c#
 FaultInjectionRule rule = new FaultInjectionRuleBuilder(
@@ -168,7 +218,7 @@ FaultInjectionRule rule = new FaultInjectionRuleBuilder(
 
 ### Server Unavailable
 
-This rule will return a 503 Service Unavailable error for 10% of all operations in the East US region.
+This rule will return a 503 Service Unavailable error for 10% of all operations in the East US region. Note that the injection rate is set on the **result** builder (`WithInjectionRate`), not the rule builder.
 
 ```c#
 FaultInjectionRule rule = new FaultInjectionRuleBuilder(
@@ -177,8 +227,8 @@ FaultInjectionRule rule = new FaultInjectionRuleBuilder(
         .WithRegion("East US")
         .Build(),
     result: FaultInjectionResultBuilder.GetResultBuilder(FaultInjectionServerErrorType.ServiceUnavailable)
+        .WithInjectionRate(0.1)
         .Build())
-    .WithInjectionRate(0.1)
     .Build();
 ```
 
@@ -198,7 +248,7 @@ FaultInjectionRule rule = new FaultInjectionRuleBuilder(
         .Build())
     .WithDuration(TimeSpan.FromSeconds(30))
     .Build();
-``
+```
 
 ### Create a `CosmosClient` with Fault Injection Enabled
 
@@ -213,17 +263,17 @@ FaultInjector faultInjector = new FaultInjector(rules);
 
 ```
 
-Once you have created the `FaultInjector`, you can pass it to the `CosmosClient` constructor:
+Once you have created the `FaultInjector`, you can pass it to the `CosmosClient` via the `CosmosClientBuilder`:
 
 ```c#
 
 CosmosClient client = new CosmosClientBuilder("connectionString")
-    .WithFaultInjector(faultInjector)
+    .WithFaultInjection(faultInjector)
     .Build();
 
 ```
 
-or
+or via `CosmosClientOptions`:
 
 ```c#
 
@@ -236,5 +286,9 @@ CosmosClient client = new CosmosClient("connectionString", options);
 
 ```
 
+## Related documentation
 
+- [DEVELOPMENT.md](./DEVELOPMENT.md) — build, test, release, and maintenance guide for contributors.
+- [changelog.md](./changelog.md) — release notes for the `Microsoft.Azure.Cosmos.FaultInjection` package.
+- [Repository CONTRIBUTING guide](../../CONTRIBUTING.md) — changelog rules, PR title format, and general contribution workflow.
 


### PR DESCRIPTION
## Description

Complete audit and refresh of the .NET Fault Injection docs (`Microsoft.Azure.Cosmos/FaultInjection/`). Cross-checked the README against the actual public API (builders, enums, `FaultInjector`, `CosmosClientBuilder.WithFaultInjection`, `CosmosClientOptions.FaultInjector`), the test project, and the release pipeline.

### `README.md` — bug fixes
- **Wrong API name**: `.WithFaultInjector(faultInjector)` → **`.WithFaultInjection(faultInjector)`** (the real public method).
- **Non-compiling example**: the *Server Unavailable* sample called `.WithInjectionRate(0.1)` on the **rule** builder; that method only exists on `FaultInjectionServerErrorResultBuilder`. Moved onto the result builder.
- **Broken markdown fence** (two backticks) that swallowed the *Random Connection Closed* example.
- **Incomplete server-error table**: added `DatabaseAccountNotFound` (403:1008), `LeaseNotFound` (410:1022), `Unauthorized` (401), `AadTokenRevoked` (401:5013) + Direct/Gateway mode-applicability note.
- **Incomplete operation-type table**: added the five `Metadata*` operation types and their Gateway-mode restrictions.
- **Missing properties**: `IsEnabled` (rule), `SuppressServiceRequest` (server result), `Interval`/`Threshold` (connection result), with builder methods.
- Added an **Installation** section (`dotnet add package … --prerelease`), a **results-retrieval** example (`GetApplicationContext` / `GetFaultInjectionRuleId`), fixed the `conductiong` typo and a misleading "Gone ignores the condition" note, and a **Related documentation** footer.

### New file: `DEVELOPMENT.md`
Contributor/maintainer guide: project layout, how the library plugs into the SDK, building, running unit vs live-account integration tests (`COSMOSDB_MULTI_REGION` / `COSMOSDB_THIN_CLIENT`), adding a new fault type, changelog rules, the release pipeline, and a troubleshooting table.

## Changelog

No changelog entry required — this is a **docs-only** change touching no shipped `Microsoft.Azure.Cosmos/FaultInjection/src/**` source, so per the repo's changelog classifier an entry is not needed.

## Type of change

- [x] Documentation

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>