### PR TITLE
Distributed Transactions: Refactors CommitTransactionAsync to ExecuteTransactionAsync

### DIFF
--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedReadTransaction.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedReadTransaction.cs
@@ -12,7 +12,7 @@ namespace Microsoft.Azure.Cosmos
     /// <remarks>
     /// Use <see cref="CosmosClient.CreateDistributedReadTransaction"/> to obtain an instance.
     /// Add read operations using <see cref="ReadItem"/> then call
-    /// <see cref="DistributedTransaction.CommitTransactionAsync"/> to execute all reads atomically.
+    /// <see cref="DistributedTransaction.ExecuteTransactionAsync"/> to execute all reads atomically.
     /// <para>
     /// <b>Isolation semantics:</b> All reads execute under snapshot isolation so the results reflect a
     /// consistent point in time across participating partitions.

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedReadTransactionCore.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedReadTransactionCore.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Azure.Cosmos
     internal class DistributedReadTransactionCore : DistributedReadTransaction
     {
         internal const string CommitAlreadyCalledMessage =
-            "CommitTransactionAsync has already been called on this transaction instance. " +
+            "ExecuteTransactionAsync has already been called on this transaction instance. " +
             "A DistributedReadTransaction is single-use; to retry, construct a new " +
             "DistributedReadTransaction with the same items.";
 
@@ -53,7 +53,7 @@ namespace Microsoft.Azure.Cosmos
 
         /// <inheritdoc/>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken"/> is cancelled before or during the commit.</exception>
-        public override Task<DistributedTransactionResponse> CommitTransactionAsync(
+        public override Task<DistributedTransactionResponse> ExecuteTransactionAsync(
             CancellationToken cancellationToken = default)
         {
             if (this.operations.Count == 0)
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.Cosmos
             }
 
             return this.clientContext.OperationHelperAsync(
-                operationName: $"{nameof(DistributedReadTransaction)}.{nameof(CommitTransactionAsync)}",
+                operationName: $"{nameof(DistributedReadTransaction)}.{nameof(ExecuteTransactionAsync)}",
                 containerName: null,
                 databaseName: null,
                 operationType: OperationType.Read,
@@ -79,9 +79,9 @@ namespace Microsoft.Azure.Cosmos
                         clientContext: this.clientContext,
                         operationType: OperationType.Read);
 
-                    return committer.CommitTransactionAsync(trace, cancellationToken);
+                    return committer.ExecuteTransactionAsync(trace, cancellationToken);
                 },
-                openTelemetry: new (OpenTelemetryConstants.Operations.CommitDistributedReadTransaction,
+                openTelemetry: new (OpenTelemetryConstants.Operations.ExecuteDistributedReadTransaction,
                                     (response) => new OpenTelemetryResponse(response)),
                 traceComponent: TraceComponent.Batch);
         }

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransaction.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransaction.cs
@@ -29,8 +29,8 @@ namespace Microsoft.Azure.Cosmos
         /// </remarks>
         /// <param name="cancellationToken">A <see cref="CancellationToken"/> to observe while waiting for the task to complete.</param>
         /// <returns>A <see cref="Task{TResult}"/> containing a <see cref="DistributedTransactionResponse"/> that represents the result of the transaction.</returns>
-        /// <exception cref="InvalidOperationException">Thrown if <see cref="CommitTransactionAsync"/> has already been called on this instance.</exception>
+        /// <exception cref="InvalidOperationException">Thrown if <see cref="ExecuteTransactionAsync"/> has already been called on this instance.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken"/> is cancelled before or during the commit.</exception>
-        public abstract Task<DistributedTransactionResponse> CommitTransactionAsync(CancellationToken cancellationToken = default);
+        public abstract Task<DistributedTransactionResponse> ExecuteTransactionAsync(CancellationToken cancellationToken = default);
     }
 }

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionCommitter.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionCommitter.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Azure.Cosmos
             this.maxCumulativeRetryDelay = maxCumulativeRetryDelay ?? DistributedTransactionCommitter.MaxCumulativeRetryDelay;
         }
 
-        public async Task<DistributedTransactionResponse> CommitTransactionAsync(
+        public async Task<DistributedTransactionResponse> ExecuteTransactionAsync(
             ITrace trace,
             CancellationToken cancellationToken)
         {

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionResponse.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionResponse.cs
@@ -178,7 +178,7 @@ namespace Microsoft.Azure.Cosmos
         /// Gets the client-side diagnostics for the distributed transaction, covering the full
         /// retry loop and per-attempt spans (address resolution, network, retries, latency).
         /// </summary>
-        /// <remarks>Non-null when the response is returned from <c>CommitTransactionAsync</c>. The SDK sets this property
+        /// <remarks>Non-null when the response is returned from <c>ExecuteTransactionAsync</c>. The SDK sets this property
         /// before returning; callers should treat it as non-null in normal usage but guard defensively in edge cases.</remarks>
         public virtual CosmosDiagnostics Diagnostics { get; internal set; }
 

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedWriteTransactionCore.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedWriteTransactionCore.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Azure.Cosmos
     internal class DistributedWriteTransactionCore : DistributedWriteTransaction
     {
         internal const string CommitAlreadyCalledMessage =
-            "CommitTransactionAsync has already been called on this transaction instance. " +
+            "ExecuteTransactionAsync has already been called on this transaction instance. " +
             "A DistributedWriteTransaction is single-use because each commit generates a new " +
             "idempotency token; a second call would bypass server-side duplicate detection and " +
             "risk a double-commit. To retry, construct a new DistributedWriteTransaction with " +
@@ -280,16 +280,16 @@ namespace Microsoft.Azure.Cosmos
 
         /// <inheritdoc/>
         /// <remarks>
-        /// Each call to <see cref="DistributedTransaction.CommitTransactionAsync"/> generates a unique
+        /// Each call to <see cref="DistributedTransaction.ExecuteTransactionAsync"/> generates a unique
         /// idempotency token that the server uses for duplicate detection during the SDK's internal
         /// retries. A second call would generate a new token and bypass that server-side duplicate
         /// detection, risking a double-commit. When the previous commit's outcome is unknown
         /// (e.g., cancellation or network failure), verify the resulting state before retrying
         /// to avoid duplicate writes.
         /// </remarks>
-        /// <exception cref="InvalidOperationException">Thrown if <see cref="DistributedTransaction.CommitTransactionAsync"/> has already been called on this instance.</exception>
+        /// <exception cref="InvalidOperationException">Thrown if <see cref="DistributedTransaction.ExecuteTransactionAsync"/> has already been called on this instance.</exception>
         /// <exception cref="OperationCanceledException">Thrown if <paramref name="cancellationToken"/> is cancelled before or during the commit.</exception>
-        public override Task<DistributedTransactionResponse> CommitTransactionAsync(CancellationToken cancellationToken = default)
+        public override Task<DistributedTransactionResponse> ExecuteTransactionAsync(CancellationToken cancellationToken = default)
         {
             if (this.operations.Count == 0)
             {
@@ -302,7 +302,7 @@ namespace Microsoft.Azure.Cosmos
             }
 
             return this.clientContext.OperationHelperAsync(
-                operationName: $"{nameof(DistributedWriteTransaction)}.{nameof(CommitTransactionAsync)}",
+                operationName: $"{nameof(DistributedWriteTransaction)}.{nameof(ExecuteTransactionAsync)}",
                 containerName: null,
                 databaseName: null,
                 operationType: OperationType.CommitDistributedTransaction,
@@ -314,9 +314,9 @@ namespace Microsoft.Azure.Cosmos
                         clientContext: this.clientContext,
                         operationType: OperationType.CommitDistributedTransaction);
 
-                    return committer.CommitTransactionAsync(trace, cancellationToken);
+                    return committer.ExecuteTransactionAsync(trace, cancellationToken);
                 },
-                openTelemetry: new (OpenTelemetryConstants.Operations.CommitDistributedWriteTransaction,
+                openTelemetry: new (OpenTelemetryConstants.Operations.ExecuteDistributedWriteTransaction,
                                     (response) => new OpenTelemetryResponse(response)),
                 traceComponent: TraceComponent.Batch);
         }

--- a/Microsoft.Azure.Cosmos/src/Telemetry/OpenTelemetry/OpenTelemetryConstants.cs
+++ b/Microsoft.Azure.Cosmos/src/Telemetry/OpenTelemetry/OpenTelemetryConstants.cs
@@ -13,8 +13,8 @@ namespace Microsoft.Azure.Cosmos.Telemetry.OpenTelemetry
             public const string ExecuteBulkPrefix = "bulk_";
 
             // Distributed Transaction Operations
-            public const string CommitDistributedReadTransaction = "commit_distributed_read_transaction";
-            public const string CommitDistributedWriteTransaction = "commit_distributed_write_transaction";
+            public const string ExecuteDistributedReadTransaction = "execute_distributed_read_transaction";
+            public const string ExecuteDistributedWriteTransaction = "execute_distributed_write_transaction";
 
             // Change feed operations
             public const string QueryChangeFeed = "query_change_feed";

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/DistributedTransaction/DistributedReadTransactionE2ETests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/DistributedTransaction/DistributedReadTransactionE2ETests.cs
@@ -97,7 +97,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             DistributedTransactionResponse response = await this.client
                 .CreateDistributedReadTransaction()
                 .ReadItem(this.container, new PartitionKey(doc.pk), doc.id)
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode, $"Envelope status should be 200 OK. Got: {response.StatusCode}");
             Assert.AreEqual(1, response.Count);
@@ -122,7 +122,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 .ReadItem(this.container, new PartitionKey(doc1.pk), doc1.id)
                 .ReadItem(this.container, new PartitionKey(doc2.pk), doc2.id)
                 .ReadItem(this.container, new PartitionKey(doc3.pk), doc3.id)
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode, $"Envelope status should be 200 OK. Got: {response.StatusCode}");
             Assert.AreEqual(3, response.Count);
