### PR TITLE
DistributedTransaction: Refactors abort retry to resubmit with a new idempotency token

### DIFF
--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionCommitter.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionCommitter.cs
@@ -167,7 +167,7 @@ namespace Microsoft.Azure.Cosmos
                 }
 
                 DefaultTrace.TraceWarning(
-                    $"Distributed transaction commit retriable (StatusCode={response.StatusCode}, IsRetriable={response.IsRetriable}, DiagnosticString={TruncateForLog(response.DiagnosticString)}, attempt={attempt}, delayMs={(int)delay.TotalMilliseconds}, cumulativeDelayMs={(int)cumulativeRetryDelay.TotalMilliseconds}). Retrying with idempotency token {serverRequest.IdempotencyToken}.");
+                    $"Distributed transaction commit retriable (StatusCode={response.StatusCode}, IsRetriable={response.IsRetriable}, DiagnosticString={TruncateForLog(response.DiagnosticString)}, attempt={attempt}, delayMs={(int)delay.TotalMilliseconds}, cumulativeDelayMs={(int)cumulativeRetryDelay.TotalMilliseconds}). Aborted idempotency token {serverRequest.IdempotencyToken} will not be replayed; the next attempt resubmits under a new token.");
 
                 response.Dispose();
                 attempt++;
@@ -197,6 +197,12 @@ namespace Microsoft.Azure.Cosmos
         {
             using (ITrace attemptTrace = parentTrace.StartChild("Execute Distributed Transaction Commit", TraceComponent.Batch, TraceLevel.Info))
             {
+                // Each wire attempt (including the first) is a new logical attempt and must carry a
+                // fresh idempotency token (spec §4.2). The serialized body is reused byte-for-byte;
+                // only the token rotates. The prior token remains terminally Aborted on the
+                // coordinator and is never replayed.
+                serverRequest.RotateIdempotencyToken();
+
                 using (MemoryStream bodyStream = serverRequest.CreateBodyStream())
                 {
                     ResponseMessage responseMessage = await this.clientContext.ProcessResourceOperationStreamAsync(

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionServerRequest.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionServerRequest.cs
@@ -26,7 +26,27 @@ namespace Microsoft.Azure.Cosmos
 
         public IReadOnlyList<DistributedTransactionOperation> Operations { get; }
 
-        public Guid IdempotencyToken { get; }
+        /// <summary>
+        /// The idempotency token for the current attempt. Each retry is a new logical attempt that
+        /// MUST carry a fresh token (see DistributedTransactionFastResponseMode.md §4.2): the prior
+        /// token remains terminally Aborted on the coordinator and must never be replayed. The token
+        /// is decoupled from the immutable serialized body — the body bytes are serialized exactly
+        /// once and reused, while the token rotates per attempt via <see cref="RotateIdempotencyToken"/>.
+        /// </summary>
+        public Guid IdempotencyToken { get; private set; }
+
+        /// <summary>
+        /// Assigns a fresh <see cref="Guid"/> to <see cref="IdempotencyToken"/> and returns it. Called
+        /// before every wire attempt (including the first) so that each retry is submitted under a new
+        /// idempotency token while reusing the identical serialized body. The prior token stays
+        /// terminally Aborted on the coordinator and is never replayed.
+        /// </summary>
+        /// <returns>The newly generated idempotency token.</returns>
+        public Guid RotateIdempotencyToken()
+        {
+            this.IdempotencyToken = Guid.NewGuid();
+            return this.IdempotencyToken;
+        }
 
         public static async Task<DistributedTransactionServerRequest> CreateAsync(
             IReadOnlyList<DistributedTransactionOperation> operations,

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionCommitterTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionCommitterTests.cs
@@ -1102,8 +1102,8 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
         }
 
         [TestMethod]
-        [Description("Verifies that the SDK sends byte-for-byte identical request bodies AND the same idempotency token on every outer-loop retry. Required so the coordinator can recognise replays via the idempotency token and safely re-prepare from the same payload (per dtx-sdk-response-status-codes.md, Part C §9: 'Aborted (SDK retry): Resets record to Preparing with new transaction ID, same idempotency token').")]
-        public async Task CommitTransaction_SameBodyAndTokenSentOnEveryRetryAttempt()
+        [Description("Verifies that the SDK sends byte-for-byte identical request bodies but a NEW, distinct idempotency token on every outer-loop attempt. Per DistributedTransactionFastResponseMode.md §4.2, each retriable-abort retry is a new logical attempt that MUST use a fresh idempotency token; the prior token remains terminally Aborted and must never be replayed. The serialized body is reused unchanged so the coordinator re-prepares from the identical payload under the new token.")]
+        public async Task CommitTransaction_SendsNewIdempotencyTokenOnEachRetry()
         {
             int callCount = 0;
             List<string> capturedTokens = new List<string>();
@@ -1159,8 +1159,10 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             }
 
             Assert.AreEqual(3, capturedTokens.Count, "Three attempts expected: two retriable failures plus one success.");
-            Assert.AreEqual(1, new HashSet<string>(capturedTokens).Count,
-                "The same idempotency token must be used on every retry attempt.");
+            Assert.AreEqual(3, new HashSet<string>(capturedTokens).Count,
+                "Each attempt must use a NEW, distinct idempotency token; the prior aborted token must never be replayed.");
+            Assert.IsFalse(capturedTokens.Contains(Guid.Empty.ToString()),
+                "Every attempt must carry a real (non-empty) idempotency token.");
 
             Assert.AreEqual(3, capturedBodies.Count);
             Assert.IsTrue(capturedBodies[0].Length > 0, "Captured body must be non-empty.");
@@ -1168,6 +1170,52 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                 "Retry attempt #2 must send a byte-for-byte identical request body.");
             CollectionAssert.AreEqual(capturedBodies[0], capturedBodies[2],
                 "Retry attempt #3 must send a byte-for-byte identical request body.");
+        }
+
+        [TestMethod]
+        [Description("Verifies that the first attempt gets a freshly rotated idempotency token and that N retriable-abort responses produce N+1 distinct tokens across attempts (spec §4.2).")]
+        public async Task CommitTransaction_NRetriableAbortsProduceNPlusOneDistinctTokens()
+        {
+            const int retriableAbortCount = 4;
+            int callCount = 0;
+            List<string> capturedTokens = new List<string>();
+            Mock<CosmosClientContext> mockContext = this.CreateMockClientContext();
+            this.SetupProcessResourceOperationWithStreamAndEnricherCapture(
+                mockContext,
+                (stream, enricher) =>
+                {
+                    RequestMessage request = new RequestMessage
+                    {
+                        ResourceType = ResourceType.DistributedTransactionBatch,
+                        OperationType = OperationType.CommitDistributedTransaction,
+                    };
+                    enricher(request);
+                    capturedTokens.Add(request.Headers[HttpConstants.HttpHeaders.IdempotencyToken]);
+                },
+                () =>
+                {
+                    callCount++;
+                    return callCount <= retriableAbortCount
+                        ? Task.FromResult(CreateRetriableErrorResponseMessage())
+                        : Task.FromResult(CreateSuccessResponseMessage(operationCount: 2));
+                });
+
+            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
+                CreateTestOperations(count: 2),
+                mockContext.Object,
+                OperationType.CommitDistributedTransaction,
+                TimeSpan.Zero);
+
+            using (DistributedTransactionResponse response = await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None))
+            {
+                Assert.IsTrue(response.IsSuccessStatusCode);
+            }
+
+            Assert.AreEqual(retriableAbortCount + 1, callCount, "Expected N retriable aborts followed by one success.");
+            Assert.AreEqual(retriableAbortCount + 1, capturedTokens.Count,
+                "Each wire attempt — including the first — must stamp an idempotency token.");
+            Assert.AreEqual(retriableAbortCount + 1, new HashSet<string>(capturedTokens).Count,
+                "N retriable aborts must produce N+1 distinct idempotency tokens (a fresh token per attempt, including the first).");
         }
 
         [DataTestMethod]

