### PR TITLE
[Internal] Pipelines: Fixes run-creation failure caused by duplicate timeline record insert

### DIFF
--- a/templates/build-test-msdata.yml
+++ b/templates/build-test-msdata.yml
@@ -9,10 +9,10 @@ parameters:
   EmulatorPipeline2Arguments: ' --filter "TestCategory!=Flaky & TestCategory!=Quarantine & TestCategory!=Functional & TestCategory!=ClientTelemetryRelease & TestCategory !=ThinClient & TestCategory!=ClientTelemetryEmulator & TestCategory!=Query & TestCategory!=ReadFeed & TestCategory!=Batch & TestCategory!=ChangeFeed & TestCategory!=LongRunning & TestCategory!=MultiRegion & TestCategory!=MultiMaster & TestCategory !=UpdateContract & TestCategory!=Ignore" --verbosity normal '
   EmulatorPipeline3Arguments: ' --filter "TestCategory=MultiRegion" --verbosity normal '
   EmulatorPipeline4Arguments: ' --filter "TestCategory=MultiMaster" --verbosity normal '
-  EmulatorPipeline1CategoryListName: ' Client Telemetry, Query, ChangeFeed, ReadFeed, Batch ' # Divided in 2 categories to run them in parallel and reduce the PR feedback time
-  EmulatorPipeline2CategoryListName: ' Others '
-  EmulatorPipeline3CategoryListName: ' MultiRegion '
-  EmulatorPipeline4CategoryListName: ' MultiMaster '
+  EmulatorPipeline1CategoryListName: 'Client Telemetry, Query, ChangeFeed, ReadFeed, Batch' # Divided in 2 categories to run them in parallel and reduce the PR feedback time
+  EmulatorPipeline2CategoryListName: 'Others'
+  EmulatorPipeline3CategoryListName: 'MultiRegion'
+  EmulatorPipeline4CategoryListName: 'MultiMaster'
   MultiRegionConnectionString : ''
   MultiRegionMultiMasterConnectionString : ''
   IncludeEncryption: true

--- a/templates/build-test.yml
+++ b/templates/build-test.yml
@@ -9,10 +9,10 @@ parameters:
   EmulatorPipeline2Arguments: ' --filter "TestCategory!=Flaky & TestCategory!=Quarantine & TestCategory!=Functional & TestCategory!=ClientTelemetryRelease & TestCategory !=ThinClient & TestCategory!=ClientTelemetryEmulator & TestCategory!=Query & TestCategory!=ReadFeed & TestCategory!=Batch & TestCategory!=ChangeFeed & TestCategory!=LongRunning & TestCategory!=MultiRegion & TestCategory!=MultiMaster & TestCategory!=Ignore" --verbosity normal '
   EmulatorPipeline3Arguments: ' --filter "TestCategory=MultiRegion" --verbosity normal '
   EmulatorPipeline4Arguments: ' --filter "TestCategory=MultiMaster" --verbosity normal '
-  EmulatorPipeline1CategoryListName: ' Client Telemetry, Query, ChangeFeed, ReadFeed, Batch ' # Divided in 2 categories to run them in parallel and reduce the PR feedback time
-  EmulatorPipeline2CategoryListName: ' Others '
-  EmulatorPipeline3CategoryListName: ' MultiRegion '
-  EmulatorPipeline4CategoryListName: ' MultiMaster '
+  EmulatorPipeline1CategoryListName: 'Client Telemetry, Query, ChangeFeed, ReadFeed, Batch' # Divided in 2 categories to run them in parallel and reduce the PR feedback time
+  EmulatorPipeline2CategoryListName: 'Others'
+  EmulatorPipeline3CategoryListName: 'MultiRegion'
+  EmulatorPipeline4CategoryListName: 'MultiMaster'
   MultiRegionConnectionString : ''
   MultiRegionMultiMasterConnectionString : ''
   IncludeEncryption: true