@@ -147,7 +147,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 .CreateDistributedReadTransaction()
                 .ReadItem(this.container, new PartitionKey(doc1.pk), doc1.id)
                 .ReadItem(secondContainer, new PartitionKey(doc2.pk), doc2.id)
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode, $"Envelope status should be 200 OK. Got: {response.StatusCode}");
             Assert.AreEqual(2, response.Count);
@@ -169,7 +169,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 .CreateDistributedReadTransaction()
                 .ReadItem(this.container, new PartitionKey(doc1.pk), doc1.id)
                 .ReadItem(this.container, new PartitionKey(doc2.pk), doc2.id)
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode, $"Envelope status should be 200 OK. Got: {response.StatusCode}");
             Assert.AreEqual(2, response.Count);
@@ -192,7 +192,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 .CreateDistributedReadTransaction()
                 .ReadItem(this.container, new PartitionKey(pk1), Guid.NewGuid().ToString())
                 .ReadItem(this.container, new PartitionKey(pk2), Guid.NewGuid().ToString())
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             // Pin the coordinator contract: envelope is 200 (multi-status), each missing item surfaces as a per-op 404.
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode, "Envelope status should be 200 even when all per-op results are 404.");
@@ -216,7 +216,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 .CreateDistributedReadTransaction()
                 .ReadItem(this.container, new PartitionKey(existing.pk), existing.id)
                 .ReadItem(this.container, new PartitionKey(missingPk), missingId)
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode, "Envelope status should be 200 even with mixed per-op results.");
             Assert.AreEqual(2, response.Count);
@@ -236,7 +236,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 .CreateDistributedReadTransaction()
                 .ReadItem(this.container, new PartitionKey(doc1.pk), doc1.id)
                 .ReadItem(this.container, new PartitionKey(doc2.pk), doc2.id)
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode, $"Envelope status should be 200 OK. Got: {response.StatusCode}");
             Assert.AreEqual(HttpStatusCode.OK, response[0].StatusCode, "Per-op[0] should be 200 OK.");
@@ -259,7 +259,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             await Assert.ThrowsExceptionAsync<InvalidOperationException>(() =>
                 this.client
                     .CreateDistributedReadTransaction()
-                    .CommitTransactionAsync(CancellationToken.None));
+                    .ExecuteTransactionAsync(CancellationToken.None));
         }
 
         // ─── Container resolution failure (real path, before /dtc) ─────────────
@@ -273,7 +273,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 this.client
                     .CreateDistributedReadTransaction()
                     .ReadItem(missingContainer, new PartitionKey("pk"), "item-id")
-                    .CommitTransactionAsync(CancellationToken.None));
+                    .ExecuteTransactionAsync(CancellationToken.None));
 
             Assert.AreEqual(
                 HttpStatusCode.NotFound,
@@ -307,7 +307,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 .CreateDistributedReadTransaction()
                 .ReadItem(containerA, new PartitionKey(docA.pk), docA.id)
                 .ReadItem(containerB, new PartitionKey(docB.pk), docB.id)
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode, $"Envelope status should be 200 OK. Got: {response.StatusCode}");
             Assert.AreEqual(2, response.Count);
@@ -335,7 +335,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 HttpStatusCode status = await TryGetReadTransactionStatusAsync(() => readOnlyClient
                     .CreateDistributedReadTransaction()
                     .ReadItem(readOnlyClient.GetContainer(DatabaseId, ContainerId), new PartitionKey(doc.pk), doc.id)
-                    .CommitTransactionAsync(CancellationToken.None));
+                    .ExecuteTransactionAsync(CancellationToken.None));
 
                 Assert.AreEqual(
                     HttpStatusCode.OK,
@@ -359,7 +359,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 HttpStatusCode status = await TryGetReadTransactionStatusAsync(() => readWriteClient
                     .CreateDistributedReadTransaction()
                     .ReadItem(readWriteClient.GetContainer(DatabaseId, ContainerId), new PartitionKey(doc.pk), doc.id)
-                    .CommitTransactionAsync(CancellationToken.None));
+                    .ExecuteTransactionAsync(CancellationToken.None));
 
                 Assert.AreEqual(
                     HttpStatusCode.OK,
@@ -377,7 +377,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             HttpStatusCode status = await TryGetReadTransactionStatusAsync(() => this.client
                 .CreateDistributedReadTransaction()
                 .ReadItem(this.container, new PartitionKey(doc.pk), doc.id)
-                .CommitTransactionAsync(CancellationToken.None));
+                .ExecuteTransactionAsync(CancellationToken.None));
 
             Assert.AreEqual(
                 HttpStatusCode.OK,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/DistributedTransaction/DistributedTransactionConditionalE2ETests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/DistributedTransaction/DistributedTransactionConditionalE2ETests.cs
@@ -98,7 +98,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 .CreateDistributedReadTransaction()
                 .ReadItem(this.container, new PartitionKey(pk1), id1)
                 .ReadItem(this.container, new PartitionKey(pk2), id2)
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode,
                 $"Envelope should be 200 when all ops succeed. Got: {response.StatusCode}");
@@ -142,7 +142,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 .ReadItem(this.container, new PartitionKey(pk1), id1)
                 .ReadItem(this.container, new PartitionKey(pk2), id2,
                     new DistributedTransactionRequestOptions { IfNoneMatchEtag = item2ETag })
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             // Envelope should be 207 MultiStatus when any op is non-2xx (304),
             // aligning with TransactionalBatch behavior.
@@ -187,7 +187,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 .CreateDistributedReadTransaction()
                 .ReadItem(this.container, new PartitionKey(pk), id,
                     new DistributedTransactionRequestOptions { IfNoneMatchEtag = originalETag })
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             Assert.IsTrue(response.IsSuccessStatusCode,
                 $"Stale IfNoneMatch should return success. Got: {response.StatusCode}");
@@ -231,7 +231,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     new DistributedTransactionRequestOptions { IfNoneMatchEtag = resp1.ETag })
                 .ReadItem(this.container, new PartitionKey(pk2), id2,
                     new DistributedTransactionRequestOptions { IfNoneMatchEtag = resp2.ETag })
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(2, response.Count);
 
@@ -267,7 +267,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 .CreateDistributedReadTransaction()
                 .ReadItem(this.container, new PartitionKey(pk1), id1)
                 .ReadItem(this.container, new PartitionKey(pk2), nonExistentId)
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode,
                 $"Envelope should be 404 when a read op targets a non-existent item. Got: {response.StatusCode}");
@@ -314,7 +314,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 .ReplaceItem(this.container, new PartitionKey(pk), id,
                     new { id, pk, value = "dtx-replace" },
                     new DistributedTransactionRequestOptions { IfMatchEtag = originalETag })
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(HttpStatusCode.PreconditionFailed, response.StatusCode,
                 $"Envelope should be 412 with stale IfMatch. Got: {response.StatusCode}");
@@ -349,7 +349,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 .ReplaceItem(this.container, new PartitionKey(pk), id,
                     new { id, pk, value = "dtx-replaced" },
                     new DistributedTransactionRequestOptions { IfMatchEtag = currentETag })
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             Assert.IsTrue(response.IsSuccessStatusCode,
                 $"Replace with current IfMatch should succeed. Got: {response.StatusCode}");
@@ -380,7 +380,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 .CreateDistributedReadTransaction()
                 .ReadItem(this.container, new PartitionKey(pk), id,
                     new DistributedTransactionRequestOptions { IfNoneMatchEtag = matchingETag })
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             Assert.IsTrue(response.Count > 0,
                 "Response should have at least one operation result.");
@@ -437,7 +437,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                         IfMatchEtag = "\"stale-bogus-etag\"",
                         IfNoneMatchEtag = currentETag
                     })
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             Assert.IsTrue(response.Count > 0);
 
@@ -475,7 +475,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                         IfMatchEtag = currentETag,
                         IfNoneMatchEtag = currentETag
                     })
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             // IfMatch was honoured (current → success). IfNoneMatch was ignored for writes.
             Assert.IsTrue(response.IsSuccessStatusCode,
@@ -518,7 +518,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                         IfMatchEtag = originalETag,
                         IfNoneMatchEtag = originalETag
                     })
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             // IfMatch is stale → precondition failure. IfNoneMatch cannot rescue the write.
             Assert.IsFalse(response.IsSuccessStatusCode,
@@ -550,7 +550,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     {
                         FilterPredicate = "from c where c.status = 'pending'"
                     })
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             Assert.IsTrue(response.IsSuccessStatusCode,
                 $"Patch with a satisfied FilterPredicate should succeed. Got: {response.StatusCode}");
@@ -582,7 +582,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     {
                         FilterPredicate = "from c where c.status = 'pending'"
                     })
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(HttpStatusCode.PreconditionFailed, response.StatusCode,
                 $"Patch with an unsatisfied FilterPredicate should return 412. Got: {response.StatusCode}");
