### PR TITLE
DistributedTransaction: Fixes aborted-transaction retry to require durable Aborted status

### DIFF
--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionCommitter.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionCommitter.cs
@@ -113,7 +113,18 @@ namespace Microsoft.Azure.Cosmos
 
                 DistributedTransactionResponse response = await this.ExecuteCommitAsync(serverRequest, parentTrace, cancellationToken);
 
-                if (response.IsSuccessStatusCode || !response.IsRetriable)
+                if (response.IsSuccessStatusCode)
+                {
+                    response.Diagnostics = diagnostics;
+                    return response;
+                }
+
+                // FastResponse retry model (spec PR #6021, Section 4.1): isRetriable MUST be interpreted
+                // together with transactionStatus: Aborted; it is never acted on alone. Only retry when the
+                // coordinator reports the transaction terminated in a durable Aborted state AND marks it
+                // retriable. If transactionStatus is missing (older/omitting servers), fail closed and return
+                // the response rather than retry — honoring "never act on isRetriable alone".
+                if (!response.IsRetriable || !response.IsTransactionAborted)
                 {
                     response.Diagnostics = diagnostics;
                     return response;

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionCommitter.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionCommitter.cs
@@ -119,11 +119,12 @@ namespace Microsoft.Azure.Cosmos
                     return response;
                 }
 
-                // FastResponse retry model (spec PR #6021, Section 4.1): isRetriable MUST be interpreted
-                // together with transactionStatus: Aborted; it is never acted on alone. Only retry when the
-                // coordinator reports the transaction terminated in a durable Aborted state AND marks it
-                // retriable. If transactionStatus is missing (older/omitting servers), fail closed and return
-                // the response rather than retry — honoring "never act on isRetriable alone".
+                // FastResponse retry model: isRetriable MUST be interpreted together with the durable
+                // transaction outcome; it is never acted on alone. The coordinator signals a durable abort
+                // via HTTP status code 452 (TransactionAborted), so only retry when the response is a
+                // TransactionAborted AND is marked retriable. Any other status (including responses that
+                // omit a durable-abort signal) fails closed and returns rather than retrying — honoring
+                // "never act on isRetriable alone".
                 if (!response.IsRetriable || !response.IsTransactionAborted)
                 {
                     response.Diagnostics = diagnostics;

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionResponse.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionResponse.cs
@@ -37,7 +37,8 @@ namespace Microsoft.Azure.Cosmos
             IReadOnlyList<DistributedTransactionOperation> operations,
             CosmosSerializerCore serializer,
             Guid idempotencyToken,
-            bool isRetriable = false)
+            bool isRetriable = false,
+            string transactionStatus = null)
         {
             this.Headers = headers;
             this.StatusCode = statusCode;
@@ -47,6 +48,7 @@ namespace Microsoft.Azure.Cosmos
             this.SerializerCore = serializer;
             this.IdempotencyToken = idempotencyToken;
             this.IsRetriable = isRetriable;
+            this.TransactionStatus = transactionStatus;
         }
 
         /// <summary>
@@ -170,6 +172,21 @@ namespace Microsoft.Azure.Cosmos
         public virtual bool IsRetriable { get; }
 
         /// <summary>
+        /// Gets the coordinator-reported durable transaction status (e.g. "Aborted"), or <c>null</c>
+        /// when the server did not populate it. Internal only: consumed by the commit retry gate,
+        /// which requires a durable Aborted status before honoring <see cref="IsRetriable"/>.
+        /// </summary>
+        internal string TransactionStatus { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the coordinator reported the transaction as durably Aborted.
+        /// </summary>
+        internal bool IsTransactionAborted => string.Equals(
+            this.TransactionStatus,
+            DistributedTransactionSerializer.TransactionStatusAborted,
+            StringComparison.OrdinalIgnoreCase);
+
+        /// <summary>
         /// Gets the diagnostic string from the coordinator describing the transaction outcome
         /// </summary>
         public virtual string DiagnosticString { get; private set; }
@@ -285,6 +302,7 @@ namespace Microsoft.Azure.Cosmos
                             // result count is no more trustworthy than bad indices, and the retry signal is
                             // independent of the unusable payload. Matches the two unmappable fail-closed paths.
                             bool wireIsRetriable = response.IsRetriable;
+                            string wireTransactionStatus = response.TransactionStatus;
                             string wireDiagnosticString = response.DiagnosticString;
                             response.Dispose();
 
@@ -296,7 +314,8 @@ namespace Microsoft.Azure.Cosmos
                                 serverRequest.Operations,
                                 serializer,
                                 idempotencyToken,
-                                wireIsRetriable)
+                                wireIsRetriable,
+                                wireTransactionStatus)
                             {
                                 DiagnosticString = wireDiagnosticString,
                             };
