### PR TITLE
Distributed Transactions: Fixes resource body to surface coordinator data verbatim

### DIFF
--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperationResult.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperationResult.cs
@@ -7,6 +7,7 @@ namespace Microsoft.Azure.Cosmos
     using System;
     using System.IO;
     using System.Net;
+    using System.Text;
     using System.Text.Json;
     using Microsoft.Azure.Cosmos.Core.Trace;
     using Microsoft.Azure.Cosmos.Tracing;
@@ -209,7 +210,10 @@ namespace Microsoft.Azure.Cosmos
                     throw new JsonException($"The 'resourceBody' value must be a JSON object, but was '{resourceBody.ValueKind}'.");
                 }
 
-                byte[] bytes = JsonSerializer.SerializeToUtf8Bytes(resourceBody);
+                // Surface the coordinator's document verbatim: GetRawText() preserves raw UTF-8, quotes, and
+                // numeric tokens as received (no SDK re-escaping). Pure pass-through — escapes are not decoded.
+                // Do NOT use Utf8JsonWriter/WriteTo: its encoder re-introduces \uXXXX escaping.
+                byte[] bytes = Encoding.UTF8.GetBytes(resourceBody.GetRawText());
                 result.ResourceStream = new MemoryStream(bytes, 0, bytes.Length, writable: false, publiclyVisible: true);
             }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionResponseTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionResponseTests.cs
@@ -1869,6 +1869,87 @@ namespace Microsoft.Azure.Cosmos.Tests
         }
 
         [TestMethod]
