### PR TITLE
DistributedTransaction: Adds tunable abort-retry options to CosmosClientOptions

### DIFF
--- a/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
+++ b/Microsoft.Azure.Cosmos/src/CosmosClientOptions.cs
@@ -480,6 +480,63 @@ namespace Microsoft.Azure.Cosmos
         public TimeSpan? MaxRetryWaitTimeOnRateLimitedRequests { get; set; }
 
         /// <summary>
+        /// Gets or sets the maximum number of retries in the case where a distributed transaction
+        /// commit fails because the Azure Cosmos DB service reports the transaction as aborted but
+        /// retriable.
+        /// </summary>
+        /// <value>
+        /// The default value is 10. This means in the case where a distributed transaction commit is
+        /// reported as retriable, the SDK will re-issue the commit (with a fresh idempotency token) for
+        /// a maximum of 10 attempts before returning the last response to the application.
+        ///
+        /// If the value of this property is set to 0, there will be no automatic retry on retriable
+        /// aborted distributed transactions from the client and the first retriable response is returned
+        /// to the application to be handled at the application level.
+        /// </value>
+        /// <remarks>
+        /// <para>
+        /// When a distributed transaction commit is reported by the service as aborted but retriable, the
+        /// SDK re-issues the commit after an exponentially increasing backoff. This property caps the number
+        /// of such retry attempts. Retries also stop once the cumulative wait time exceeds
+        /// <see cref="MaxRetryWaitTimeOnAbortedTransactions"/>, whichever budget is exhausted first.
+        /// </para>
+        /// </remarks>
+#if PREVIEW
+        public
+#else
+        internal
+#endif
+        int? MaxRetryAttemptsOnAbortedTransactions { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum cumulative wait time across all retry attempts when a distributed
+        /// transaction commit fails because the Azure Cosmos DB service reports the transaction as aborted
+        /// but retriable.
+        /// </summary>
+        /// <value>
+        /// The default value is 30 seconds.
+        /// </value>
+        /// <remarks>
+        /// <para>
+        /// When a distributed transaction commit is reported by the service as aborted but retriable, the
+        /// SDK waits (using an exponentially increasing backoff, honoring any server retry-after hint) before
+        /// re-issuing the commit. This property caps the total cumulative wait time accumulated across all
+        /// retry attempts. If the next planned delay would push the cumulative wait time past this value, the
+        /// client stops retrying and returns the last response to the application.
+        /// </para>
+        /// <para>
+        /// Retries also stop once the number of attempts exceeds
+        /// <see cref="MaxRetryAttemptsOnAbortedTransactions"/>, whichever budget is exhausted first.
+        /// </para>
+        /// </remarks>
+#if PREVIEW
+        public
+#else
+        internal
+#endif
+        TimeSpan? MaxRetryWaitTimeOnAbortedTransactions { get; set; }
+
+        /// <summary>
         /// Gets or sets the boolean to only return the headers and status code in
         /// the Cosmos DB response for write item operation like Create, Upsert, Patch and Replace.
         /// Setting the option to false will cause the response to have a null resource. This reduces networking and CPU load by not sending

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionCommitter.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionCommitter.cs
@@ -21,14 +21,16 @@ namespace Microsoft.Azure.Cosmos
         // Outer-loop retry parameters. The inner loop (ClientRetryPolicy) handles envelope failures with empty body;
         // the outer loop handles body-bearing semantic failures whose JSON body sets isRetriable: true.
         //
-        // Hard ceiling on outer-loop wire requests. With non-trivial retryBaseDelay the cumulative
-        // MaxCumulativeRetryDelay budget will typically fire first; this cap only binds when delays
-        // are very small (e.g., zero in tests or hypothetical fast-server scenarios) — it guards
-        // against unbounded wire-request amplification when delays are degenerate.
+        // Default attempt-count cap and hard ceiling on outer-loop wire requests. With non-trivial
+        // retryBaseDelay the cumulative MaxCumulativeRetryDelay budget will typically fire first; this cap
+        // only binds when delays are very small (e.g., zero in tests or hypothetical fast-server scenarios)
+        // — it guards against unbounded wire-request amplification when delays are degenerate. Applied as
+        // the default when CosmosClientOptions.MaxRetryAttemptsOnAbortedTransactions is unset.
         internal const int MaxIsRetriableRetryCount = 10;
         // Default cumulative planned-delay budget. With default 1s base and maxExponent=5 (±25% jitter),
         // the budget is the binding constraint (~4-5 retries) rather than the attempt-count cap (10).
-        // Mirrors ResourceThrottleRetryPolicy's cumulative cap pattern. Overridable via the internal
+        // Mirrors ResourceThrottleRetryPolicy's cumulative cap pattern. Applied as the default when
+        // CosmosClientOptions.MaxRetryWaitTimeOnAbortedTransactions is unset; overridable via the internal
         // constructor for tests that need to exercise the attempt-count cap with realistic delays.
         internal static readonly TimeSpan MaxCumulativeRetryDelay = TimeSpan.FromSeconds(30);
         private const int RetryMaxExponent = 5; // ~32 s max base delay before jitter
@@ -39,6 +41,7 @@ namespace Microsoft.Azure.Cosmos
         private readonly CosmosClientContext clientContext;
         private readonly OperationType operationType;
         private readonly TimeSpan retryBaseDelay;
+        private readonly int maxIsRetriableRetryCount;
         private readonly TimeSpan maxCumulativeRetryDelay;
         private readonly Func<TimeSpan, CancellationToken, Task> delayProvider;
 
@@ -56,14 +59,24 @@ namespace Microsoft.Azure.Cosmos
             OperationType operationType,
             TimeSpan retryBaseDelay,
             Func<TimeSpan, CancellationToken, Task> delayProvider = null,
-            TimeSpan? maxCumulativeRetryDelay = null)
+            TimeSpan? maxCumulativeRetryDelay = null,
+            int? maxIsRetriableRetryCount = null)
         {
             this.operations = operations ?? throw new ArgumentNullException(nameof(operations));
             this.clientContext = clientContext ?? throw new ArgumentNullException(nameof(clientContext));
             this.operationType = operationType;
             this.retryBaseDelay = retryBaseDelay;
             this.delayProvider = delayProvider ?? Task.Delay;
-            this.maxCumulativeRetryDelay = maxCumulativeRetryDelay ?? DistributedTransactionCommitter.MaxCumulativeRetryDelay;
+
+            CosmosClientOptions clientOptions = clientContext?.ClientOptions;
+
+            // Explicit test overrides win; otherwise derive from the client options; otherwise fall back to defaults.
+            this.maxIsRetriableRetryCount = maxIsRetriableRetryCount
+                ?? clientOptions?.MaxRetryAttemptsOnAbortedTransactions
+                ?? DistributedTransactionCommitter.MaxIsRetriableRetryCount;
+            this.maxCumulativeRetryDelay = maxCumulativeRetryDelay
+                ?? clientOptions?.MaxRetryWaitTimeOnAbortedTransactions
+                ?? DistributedTransactionCommitter.MaxCumulativeRetryDelay;
         }
 
         public async Task<DistributedTransactionResponse> CommitTransactionAsync(
@@ -119,7 +132,7 @@ namespace Microsoft.Azure.Cosmos
                     return response;
                 }
 