@@ -634,7 +634,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     })
                 .ReplaceItem(this.container, new PartitionKey(pkSibling), idSibling,
                     new { id = idSibling, pk = pkSibling, payload = "sibling-mutated" })
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(HttpStatusCode.PreconditionFailed, response.StatusCode,
                 $"An unsatisfied FilterPredicate must fail the whole DTx with 412. Got: {response.StatusCode} " +

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/DistributedTransaction/DistributedTransactionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/DistributedTransaction/DistributedTransactionTests.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
                 .CreateItem(this.GetContainerForClient(client, this.container), new PartitionKey(doc1.pk), doc1.id, doc1)
                 .CreateItem(this.GetContainerForClient(client, this.container), new PartitionKey(doc2.pk), doc2.id, doc2)
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             Assert.IsTrue(response.IsSuccessStatusCode);
@@ -98,7 +98,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 .CreateItem(this.GetContainerForClient(client, this.container), new PartitionKey(createDoc.pk), createDoc.id, createDoc)
                 .ReplaceItem(this.GetContainerForClient(client, this.container), new PartitionKey(replaceDoc.pk), replaceDoc.id, replaceDoc)
                 .DeleteItem(this.GetContainerForClient(client, this.container), new PartitionKey("delete-pk"), "delete-id")
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             using JsonDocument requestJson = JsonDocument.Parse(handler.CapturedRequestBody);
             JsonElement ops = requestJson.RootElement.GetProperty(DistributedTransactionSerializer.Operations);
@@ -124,7 +124,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
                 .CreateItem(this.GetContainerForClient(client, this.container), new PartitionKey(createDoc.pk), createDoc.id, createDoc)
                 .UpsertItem(this.GetContainerForClient(client, this.container), new PartitionKey(upsertDoc.pk), upsertDoc.id, upsertDoc)
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             using JsonDocument requestJson = JsonDocument.Parse(handler.CapturedRequestBody);
             JsonElement ops = requestJson.RootElement.GetProperty(DistributedTransactionSerializer.Operations);
@@ -151,7 +151,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             await client.CreateDistributedWriteTransaction()
                 .CreateItem(this.GetContainerForClient(client, this.container), new PartitionKey(createDoc.pk), createDoc.id, createDoc)
                 .PatchItem(this.GetContainerForClient(client, this.container), new PartitionKey("patch-pk"), "item-to-patch", patchOps)
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             using JsonDocument requestJson = JsonDocument.Parse(handler.CapturedRequestBody);
             JsonElement ops = requestJson.RootElement.GetProperty(DistributedTransactionSerializer.Operations);
@@ -181,7 +181,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
                 .CreateItem(this.GetContainerForClient(client, this.container), new PartitionKey(doc1.pk), doc1.id, doc1)
                 .CreateItem(this.GetContainerForClient(client, secondContainer), new PartitionKey(doc2.pk), doc2.id, doc2)
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             using JsonDocument requestJson = JsonDocument.Parse(handler.CapturedRequestBody);
             JsonElement ops = requestJson.RootElement.GetProperty(DistributedTransactionSerializer.Operations);
@@ -215,7 +215,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
                 .CreateItem(this.GetContainerForClient(client, this.container), new PartitionKey(doc.pk), doc.id, doc)
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             Assert.AreNotEqual(Guid.Empty, response.IdempotencyToken, "Response must carry the idempotency token.");
 
@@ -239,7 +239,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 .CreateItem(this.GetContainerForClient(client, this.container), new PartitionKey(doc1.pk), doc1.id, doc1)
                 .CreateItem(this.GetContainerForClient(client, this.container), new PartitionKey(doc2.pk), doc2.id, doc2)
                 .CreateItem(this.GetContainerForClient(client, this.container), new PartitionKey(doc3.pk), doc3.id, doc3)
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(3, response.Count);
             for (int i = 0; i < response.Count; i++)
@@ -273,7 +273,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
                 .CreateItem(this.GetContainerForClient(client, this.container), new PartitionKey(expectedDoc.pk), expectedDoc.id, expectedDoc)
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(HttpStatusCode.Created, response[0].StatusCode);
             Assert.AreEqual("\"test-etag\"", response[0].ETag);
@@ -310,7 +310,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
                 .CreateItem(this.GetContainerForClient(client, this.container), new PartitionKey(doc.pk), doc.id, doc)
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(HttpStatusCode.Conflict, response.StatusCode);
             Assert.IsFalse(response.IsSuccessStatusCode);
@@ -340,7 +340,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
                 .ReplaceItem(this.GetContainerForClient(client, this.container), new PartitionKey(doc.pk), doc.id, doc)
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(HttpStatusCode.NotFound, response.StatusCode);
             Assert.IsFalse(response.IsSuccessStatusCode);
@@ -371,7 +371,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
                 .CreateItem(this.GetContainerForClient(client, this.container), new PartitionKey(doc1.pk), doc1.id, doc1)
                 .CreateItem(this.GetContainerForClient(client, this.container), new PartitionKey(doc2.pk), doc2.id, doc2)
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             // All results must be present regardless of partial failure
             Assert.AreEqual(2, response.Count, "Response must contain a result for every operation.");
@@ -398,7 +398,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 .CreateItem(this.GetContainerForClient(client, this.container), new PartitionKey(createDoc.pk), createDoc.id, createDoc)
                 .ReplaceItem(this.GetContainerForClient(client, this.container), new PartitionKey(replaceDoc.pk), replaceDoc.id, replaceDoc)
                 .DeleteItem(this.GetContainerForClient(client, this.container), new PartitionKey("delete-pk"), "delete-id")
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             using JsonDocument requestJson = JsonDocument.Parse(handler.CapturedRequestBody);
 
@@ -470,7 +470,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     doc.id,
                     doc,
                     new DistributedTransactionRequestOptions { IfMatchEtag = expectedEtag })
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             Assert.IsTrue(response.IsSuccessStatusCode);
             using JsonDocument requestJson = JsonDocument.Parse(handler.CapturedRequestBody);
@@ -500,7 +500,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     new PartitionKey("delete-pk"),
                     "delete-id",
                     new DistributedTransactionRequestOptions { IfMatchEtag = expectedEtag })
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             Assert.IsTrue(response.IsSuccessStatusCode);
             using JsonDocument requestJson = JsonDocument.Parse(handler.CapturedRequestBody);
@@ -532,7 +532,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     "patch-id",
                     patchOps,
                     new DistributedTransactionPatchItemRequestOptions { IfMatchEtag = expectedEtag })
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             Assert.IsTrue(response.IsSuccessStatusCode);
             using JsonDocument requestJson = JsonDocument.Parse(handler.CapturedRequestBody);
@@ -564,7 +564,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     "patch-id",
                     patchOps,
                     new DistributedTransactionPatchItemRequestOptions { FilterPredicate = predicate })
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             Assert.IsTrue(response.IsSuccessStatusCode);
             using JsonDocument requestJson = JsonDocument.Parse(handler.CapturedRequestBody);
@@ -603,7 +603,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     doc.id,
                     doc,
                     new DistributedTransactionRequestOptions { IfMatchEtag = "\"stale-etag\"" })
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(HttpStatusCode.PreconditionFailed, response.StatusCode);
             Assert.IsFalse(response.IsSuccessStatusCode);
@@ -628,7 +628,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
                 .CreateItem(this.GetContainerForClient(client, this.container), new PartitionKey(createDoc.pk), createDoc.id, createDoc)
                 .ReplaceItem(this.GetContainerForClient(client, this.container), new PartitionKey(replaceDoc.pk), replaceDoc.id, replaceDoc)
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             using JsonDocument requestJson = JsonDocument.Parse(handler.CapturedRequestBody);
             JsonElement ops = requestJson.RootElement.GetProperty(DistributedTransactionSerializer.Operations);
@@ -658,7 +658,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             using MemoryStream stream = new MemoryStream(docBytes);
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
                 .CreateItemStream(this.GetContainerForClient(client, this.container), new PartitionKey(doc.pk), doc.id, stream)
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             Assert.IsTrue(response.IsSuccessStatusCode);
             using JsonDocument requestJson = JsonDocument.Parse(handler.CapturedRequestBody);
@@ -688,7 +688,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             using MemoryStream stream = new MemoryStream(docBytes);
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
                 .ReplaceItemStream(this.GetContainerForClient(client, this.container), new PartitionKey(doc.pk), doc.id, stream)
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             Assert.IsTrue(response.IsSuccessStatusCode);
             using JsonDocument requestJson = JsonDocument.Parse(handler.CapturedRequestBody);
@@ -719,7 +719,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             using MemoryStream stream = new MemoryStream(patchBytes);
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
                 .PatchItemStream(this.GetContainerForClient(client, this.container), new PartitionKey("patch-pk"), "patch-id", stream)
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             Assert.IsTrue(response.IsSuccessStatusCode);
             using JsonDocument requestJson = JsonDocument.Parse(handler.CapturedRequestBody);
@@ -745,7 +745,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             using MemoryStream stream = new MemoryStream(docBytes);
             DistributedTransactionResponse response = await client.CreateDistributedWriteTransaction()
                 .UpsertItemStream(this.GetContainerForClient(client, this.container), new PartitionKey(doc.pk), doc.id, stream)
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             Assert.IsTrue(response.IsSuccessStatusCode);
             using JsonDocument requestJson = JsonDocument.Parse(handler.CapturedRequestBody);
@@ -801,7 +801,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             DistributedTransactionResponse dtcResponse = await dtcClient
                 .CreateDistributedWriteTransaction()
                 .CreateItem(this.GetContainerForClient(dtcClient, this.container), new PartitionKey(newDoc.pk), newDoc.id, newDoc)