--- a/templates/build-thinclient.yml
+++ b/templates/build-thinclient.yml
@@ -6,7 +6,7 @@ parameters:
   VmImage: '' # https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops
   OS: 'Windows'
   EmulatorPipeline5Arguments: ' --filter "TestCategory=ThinClient" --verbosity normal '
-  EmulatorPipeline5CategoryListName: ' ThinClient '
+  EmulatorPipeline5CategoryListName: 'ThinClient'
   ThinClientStrongConsistencyString: ''
   ThinClientConnectionString: ''
   MultiRegionConnectionString : ''


### PR DESCRIPTION
## Description

Since **2026-07-27 ~16:00 UTC**, Azure DevOps has rejected **every** run of `dotnet-v3-ci` (def 63) and `dotnet-v3-rolling` (def 78) — including `refs/heads/main` — at **plan-creation time**, before any agent is allocated. Runs appear as 0-second failures with a raw SQL error leaked into `validationResults`:

```
Cannot insert duplicate key row in object 'Task.tbl_TimelineRecord'
with unique index 'PK_Task_tbl_TimelineRecord'.
The duplicate key value is (6355, 640247, 58081, 1, 0d56ebbb-8b3a-5c8b-0908-293835fdde38).
```

No repo change caused it — definition 63 was last edited 2026-06-05 and no `azure-pipelines*.yml` / `templates/**` change landed in `main` since 2026-05-13.

## Root cause (empirically isolated)

The failure is triggered by **five specific job `displayName` literals**. A single anonymous job carrying one of them is enough to reproduce:

```yaml
trigger: none
pr: none
jobs:
- job:
  displayName: 'EmulatorTests Release -  Others '
  pool: { vmImage: windows-latest }
  steps:
  - script: echo hi
```

All five poisoned strings are the expansions of `EmulatorPipelineNCategoryListName`:

| displayName | Result |
|---|---|
| `EmulatorTests Release -  Client Telemetry, Query, ChangeFeed, ReadFeed, Batch ` | COLLIDE |
| `EmulatorTests Release -  Others ` | COLLIDE |
| `EmulatorTests Release -  MultiRegion ` | COLLIDE |
| `EmulatorTests Release -  MultiMaster ` | COLLIDE |
| `EmulatorTests Release -  ThinClient ` | COLLIDE |
| the other 19 displayNames in the pipeline | OK |

**Any** single-character perturbation clears it (case change, removing one space, changing the suffix, changing one letter). No structural property reproduces it — length, commas, hyphens, leading/trailing whitespace and shape-matched synthetic strings all pass. It is not per-definition either: the same string breaks `dotnet-v3-nightly` (def 75), which is otherwise healthy.

## The fix

Trim the redundant leading/trailing spaces from the five `EmulatorPipelineNCategoryListName` parameters. This rewrites all five poisoned strings and also removes a long-standing cosmetic double-space in the job titles.

These parameters are **display-only** — the actual test selection lives in the separate `EmulatorPipelineNArguments` parameters (`--filter "TestCategory=..."`), so test coverage and behaviour are unchanged.

## Verification

| Check | Result |
|---|---|
| `dotnet-v3-ci` (def 63) run creation | 3/3 created, all **25** phases materialised |
| `dotnet-v3-rolling` (def 78) run creation | created |
| Expanded `finalYaml` displayNames | all 5 rewritten as intended |

Probe runs were cancelled immediately after creation; no agent time consumed.

## Note

This is a workaround for what looks like an Azure DevOps service-side regression in plan creation — the offending job's *own* `Phase` timeline record is emitted twice, and the reported GUID is a deterministic hash of the job identifier (`Job1` → `d768f2aa-…`), unaffected by displayName. A support ticket should still be filed so ADO fixes the underlying defect; this PR unblocks the repo in the meantime.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changelog

**No changelog entry required.** Per the classifier in `CONTRIBUTING.md` / `.github/copilot-instructions.md`: the diff touches only `templates/**` (CI infrastructure), not `Microsoft.Azure.Cosmos/src/**` or any other shipped-package source tree. There is no customer-observable impact from upgrading the SDK.