-                if (attempt >= DistributedTransactionCommitter.MaxIsRetriableRetryCount)
+                if (attempt >= this.maxIsRetriableRetryCount)
                 {
                     DefaultTrace.TraceWarning(
                         $"Distributed transaction isRetriable retry budget exhausted after {attempt} attempts " +

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetPreviewSDKAPI.net6.json
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetPreviewSDKAPI.net6.json
@@ -107,6 +107,13 @@
           "Attributes": [],
           "MethodInfo": "System.Nullable`1[Microsoft.Azure.Cosmos.ReadConsistencyStrategy] ReadConsistencyStrategy;CanRead:True;CanWrite:True;System.Nullable`1[Microsoft.Azure.Cosmos.ReadConsistencyStrategy] get_ReadConsistencyStrategy();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;Void set_ReadConsistencyStrategy(System.Nullable`1[Microsoft.Azure.Cosmos.ReadConsistencyStrategy]);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
         },
+        "System.Nullable`1[System.Int32] get_MaxRetryAttemptsOnAbortedTransactions()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Nullable`1[System.Int32] get_MaxRetryAttemptsOnAbortedTransactions();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
         "System.Nullable`1[System.Int32] get_ThroughputBucket()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
           "Type": "Method",
           "Attributes": [
@@ -114,10 +121,27 @@
           ],
           "MethodInfo": "System.Nullable`1[System.Int32] get_ThroughputBucket();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
         },