-                .CommitTransactionAsync(this.cancellationToken);
+                .ExecuteTransactionAsync(this.cancellationToken);
 
             Assert.IsTrue(dtcResponse.IsSuccessStatusCode, "The simulated DTC commit should appear successful to the client.");
             Assert.AreEqual(canonicalToken, dtcResponse[0].SessionToken,
@@ -864,7 +864,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             DistributedTransactionResponse dtcResponse = await dtcClient
                 .CreateDistributedWriteTransaction()
                 .CreateItem(this.GetContainerForClient(dtcClient, this.container), new PartitionKey(newDoc.pk), newDoc.id, newDoc)
-                .CommitTransactionAsync(this.cancellationToken);
+                .ExecuteTransactionAsync(this.cancellationToken);
 
             // Commit must succeed — this was the crash point before the fix (IndexOutOfRangeException
             // in SessionContainer.SetSessionToken when it tried tokenParts[1] on an LSN-only token).
@@ -897,7 +897,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                 .CreateDistributedReadTransaction()
                 .ReadItem(this.GetContainerForClient(client, this.container), new PartitionKey(doc1.pk), doc1.id)
                 .ReadItem(this.GetContainerForClient(client, this.container), new PartitionKey(doc2.pk), doc2.id)
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             // Assert
             Assert.IsNotNull(handler.CapturedRequestBody);
@@ -925,7 +925,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             DistributedTransactionResponse response = await client
                 .CreateDistributedReadTransaction()
                 .ReadItem(this.GetContainerForClient(client, this.container), new PartitionKey(doc.pk), doc.id)
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             // Assert – request structure
             Assert.IsNotNull(handler.CapturedRequestBody);
@@ -959,7 +959,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             DistributedTransactionResponse response = await client
                 .CreateDistributedReadTransaction()
                 .ReadItem(this.GetContainerForClient(client, this.container), new PartitionKey(expectedDoc.pk), expectedDoc.id)
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             // Assert
             Assert.IsTrue(response.IsSuccessStatusCode);
@@ -989,7 +989,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             DistributedTransactionResponse response = await client
                 .CreateDistributedReadTransaction()
                 .ReadItem(this.GetContainerForClient(client, this.container), new PartitionKey(expectedDoc.pk), expectedDoc.id)
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             // Assert – raw stream access
             Stream stream = response[0].ResourceStream;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetPreviewSDKAPI.net6.json
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetPreviewSDKAPI.net6.json
@@ -1079,10 +1079,10 @@
         }
       },
       "Members": {
-        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.DistributedTransactionResponse] CommitTransactionAsync(System.Threading.CancellationToken)": {
+        "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.DistributedTransactionResponse] ExecuteTransactionAsync(System.Threading.CancellationToken)": {
           "Type": "Method",
           "Attributes": [],
-          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.DistributedTransactionResponse] CommitTransactionAsync(System.Threading.CancellationToken);IsAbstract:True;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+          "MethodInfo": "System.Threading.Tasks.Task`1[Microsoft.Azure.Cosmos.DistributedTransactionResponse] ExecuteTransactionAsync(System.Threading.CancellationToken);IsAbstract:True;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
         }
       },
       "NestedTypes": {}

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedReadTransactionCoreTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedReadTransactionCoreTests.cs
@@ -254,7 +254,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             DistributedReadTransactionCore txn = this.CreateTransaction();
 
             InvalidOperationException ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
-                () => txn.CommitTransactionAsync(CancellationToken.None));
+                () => txn.ExecuteTransactionAsync(CancellationToken.None));
 
             Assert.IsTrue(ex.Message.Contains("zero operations"), $"Unexpected message: {ex.Message}");
         }
@@ -283,11 +283,11 @@ namespace Microsoft.Azure.Cosmos.Tests
             DistributedReadTransactionCore tx = new DistributedReadTransactionCore(contextMock.Object);
 
             await Assert.ThrowsExceptionAsync<InvalidOperationException>(
-                () => tx.CommitTransactionAsync(CancellationToken.None));
+                () => tx.ExecuteTransactionAsync(CancellationToken.None));
 
             // Instance is not consumed: adding an operation and committing now succeeds.
             tx.ReadItem(BuildMockContainer(), TestPartitionKey, ItemId);
-            DistributedTransactionResponse response = await tx.CommitTransactionAsync(CancellationToken.None);
+            DistributedTransactionResponse response = await tx.ExecuteTransactionAsync(CancellationToken.None);
             Assert.IsTrue(response.IsSuccessStatusCode);
         }
 
@@ -317,11 +317,11 @@ namespace Microsoft.Azure.Cosmos.Tests
             DistributedReadTransaction tx = new DistributedReadTransactionCore(contextMock.Object)
                 .ReadItem(BuildMockContainer(), TestPartitionKey, ItemId);
 
-            DistributedTransactionResponse response = await tx.CommitTransactionAsync(CancellationToken.None);
+            DistributedTransactionResponse response = await tx.ExecuteTransactionAsync(CancellationToken.None);
             Assert.IsTrue(response.IsSuccessStatusCode);
 
             InvalidOperationException ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
-                () => tx.CommitTransactionAsync(CancellationToken.None));
+                () => tx.ExecuteTransactionAsync(CancellationToken.None));
             Assert.AreEqual(DistributedReadTransactionCore.CommitAlreadyCalledMessage, ex.Message);
         }
 
@@ -348,11 +348,11 @@ namespace Microsoft.Azure.Cosmos.Tests
                 .ReadItem(BuildMockContainer(), TestPartitionKey, ItemId);
 
             // First commit returns a server error — instance is still consumed.
-            DistributedTransactionResponse response = await tx.CommitTransactionAsync(CancellationToken.None);
+            DistributedTransactionResponse response = await tx.ExecuteTransactionAsync(CancellationToken.None);
             Assert.IsFalse(response.IsSuccessStatusCode);
 
             InvalidOperationException ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
-                () => tx.CommitTransactionAsync(CancellationToken.None));
+                () => tx.ExecuteTransactionAsync(CancellationToken.None));
             Assert.AreEqual(DistributedReadTransactionCore.CommitAlreadyCalledMessage, ex.Message);
         }
 
@@ -397,7 +397,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 tasks[i] = Task.Run(async () =>
                 {
                     gate.Wait();
-                    return await tx.CommitTransactionAsync(CancellationToken.None);
+                    return await tx.ExecuteTransactionAsync(CancellationToken.None);
                 });
             }
 
@@ -428,8 +428,8 @@ namespace Microsoft.Azure.Cosmos.Tests
         #region OperationHelperAsync wiring
 
         [TestMethod]
-        [Description("Verifies CommitTransactionAsync routes through OperationHelperAsync with the qualified operationName, the read-specific OTel constant, the Read operation type, and TraceComponent.Batch.")]
-        public async Task CommitTransactionAsync_RoutesThroughOperationHelper_WithExpectedWiring()
+        [Description("Verifies ExecuteTransactionAsync routes through OperationHelperAsync with the qualified operationName, the read-specific OTel constant, the Read operation type, and TraceComponent.Batch.")]
+        public async Task ExecuteTransactionAsync_RoutesThroughOperationHelper_WithExpectedWiring()
         {
             string capturedOperationName = null;
             OperationType capturedOperationType = default;
@@ -465,12 +465,12 @@ namespace Microsoft.Azure.Cosmos.Tests
             DistributedReadTransactionCore txn = new DistributedReadTransactionCore(contextMock.Object);
             txn.ReadItem(BuildMockContainer(), TestPartitionKey, ItemId);
 
-            await txn.CommitTransactionAsync(CancellationToken.None);
+            await txn.ExecuteTransactionAsync(CancellationToken.None);
 
-            Assert.AreEqual($"{nameof(DistributedReadTransaction)}.{nameof(DistributedReadTransaction.CommitTransactionAsync)}", capturedOperationName);
+            Assert.AreEqual($"{nameof(DistributedReadTransaction)}.{nameof(DistributedReadTransaction.ExecuteTransactionAsync)}", capturedOperationName);
             Assert.AreEqual(OperationType.Read, capturedOperationType);
             Assert.AreEqual(TraceComponent.Batch, capturedTraceComponent);
-            Assert.AreEqual(OpenTelemetryConstants.Operations.CommitDistributedReadTransaction, capturedOTelOperationName);
+            Assert.AreEqual(OpenTelemetryConstants.Operations.ExecuteDistributedReadTransaction, capturedOTelOperationName);
         }
 
         [TestMethod]
@@ -504,7 +504,7 @@ namespace Microsoft.Azure.Cosmos.Tests
 
             await new DistributedReadTransactionCore(contextMock.Object)
                 .ReadItem(BuildMockContainer(), TestPartitionKey, ItemId)
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(ResourceType.DistributedTransactionBatch, capturedResourceType);
             Assert.AreEqual(OperationType.Read, capturedOperationType);
@@ -550,7 +550,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 tx.ReadItem(BuildMockContainer(), new CosmosPK($"pk{i}"), $"id{i}");
             }
 
-            DistributedTransactionResponse response = await tx.CommitTransactionAsync(CancellationToken.None);
+            DistributedTransactionResponse response = await tx.ExecuteTransactionAsync(CancellationToken.None);
 
             Assert.IsTrue(response.IsSuccessStatusCode);
             Assert.AreEqual(OperationCount, response.Count);
@@ -595,7 +595,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 .ReadItem(BuildMockContainer(), new CosmosPK("pk0"), "id0")
                 .ReadItem(BuildMockContainer(), new CosmosPK("pk1"), "id1")
                 .ReadItem(BuildMockContainer(), new CosmosPK("pk2"), "id2")
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(HttpStatusCode.InternalServerError, response.StatusCode,
                 "A duplicate operation index must fail closed with HTTP 500.");

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionCommitterTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionCommitterTests.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
 
         [TestMethod]
         [Description("Verifies that when the DTC response carries a session token, the token is merged into the SessionContainer")]
-        public async Task CommitTransactionAsync_MergesSessionTokensIntoSessionContainer()
+        public async Task ExecuteTransactionAsync_MergesSessionTokensIntoSessionContainer()
         {
             const string lsnOnly = "1#9#4=8#5=7";
             const string pkRangeId = "0";
@@ -67,7 +67,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
                 operations, mockContext.Object, OperationType.CommitDistributedTransaction);
 
