### PR TITLE
Distributed Transactions: Adds public SessionToken getter on DistributedTransactionOperationResult

### DIFF
--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperationResult.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperationResult.cs
@@ -96,7 +96,18 @@ namespace Microsoft.Azure.Cosmos
         /// </summary>
         internal bool HasIndex { get; set; }
 
-        internal virtual string SessionToken { get; set; }
+        /// <summary>
+        /// Gets the session token returned by the distributed transaction coordinator for
+        /// this operation. Callers can pass this value back through
+        /// <c>DistributedTransactionRequestOptions.SessionToken</c> on a subsequent DTx
+        /// operation to enforce read-your-writes session consistency for that op.
+        /// </summary>
+        /// <remarks>
+        /// Treat the value as opaque: pass it back unchanged via
+        /// <c>DistributedTransactionRequestOptions.SessionToken</c>. It may be <c>null</c> or
+        /// non-canonical if the coordinator omits or misformats the token.
+        /// </remarks>
+        public virtual string SessionToken { get; internal set; }
 
         internal virtual string PartitionKeyRangeId { get; set; }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetPreviewSDKAPI.net6.json
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/Contracts/DotNetPreviewSDKAPI.net6.json
@@ -1185,6 +1185,18 @@
             "CompilerGeneratedAttribute"
           ],
           "MethodInfo": "System.String get_ETag();IsAbstract:False;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "System.String get_SessionToken()[System.Runtime.CompilerServices.CompilerGeneratedAttribute()]": {
+          "Type": "Method",
+          "Attributes": [
+            "CompilerGeneratedAttribute"
+          ],
+          "MethodInfo": "System.String get_SessionToken();IsAbstract:False;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
+        },
+        "System.String SessionToken": {
+          "Type": "Property",
+          "Attributes": [],
+          "MethodInfo": "System.String SessionToken;CanRead:True;CanWrite:True;System.String get_SessionToken();IsAbstract:False;IsStatic:False;IsVirtual:True;IsGenericMethod:False;IsConstructor:False;IsFinal:False;"
         }
       },
       "NestedTypes": {}

--- a/changelog.md
+++ b/changelog.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Features Added
 
-- [PRNUMBER](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/PRNUMBER) Distributed Transactions: Adds a public `SessionToken` getter on `DistributedTransactionOperationResult`, letting callers read the per-operation session token returned by the coordinator and pass it back via `DistributedTransactionRequestOptions.SessionToken` to enforce read-your-writes session consistency.
+- [6049](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/6049) Distributed Transactions: Adds a public `SessionToken` getter on `DistributedTransactionOperationResult`, letting callers read the per-operation session token returned by the coordinator and pass it back via `DistributedTransactionRequestOptions.SessionToken` to enforce read-your-writes session consistency.
 
 #### Breaking Changes
 

--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Features Added
 
+- [PRNUMBER](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/PRNUMBER) Distributed Transactions: Adds a public `SessionToken` getter on `DistributedTransactionOperationResult`, letting callers read the per-operation session token returned by the coordinator and pass it back via `DistributedTransactionRequestOptions.SessionToken` to enforce read-your-writes session consistency.
+
 #### Breaking Changes
 
 #### Bugs Fixed


### PR DESCRIPTION
## Description

Extracts a single, self-contained change from the larger distributed-transaction session-token work (`users/Meghana-Palaparthi/dtx_session_tokens`) so it can be reviewed and merged independently.

This makes the per-operation session token readable by callers:

- `DistributedTransactionOperationResult.SessionToken` changes from `internal virtual string SessionToken { get; set; }` to `public virtual string SessionToken { get; internal set; }` (public getter, internal setter), with XML docs describing usage.
- Updates the preview API contract baseline (`DotNetPreviewSDKAPI.net6.json`) to reflect the new public surface.
- Adds a `Features Added` changelog entry.

Callers can read the coordinator-returned session token for an operation and pass it back via `DistributedTransactionRequestOptions.SessionToken` on a subsequent DTx operation to enforce read-your-writes session consistency. The value should be treated as opaque.

## Type of change

- [x] New feature (non-breaking change which adds functionality) — preview API surface

## Validation

- `dotnet build Microsoft.Azure.Cosmos/src/Microsoft.Azure.Cosmos.csproj -c Release` — succeeded, 0 warnings.
- `ContractEnforcementTests.PreviewContractChanges` (built with `/p:IsPreview=true`) — passed.

## Closing issues

N/A