+        "System.Nullable`1[System.Int32] MaxRetryAttemptsOnAbortedTransactions": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": "System.Nullable`1[System.Int32] MaxRetryAttemptsOnAbortedTransactions;CanRead:True;CanWrite:True;System.Nullable`1[System.Int32] get_MaxRetryAttemptsOnAbortedTransactions();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;Void set_MaxRetryAttemptsOnAbortedTransactions(System.Nullable`1[System.Int32]);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
         "System.Nullable`1[System.Int32] ThroughputBucket": {
           "Type": "Property",
           "Attributes": [],
           "MethodInfo": "System.Nullable`1[System.Int32] ThroughputBucket;CanRead:True;CanWrite:True;System.Nullable`1[System.Int32] get_ThroughputBucket();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;Void set_ThroughputBucket(System.Nullable`1[System.Int32]);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "System.Nullable`1[System.TimeSpan] get_MaxRetryWaitTimeOnAbortedTransactions()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.Nullable`1[System.TimeSpan] get_MaxRetryWaitTimeOnAbortedTransactions();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "System.Nullable`1[System.TimeSpan] MaxRetryWaitTimeOnAbortedTransactions": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": "System.Nullable`1[System.TimeSpan] MaxRetryWaitTimeOnAbortedTransactions;CanRead:True;CanWrite:True;System.Nullable`1[System.TimeSpan] get_MaxRetryWaitTimeOnAbortedTransactions();IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;Void set_MaxRetryWaitTimeOnAbortedTransactions(System.Nullable`1[System.TimeSpan]);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
         },
         "System.TimeSpan get_InferenceRequestTimeout()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
           "Type": "Method",
@@ -149,6 +173,20 @@
             "CompilerGeneratedAttribute"
           ],
           "MethodInfo": "Void set_InferenceRequestTimeout(System.TimeSpan);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "Void set_MaxRetryAttemptsOnAbortedTransactions(System.Nullable`1[System.Int32])[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_MaxRetryAttemptsOnAbortedTransactions(System.Nullable`1[System.Int32]);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "Void set_MaxRetryWaitTimeOnAbortedTransactions(System.Nullable`1[System.TimeSpan])[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "Void set_MaxRetryWaitTimeOnAbortedTransactions(System.Nullable`1[System.TimeSpan]);IsAbstract:False;IsStatic:False;IsVirtual:False;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
         },
         "Void set_ReadConsistencyStrategy(System.Nullable`1[Microsoft.Azure.Cosmos.ReadConsistencyStrategy])[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
           "Type": "Method",

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/CosmosClientOptionsUnitTests.cs
@@ -347,6 +347,35 @@ namespace Microsoft.Azure.Cosmos.Tests
         }
 
         [TestMethod]
+        public void CosmosClientOptions_Clone_PreservesAbortedTransactionRetryOptions()
+        {
+            CosmosClientOptions options = new CosmosClientOptions
+            {
+                MaxRetryAttemptsOnAbortedTransactions = 5,
+                MaxRetryWaitTimeOnAbortedTransactions = TimeSpan.FromSeconds(12),
+            };
+
+            CosmosClientOptions clone = options.Clone();
+
+            Assert.AreEqual(5, clone.MaxRetryAttemptsOnAbortedTransactions,
+                "Clone() must preserve MaxRetryAttemptsOnAbortedTransactions");
+            Assert.AreEqual(TimeSpan.FromSeconds(12), clone.MaxRetryWaitTimeOnAbortedTransactions,
+                "Clone() must preserve MaxRetryWaitTimeOnAbortedTransactions");
+            Assert.AreNotSame(options, clone, "Clone() must return a distinct instance");
+        }
+
+        [TestMethod]
+        public void CosmosClientOptions_AbortedTransactionRetryOptions_DefaultToNull()
+        {
+            CosmosClientOptions options = new CosmosClientOptions();
+
+            Assert.IsNull(options.MaxRetryAttemptsOnAbortedTransactions,
+                "MaxRetryAttemptsOnAbortedTransactions must be null by default so the SDK default applies");
+            Assert.IsNull(options.MaxRetryWaitTimeOnAbortedTransactions,
+                "MaxRetryWaitTimeOnAbortedTransactions must be null by default so the SDK default applies");
+        }
+
+        [TestMethod]
         public void CosmosClientOptions_Clone_PreservesEmbeddingGenerator()
         {
             ICosmosEmbeddingGenerator generator = new MockEmbeddingGenerator();

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionCommitterTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionCommitterTests.cs
@@ -769,6 +769,196 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
         }
 
         [TestMethod]
+        [Description("Verifies that the attempt-count cap is read from CosmosClientOptions.MaxRetryAttemptsOnAbortedTransactions.")]
+        public async Task CommitTransaction_AttemptCapFromClientOptions_IsHonored()
+        {
+            const int configuredCap = 3;
+            int callCount = 0;
+            List<TimeSpan> capturedDelays = new List<TimeSpan>();
+            Mock<CosmosClientContext> mockContext = this.CreateMockClientContext(
+                new CosmosClientOptions { MaxRetryAttemptsOnAbortedTransactions = configuredCap });
+            this.SetupProcessResourceOperation(
+                mockContext,
+                () =>
+                {
+                    callCount++;
+                    return Task.FromResult(CreateRetriableErrorResponseMessage());
+                });
+
+            Func<TimeSpan, CancellationToken, Task> captureDelay = (delay, _) =>
+            {
+                capturedDelays.Add(delay);
+                return Task.CompletedTask;
+            };
+
+            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
+                CreateTestOperations(),
+                mockContext.Object,
+                OperationType.CommitDistributedTransaction,
+                retryBaseDelay: TimeSpan.Zero,
+                delayProvider: captureDelay);
+
+            using (DistributedTransactionResponse response = await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None))
+            {
+                Assert.AreEqual(configuredCap + 1, callCount,
+                    "Expected exactly configuredCap retries plus one final call that triggers budget exhaustion.");
+                Assert.AreEqual(configuredCap, capturedDelays.Count,
+                    "Delay provider must be called once per retry attempt.");
+                Assert.IsTrue(response.IsRetriable);
+            }
+        }
+
+        [TestMethod]
+        [Description("Verifies that the cumulative wait cap is read from CosmosClientOptions.MaxRetryWaitTimeOnAbortedTransactions.")]
+        public async Task CommitTransaction_CumulativeWaitCapFromClientOptions_IsHonored()
+        {
+            int callCount = 0;
+            List<TimeSpan> capturedDelays = new List<TimeSpan>();
+            // Small cumulative budget (10s) with a 15s base delay: the first planned delay already exceeds it,
+            // so exactly one call happens and no delay is slept.
+            Mock<CosmosClientContext> mockContext = this.CreateMockClientContext(
+                new CosmosClientOptions { MaxRetryWaitTimeOnAbortedTransactions = TimeSpan.FromSeconds(10) });
+            this.SetupProcessResourceOperation(
+                mockContext,
+                () =>
+                {
+                    callCount++;
+                    return Task.FromResult(CreateRetriableErrorResponseMessage());
+                });
+
+            Func<TimeSpan, CancellationToken, Task> captureDelay = (delay, _) =>
+            {
+                capturedDelays.Add(delay);
+                return Task.CompletedTask;
+            };
+
+            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
+                CreateTestOperations(),
+                mockContext.Object,
+                OperationType.CommitDistributedTransaction,
+                retryBaseDelay: TimeSpan.FromSeconds(15),
+                delayProvider: captureDelay);
+
+            using (DistributedTransactionResponse response = await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None))
+            {
+                Assert.AreEqual(1, callCount,
+                    "Expected exactly 1 call: the first planned delay (~15s) exceeds the 10s cumulative budget.");
+                Assert.AreEqual(0, capturedDelays.Count,
+                    "No delay should be slept once the first planned delay exceeds the cumulative budget.");
+                Assert.IsTrue(response.IsRetriable);
+            }
+        }
+
+        [TestMethod]
+        [Description("Verifies that setting CosmosClientOptions.MaxRetryAttemptsOnAbortedTransactions to 0 disables automatic abort retries.")]
+        public async Task CommitTransaction_ZeroAttemptCapFromClientOptions_DisablesRetries()
+        {
+            int callCount = 0;
+            List<TimeSpan> capturedDelays = new List<TimeSpan>();
+            Mock<CosmosClientContext> mockContext = this.CreateMockClientContext(
+                new CosmosClientOptions { MaxRetryAttemptsOnAbortedTransactions = 0 });
+            this.SetupProcessResourceOperation(
+                mockContext,
+                () =>
+                {
+                    callCount++;
+                    return Task.FromResult(CreateRetriableErrorResponseMessage());
+                });
+
+            Func<TimeSpan, CancellationToken, Task> captureDelay = (delay, _) =>
+            {
+                capturedDelays.Add(delay);
+                return Task.CompletedTask;
+            };
+
+            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
+                CreateTestOperations(),
+                mockContext.Object,
+                OperationType.CommitDistributedTransaction,
+                retryBaseDelay: TimeSpan.Zero,
+                delayProvider: captureDelay);
+
+            using (DistributedTransactionResponse response = await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None))
+            {
+                Assert.AreEqual(1, callCount,
+                    "With the attempt cap at 0, the first retriable response must be returned without retrying.");
+                Assert.AreEqual(0, capturedDelays.Count,
+                    "No delay should be slept when abort retries are disabled.");
+                Assert.IsTrue(response.IsRetriable);
+            }
+        }
+
+        [TestMethod]
+        [Description("Verifies that when CosmosClientOptions leaves the abort-retry bounds unset, the committer falls back to the SDK defaults.")]
+        public async Task CommitTransaction_UnsetClientOptions_FallsBackToDefaults()
+        {
+            int callCount = 0;
+            List<TimeSpan> capturedDelays = new List<TimeSpan>();
+            // Client options present but bounds unset -> defaults apply (10 attempts).
+            Mock<CosmosClientContext> mockContext = this.CreateMockClientContext(new CosmosClientOptions());
+            this.SetupProcessResourceOperation(
+                mockContext,
+                () =>
+                {
+                    callCount++;
+                    return Task.FromResult(CreateRetriableErrorResponseMessage());
+                });
+
+            Func<TimeSpan, CancellationToken, Task> captureDelay = (delay, _) =>
+            {
+                capturedDelays.Add(delay);
+                return Task.CompletedTask;
+            };
+
+            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
+                CreateTestOperations(),
+                mockContext.Object,
+                OperationType.CommitDistributedTransaction,
+                retryBaseDelay: TimeSpan.Zero,
+                delayProvider: captureDelay);
+
+            using (DistributedTransactionResponse response = await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None))
+            {
+                Assert.AreEqual(DistributedTransactionCommitter.MaxIsRetriableRetryCount + 1, callCount,
+                    "Unset options must fall back to the default attempt cap.");
+                Assert.AreEqual(DistributedTransactionCommitter.MaxIsRetriableRetryCount, capturedDelays.Count,
+                    "Delay provider must be called once per retry attempt under the default cap.");
+            }
+        }
+
+        [TestMethod]
+        [Description("Verifies that an explicit test override for maxIsRetriableRetryCount takes precedence over CosmosClientOptions.")]
+        public async Task CommitTransaction_ExplicitAttemptCapOverridesClientOptions()
+        {
+            const int optionsCap = 8;
+            const int explicitCap = 2;
+            int callCount = 0;
+            Mock<CosmosClientContext> mockContext = this.CreateMockClientContext(
+                new CosmosClientOptions { MaxRetryAttemptsOnAbortedTransactions = optionsCap });
+            this.SetupProcessResourceOperation(
+                mockContext,
+                () =>
+                {
+                    callCount++;
+                    return Task.FromResult(CreateRetriableErrorResponseMessage());
+                });
+
+            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
+                CreateTestOperations(),
+                mockContext.Object,
+                OperationType.CommitDistributedTransaction,
+                retryBaseDelay: TimeSpan.Zero,
+                delayProvider: (delay, _) => Task.CompletedTask,
+                maxIsRetriableRetryCount: explicitCap);
+
+            using (DistributedTransactionResponse response = await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None))
+            {
+                Assert.AreEqual(explicitCap + 1, callCount,
+                    "The explicit constructor override must take precedence over the client options value.");
+            }
+        }
+
+        [TestMethod]
         [Description("Verifies that the outer retry loop stops when the cumulative delay budget (MaxCumulativeRetryDelay) is exceeded, even if attempt count has not been reached.")]
         public async Task CommitTransaction_ExhaustsCumulativeDelayBudget_ReturnsLastResponse()
         {
@@ -1651,6 +1841,13 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                 It.IsAny<CancellationToken>()))
                 .ReturnsAsync(ContainerProperties.CreateWithResourceId(TestCollectionResourceId));
 