@@ -377,6 +396,7 @@ namespace Microsoft.Azure.Cosmos
         {
             List<DistributedTransactionOperationResult> results = new List<DistributedTransactionOperationResult>();
             bool isRetriable = false;
+            string transactionStatus = null;
             string diagnosticString = null;
 
             JsonDocument responseJson;
@@ -406,6 +426,12 @@ namespace Microsoft.Azure.Cosmos
                     isRetriableElement.ValueKind == JsonValueKind.True)
                 {
                     isRetriable = true;
+                }
+
+                if (DistributedTransactionOperationResult.TryGetProperty(root, DistributedTransactionSerializer.TransactionStatus, out JsonElement transactionStatusElement) &&
+                    transactionStatusElement.ValueKind == JsonValueKind.String)
+                {
+                    transactionStatus = transactionStatusElement.GetString();
                 }
 
                 if (DistributedTransactionOperationResult.TryGetProperty(root, DistributedTransactionSerializer.DiagnosticString, out JsonElement diagnosticStringElement) &&
@@ -441,7 +467,7 @@ namespace Microsoft.Azure.Cosmos
                         // root before this loop and is independent of any single operationResponses element.
                         if (responseMessage.IsSuccessStatusCode)
                         {
-                            return CreateDeserializationFailureResponse(responseMessage, serverRequest, serializer, idempotencyToken, diagnosticString, isRetriable);
+                            return CreateDeserializationFailureResponse(responseMessage, serverRequest, serializer, idempotencyToken, diagnosticString, isRetriable, transactionStatus);
                         }
                     }
                 }
@@ -485,7 +511,7 @@ namespace Microsoft.Azure.Cosmos
                     // count-mismatch path pads with uniform error placeholders.
                     if (responseMessage.IsSuccessStatusCode)
                     {
-                        return CreateDeserializationFailureResponse(responseMessage, serverRequest, serializer, idempotencyToken, diagnosticString, isRetriable);
+                        return CreateDeserializationFailureResponse(responseMessage, serverRequest, serializer, idempotencyToken, diagnosticString, isRetriable, transactionStatus);
                     }
                 }
             }
@@ -528,7 +554,8 @@ namespace Microsoft.Azure.Cosmos
                 serverRequest.Operations,
                 serializer,
                 idempotencyToken,
-                isRetriable)
+                isRetriable,
+                transactionStatus)
             {
                 results = results,
                 DiagnosticString = diagnosticString
@@ -570,7 +597,8 @@ namespace Microsoft.Azure.Cosmos
             CosmosSerializerCore serializer,
             Guid idempotencyToken,
             string diagnosticString = null,
-            bool isRetriable = false)
+            bool isRetriable = false,
+            string transactionStatus = null)
         {
             DistributedTransactionResponse failedResponse = new DistributedTransactionResponse(
                 HttpStatusCode.InternalServerError,
@@ -580,7 +608,8 @@ namespace Microsoft.Azure.Cosmos
                 serverRequest.Operations,
                 serializer,
                 idempotencyToken,
-                isRetriable)
+                isRetriable,
+                transactionStatus)
             {
                 DiagnosticString = diagnosticString,
             };

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionResponse.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionResponse.cs
@@ -37,8 +37,7 @@ namespace Microsoft.Azure.Cosmos
             IReadOnlyList<DistributedTransactionOperation> operations,
             CosmosSerializerCore serializer,
             Guid idempotencyToken,
-            bool isRetriable = false,
-            string transactionStatus = null)
+            bool isRetriable = false)
         {
             this.Headers = headers;
             this.StatusCode = statusCode;
@@ -48,7 +47,6 @@ namespace Microsoft.Azure.Cosmos
             this.SerializerCore = serializer;
             this.IdempotencyToken = idempotencyToken;
             this.IsRetriable = isRetriable;
-            this.TransactionStatus = transactionStatus;
         }
 
         /// <summary>