-            await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
+            await committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
 
             string storedToken = sessionContainer.GetSessionToken(DistributedTransactionConstants.GetCollectionFullName(DatabaseName, ContainerName));
             Assert.AreEqual(expectedToken, storedToken,
@@ -76,7 +76,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
 
         [TestMethod]
         [Description("When a per-operation session token is absent, SetSessionToken is NOT called for that operation and the SessionContainer is not updated")]
-        public async Task CommitTransactionAsync_SkipsMerge_WhenSessionTokenIsNull()
+        public async Task ExecuteTransactionAsync_SkipsMerge_WhenSessionTokenIsNull()
         {
             // sessionToken: null omits the field from the JSON body entirely
             string responseJson = BuildDtcResponseJson(new[] { (statusCode: 201, sessionToken: (string)null) });
@@ -101,7 +101,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
                 operations, mockContext.Object, OperationType.CommitDistributedTransaction);
 
-            await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
+            await committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
 
             string storedToken = sessionContainer.GetSessionToken(DistributedTransactionConstants.GetCollectionFullName(DatabaseName, ContainerName));
             Assert.IsTrue(string.IsNullOrEmpty(storedToken),
@@ -110,7 +110,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
 
         [TestMethod]
         [Description("Verifies that the correct collectionRid and collectionFullname are passed to SetSessionToken for each operation")]
-        public async Task CommitTransactionAsync_PassesCorrectCollectionToSetSessionToken()
+        public async Task ExecuteTransactionAsync_PassesCorrectCollectionToSetSessionToken()
         {
             const string lsnOnly = "1#5#4=3";
             const string pkRangeId = "0";
@@ -191,7 +191,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
                 operations, mockContext.Object, OperationType.CommitDistributedTransaction);
 
-            await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
+            await committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
 
             // Verify SetSessionToken was called once per operation with the correct collection identity.
             mockSessionContainer.Verify(
@@ -213,7 +213,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
 
         [TestMethod]
         [Description("Verifies that session tokens are still merged into the SessionContainer even when the DTC response indicates a failure")]
-        public async Task CommitTransactionAsync_MergesSessionTokens_OnFailureResponse()
+        public async Task ExecuteTransactionAsync_MergesSessionTokens_OnFailureResponse()
         {
             // Deliberately distinct from the success-path token so a copy-paste regression would be caught.
             const string lsnOnly = "1#3#4=2#5=1";
@@ -241,7 +241,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
                 operations, mockContext.Object, OperationType.CommitDistributedTransaction);
 
-            DistributedTransactionResponse response = await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
+            DistributedTransactionResponse response = await committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
 
             string storedToken = sessionContainer.GetSessionToken(DistributedTransactionConstants.GetCollectionFullName(DatabaseName, ContainerName));
             Assert.AreEqual(expectedToken, storedToken,
@@ -250,7 +250,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
 
         [TestMethod]
         [Description("When session token is LSN-only and partitionKeyRangeId is present, the token is assembled as {pkRangeId}:{lsn}")]
-        public async Task CommitTransactionAsync_AssemblesSessionToken_WhenPartitionKeyRangeIdIsPresent()
+        public async Task ExecuteTransactionAsync_AssemblesSessionToken_WhenPartitionKeyRangeIdIsPresent()
         {
             const string lsnOnly = "1#9#4=8#5=7";
             const string pkRangeId = "0";
@@ -280,7 +280,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
                 operations, mockContext.Object, OperationType.CommitDistributedTransaction);
 
-            await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
+            await committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
 
             string storedToken = sessionContainer.GetSessionToken(DistributedTransactionConstants.GetCollectionFullName(DatabaseName, ContainerName));
             Assert.AreEqual(expectedToken, storedToken,
@@ -289,7 +289,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
 
         [TestMethod]
         [Description("When partitionKeyRangeId is absent, merge is silently skipped")]
-        public async Task CommitTransactionAsync_SkipsMerge_WhenLsnOnlyAndPartitionKeyRangeIdIsAbsent()
+        public async Task ExecuteTransactionAsync_SkipsMerge_WhenLsnOnlyAndPartitionKeyRangeIdIsAbsent()
         {
             const string lsnOnly = "1#9#4=8#5=7";
 
@@ -318,7 +318,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
                 operations, mockContext.Object, OperationType.CommitDistributedTransaction);
 
-            await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
+            await committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
 
             string storedToken = sessionContainer.GetSessionToken(DistributedTransactionConstants.GetCollectionFullName(DatabaseName, ContainerName));
             Assert.IsTrue(string.IsNullOrEmpty(storedToken),
@@ -332,7 +332,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
         [DataRow("   ", DisplayName = "Multiple whitespace partitionKeyRangeId")]
         [Description("When partitionKeyRangeId is present but empty or whitespace, merge is silently skipped. " +
                      "The server has no validation on this field; throwing would risk failing a committed transaction.")]
-        public async Task CommitTransactionAsync_SkipsMerge_WhenPartitionKeyRangeIdIsEmptyOrWhitespace(string pkRangeId)
+        public async Task ExecuteTransactionAsync_SkipsMerge_WhenPartitionKeyRangeIdIsEmptyOrWhitespace(string pkRangeId)
         {
             const string lsnOnly = "1#9#4=8#5=7";
 
@@ -360,7 +360,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
                 operations, mockContext.Object, OperationType.CommitDistributedTransaction);
 
-            await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
+            await committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
 
             string storedToken = sessionContainer.GetSessionToken(DistributedTransactionConstants.GetCollectionFullName(DatabaseName, ContainerName));
             Assert.IsTrue(string.IsNullOrEmpty(storedToken),
@@ -372,7 +372,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
         [TestMethod]
         [Description("m8: In a multi-operation response, an op whose pkRangeId is absent is skipped while " +
                      "subsequent ops with pkRangeId still have their session tokens merged correctly.")]
-        public async Task CommitTransactionAsync_MultiOp_SkipsOpWithMissingPkRangeId_MergesRemainingOps()
+        public async Task ExecuteTransactionAsync_MultiOp_SkipsOpWithMissingPkRangeId_MergesRemainingOps()
         {
             const string lsnOnly = "1#9#4=8#5=7";
             const string pkRangeId = "0";
@@ -446,7 +446,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
                 operations, mockContext.Object, OperationType.CommitDistributedTransaction);
 
-            await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
+            await committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
 
             // op 0 (missing pkRangeId) must NOT have been merged.
             mockSessionContainer.Verify(
@@ -470,7 +470,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
         [TestMethod]
         [Description("m9: When an operation result has no partitionKeyRangeId, FromJson emits a TraceWarning " +
                      "so the skip is observable in diagnostic traces.")]
-        public async Task CommitTransactionAsync_EmitsTraceWarning_WhenPartitionKeyRangeIdIsAbsent()
+        public async Task ExecuteTransactionAsync_EmitsTraceWarning_WhenPartitionKeyRangeIdIsAbsent()
         {
             const string lsnOnly = "1#9#4=8#5=7";
 
@@ -509,7 +509,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             DefaultTrace.TraceSource.Listeners.Add(listener);
             try
             {
-                await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
+                await committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
             }
             finally
             {
@@ -524,8 +524,8 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
 
 
         [TestMethod]
-        [Description("When SetSessionToken throws, the exception is swallowed and CommitTransactionAsync still returns the response rather than rethrowing")]
-        public async Task CommitTransactionAsync_SwallowsSetSessionTokenException()
+        [Description("When SetSessionToken throws, the exception is swallowed and ExecuteTransactionAsync still returns the response rather than rethrowing")]
+        public async Task ExecuteTransactionAsync_SwallowsSetSessionTokenException()
         {
             const string lsnOnly = "1#9#4=8#5=7";
             const string pkRangeId = "0";
@@ -591,14 +591,14 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                 operations, mockContext.Object, OperationType.CommitDistributedTransaction);
 
             // Must not throw even though SetSessionToken throws internally.
-            DistributedTransactionResponse response = await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
-            Assert.IsNotNull(response, "CommitTransactionAsync should return a response even when SetSessionToken throws.");
+            DistributedTransactionResponse response = await committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
+            Assert.IsNotNull(response, "ExecuteTransactionAsync should return a response even when SetSessionToken throws.");
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
         }
 
         [TestMethod]
         [Description("When SetSessionToken throws OperationCanceledException, the exception must propagate — it must not be swallowed by the MergeSessionTokens catch block.")]
-        public async Task CommitTransactionAsync_PropagatesOperationCanceledException_FromSetSessionToken()
+        public async Task ExecuteTransactionAsync_PropagatesOperationCanceledException_FromSetSessionToken()
         {
             const string lsnOnly = "1#9#4=8#5=7";
             const string pkRangeId = "0";
@@ -632,7 +632,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                 operations, mockContext.Object, OperationType.CommitDistributedTransaction);
 
             await Assert.ThrowsExceptionAsync<OperationCanceledException>(
-                () => committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None),
+                () => committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None),
                 "OperationCanceledException from SetSessionToken must propagate, not be swallowed.");
         }
 
@@ -653,7 +653,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
 
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(CreateTestOperations(), mockContext.Object, OperationType.CommitDistributedTransaction, TimeSpan.Zero);
 
-            using (DistributedTransactionResponse response = await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None))
+            using (DistributedTransactionResponse response = await committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None))
             {
                 Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
                 Assert.IsTrue(response.IsSuccessStatusCode);
@@ -683,7 +683,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
 
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(CreateTestOperations(), mockContext.Object, OperationType.CommitDistributedTransaction, TimeSpan.Zero);
 
-            using (DistributedTransactionResponse response = await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None))
+            using (DistributedTransactionResponse response = await committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None))
             {
                 Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
                 Assert.IsTrue(response.IsSuccessStatusCode);
@@ -717,7 +717,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                     CreateTestOperations(), mockContext.Object, OperationType.CommitDistributedTransaction, TimeSpan.FromMilliseconds(1));
 
                 await Assert.ThrowsExceptionAsync<OperationCanceledException>(
-                    () => committer.CommitTransactionAsync(NoOpTrace.Singleton, cts.Token));
+                    () => committer.ExecuteTransactionAsync(NoOpTrace.Singleton, cts.Token));
 
                 // Retries continue until the cancellation token fires (before exhausting the budget).
                 Assert.AreEqual(3, callCount);
@@ -752,7 +752,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                 retryBaseDelay: TimeSpan.Zero,
                 delayProvider: captureDelay);
 
-            using (DistributedTransactionResponse response = await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None))
+            using (DistributedTransactionResponse response = await committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None))
             {
                 // MaxIsRetriableRetryCount (10) retries + 1 final call that hits the budget check = 11 total calls.
                 Assert.AreEqual(DistributedTransactionCommitter.MaxIsRetriableRetryCount + 1, callCount,
@@ -798,7 +798,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                 retryBaseDelay: TimeSpan.FromSeconds(15),
                 delayProvider: captureDelay);
 
-            using (DistributedTransactionResponse response = await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None))
+            using (DistributedTransactionResponse response = await committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None))
             {
                 // With 15s base delay and exponential backoff (±25% jitter):
                 //   attempt 0 delay = 15s * 2^0 * jitter ≈ 11.25–18.75s (cumulative ≈ 11.25–18.75s, under 30s budget)
@@ -856,7 +856,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                 retryBaseDelay: TimeSpan.FromMilliseconds(100),
                 delayProvider: captureDelay);
 