+            return mockContext;
+        }
+
+        private Mock<CosmosClientContext> CreateMockClientContext(CosmosClientOptions clientOptions)
+        {
+            Mock<CosmosClientContext> mockContext = this.CreateMockClientContext();
+            mockContext.Setup(x => x.ClientOptions).Returns(clientOptions);
             return mockContext;
         }
 

--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Features Added
 
+- [6021](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/6021) Distributed Transactions (preview): Adds `CosmosClientOptions.MaxRetryAttemptsOnAbortedTransactions` and `CosmosClientOptions.MaxRetryWaitTimeOnAbortedTransactions` to tune the automatic retry bounds (attempt-count cap and cumulative wait-time budget) applied when a distributed transaction commit is reported as aborted but retriable. Setting the attempt cap to 0 disables automatic abort retries; leaving the options unset applies the SDK defaults.
+
 #### Breaking Changes
 
 #### Bugs Fixed


### PR DESCRIPTION
## Description

Adds tunable aborted-transaction retry bounds for distributed transaction commit via CosmosClientOptions.

### Changes
- Adds MaxRetryAttemptsOnAbortedTransactions and MaxRetryWaitTimeOnAbortedTransactions to CosmosClientOptions (preview-gated).
- Wires DistributedTransactionCommitter to read these options with existing defaults preserved when unset (10 attempts, 30s cumulative wait).
- Keeps explicit internal constructor test overrides working.
- Treats attempt cap 