+        [Description("The resource body stream must preserve non-ASCII characters as raw UTF-8 (e.g. 北京, 😀), " +
+                     "including non-ASCII property names, instead of emitting \\uXXXX escape sequences.")]
+        public async Task FromResponseMessage_ResourceBody_PreservesNonAsciiCharacters()
+        {
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
+
+            // resourceBody contains CJK text, a supplementary-plane emoji, and a non-ASCII property name,
+            // all as raw UTF-8. The SDK must surface this object verbatim.
+            const string resourceBody = "{\"id\":\"item1\",\"city\":\"北京\",\"mood\":\"😀\",\"名前\":\"東京\"}";
+            string json = "{\"operationResponses\":[{\"index\":0,\"statusCode\":200,\"resourceBody\":" + resourceBody + "}]}";
+            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.OK, json);
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            using StreamReader reader = new StreamReader(response[0].ResourceStream, Encoding.UTF8);
+            string body = reader.ReadToEnd();
+
+            // Exact equality proves the body is verbatim, not merely that the fragments survived.
+            Assert.AreEqual(resourceBody, body, "Resource body must be surfaced byte-for-byte, including the non-ASCII property name.");
+        }
+
+        [TestMethod]
+        [Description("The resource body is a pure pass-through: escape sequences the transaction service sends " +
+                     "(e.g. \\u00e9, \\n) are surfaced verbatim and are NOT decoded/normalized by the SDK.")]
+        public async Task FromResponseMessage_ResourceBody_DoesNotDecodeEscapeSequences()
+        {
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
+
+            // The coordinator sends a \uXXXX escape and a \n escape. A pass-through must preserve them
+            // literally rather than decoding \u00e9 -> é or \n -> a newline.
+            const string resourceBody = "{\"id\":\"item1\",\"name\":\"caf\\u00e9\",\"note\":\"a\\nb\"}";
+            string json = "{\"operationResponses\":[{\"index\":0,\"statusCode\":200,\"resourceBody\":" + resourceBody + "}]}";
+            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.OK, json);
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            using StreamReader reader = new StreamReader(response[0].ResourceStream, Encoding.UTF8);
+            string body = reader.ReadToEnd();
+
+            Assert.AreEqual(resourceBody, body, "Escaped input must be surfaced verbatim, not decoded.");
+            Assert.IsFalse(body.Contains("café"), "\\u00e9 must not be decoded to é.");
+        }
+
+        [TestMethod]
+        [Description("The resource body must surface every value exactly as the transaction coordinator sent it. " +
+                     "Numeric tokens — including scientific/exponent notation (e.g. 3.141592653589793E0), large " +
+                     "integers, and trailing-zero decimals — are passed through verbatim without any re-formatting.")]
+        public async Task FromResponseMessage_ResourceBody_PreservesNumericTokensVerbatim()
+        {
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
+
+            // Every numeric token below must appear byte-for-byte in the resource body, exactly as received.
+            const string resourceBody = "{\"id\":\"item1\",\"pi\":3.141592653589793E0,\"scaled\":1.5E2,\"largeInt\":12345678901234567890,\"plain\":1.50}";
+            string json = "{\"operationResponses\":[{\"index\":0,\"statusCode\":200,\"resourceBody\":" + resourceBody + "}]}";
+            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.OK, json);
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            using StreamReader reader = new StreamReader(response[0].ResourceStream, Encoding.UTF8);
+            string body = reader.ReadToEnd();
+
+            // Exact equality proves no numeric token was re-formatted (E-notation, trailing zeros, large int all intact).
+            Assert.AreEqual(resourceBody, body, "Numeric tokens must be surfaced exactly as received, with no re-formatting.");
+        }
+
+        [TestMethod]
         [Description("GetOperationResultAtIndex<T> returns default(T) when the operation has no resource body.")]
         public async Task GetOperationResultAtIndex_WithoutResourceBody_ResourceIsDefault()
         {

--- a/changelog.md
+++ b/changelog.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Bugs Fixed
 
-- Distributed Transactions (preview): Fixes the resource body returned by distributed-transaction reads so it is surfaced verbatim, exactly as received from the transaction service.
+- [6036](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/6036) Distributed Transactions (preview): Fixes the resource body returned by distributed-transaction reads so it is surfaced verbatim, exactly as received from the transaction service.
 
 #### Other Changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Bugs Fixed
 
+- Distributed Transactions (preview): Fixes the resource body returned by distributed-transaction reads so it is surfaced verbatim, exactly as received from the transaction service.
+
 #### Other Changes
 
 - [5991](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5991) TargetReplicaSetSize : Updated address cache logic to use partition-specific target replica set size when available, falling back to the user replication policy value.


### PR DESCRIPTION
## Description

Distributed Transaction (DTx) reads were re-escaping non-ASCII characters in the returned resource body. When a stored document contained raw UTF-8 (e.g. `北京`, `😀`), a DTx read surfaced it as `\uXXXX` escape sequences (`北京` → `\u5317\u4eac`), unlike a point read which preserves the raw bytes.

### Root cause

`DistributedTransactionOperationResult.FromJson` built the `ResourceStream` via `JsonSerializer.SerializeToUtf8Bytes(resourceBody)`. The default `JavaScriptEncoder` escapes every non-ASCII character (and `"` → `\u0022`), so the SDK re-encoded the coordinator's document instead of surfacing it as-is.

### Fix

Surface the coordinator's document **verbatim** using `JsonElement.GetRawText()`, which returns the exact JSON text as received — raw UTF-8, quotes, and numeric tokens preserved, with no SDK re-escaping. This is a pure pass-through: escape sequences are not decoded or normalized by the SDK.

```csharp
byte[] bytes = Encoding.UTF8.GetBytes(resourceBody.GetRawText());
```

### Notes on numeric fidelity

Floating-point tokens (e.g. `3.1415926535897931`) can still surface in exponent notation (`3.141592653589793E0`) on the DTx path. This originates in the transaction **coordinator** (it round-trips numbers through IEEE-754 doubles and re-emits before the SDK receives them), not in the SDK. Per design, the SDK surfaces coordinator data as-is and does not attempt to normalize it. This was verified end-to-end against a live DTx account by capturing the raw HTTP envelope: the SDK output is byte-identical to what the coordinator sends.

## Testing

Added unit tests in `DistributedTransactionResponseTests`:
- `FromResponseMessage_ResourceBody_PreservesNonAsciiCharacters` — exact-equality on a body with CJK, emoji, and a non-ASCII property name.
- `FromResponseMessage_ResourceBody_DoesNotDecodeEscapeSequences` — pins pass-through semantics (`\u00e9` / `\n` surfaced verbatim, not decoded).
- `FromResponseMessage_ResourceBody_PreservesNumericTokensVerbatim` — exact-equality on E-notation, large-int, and trailing-zero tokens.

All 109 `DistributedTransactionResponseTests` pass; SDK builds clean in Release.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changelog

- [x] Added entry under `### Unreleased` → `#### Bugs Fixed` (preview feature, customer-observable output change).