@@ -172,19 +170,12 @@ namespace Microsoft.Azure.Cosmos
         public virtual bool IsRetriable { get; }
 
         /// <summary>
-        /// Gets the coordinator-reported durable transaction status (e.g. "Aborted"), or <c>null</c>
-        /// when the server did not populate it. Internal only: consumed by the commit retry gate,
-        /// which requires a durable Aborted status before honoring <see cref="IsRetriable"/>.
-        /// </summary>
-        internal string TransactionStatus { get; }
-
-        /// <summary>
         /// Gets a value indicating whether the coordinator reported the transaction as durably Aborted.
+        /// The coordinator signals a durable abort via HTTP status code 452 (TransactionAborted) rather
+        /// than a separate body field, so this is derived from <see cref="StatusCode"/>.
         /// </summary>
-        internal bool IsTransactionAborted => string.Equals(
-            this.TransactionStatus,
-            DistributedTransactionSerializer.TransactionStatusAborted,
-            StringComparison.OrdinalIgnoreCase);
+        internal bool IsTransactionAborted =>
+            (int)this.StatusCode == (int)StatusCodes.TransactionAborted;
 
         /// <summary>
         /// Gets the diagnostic string from the coordinator describing the transaction outcome
@@ -302,7 +293,6 @@ namespace Microsoft.Azure.Cosmos
                             // result count is no more trustworthy than bad indices, and the retry signal is
                             // independent of the unusable payload. Matches the two unmappable fail-closed paths.
                             bool wireIsRetriable = response.IsRetriable;
-                            string wireTransactionStatus = response.TransactionStatus;
                             string wireDiagnosticString = response.DiagnosticString;
                             response.Dispose();
 
@@ -314,8 +304,7 @@ namespace Microsoft.Azure.Cosmos
                                 serverRequest.Operations,
                                 serializer,
                                 idempotencyToken,
-                                wireIsRetriable,
-                                wireTransactionStatus)
+                                wireIsRetriable)
                             {
                                 DiagnosticString = wireDiagnosticString,
                             };
@@ -396,7 +385,6 @@ namespace Microsoft.Azure.Cosmos
         {
             List<DistributedTransactionOperationResult> results = new List<DistributedTransactionOperationResult>();
             bool isRetriable = false;
-            string transactionStatus = null;
             string diagnosticString = null;
 
             JsonDocument responseJson;
@@ -426,12 +414,6 @@ namespace Microsoft.Azure.Cosmos
                     isRetriableElement.ValueKind == JsonValueKind.True)
                 {
                     isRetriable = true;
-                }
-
-                if (DistributedTransactionOperationResult.TryGetProperty(root, DistributedTransactionSerializer.TransactionStatus, out JsonElement transactionStatusElement) &&
-                    transactionStatusElement.ValueKind == JsonValueKind.String)
-                {
-                    transactionStatus = transactionStatusElement.GetString();
                 }
 
                 if (DistributedTransactionOperationResult.TryGetProperty(root, DistributedTransactionSerializer.DiagnosticString, out JsonElement diagnosticStringElement) &&
@@ -467,7 +449,7 @@ namespace Microsoft.Azure.Cosmos
                         // root before this loop and is independent of any single operationResponses element.
                         if (responseMessage.IsSuccessStatusCode)
                         {
-                            return CreateDeserializationFailureResponse(responseMessage, serverRequest, serializer, idempotencyToken, diagnosticString, isRetriable, transactionStatus);
+                            return CreateDeserializationFailureResponse(responseMessage, serverRequest, serializer, idempotencyToken, diagnosticString, isRetriable);
                         }
                     }
                 }
@@ -511,7 +493,7 @@ namespace Microsoft.Azure.Cosmos
                     // count-mismatch path pads with uniform error placeholders.
                     if (responseMessage.IsSuccessStatusCode)
                     {
-                        return CreateDeserializationFailureResponse(responseMessage, serverRequest, serializer, idempotencyToken, diagnosticString, isRetriable, transactionStatus);
+                        return CreateDeserializationFailureResponse(responseMessage, serverRequest, serializer, idempotencyToken, diagnosticString, isRetriable);
                     }
                 }
             }
@@ -554,8 +536,7 @@ namespace Microsoft.Azure.Cosmos
                 serverRequest.Operations,
                 serializer,
                 idempotencyToken,