-            using (DistributedTransactionResponse response = await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None))
+            using (DistributedTransactionResponse response = await committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None))
             {
                 // With 25s server hint per attempt: attempt 0 delay=25s (cumulative=25s OK), attempt 1 delay=25s (cumulative=50s > 30s budget).
                 // So only 1 retry should succeed before budget exhaustion stops the loop.
@@ -899,7 +899,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(CreateTestOperations(), mockContext.Object, OperationType.CommitDistributedTransaction, TimeSpan.Zero);
 
             CosmosException thrown = await Assert.ThrowsExceptionAsync<CosmosException>(
-                () => committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None));
+                () => committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None));
 
             Assert.AreEqual((HttpStatusCode)statusCode, thrown.StatusCode);
             Assert.AreEqual(1, callCount);
@@ -927,7 +927,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
 
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(CreateTestOperations(), mockContext.Object, OperationType.CommitDistributedTransaction, TimeSpan.Zero);
 
-            using (DistributedTransactionResponse response = await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None))
+            using (DistributedTransactionResponse response = await committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None))
             {
                 Assert.AreEqual((HttpStatusCode)statusCode, response.StatusCode);
                 Assert.IsFalse(response.IsSuccessStatusCode);
@@ -937,7 +937,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
         }
 
         [TestMethod]
-        [Description("Verifies that a pre-cancelled CancellationToken causes CommitTransactionAsync to throw immediately without issuing any network request.")]
+        [Description("Verifies that a pre-cancelled CancellationToken causes ExecuteTransactionAsync to throw immediately without issuing any network request.")]
         public async Task CommitTransaction_RespectsCancellationToken_PreCancelled()
         {
             using (CancellationTokenSource cts = new CancellationTokenSource())
@@ -952,7 +952,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                 DistributedTransactionCommitter committer = new DistributedTransactionCommitter(CreateTestOperations(), mockContext.Object, OperationType.CommitDistributedTransaction, TimeSpan.Zero);
 
                 await Assert.ThrowsExceptionAsync<OperationCanceledException>(
-                    () => committer.CommitTransactionAsync(NoOpTrace.Singleton, cts.Token));
+                    () => committer.ExecuteTransactionAsync(NoOpTrace.Singleton, cts.Token));
 
                 this.VerifyProcessResourceOperationCallCount(mockContext, Times.Never());
             }
@@ -981,7 +981,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                     CreateTestOperations(), mockContext.Object, OperationType.CommitDistributedTransaction, TimeSpan.FromMilliseconds(500));
 
                 await Assert.ThrowsExceptionAsync<OperationCanceledException>(
-                    () => committer.CommitTransactionAsync(NoOpTrace.Singleton, cts.Token));
+                    () => committer.ExecuteTransactionAsync(NoOpTrace.Singleton, cts.Token));
 
                 Assert.AreEqual(1, callCount);
             }
@@ -1008,7 +1008,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
 
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(CreateTestOperations(), mockContext.Object, OperationType.CommitDistributedTransaction, TimeSpan.Zero);
 
-            using (DistributedTransactionResponse response = await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None))
+            using (DistributedTransactionResponse response = await committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None))
             {
                 // 3 retriable failures + 1 success = 4 total calls.
                 Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
@@ -1034,7 +1034,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(CreateTestOperations(), mockContext.Object, OperationType.CommitDistributedTransaction, TimeSpan.Zero);
 
             IOException ex = await Assert.ThrowsExceptionAsync<IOException>(
-                () => committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None));
+                () => committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None));
 
             Assert.AreEqual("Network error", ex.Message);
             Assert.AreEqual(1, callCount);
@@ -1091,7 +1091,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                 OperationType.CommitDistributedTransaction,
                 TimeSpan.Zero);
 
-            using (DistributedTransactionResponse response = await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None))
+            using (DistributedTransactionResponse response = await committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None))
             {
                 Assert.IsTrue(response.IsSuccessStatusCode);
                 Assert.AreEqual(3, callCount);
@@ -1127,7 +1127,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
 
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(CreateTestOperations(), mockContext.Object, OperationType.CommitDistributedTransaction, TimeSpan.Zero);
 
-            using (DistributedTransactionResponse response = await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None))
+            using (DistributedTransactionResponse response = await committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None))
             {
                 Assert.AreEqual((HttpStatusCode)statusCode, response.StatusCode);
                 Assert.AreEqual(1, callCount, "Envelope response without a DTX sub-status code must not be retried.");
@@ -1156,7 +1156,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
 
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(CreateTestOperations(), mockContext.Object, OperationType.CommitDistributedTransaction, TimeSpan.Zero);
 
-            using (DistributedTransactionResponse response = await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None))
+            using (DistributedTransactionResponse response = await committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None))
             {
                 Assert.AreEqual(HttpStatusCode.BadRequest, response.StatusCode);
                 Assert.AreEqual(1, callCount, $"Validation failure 400/{subStatusCode} must not be retried.");
@@ -1201,7 +1201,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                 delayProvider: captureDelay,
                 maxCumulativeRetryDelay: TimeSpan.FromMinutes(5));
 
-            using (DistributedTransactionResponse response = await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None))
+            using (DistributedTransactionResponse response = await committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None))
             {
                 Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             }
@@ -1237,7 +1237,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
 
         [TestMethod]
         [Description("A SessionToken set on DistributedTransactionRequestOptions is propagated to the operation's SessionToken field and serialized in the request body JSON.")]
-        public async Task CommitTransactionAsync_PerOperationSessionToken_IsSerializedInRequestBody()
+        public async Task ExecuteTransactionAsync_PerOperationSessionToken_IsSerializedInRequestBody()
         {
             const string expectedToken = "0:1#9#4=8#5=7";
             byte[] capturedBody = null;
@@ -1278,7 +1278,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             };
 
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(operations, mockContext.Object, OperationType.CommitDistributedTransaction);
-            await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
+            await committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
 
             Assert.IsNotNull(capturedBody, "Request body must have been captured.");
             string bodyJson = Encoding.UTF8.GetString(capturedBody);
@@ -1288,7 +1288,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
 
         [TestMethod]
         [Description("When no SessionToken is set on the per-operation options, no sessionToken field appears in the serialized request body.")]
-        public async Task CommitTransactionAsync_NoPerOperationSessionToken_OmitsFieldFromRequestBody()
+        public async Task ExecuteTransactionAsync_NoPerOperationSessionToken_OmitsFieldFromRequestBody()
         {
             byte[] capturedBody = null;
 
@@ -1316,7 +1316,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                 .ReturnsAsync(CreateSuccessResponseMessage(operationCount: 1));
 
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(CreateTestOperations(), mockContext.Object, OperationType.CommitDistributedTransaction);
-            await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
+            await committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
 
             Assert.IsNotNull(capturedBody);
             string bodyJson = Encoding.UTF8.GetString(capturedBody);
@@ -1329,7 +1329,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
         [DataRow(" ", DisplayName = "Single space session token")]
         [DataRow("   ", DisplayName = "Multi-space session token")]
         [Description("A whitespace-only or empty SessionToken on DistributedTransactionRequestOptions must be treated as absent and must not appear in the serialized request body.")]
-        public async Task CommitTransactionAsync_WhitespaceOrEmptyPerOperationSessionToken_OmitsFieldFromRequestBody(string sessionToken)
+        public async Task ExecuteTransactionAsync_WhitespaceOrEmptyPerOperationSessionToken_OmitsFieldFromRequestBody(string sessionToken)
         {
             byte[] capturedBody = null;
 
@@ -1369,7 +1369,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             };
 
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(operations, mockContext.Object, OperationType.CommitDistributedTransaction);
-            await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
+            await committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
 
             Assert.IsNotNull(capturedBody);
             string bodyJson = Encoding.UTF8.GetString(capturedBody);
@@ -1379,7 +1379,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
 
         [TestMethod]
         [Description("Each operation independently carries its own session token in the request body.")]
-        public async Task CommitTransactionAsync_MultipleOperations_EachCarriesOwnSessionToken()
+        public async Task ExecuteTransactionAsync_MultipleOperations_EachCarriesOwnSessionToken()
         {
             const string token1 = "0:1#5";
             const string token2 = "1:2#8";
@@ -1422,7 +1422,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             };
 
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(operations, mockContext.Object, OperationType.CommitDistributedTransaction);
-            await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
+            await committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
 
             Assert.IsNotNull(capturedBody);
             string bodyJson = Encoding.UTF8.GetString(capturedBody);
@@ -1436,7 +1436,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
 
         [TestMethod]
         [Description("Verifies that the response Diagnostics is non-null and covers the caller's trace span on a successful single-attempt commit.")]
-        public async Task CommitTransactionAsync_Diagnostics_IsNonNullOnSuccess()
+        public async Task ExecuteTransactionAsync_Diagnostics_IsNonNullOnSuccess()
         {
             Mock<CosmosClientContext> mockContext = this.CreateMockClientContext();
             this.SetupProcessResourceOperation(
@@ -1447,7 +1447,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                 CreateTestOperations(), mockContext.Object, OperationType.CommitDistributedTransaction, TimeSpan.Zero);
 
             using (ITrace trace = Trace.GetRootTrace("CommitDistributedTransaction", TraceComponent.Batch, TraceLevel.Info))
-            using (DistributedTransactionResponse response = await committer.CommitTransactionAsync(trace, CancellationToken.None))
+            using (DistributedTransactionResponse response = await committer.ExecuteTransactionAsync(trace, CancellationToken.None))
             {
                 Assert.IsNotNull(response.Diagnostics, "Diagnostics must not be null.");
                 string diagnosticText = response.Diagnostics.ToString();
@@ -1461,7 +1461,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
 
         [TestMethod]
         [Description("Verifies that Diagnostics spans all retry attempts — the caller's trace is attached to the final returned response even after multiple isRetriable retries.")]
-        public async Task CommitTransactionAsync_Diagnostics_CoversRetryAttempts()
+        public async Task ExecuteTransactionAsync_Diagnostics_CoversRetryAttempts()
         {
             int callCount = 0;
             Mock<CosmosClientContext> mockContext = this.CreateMockClientContext();
@@ -1479,7 +1479,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                 CreateTestOperations(), mockContext.Object, OperationType.CommitDistributedTransaction, TimeSpan.Zero);
 
             using (ITrace trace = Trace.GetRootTrace("CommitDistributedTransaction", TraceComponent.Batch, TraceLevel.Info))
-            using (DistributedTransactionResponse response = await committer.CommitTransactionAsync(trace, CancellationToken.None))
+            using (DistributedTransactionResponse response = await committer.ExecuteTransactionAsync(trace, CancellationToken.None))
             {
                 Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
                 Assert.IsNotNull(response.Diagnostics, "Diagnostics must not be null after retries.");
@@ -1492,8 +1492,8 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
         }
 
         [TestMethod]
-        [Description("Verifies that DiagnosticString parsed from the wire response body is correctly propagated through CommitTransactionAsync — protects against accidental omission of the property assignment in the object initializer.")]
-        public async Task CommitTransactionAsync_DiagnosticString_PropagatedFromWireResponse()
+        [Description("Verifies that DiagnosticString parsed from the wire response body is correctly propagated through ExecuteTransactionAsync — protects against accidental omission of the property assignment in the object initializer.")]
+        public async Task ExecuteTransactionAsync_DiagnosticString_PropagatedFromWireResponse()
         {
             const string expectedDiagnosticString = "TransactionAbortedByCoordinator";
             Mock<CosmosClientContext> mockContext = this.CreateMockClientContext();
@@ -1507,16 +1507,16 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
                 CreateTestOperations(), mockContext.Object, OperationType.CommitDistributedTransaction, TimeSpan.Zero);
 
-            using (DistributedTransactionResponse response = await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None))
+            using (DistributedTransactionResponse response = await committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None))
             {
                 Assert.AreEqual(expectedDiagnosticString, response.DiagnosticString,
-                    "DiagnosticString must be propagated from the wire response body through CommitTransactionAsync.");
+                    "DiagnosticString must be propagated from the wire response body through ExecuteTransactionAsync.");
             }
         }
 
         [TestMethod]