--- a/changelog.md
+++ b/changelog.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Other Changes
 
+- [Distributed Transactions (preview)] Retriable aborted distributed transactions are now resubmitted under a new idempotency token on each retry attempt (the prior token stays terminally aborted and is never replayed), preserving server-side duplicate protection while reusing the identical request payload.
 - [5991](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5991) TargetReplicaSetSize : Updated address cache logic to use partition-specific target replica set size when available, falling back to the user replication policy value.
 
 ### <a name="3.63.0-preview.0"/> [3.63.0-preview.0](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.63.0-preview.0) - 2026-7-15


### PR DESCRIPTION
## Summary

Implements PR 3 of the DTX FastResponse retry model: **new-token resubmission per retry** (spec `docs/design/DistributedTransactionFastResponseMode.md`, §4.2). Stacked on `meghana-palaparthi-dtx-abort-retry-gating` (PR #6038).

Per §4.2, each retriable-abort retry is a **new logical attempt** that MUST use a **fresh idempotency token**. The prior token remains terminally Aborted on the coordinator and must never be replayed. The same serialized operation bytes are reused for every attempt.

## Changes

- **`DistributedTransactionServerRequest.cs`** — Decouples the idempotency token from the immutable serialized body. The body bytes are still serialized exactly once and reused; `IdempotencyToken` now has a private setter and a new `RotateIdempotencyToken()` method assigns a fresh `Guid.NewGuid()` and returns it.
- **`DistributedTransactionCommitter.cs`** — Rotates the token at the start of every dispatch attempt (including the first) in `ExecuteCommitAsync`, so each wire attempt carries a fresh token while reusing the identical `CreateBodyStream()` bytes. `EnrichRequestMessage` stamps the current rotated token. Updated the retry log to note the aborted token is not replayed and the next attempt resubmits under a new token.
- **PR 2 gating preserved** — The Aborted + isRetriable gate and `transactionStatus` parsing are untouched; token rotation is orthogonal.

## Tests

- Rewrote `CommitTransaction_SameBodyAndTokenSentOnEveryRetryAttempt` → **`CommitTransaction_SendsNewIdempotencyTokenOnEachRetry`**: asserts captured tokens across attempts are ALL DISTINCT while request bodies remain byte-for-byte identical (body-equality assertions preserved).
- Added **`CommitTransaction_NRetriableAbortsProduceNPlusOneDistinctTokens`**: N retriable-abort responses produce N+1 distinct tokens, confirming the first attempt is also freshly rotated.
- Other DTX test files assert single-attempt/fallback token behavior (not stability across retries), so no changes were required.

## Validation

- Build: `dotnet build .../Microsoft.Azure.Cosmos.Tests.csproj -c Release` — succeeded, 0 warnings.
- Tests: `--filter FullyQualifiedName~DistributedTransaction` — **209 passed, 0 failed**.

## Changelog

Added an `Other Changes` bullet under `### Unreleased` in customer-facing language.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>