-                isRetriable,
-                transactionStatus)
+                isRetriable)
             {
                 results = results,
                 DiagnosticString = diagnosticString
@@ -597,8 +578,7 @@ namespace Microsoft.Azure.Cosmos
             CosmosSerializerCore serializer,
             Guid idempotencyToken,
             string diagnosticString = null,
-            bool isRetriable = false,
-            string transactionStatus = null)
+            bool isRetriable = false)
         {
             DistributedTransactionResponse failedResponse = new DistributedTransactionResponse(
                 HttpStatusCode.InternalServerError,
@@ -608,8 +588,7 @@ namespace Microsoft.Azure.Cosmos
                 serverRequest.Operations,
                 serializer,
                 idempotencyToken,
-                isRetriable,
-                transactionStatus)
+                isRetriable)
             {
                 DiagnosticString = diagnosticString,
             };

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionSerializer.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionSerializer.cs
@@ -29,6 +29,13 @@ namespace Microsoft.Azure.Cosmos
         internal const string ResourceBody = "resourceBody";
         internal const string RequestCharge = "requestCharge";
         internal const string IsRetriable = "isRetriable";
+
+        // Top-level JSON field carrying the coordinator's durable transaction outcome. Per the DTX
+        // FastResponse mode spec (PR #6021, Section 4.1) isRetriable MUST be interpreted together with
+        // transactionStatus: Aborted; it is never acted on alone. The exact field name and the "Aborted"
+        // value string are not otherwise documented in-repo, so these are assumed per that spec.
+        internal const string TransactionStatus = "transactionStatus";
+        internal const string TransactionStatusAborted = "Aborted";
         internal const string OperationResponses = "operationResponses";
         internal const string SessionToken = "sessionToken";
         internal const string PartitionKeyRangeId = "partitionKeyRangeId";

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionSerializer.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionSerializer.cs
@@ -29,13 +29,6 @@ namespace Microsoft.Azure.Cosmos
         internal const string ResourceBody = "resourceBody";
         internal const string RequestCharge = "requestCharge";
         internal const string IsRetriable = "isRetriable";
-
-        // Top-level JSON field carrying the coordinator's durable transaction outcome. Per the DTX
-        // FastResponse mode spec (PR #6021, Section 4.1) isRetriable MUST be interpreted together with
-        // transactionStatus: Aborted; it is never acted on alone. The exact field name and the "Aborted"
-        // value string are not otherwise documented in-repo, so these are assumed per that spec.
-        internal const string TransactionStatus = "transactionStatus";
-        internal const string TransactionStatusAborted = "Aborted";
         internal const string OperationResponses = "operationResponses";
         internal const string SessionToken = "sessionToken";
         internal const string PartitionKeyRangeId = "partitionKeyRangeId";

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionCommitterTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionCommitterTests.cs
@@ -936,8 +936,69 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             }
         }
 
+        [DataTestMethod]
+        [Description("FastResponse retry model: isRetriable is never acted on alone. A body with isRetriable:true but a transactionStatus that is not durably Aborted (or omitted entirely) must NOT be retried — the response is returned after a single call.")]
+        [DataRow("{\"isRetriable\":true,\"transactionStatus\":\"InProgress\"}", DisplayName = "isRetriable:true + InProgress — no retry")]
+        [DataRow("{\"isRetriable\":true,\"transactionStatus\":\"Committed\"}", DisplayName = "isRetriable:true + Committed — no retry")]
+        [DataRow("{\"isRetriable\":true}", DisplayName = "isRetriable:true + missing transactionStatus — no retry (fail closed)")]
+        public async Task CommitTransaction_DoesNotRetryWhenRetriableButNotAborted(string json)
+        {
+            int callCount = 0;
+            Mock<CosmosClientContext> mockContext = this.CreateMockClientContext();
+            this.SetupProcessResourceOperation(
+                mockContext,
+                () =>
+                {
+                    callCount++;
+                    return Task.FromResult(
+                        new ResponseMessage(HttpStatusCode.ServiceUnavailable)
+                        {
+                            Content = new MemoryStream(Encoding.UTF8.GetBytes(json))
+                        });
+                });
+
+            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(CreateTestOperations(), mockContext.Object, OperationType.CommitDistributedTransaction, TimeSpan.Zero);
+
+            using (DistributedTransactionResponse response = await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None))
+            {
+                Assert.AreEqual(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+                Assert.IsTrue(response.IsRetriable, "isRetriable must still be surfaced from the body.");
+                Assert.AreEqual(1, callCount, "The committer must not retry unless the transaction is durably Aborted.");
+            }
+        }
+
         [TestMethod]