-        [Description("Verifies that DiagnosticString from a successful commit is propagated through CommitTransactionAsync and does NOT leak into ErrorMessage (which must remain null on success).")]
-        public async Task CommitTransactionAsync_DiagnosticString_PropagatedOnSuccess_DoesNotPolluteErrorMessage()
+        [Description("Verifies that DiagnosticString from a successful commit is propagated through ExecuteTransactionAsync and does NOT leak into ErrorMessage (which must remain null on success).")]
+        public async Task ExecuteTransactionAsync_DiagnosticString_PropagatedOnSuccess_DoesNotPolluteErrorMessage()
         {
             const string expectedDiagnosticString = "TransactionCommitted";
             Mock<CosmosClientContext> mockContext = this.CreateMockClientContext();
@@ -1530,7 +1530,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
                 CreateTestOperations(), mockContext.Object, OperationType.CommitDistributedTransaction, TimeSpan.Zero);
 
-            using (DistributedTransactionResponse response = await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None))
+            using (DistributedTransactionResponse response = await committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None))
             {
                 Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
                 Assert.AreEqual(expectedDiagnosticString, response.DiagnosticString,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionSerializerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionSerializerTests.cs
@@ -687,7 +687,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                     });
 
             DistributedWriteTransaction tx = new DistributedWriteTransactionCore(contextMock.Object);
-            await buildTransaction(tx).CommitTransactionAsync(CancellationToken.None);
+            await buildTransaction(tx).ExecuteTransactionAsync(CancellationToken.None);
 
             Assert.IsNotNull(capturedJson, "The commit body was not captured — the mock was not invoked.");
             return capturedJson;
@@ -723,7 +723,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                     });
 
             DistributedReadTransaction tx = new DistributedReadTransactionCore(contextMock.Object);
-            await buildTransaction(tx).CommitTransactionAsync(CancellationToken.None);
+            await buildTransaction(tx).ExecuteTransactionAsync(CancellationToken.None);
 
             Assert.IsNotNull(capturedJson, "The commit body was not captured — the mock was not invoked.");
             return capturedJson;

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedWriteTransactionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedWriteTransactionTests.cs
@@ -221,7 +221,7 @@ namespace Microsoft.Azure.Cosmos.Tests
 
             await new DistributedWriteTransactionCore(contextMock.Object)
                 .CreateItem(BuildMockContainer(), new PartitionKey("pk"), "item-id", new TestItem())
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(ResourceType.DistributedTransactionBatch, capturedResourceType);
             Assert.AreEqual(OperationType.CommitDistributedTransaction, capturedOperationType);
@@ -257,7 +257,7 @@ namespace Microsoft.Azure.Cosmos.Tests
 
             await new DistributedWriteTransactionCore(contextMock.Object)
                 .CreateItem(BuildMockContainer(), new PartitionKey("pk"), "item-id", new TestItem())
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             Assert.IsNotNull(capturedToken, "Idempotency token header must be set.");
             Assert.IsTrue(Guid.TryParse(capturedToken, out _), "Idempotency token must be a valid GUID.");
@@ -297,7 +297,7 @@ namespace Microsoft.Azure.Cosmos.Tests
 
             DistributedTransactionResponse response = await new DistributedWriteTransactionCore(contextMock.Object)
                 .CreateItem(BuildMockContainer(), new PartitionKey("pk"), "item-id", new TestItem())
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             Assert.AreNotEqual(Guid.Empty, response.IdempotencyToken, "Response must carry the idempotency token.");
         }
@@ -334,7 +334,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 .CreateItem(BuildMockContainer(), new PartitionKey("pk1"), "id1", new TestItem("id1"))
                 .ReplaceItem(BuildMockContainer(), new PartitionKey("pk2"), "id2", new TestItem("id2"))
                 .DeleteItem(BuildMockContainer(), new PartitionKey("pk3"), "id3")
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
             JsonElement ops = doc.RootElement.GetProperty("operations");
@@ -388,7 +388,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 .DeleteItem(BuildMockContainer(), new PartitionKey("pk2"), "id2")
                 .PatchItem(BuildMockContainer(), new PartitionKey("pk3"), "id3", new[] { PatchOperation.Add("/value", "v3") })
                 .UpsertItem(BuildMockContainer(), new PartitionKey("pk4"), "id4", new TestItem("id4"))
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             // Verify request indices are 0-based and ordered.
             using JsonDocument requestDoc = JsonDocument.Parse(capturedRequestJson);
@@ -449,7 +449,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 tx.CreateItem(BuildMockContainer(), new PartitionKey($"pk{i}"), $"id{i}", new TestItem($"id{i}"));
             }
 
-            DistributedTransactionResponse response = await tx.CommitTransactionAsync(CancellationToken.None);
+            DistributedTransactionResponse response = await tx.ExecuteTransactionAsync(CancellationToken.None);
 
             Assert.IsTrue(response.IsSuccessStatusCode);
             Assert.AreEqual(OperationCount, response.Count);
@@ -494,7 +494,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 .CreateItem(BuildMockContainer(), new PartitionKey("pk0"), "id0", new TestItem("id0"))
                 .CreateItem(BuildMockContainer(), new PartitionKey("pk1"), "id1", new TestItem("id1"))
                 .CreateItem(BuildMockContainer(), new PartitionKey("pk2"), "id2", new TestItem("id2"))
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(HttpStatusCode.InternalServerError, response.StatusCode,
                 "A duplicate operation index must fail closed with HTTP 500.");
@@ -543,7 +543,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 .DeleteItem(BuildMockContainer(), new PartitionKey("pk"), "delete")
                 .PatchItem(BuildMockContainer(), new PartitionKey("pk"), "patch", new[] { PatchOperation.Add("/value", "v") })
                 .UpsertItem(BuildMockContainer(), new PartitionKey("pk"), "upsert", new TestItem("upsert"))
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             using JsonDocument doc = JsonDocument.Parse(capturedJson);
             JsonElement ops = doc.RootElement.GetProperty("operations");
@@ -585,7 +585,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             DistributedTransactionResponse response = await new DistributedWriteTransactionCore(contextMock.Object)
                 .CreateItem(BuildMockContainer(), new PartitionKey("pk1"), "id1", new TestItem("id1"))
                 .CreateItem(BuildMockContainer(), new PartitionKey("pk2"), "id2", new TestItem("id2"))
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
             Assert.IsTrue(response.IsSuccessStatusCode);
@@ -613,7 +613,7 @@ namespace Microsoft.Azure.Cosmos.Tests
 
             DistributedTransactionResponse response = await new DistributedWriteTransactionCore(contextMock.Object)
                 .CreateItem(BuildMockContainer(), new PartitionKey("pk"), "item-id", new TestItem())
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
             Assert.AreEqual(HttpStatusCode.Conflict, response.StatusCode);
             Assert.IsFalse(response.IsSuccessStatusCode);
@@ -627,7 +627,7 @@ namespace Microsoft.Azure.Cosmos.Tests
             DistributedWriteTransaction tx = this.NewTransaction();
 
             InvalidOperationException ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
-                () => tx.CommitTransactionAsync(CancellationToken.None));
+                () => tx.ExecuteTransactionAsync(CancellationToken.None));
 
             Assert.IsTrue(ex.Message.Contains("zero operations"), $"Unexpected message: {ex.Message}");
         }
@@ -657,12 +657,12 @@ namespace Microsoft.Azure.Cosmos.Tests
                 .CreateItem(BuildMockContainer(), new PartitionKey("pk"), "item-id", new TestItem());
 
             // First commit should succeed
-            DistributedTransactionResponse response = await tx.CommitTransactionAsync(CancellationToken.None);
+            DistributedTransactionResponse response = await tx.ExecuteTransactionAsync(CancellationToken.None);
             Assert.IsTrue(response.IsSuccessStatusCode);
 
             // Second commit must throw
             InvalidOperationException ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
-                () => tx.CommitTransactionAsync(CancellationToken.None));
+                () => tx.ExecuteTransactionAsync(CancellationToken.None));
             Assert.AreEqual(DistributedWriteTransactionCore.CommitAlreadyCalledMessage, ex.Message);
         }
 
@@ -689,12 +689,12 @@ namespace Microsoft.Azure.Cosmos.Tests
                 .CreateItem(BuildMockContainer(), new PartitionKey("pk"), "item-id", new TestItem());
 
             // First commit returns an error (but the call was made — idempotency token was consumed)
-            DistributedTransactionResponse response = await tx.CommitTransactionAsync(CancellationToken.None);
+            DistributedTransactionResponse response = await tx.ExecuteTransactionAsync(CancellationToken.None);
             Assert.IsFalse(response.IsSuccessStatusCode);
 
             // Second commit must still throw — the token was already issued
             InvalidOperationException ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
-                () => tx.CommitTransactionAsync(CancellationToken.None));
+                () => tx.ExecuteTransactionAsync(CancellationToken.None));
             Assert.AreEqual(DistributedWriteTransactionCore.CommitAlreadyCalledMessage, ex.Message);
         }
 
@@ -732,13 +732,13 @@ namespace Microsoft.Azure.Cosmos.Tests
 
             // First commit attempt: a transient network exception escapes to the caller.
             await Assert.ThrowsExceptionAsync<HttpRequestException>(
-                () => tx.CommitTransactionAsync(CancellationToken.None));
+                () => tx.ExecuteTransactionAsync(CancellationToken.None));
 
             // Second commit attempt: must throw InvalidOperationException, NOT re-attempt the network call.
             // The SDK has no way to know whether the first attempt's request reached the server,
             // so a retry with a new idempotency token would risk a double-commit.
             InvalidOperationException ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
-                () => tx.CommitTransactionAsync(CancellationToken.None));
+                () => tx.ExecuteTransactionAsync(CancellationToken.None));
             Assert.AreEqual(DistributedWriteTransactionCore.CommitAlreadyCalledMessage, ex.Message);
             Assert.AreEqual(1, invocationCount, "Second call must not re-attempt the network operation.");
         }
@@ -777,18 +777,18 @@ namespace Microsoft.Azure.Cosmos.Tests
                 .CreateItem(BuildMockContainer(), new PartitionKey("pk"), "item-id", new TestItem());
 
             await Assert.ThrowsExceptionAsync<OperationCanceledException>(
-                () => tx.CommitTransactionAsync(cts.Token));
+                () => tx.ExecuteTransactionAsync(cts.Token));
 
             // Retry with a fresh CancellationToken should still be rejected.
             InvalidOperationException ex = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
-                () => tx.CommitTransactionAsync(CancellationToken.None));
+                () => tx.ExecuteTransactionAsync(CancellationToken.None));
             Assert.AreEqual(DistributedWriteTransactionCore.CommitAlreadyCalledMessage, ex.Message);
             Assert.AreEqual(1, invocationCount, "Second call must not re-attempt the network operation.");
         }
 
         [TestMethod]
         [Description("Verifies that only one of N concurrent callers wins the Interlocked.CompareExchange gate. " +
-                     "Uses Task.Run + ManualResetEventSlim so that all racers hit CommitTransactionAsync from " +
+                     "Uses Task.Run + ManualResetEventSlim so that all racers hit ExecuteTransactionAsync from " +
                      "separate thread-pool threads simultaneously, providing genuine concurrency coverage.")]
         public async Task CommitAsync_ConcurrentCalls_OnlyOneSucceeds()
         {
@@ -829,7 +829,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 tasks[i] = Task.Run(async () =>
                 {
                     gate.Wait();
-                    return await tx.CommitTransactionAsync(CancellationToken.None);
+                    return await tx.ExecuteTransactionAsync(CancellationToken.None);
                 });
             }
 
@@ -859,8 +859,8 @@ namespace Microsoft.Azure.Cosmos.Tests
         }
 
         [TestMethod]
-        [Description("CommitTransactionAsync must route through OperationHelperAsync with the correct operation name, OperationType, TraceComponent, and OTel operation name for the write path — ensuring the write path is distinct from the read path.")]
-        public async Task CommitTransactionAsync_RoutesThroughOperationHelper_WithExpectedWiring()
+        [Description("ExecuteTransactionAsync must route through OperationHelperAsync with the correct operation name, OperationType, TraceComponent, and OTel operation name for the write path — ensuring the write path is distinct from the read path.")]
+        public async Task ExecuteTransactionAsync_RoutesThroughOperationHelper_WithExpectedWiring()
         {
             string capturedOperationName = null;
             OperationType capturedOperationType = default;
@@ -895,19 +895,19 @@ namespace Microsoft.Azure.Cosmos.Tests
 
             await new DistributedWriteTransactionCore(contextMock.Object)
                 .CreateItem(BuildMockContainer(), new PartitionKey("pk"), "id", new TestItem())
-                .CommitTransactionAsync(CancellationToken.None);
+                .ExecuteTransactionAsync(CancellationToken.None);
 
-            Assert.AreEqual($"{nameof(DistributedWriteTransaction)}.{nameof(DistributedWriteTransaction.CommitTransactionAsync)}", capturedOperationName);
+            Assert.AreEqual($"{nameof(DistributedWriteTransaction)}.{nameof(DistributedWriteTransaction.ExecuteTransactionAsync)}", capturedOperationName);
             Assert.AreEqual(OperationType.CommitDistributedTransaction, capturedOperationType);
             Assert.AreEqual(TraceComponent.Batch, capturedTraceComponent);
-            Assert.AreEqual(OpenTelemetryConstants.Operations.CommitDistributedWriteTransaction, capturedOTelOperationName);
+            Assert.AreEqual(OpenTelemetryConstants.Operations.ExecuteDistributedWriteTransaction, capturedOTelOperationName);
         }
 
         // Helpers
 
         /// <summary>
         /// Creates a transaction backed by a minimal context mock — suitable for
-        /// validation-only tests that do not invoke <see cref="DistributedWriteTransaction.CommitTransactionAsync"/>.
+        /// validation-only tests that do not invoke <see cref="DistributedWriteTransaction.ExecuteTransactionAsync"/>.
         /// </summary>
         private DistributedWriteTransaction NewTransaction()
         {

--- a/changelog.md
+++ b/changelog.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Breaking Changes
 
+- [XXXX](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/XXXX) Distributed Transactions (preview): Renamed `DistributedTransaction.CommitTransactionAsync` to `ExecuteTransactionAsync` to reflect that, in Fast Response mode, the call executes the transaction and may return before the terminal commit/abort outcome. The associated OpenTelemetry span operation names were also renamed from `commit_distributed_{read,write}_transaction` to `execute_distributed_{read,write}_transaction`.
+
 #### Bugs Fixed
 
 #### Other Changes

--- a/changelog.md
+++ b/changelog.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Breaking Changes
 
-- [XXXX](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/XXXX) Distributed Transactions (preview): Renamed `DistributedTransaction.CommitTransactionAsync` to `ExecuteTransactionAsync` to reflect that, in Fast Response mode, the call executes the transaction and may return before the terminal commit/abort outcome. The associated OpenTelemetry span operation names were also renamed from `commit_distributed_{read,write}_transaction` to `execute_distributed_{read,write}_transaction`.
+- [6037](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/XXXX) Distributed Transactions (preview): Renamed `DistributedTransaction.CommitTransactionAsync` to `ExecuteTransactionAsync` to reflect that, in Fast Response mode, the call executes the transaction and may return before the terminal commit/abort outcome. The associated OpenTelemetry span operation names were also renamed from `commit_distributed_{read,write}_transaction` to `execute_distributed_{read,write}_transaction`.
 
 #### Bugs Fixed
 


### PR DESCRIPTION
## Why

The DTX FastResponseMode API spec ([#6021](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/6021)) renames the distributed-transaction commit entry point. In Fast Response mode the call acknowledges as soon as the coordinator has durably completed Phase 1, so it *executes* (rather than necessarily *commits*) the transaction and may return before the terminal commit/abort outcome. The verb `Commit` is misleading in that mode; `Execute` is mode-neutral.

## What changed

This is a **breaking change to the preview API surface** (`DistributedTransaction` is public only under `#if PREVIEW`).

- **Public API**: `DistributedTransaction.CommitTransactionAsync` -> `ExecuteTransactionAsync`, plus the `DistributedWriteTransactionCore` / `DistributedReadTransactionCore` overrides, diagnostics operation names, and XML doc references.
- **Internal**: renamed the `DistributedTransactionCommitter.CommitTransactionAsync(trace, ct)` helper and the "already been called" error-message text. The `DistributedTransactionCommitter` class name is intentionally kept.
- **OpenTelemetry**: renamed the span operation constants and their emitted string values from `commit_distributed_{read,write}_transaction` to `execute_distributed_{read,write}_transaction`, so telemetry stays consistent with the API and diagnostics.
- **Contract**: updated the enforced preview baseline `DotNetPreviewSDKAPI.net6.json`. The frozen released `API_3.6x.0-preview.0.txt` snapshots are deliberately left untouched.
- **Tests / changelog**: updated all DTX call sites and message assertions across the unit and emulator test suites, and added a Breaking Changes entry under `Unreleased`.

## Notes for reviewers

- The emitted OpenTelemetry span name values change, which is itself a telemetry-observable change on the preview surface. This was a deliberate choice to avoid the diagnostics-say-execute / spans-say-commit inconsistency; it is called out in the changelog.
- Protocol/operation-type identifiers (`OperationType.CommitDistributedTransaction`) are unchanged, as they refer to the underlying protocol phase, not the API verb.

## Validation

- Preview `src` and unit-test projects build clean (0 warnings / 0 errors).
- DTX + Contracts + OpenTelemetry unit tests pass (including `ContractEnforcement`, which validates the updated baseline against the compiled API). Emulator-backed E2E tests were compiled but not executed locally.