-        [Description("Verifies that a pre-cancelled CancellationToken causes CommitTransactionAsync to throw immediately without issuing any network request.")]
+        [Description("FastResponse retry model: a body with isRetriable:true AND transactionStatus:Aborted is retried until success.")]
+        public async Task CommitTransaction_RetriesWhenRetriableAndAborted_ThenSucceeds()
+        {
+            int callCount = 0;
+            Mock<CosmosClientContext> mockContext = this.CreateMockClientContext();
+            this.SetupProcessResourceOperation(
+                mockContext,
+                () =>
+                {
+                    callCount++;
+                    if (callCount == 1)
+                    {
+                        return Task.FromResult(
+                            new ResponseMessage(HttpStatusCode.ServiceUnavailable)
+                            {
+                                Content = new MemoryStream(Encoding.UTF8.GetBytes("{\"isRetriable\":true,\"transactionStatus\":\"Aborted\"}"))
+                            });
+                    }
+
+                    return Task.FromResult(CreateSuccessResponseMessage(operationCount: 1));
+                });
+
+            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(CreateTestOperations(), mockContext.Object, OperationType.CommitDistributedTransaction, TimeSpan.Zero);
+
+            using (DistributedTransactionResponse response = await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None))
+            {
+                Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+                Assert.IsTrue(response.IsSuccessStatusCode);
+                Assert.AreEqual(2, callCount);
+            }
+        }
         public async Task CommitTransaction_RespectsCancellationToken_PreCancelled()
         {
             using (CancellationTokenSource cts = new CancellationTokenSource())
@@ -1755,7 +1816,9 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
 
         private static ResponseMessage CreateRetriableErrorResponseMessage()
         {
-            string json = "{\"isRetriable\":true}";
+            // FastResponse retry model: the outer loop only retries when the coordinator reports the
+            // transaction as durably Aborted AND retriable, so the fixture must set both.
+            string json = "{\"isRetriable\":true,\"transactionStatus\":\"Aborted\"}";
             return new ResponseMessage(HttpStatusCode.ServiceUnavailable)
             {
                 Content = new MemoryStream(Encoding.UTF8.GetBytes(json))

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionCommitterTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionCommitterTests.cs
@@ -937,11 +937,11 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
         }
 
         [DataTestMethod]
-        [Description("FastResponse retry model: isRetriable is never acted on alone. A body with isRetriable:true but a transactionStatus that is not durably Aborted (or omitted entirely) must NOT be retried — the response is returned after a single call.")]
-        [DataRow("{\"isRetriable\":true,\"transactionStatus\":\"InProgress\"}", DisplayName = "isRetriable:true + InProgress — no retry")]
-        [DataRow("{\"isRetriable\":true,\"transactionStatus\":\"Committed\"}", DisplayName = "isRetriable:true + Committed — no retry")]
-        [DataRow("{\"isRetriable\":true}", DisplayName = "isRetriable:true + missing transactionStatus — no retry (fail closed)")]
-        public async Task CommitTransaction_DoesNotRetryWhenRetriableButNotAborted(string json)
+        [Description("FastResponse retry model: isRetriable is never acted on alone. A body with isRetriable:true whose HTTP status is not 452 TransactionAborted must NOT be retried — the response is returned after a single call.")]
+        [DataRow((int)HttpStatusCode.ServiceUnavailable, DisplayName = "isRetriable:true + 503 (not TransactionAborted) — no retry")]
+        [DataRow((int)HttpStatusCode.Conflict, DisplayName = "isRetriable:true + 409 Conflict (not TransactionAborted) — no retry")]
+        [DataRow((int)HttpStatusCode.InternalServerError, DisplayName = "isRetriable:true + 500 (not TransactionAborted) — no retry")]
+        public async Task CommitTransaction_DoesNotRetryWhenRetriableButNotAborted(int statusCode)
         {
             int callCount = 0;
             Mock<CosmosClientContext> mockContext = this.CreateMockClientContext();
@@ -951,9 +951,9 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                 {
                     callCount++;
                     return Task.FromResult(
-                        new ResponseMessage(HttpStatusCode.ServiceUnavailable)
+                        new ResponseMessage((HttpStatusCode)statusCode)
                         {
-                            Content = new MemoryStream(Encoding.UTF8.GetBytes(json))
+                            Content = new MemoryStream(Encoding.UTF8.GetBytes("{\"isRetriable\":true}"))
                         });
                 });
 
@@ -961,14 +961,42 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
 
             using (DistributedTransactionResponse response = await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None))
             {
-                Assert.AreEqual(HttpStatusCode.ServiceUnavailable, response.StatusCode);
+                Assert.AreEqual((HttpStatusCode)statusCode, response.StatusCode);
                 Assert.IsTrue(response.IsRetriable, "isRetriable must still be surfaced from the body.");
-                Assert.AreEqual(1, callCount, "The committer must not retry unless the transaction is durably Aborted.");
+                Assert.AreEqual(1, callCount, "The committer must not retry unless the transaction is durably Aborted (HTTP 452).");
             }
         }
 
         [TestMethod]
-        [Description("FastResponse retry model: a body with isRetriable:true AND transactionStatus:Aborted is retried until success.")]
+        [Description("FastResponse retry model: isRetriable is never acted on alone. A durable abort (HTTP 452 TransactionAborted) whose body does NOT mark the transaction retriable must NOT be retried.")]
+        public async Task CommitTransaction_DoesNotRetryWhenAbortedButNotRetriable()
+        {
+            int callCount = 0;
+            Mock<CosmosClientContext> mockContext = this.CreateMockClientContext();
+            this.SetupProcessResourceOperation(
+                mockContext,
+                () =>
+                {
+                    callCount++;
+                    return Task.FromResult(
+                        new ResponseMessage((HttpStatusCode)StatusCodes.TransactionAborted)
+                        {
+                            Content = new MemoryStream(Encoding.UTF8.GetBytes("{\"isRetriable\":false}"))
+                        });
+                });
+
+            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(CreateTestOperations(), mockContext.Object, OperationType.CommitDistributedTransaction, TimeSpan.Zero);
+
+            using (DistributedTransactionResponse response = await committer.CommitTransactionAsync(NoOpTrace.Singleton, CancellationToken.None))
+            {
+                Assert.AreEqual((HttpStatusCode)StatusCodes.TransactionAborted, response.StatusCode);
+                Assert.IsFalse(response.IsRetriable);
+                Assert.AreEqual(1, callCount, "The committer must not retry a TransactionAborted response that is not marked retriable.");
+            }
+        }
+
+        [TestMethod]
+        [Description("FastResponse retry model: a durable abort (HTTP 452 TransactionAborted) whose body marks the transaction retriable is retried until success.")]
         public async Task CommitTransaction_RetriesWhenRetriableAndAborted_ThenSucceeds()
         {
             int callCount = 0;
@@ -981,9 +1009,9 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                     if (callCount == 1)
                     {
                         return Task.FromResult(
-                            new ResponseMessage(HttpStatusCode.ServiceUnavailable)
+                            new ResponseMessage((HttpStatusCode)StatusCodes.TransactionAborted)
                             {
-                                Content = new MemoryStream(Encoding.UTF8.GetBytes("{\"isRetriable\":true,\"transactionStatus\":\"Aborted\"}"))
+                                Content = new MemoryStream(Encoding.UTF8.GetBytes("{\"isRetriable\":true}"))
                             });
                     }
 
@@ -1816,10 +1844,11 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
 
         private static ResponseMessage CreateRetriableErrorResponseMessage()
         {
-            // FastResponse retry model: the outer loop only retries when the coordinator reports the
-            // transaction as durably Aborted AND retriable, so the fixture must set both.
-            string json = "{\"isRetriable\":true,\"transactionStatus\":\"Aborted\"}";
-            return new ResponseMessage(HttpStatusCode.ServiceUnavailable)
+            // FastResponse retry model: the outer loop only retries when the coordinator reports a durable
+            // abort (HTTP 452 TransactionAborted) AND the body marks the transaction retriable, so the
+            // fixture must return both.
+            string json = "{\"isRetriable\":true}";
+            return new ResponseMessage((HttpStatusCode)StatusCodes.TransactionAborted)
             {
                 Content = new MemoryStream(Encoding.UTF8.GetBytes(json))
             };

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionResponseTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionResponseTests.cs
@@ -1519,7 +1519,31 @@ namespace Microsoft.Azure.Cosmos.Tests
             Assert.AreEqual(expected, response.IsRetriable);
         }
 
-        // DiagnosticString parsing
+        // TransactionStatus parsing
+
+        [DataTestMethod]
+        [Description("TransactionStatus deserializes from the top-level JSON string property (case-insensitive key); it is null when absent or not a JSON string. IsTransactionAborted is true only when the value equals 'Aborted' (case-insensitive).")]
+        [DataRow(@"{""transactionStatus"":""Aborted"",""operationResponses"":[{""index"":0,""statusCode"":503}]}", "Aborted", true, DisplayName = "Aborted → IsTransactionAborted=true")]
+        [DataRow(@"{""transactionStatus"":""aborted"",""operationResponses"":[{""index"":0,""statusCode"":503}]}", "aborted", true, DisplayName = "lowercase 'aborted' → IsTransactionAborted=true")]
+        [DataRow(@"{""TransactionStatus"":""Aborted"",""operationResponses"":[{""index"":0,""statusCode"":503}]}", "Aborted", true, DisplayName = "PascalCase key is accepted")]
+        [DataRow(@"{""transactionStatus"":""InProgress"",""operationResponses"":[{""index"":0,""statusCode"":503}]}", "InProgress", false, DisplayName = "InProgress → IsTransactionAborted=false")]
+        [DataRow(@"{""operationResponses"":[{""index"":0,""statusCode"":503}]}", null, false, DisplayName = "absent → TransactionStatus=null, IsTransactionAborted=false")]
+        [DataRow(@"{""transactionStatus"":true,""operationResponses"":[{""index"":0,""statusCode"":503}]}", null, false, DisplayName = "non-string value → TransactionStatus=null")]
+        public async Task FromResponseMessage_TransactionStatus_Parsing(string json, string expectedStatus, bool expectedAborted)
+        {
+            DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
+            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.ServiceUnavailable, json);
+
+            DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
+                responseMessage,
+                serverRequest,
+                MockCosmosUtil.Serializer,
+                NoOpTrace.Singleton,
+                CancellationToken.None);
+
+            Assert.AreEqual(expectedStatus, response.TransactionStatus);
+            Assert.AreEqual(expectedAborted, response.IsTransactionAborted);
+        }
 
         [DataTestMethod]
         [Description("DiagnosticString deserializes from the top-level JSON property case-insensitively.")]

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionResponseTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionResponseTests.cs
@@ -1519,20 +1519,19 @@ namespace Microsoft.Azure.Cosmos.Tests
             Assert.AreEqual(expected, response.IsRetriable);
         }
 
-        // TransactionStatus parsing
+        // IsTransactionAborted derivation (from HTTP status code)
 
         [DataTestMethod]
-        [Description("TransactionStatus deserializes from the top-level JSON string property (case-insensitive key); it is null when absent or not a JSON string. IsTransactionAborted is true only when the value equals 'Aborted' (case-insensitive).")]
-        [DataRow(@"{""transactionStatus"":""Aborted"",""operationResponses"":[{""index"":0,""statusCode"":503}]}", "Aborted", true, DisplayName = "Aborted → IsTransactionAborted=true")]
-        [DataRow(@"{""transactionStatus"":""aborted"",""operationResponses"":[{""index"":0,""statusCode"":503}]}", "aborted", true, DisplayName = "lowercase 'aborted' → IsTransactionAborted=true")]
-        [DataRow(@"{""TransactionStatus"":""Aborted"",""operationResponses"":[{""index"":0,""statusCode"":503}]}", "Aborted", true, DisplayName = "PascalCase key is accepted")]
-        [DataRow(@"{""transactionStatus"":""InProgress"",""operationResponses"":[{""index"":0,""statusCode"":503}]}", "InProgress", false, DisplayName = "InProgress → IsTransactionAborted=false")]
-        [DataRow(@"{""operationResponses"":[{""index"":0,""statusCode"":503}]}", null, false, DisplayName = "absent → TransactionStatus=null, IsTransactionAborted=false")]
-        [DataRow(@"{""transactionStatus"":true,""operationResponses"":[{""index"":0,""statusCode"":503}]}", null, false, DisplayName = "non-string value → TransactionStatus=null")]
-        public async Task FromResponseMessage_TransactionStatus_Parsing(string json, string expectedStatus, bool expectedAborted)
+        [Description("IsTransactionAborted is derived from the HTTP status code: true only when the response is 452 (TransactionAborted). No separate body field is used.")]
+        [DataRow((int)StatusCodes.TransactionAborted, true, DisplayName = "452 TransactionAborted → IsTransactionAborted=true")]
+        [DataRow((int)HttpStatusCode.Conflict, false, DisplayName = "409 Conflict → IsTransactionAborted=false")]
+        [DataRow((int)HttpStatusCode.ServiceUnavailable, false, DisplayName = "503 ServiceUnavailable → IsTransactionAborted=false")]
+        [DataRow((int)HttpStatusCode.InternalServerError, false, DisplayName = "500 InternalServerError → IsTransactionAborted=false")]
+        public async Task FromResponseMessage_IsTransactionAborted_DerivedFromStatusCode(int statusCode, bool expectedAborted)
         {
             DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
-            ResponseMessage responseMessage = BuildResponseMessage(HttpStatusCode.ServiceUnavailable, json);
+            string json = @"{""operationResponses"":[{""index"":0,""statusCode"":" + statusCode + "}]}";
+            ResponseMessage responseMessage = BuildResponseMessage((HttpStatusCode)statusCode, json);
 
             DistributedTransactionResponse response = await DistributedTransactionResponse.FromResponseMessageAsync(
                 responseMessage,
@@ -1541,7 +1540,7 @@ namespace Microsoft.Azure.Cosmos.Tests
                 NoOpTrace.Singleton,
                 CancellationToken.None);
 
-            Assert.AreEqual(expectedStatus, response.TransactionStatus);
+            Assert.AreEqual((HttpStatusCode)statusCode, response.StatusCode);
             Assert.AreEqual(expectedAborted, response.IsTransactionAborted);
         }
 

--- a/changelog.md
+++ b/changelog.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Bugs Fixed
 
+- [Distributed Transactions (preview)] Aborted distributed transactions are now retried only when the coordinator reports the transaction as durably Aborted and retriable; a retriable signal alone (without a durable Aborted status) no longer triggers a retry.
+
 #### Other Changes
 
 - [5991](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5991) TargetReplicaSetSize : Updated address cache logic to use partition-specific target replica set size when available, falling back to the user replication policy value.

--- a/changelog.md
+++ b/changelog.md
@@ -23,7 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Bugs Fixed
 
-- [Distributed Transactions (preview)] Aborted distributed transactions are now retried only when the coordinator reports the transaction as durably Aborted and retriable; a retriable signal alone (without a durable Aborted status) no longer triggers a retry.
+- [Distributed Transactions (preview)] Aborted distributed transactions are now retried only when the coordinator reports the transaction as durably aborted (HTTP 452 TransactionAborted) and the response is marked retriable; a retriable signal alone no longer triggers a retry.
 
 #### Other Changes
 


### PR DESCRIPTION
## Summary

Implements PR 2 of the DTX FastResponse retry model: the distributed-transaction commit outer-loop retry is now gated on whether the transaction is durably aborted, not on `isRetriable` alone. `isRetriable` is never acted on by itself.

## Changes

- **`DistributedTransactionResponse.cs`** — Added an internal `IsTransactionAborted` helper that derives the durable-abort determination from the HTTP status code: `true` only when the response is `452 TransactionAborted` (`StatusCodes.TransactionAborted`). The coordinator signals a durable abort via this status code rather than a separate body field, so no new wire parsing or public API surface is added.
- **`DistributedTransactionCommitter.cs`** — The retry gate now returns the response unless `IsRetriable && IsTransactionAborted`. Any other status (including retriable responses that are not `452`) fails closed and returns rather than retrying. The success-status early return is preserved.

## Tests

- Updated the shared `CreateRetriableErrorResponseMessage` committer fixture to return `452 TransactionAborted` with `{"isRetriable":true}` so existing retry tests continue to exercise the retry path.
- Added committer tests: retries when `452 + isRetriable`; does **not** retry when `isRetriable:true` but the status is not `452` (503/409/500); does **not** retry when `452` but `isRetriable:false`.
- Added a `DistributedTransactionResponse` test that `IsTransactionAborted` is derived from the status code (452 → true; 409/503/500 → false).

## Changelog

Added a `Bugs Fixed` entry under `### Unreleased` — this changes retry behavior for aborted distributed transactions, customer-observable on upgrade for preview DTX users.