### PR TITLE
[Internal] FaultInjection: Adds Direct version bump verification to the PR pipeline and fixes standing test failures

### DIFF
--- a/Microsoft.Azure.Cosmos/FaultInjection/DEVELOPMENT.md
+++ b/Microsoft.Azure.Cosmos/FaultInjection/DEVELOPMENT.md
@@ -9,6 +9,7 @@ instead.
 - [How it plugs into the SDK](#how-it-plugs-into-the-sdk)
 - [Building](#building)
 - [Running the tests](#running-the-tests)
+- [Verifying a Direct version bump](#verifying-a-direct-version-bump)
 - [Working on / maintaining the project](#working-on--maintaining-the-project)
 - [Adding a new fault type](#adding-a-new-fault-type)
 - [Changelog rules](#changelog-rules)
@@ -145,8 +146,93 @@ If a required variable is missing, the affected tests fail fast with
 ### How CI runs them
 
 `azure-pipelines-faultinjection.yml` runs the integration tests on the internal
-`OneES` pool with the `COSMOSDB_MULTI_REGION` secret wired in, using
-`dotnet test` over `Microsoft.Azure.Cosmos/FaultInjection/tests/*.csproj`.
+`OneES` pool with the `COSMOSDB_MULTI_REGION` secret wired in, via
+`templates/build-fault-injection.yml` with `IncludeIntegration: true`.
+
+The **same template** runs on every PR from `azure-pipelines.yml` with
+`IncludeIntegration: false` — it builds `src` + `tests`, runs the account-free
+unit tests, and validates `dotnet pack`. That PR gate exists specifically so a
+`$(DirectVersion)` bump cannot break this package unnoticed (see below).
+
+## Verifying a Direct version bump
+
+`FaultInjection.csproj` and `FaultInjectionTests.csproj` both pin
+`Microsoft.Azure.Cosmos.Direct` to `[$(DirectVersion)]` and the implementation
+binds to `Microsoft.Azure.Documents` internals (`IChaosInterceptor`,
+`Rntbd.Channel`, `Rntbd.Dispatcher`, `StoreResponse`, `TransportException`, …).
+A PR that changes `DirectVersion` in the root `Directory.Build.props` can break
+this package while the main SDK still builds cleanly, so run the ladder below on
+the PR branch before signing off.
+
+| # | Gate | Command | Catches |
+| - | ---- | ------- | ------- |
+| 1 | src compiles | `dotnet build Microsoft.Azure.Cosmos/FaultInjection/src/FaultInjection.csproj -c Release` | removed/renamed Direct APIs (`TreatWarningsAsErrors`, so warnings fail too) |
+| 2 | tests compile | `dotnet build Microsoft.Azure.Cosmos/FaultInjection/tests/FaultInjectionTests.csproj -c Release` | test-only Direct API usage |
+| 3 | unit tests | `dotnet test ...FaultInjectionTests.csproj -c Release --no-build --filter "FullyQualifiedName~FaultInjectionUnitTests\|FullyQualifiedName~FaultInjectionBuilderValidationTests"` | builder/validation regressions, no account needed |
+| 4 | packaging | `dotnet pack ...FaultInjection.csproj -c Release --no-build -o <out>` | delay-signing / nuspec regressions |
+| 5 | binding | inspect `Microsoft.Azure.Cosmos.Direct.dll` in `tests/bin/Release/net6.0` | confirms the *new* Direct is what actually got bound |
+| 6 | integration **diffed against a baseline** | see below | behavior changes in retry/failover paths |
+| 7 | downlevel compat | see below | the shipped package meeting an *older* Direct at customer runtime |
+
+Gates 1–4 are what the PR pipeline automates. Gates 5–7 are manual and matter
+most when the Direct bump is the point of the PR.
+
+### Gate 6 — always diff, never read the raw number
+
+The integration suite has a standing set of failures (Gateway-mode `Gone` cases,
+metadata response-delay timing). A raw pass/fail count from the PR branch is
+meaningless on its own — you must compare it to the same run on `main`:
+
+```powershell
+$env:COSMOSDB_MULTI_REGION = "<multi-region account connection string>"
+$proj = "Microsoft.Azure.Cosmos/FaultInjection/tests/FaultInjectionTests.csproj"
+# proxy tests need COSMOSDB_THIN_CLIENT; skip them unless you have one
+$skipProxy = '--filter', 'FullyQualifiedName!~FaultInjectionProxyTests'
+
+# PR branch
+dotnet build $proj -c Release
+dotnet test $proj -c Release --no-build @skipProxy --logger "trx;LogFileName=fi-pr.trx"
+
+# Baseline: the merge-base with main
+git checkout --detach $(git merge-base HEAD origin/main)
+dotnet build $proj -c Release
+dotnet test $proj -c Release --no-build @skipProxy --logger "trx;LogFileName=fi-baseline.trx"
+git checkout -   # back to the PR branch
+
+# Diff the failing sets - only "fails on PR but not baseline" is a regression
+$dir = "Microsoft.Azure.Cosmos/FaultInjection/tests/TestResults"
+function Fails($p) { ([xml](Get-Content $p)).TestRun.Results.UnitTestResult |
+    Where-Object outcome -eq 'Failed' | ForEach-Object testName | Sort-Object }
+Compare-Object (Fails "$dir/fi-baseline.trx") (Fails "$dir/fi-pr.trx") |
+    Where-Object SideIndicator -eq '=>'
+```
+
+An empty result from the final `Compare-Object` means **no regressions**.
+
+### Gate 7 — downlevel compatibility with the released SDK
+
+This is the failure mode a plain build cannot catch. The shipped
+`Microsoft.Azure.Cosmos.FaultInjection` nupkg takes a dependency on
+`Microsoft.Azure.Cosmos` `$(ClientOfficialVersion)` but does **not** ship Direct
+itself (`PrivateAssets="All"`). At customer runtime it therefore binds to the
+`Microsoft.Azure.Cosmos.Direct.dll` embedded in that *already-released* SDK —
+which was built against the **previous** `DirectVersion`.
+
+So when a PR moves `DirectVersion` from `X` to `Y`, `FaultInjection.dll` is
+compiled against `Y` but will meet `X` at runtime until the SDK itself ships
+again. If the implementation picks up a type or member that only exists in `Y`,
+consumers get a `TypeLoadException` / `MissingMethodException` at runtime.
+
+To check, diff the `Microsoft.Azure.Documents` types and members that
+`Microsoft.Azure.Cosmos.FaultInjection.dll` references against the *old* Direct
+assembly in the NuGet cache
+(`<globalPackagesFolder>/microsoft.azure.cosmos.direct/<oldVersion>/lib/netstandard2.0/`).
+Every referenced type and member must still exist there. If one does not, either
+hold the FaultInjection release until the SDK ships with the new Direct, or avoid
+the new API.
+
+> `dotnet nuget locals global-packages --list` prints the cache location — this
+> repo redirects it away from the default `~/.nuget/packages`.
 
 ## Working on / maintaining the project
 

--- a/Microsoft.Azure.Cosmos/FaultInjection/tests/FaultInjectionDirectModeTests.cs
+++ b/Microsoft.Azure.Cosmos/FaultInjection/tests/FaultInjectionDirectModeTests.cs
@@ -354,7 +354,10 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
 
                 writeRegionServerGoneRule.Enable();
 
-                bool ruleApplied = operationType .IsWriteOperation();
+                //Gone rules cannot be limited to an operation type: FaultInjectionRuleProcessor.CanErrorLimitToOperation
+                //returns false for Gone, so the rule's operation type filter is dropped once the addresses are
+                //resolved and the rule applies to every operation, not just writes.
+                bool ruleApplied = true;
                 await this.PerformDocumentOperationAndCheckApplication(
                     this.fiContainer,
                     operationType,
@@ -436,7 +439,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
                 condition:
                     new FaultInjectionConditionBuilder()
                         .WithRegion(preferredRegions[1])
-                        .WithConnectionType(FaultInjectionConnectionType.Gateway)
+                        .WithConnectionType(FaultInjectionConnectionType.Direct)
                         .Build(),
                 result:
                     FaultInjectionResultBuilder.GetResultBuilder(FaultInjectionServerErrorType.Gone)
@@ -1129,7 +1132,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
                         >= interceptor.GetRequestTimeout().TotalSeconds);
                 }
 
-                this.ValidateHitCount(serverErrorResponseRule, 1);
+                this.ValidateRuleHit(serverErrorResponseRule, 1);
             }
             finally
             {
@@ -1290,7 +1293,8 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
                     410, 
                     21005);
 
-                this.ValidateHitCount(includePrimaryServerGoneRule, 1);
+                this.ValidateRuleHit(includePrimaryServerGoneRule, 1);
+                long hitCountAfterCreate = includePrimaryServerGoneRule.GetHitCount();
 
                 await this.PerformDocumentOperationAndCheckApplication(
                     this.fiContainer,
@@ -1300,7 +1304,9 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
                     410,
                     21005);
 
-                this.ValidateHitCount(includePrimaryServerGoneRule, 2);
+                Assert.IsTrue(
+                    includePrimaryServerGoneRule.GetHitCount() > hitCountAfterCreate,
+                    $"Expected the rule to also be applied to the upsert. {Describe(includePrimaryServerGoneRule)}");
             }
             finally
             {
@@ -1330,7 +1336,11 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
                         .WithOperationType(FaultInjectionOperationType.ReadItem)
                         .Build(),
                 result:
-                    FaultInjectionResultBuilder.GetResultBuilder(FaultInjectionServerErrorType.Gone)
+                    // TooManyRequests (with MaxRetryAttemptsOnRateLimitedRequests = 0) is used instead of Gone so
+                    // that each injected read produces exactly one rule application. Gone cannot be limited to an
+                    // operation type (FaultInjectionRuleProcessor.CanErrorLimitToOperation), so a Gone rule also
+                    // faults address refreshes and inflates the hit count well past the injection rate.
+                    FaultInjectionResultBuilder.GetResultBuilder(FaultInjectionServerErrorType.TooManyRequests)
                         .WithInjectionRate(.5)
                         .WithTimes(1)
                         .Build())
@@ -1346,7 +1356,8 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
                 {
                     ConsistencyLevel = ConsistencyLevel.Session,
                     FaultInjector = faultInjector,
-                    Serializer = this.serializer
+                    Serializer = this.serializer,
+                    MaxRetryAttemptsOnRateLimitedRequests = 0,
                 };
 
                 this.fiClient = new CosmosClient(
@@ -1376,8 +1387,15 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
 
                 }
 
-                Assert.IsTrue(thresholdRule.GetHitCount() >= 38, "This is Expected to fail 0.602% of the time");
-                Assert.IsTrue(thresholdRule.GetHitCount() <= 62, "This is Expected to fail 0.602% of the time");
+                //50% injection rate over 100 requests is Binomial(100, 0.5): mean 50, standard deviation 5.
+                //[30, 70] is +/- 4 standard deviations, so a passing run is not a coin flip while a broken
+                //injection rate (never applied, always applied, or materially off) is still caught.
+                Assert.IsTrue(
+                    thresholdRule.GetHitCount() >= 30,
+                    $"Injection rate too low. {Describe(thresholdRule)}");
+                Assert.IsTrue(
+                    thresholdRule.GetHitCount() <= 70,
+                    $"Injection rate too high. {Describe(thresholdRule)}");
             }
             finally
             {
@@ -1803,9 +1821,30 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
             return (writeRegions, readRegions);
         }
 
+        private static string Describe(FaultInjectionRule rule)
+        {
+            return $"rule '{rule.GetId()}' hitCount={rule.GetHitCount()} "
+                + $"regionEndpoints=[{string.Join(", ", rule.GetRegionEndpoints())}] "
+                + $"addresses=[{string.Join(", ", rule.GetAddresses())}]";
+        }
+
         private void ValidateHitCount(FaultInjectionRule rule, long expectedHitCount)
         {
-            Assert.AreEqual(expectedHitCount, rule.GetHitCount());
+            Assert.AreEqual(expectedHitCount, rule.GetHitCount(), Describe(rule));
+        }
+
+        /// <summary>
+        /// Asserts a rule was applied at least <paramref name="minimumHitCount"/> times.
+        ///
+        /// Retryable errors (410, 403, ...) trigger cross region retries, and the WithTimes limit is enforced
+        /// per activity id, so every region attempt is a new application of the rule. The total hit count
+        /// therefore scales with the number of regions on the test account and cannot be asserted exactly.
+        /// </summary>
+        private void ValidateRuleHit(FaultInjectionRule rule, long minimumHitCount)
+        {
+            Assert.IsTrue(
+                minimumHitCount <= rule.GetHitCount(),
+                $"Expected the rule to be applied at least {minimumHitCount} time(s). {Describe(rule)}");
         }
 
         private void ValidateFaultInjectionRuleNotApplied(
@@ -1813,12 +1852,13 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
             FaultInjectionRule rule)
         {
             string diagnosticsString = ex.Diagnostics.ToString();
-            Assert.AreEqual(0, rule.GetHitCount());
-            Assert.AreEqual(0, ex.Diagnostics.GetFailedRequestCount());
+            Assert.AreEqual(0, rule.GetHitCount(), Describe(rule));
+            Assert.AreEqual(0, ex.Diagnostics.GetFailedRequestCount(), Describe(rule));
             Assert.IsTrue(
                 diagnosticsString.Contains("200")
                 || diagnosticsString.Contains("201")
-                || diagnosticsString.Contains("204"));
+                || diagnosticsString.Contains("204"),
+                Describe(rule));
         }
 
         private void ValidateFaultInjectionRuleNotApplied(
@@ -1826,9 +1866,9 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
             FaultInjectionRule rule,
             int expectedHitCount = 0)
         {
-            Assert.AreEqual(expectedHitCount, rule.GetHitCount());
-            Assert.AreEqual(expectedHitCount, response.Diagnostics.GetFailedRequestCount());
-            Assert.IsTrue((int)response.StatusCode < 400);
+            Assert.AreEqual(expectedHitCount, rule.GetHitCount(), Describe(rule));
+            Assert.AreEqual(expectedHitCount, response.Diagnostics.GetFailedRequestCount(), Describe(rule));
+            Assert.IsTrue((int)response.StatusCode < 400, Describe(rule));
         }
 
         private void ValidateFaultInjectionRuleNotApplied(
@@ -1836,9 +1876,9 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
             FaultInjectionRule rule,
             int expectedHitCount = 0)
         {
-            Assert.AreEqual(expectedHitCount, rule.GetHitCount());
-            Assert.AreEqual(expectedHitCount, response.Diagnostics.GetFailedRequestCount());
-            Assert.IsTrue((int)response.StatusCode < 400);
+            Assert.AreEqual(expectedHitCount, rule.GetHitCount(), Describe(rule));
+            Assert.AreEqual(expectedHitCount, response.Diagnostics.GetFailedRequestCount(), Describe(rule));
+            Assert.IsTrue((int)response.StatusCode < 400, Describe(rule));
         }
 
         private void ValidateFaultInjectionRuleApplication(
@@ -1848,11 +1888,11 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
             FaultInjectionRule rule)
         {
             string diagnosticsString = diagnostics.ToString();
-            Console.WriteLine(diagnostics.ToString());
-            Assert.IsTrue(1 <= rule.GetHitCount());
-            Assert.IsTrue(1 <= diagnostics.GetFailedRequestCount());
-            Assert.IsTrue(diagnosticsString.Contains(statusCode.ToString()));
-            Assert.IsTrue(diagnosticsString.Contains(subStatusCode.ToString()));
+            Console.WriteLine(diagnosticsString);
+            Assert.IsTrue(1 <= rule.GetHitCount(), Describe(rule));
+            Assert.IsTrue(1 <= diagnostics.GetFailedRequestCount(), Describe(rule));
+            Assert.IsTrue(diagnosticsString.Contains(statusCode.ToString()), Describe(rule));
+            Assert.IsTrue(diagnosticsString.Contains(subStatusCode.ToString()), Describe(rule));
         }
 
         private void ValidateFaultInjectionRuleApplication(
@@ -1860,9 +1900,9 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
             int statusCode,
             FaultInjectionRule rule)
         {
-            Assert.IsTrue(1 <= rule.GetHitCount());
-            Assert.IsTrue(ex.Message.Contains(rule.GetId()));
-            Assert.AreEqual(statusCode, (int)ex.StatusCode);
+            Assert.IsTrue(1 <= rule.GetHitCount(), Describe(rule));
+            Assert.IsTrue(ex.Message.Contains(rule.GetId()), ex.Message);
+            Assert.AreEqual(statusCode, (int)ex.StatusCode, ex.Message);
         }
 
         private void ValidateFaultInjectionRuleApplication(
@@ -1870,9 +1910,9 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
             int statusCode,
             FaultInjectionRule rule)
         {
-            Assert.IsTrue(1 <= rule.GetHitCount());
-            Assert.IsTrue(ex.Message.Contains(rule.GetId()));
-            Assert.AreEqual(statusCode, (int)ex.StatusCode);
+            Assert.IsTrue(1 <= rule.GetHitCount(), Describe(rule));
+            Assert.IsTrue(ex.Message.Contains(rule.GetId()), ex.Message);
+            Assert.AreEqual(statusCode, (int)ex.StatusCode, ex.Message);
         }
 
         private void ValidateFaultInjectionRuleApplication(
@@ -1881,10 +1921,10 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
             int subStatusCode,
             FaultInjectionRule rule)
         {
-            Assert.IsTrue(1 <= rule.GetHitCount());
-            Assert.IsTrue(ex.Message.Contains(rule.GetId()));
-            Assert.AreEqual(statusCode, (int)ex.StatusCode);
-            Assert.AreEqual(subStatusCode.ToString(), ex.Headers.Get(WFConstants.BackendHeaders.SubStatus));
+            Assert.IsTrue(1 <= rule.GetHitCount(), Describe(rule));
+            Assert.IsTrue(ex.Message.Contains(rule.GetId()), ex.Message);
+            Assert.AreEqual(statusCode, (int)ex.StatusCode, ex.Message);
+            Assert.AreEqual(subStatusCode.ToString(), ex.Headers.Get(WFConstants.BackendHeaders.SubStatus), ex.Message);
         }
 
         private void ValidateFaultInjectionRuleApplication(
@@ -1893,10 +1933,10 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
             int subStatusCode,
             FaultInjectionRule rule)
         {
-            Assert.IsTrue(1 <= rule.GetHitCount());
-            Assert.IsTrue(ex.Message.Contains(rule.GetId()));
-            Assert.AreEqual(statusCode, (int)ex.StatusCode);
-            Assert.AreEqual(subStatusCode, ex.SubStatusCode);
+            Assert.IsTrue(1 <= rule.GetHitCount(), Describe(rule));
+            Assert.IsTrue(ex.Message.Contains(rule.GetId()), ex.Message);
+            Assert.AreEqual(statusCode, (int)ex.StatusCode, ex.Message);
+            Assert.AreEqual(subStatusCode, ex.SubStatusCode, ex.Message);
         }
 
         private async Task InitializeHighThroughputContainerAsync()

--- a/Microsoft.Azure.Cosmos/FaultInjection/tests/FaultInjectionGatewayModeTests.cs
+++ b/Microsoft.Azure.Cosmos/FaultInjection/tests/FaultInjectionGatewayModeTests.cs
@@ -109,16 +109,22 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
             }
 
             //create fault injection rule for local region 
+            //The rules are scoped to ReadItem: an unscoped rule also faults the metadata calls that target the
+            //same region, which makes the hit count depend on cache state rather than on the tested read.
             string localRegionRuleId = "localRegionRule-" + Guid.NewGuid().ToString();
             FaultInjectionRule localRegionRule = new FaultInjectionRuleBuilder(
                 id: localRegionRuleId,
                 condition:
                     new FaultInjectionConditionBuilder()
                         .WithRegion(preferredRegions[0])
+                        .WithOperationType(FaultInjectionOperationType.ReadItem)
                         .WithConnectionType(FaultInjectionConnectionType.Gateway)
                         .Build(),
                 result:
-                    FaultInjectionResultBuilder.GetResultBuilder(FaultInjectionServerErrorType.Gone)
+                    // TooManyRequests is used (instead of Gone, which is Direct only) because it is terminal
+                    // when MaxRetryAttemptsOnRateLimitedRequests is 0. A retryable error would cross-region
+                    // failover and hit the remote region rule, which this test asserts is never applied.
+                    FaultInjectionResultBuilder.GetResultBuilder(FaultInjectionServerErrorType.TooManyRequests)
                         .WithTimes(1)
                         .Build())
                 .WithDuration(TimeSpan.FromMinutes(5))
@@ -131,10 +137,11 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
                 condition:
                     new FaultInjectionConditionBuilder()
                         .WithRegion(preferredRegions[1])
+                        .WithOperationType(FaultInjectionOperationType.ReadItem)
                         .WithConnectionType(FaultInjectionConnectionType.Gateway)
                         .Build(),
                 result:
-                    FaultInjectionResultBuilder.GetResultBuilder(FaultInjectionServerErrorType.Gone)
+                    FaultInjectionResultBuilder.GetResultBuilder(FaultInjectionServerErrorType.TooManyRequests)
                         .WithTimes(1)
                         .Build())
                 .WithDuration(TimeSpan.FromMinutes(5))
@@ -154,7 +161,8 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
                 {
                     ConsistencyLevel = ConsistencyLevel.Session,
                     ConnectionMode = ConnectionMode.Gateway,
-                    Serializer = this.serializer
+                    Serializer = this.serializer,
+                    MaxRetryAttemptsOnRateLimitedRequests = 0,
                 };
 
                 this.fiClient = new CosmosClient(
@@ -182,7 +190,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
                     this.ValidateHitCount(remoteRegionRule, 0);
                     this.ValidateFaultInjectionRuleApplication(
                         ex,
-                        (int)HttpStatusCode.Gone,
+                        (int)HttpStatusCode.TooManyRequests,
                         localRegionRule);
                 }
                 catch (CosmosException ex)
@@ -191,7 +199,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
                     this.ValidateHitCount(remoteRegionRule, 0);
                     this.ValidateFaultInjectionRuleApplication(
                         ex,
-                        (int)HttpStatusCode.Gone,
+                        (int)HttpStatusCode.TooManyRequests,
                         localRegionRule);
                 }
             }
@@ -218,7 +226,8 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
         [Description("Test Unautharized rule filtering")]
         [Owner("ntripician")]
         public async Task FIGatewayUnautharizedTest()
-        {
+        {            //403 is retried across regions, so the rule is applied once per region attempt and the total
+            //hit count depends on how many regions the test account has. Assert it was applied at least once.
             //create fault injection rule for unauthorized requests
             string unauthorizedRuleId = "unauthorizedRule-" + Guid.NewGuid().ToString();
             FaultInjectionRule unauthorizedRule = new FaultInjectionRuleBuilder(
@@ -258,7 +267,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
             }
             catch (DocumentClientException ex)
             {
-                this.ValidateHitCount(unauthorizedRule, 1);
+                this.ValidateRuleHit(unauthorizedRule, 1);
                 this.ValidateFaultInjectionRuleApplication(
                     ex,
                     (int)HttpStatusCode.Unauthorized,
@@ -266,7 +275,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
             }
             catch (CosmosException ex)
             {
-                this.ValidateHitCount(unauthorizedRule, 1);
+                this.ValidateRuleHit(unauthorizedRule, 1);
                 this.ValidateFaultInjectionRuleApplication(
                     ex,
                     (int)HttpStatusCode.Unauthorized,
@@ -280,6 +289,8 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
         [Owner("ntripician")]
         public async Task FIGatewayAADRevokedTest()
         {
+            //403 is retried across regions, so the rule is applied once per region attempt and the total
+            //hit count depends on how many regions the test account has. Assert it was applied at least once.
             //create fault injection rule for AAD token revoked requests
             string aadRevokedRuleId = "AadRevoked-" + Guid.NewGuid().ToString();
             FaultInjectionRule aadRevokedRule = new FaultInjectionRuleBuilder(
@@ -319,7 +330,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
             }
             catch (DocumentClientException ex)
             {
-                this.ValidateHitCount(aadRevokedRule, 1);
+                this.ValidateRuleHit(aadRevokedRule, 1);
                 this.ValidateFaultInjectionRuleApplication(
                     ex,
                     (int)HttpStatusCode.Unauthorized,
@@ -327,7 +338,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
             }
             catch (CosmosException ex)
             {
-                this.ValidateHitCount(aadRevokedRule, 1);
+                this.ValidateRuleHit(aadRevokedRule, 1);
                 this.ValidateFaultInjectionRuleApplication(
                     ex,
                     (int)HttpStatusCode.Unauthorized,
@@ -683,12 +694,14 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
 
         //<summary>
         //Tests to see if specific server error responses are applied, tests read and create item
+        //
+        //Gone is intentionally absent: it is a Direct only error type and the builder rejects it for Gateway.
+        //That validation is covered by FaultInjectionBuilderValidationTests.FaultInjectionRuleBuilder_GatewayWithGone_Throws.
         //</summary>
         [TestMethod]
         [Timeout(Timeout * 100)]
         [Description("Test server error responses")]
         [Owner("ntripician")]
-        [DataRow(FaultInjectionOperationType.ReadItem, FaultInjectionServerErrorType.Gone, (int)StatusCodes.Gone, (int)SubStatusCodes.ServerGenerated410, DisplayName = "Gone")]
         [DataRow(FaultInjectionOperationType.ReadItem, FaultInjectionServerErrorType.InternalServerError, (int)StatusCodes.InternalServerError, (int)SubStatusCodes.Unknown, DisplayName = "InternalServerError")]
         [DataRow(FaultInjectionOperationType.ReadItem, FaultInjectionServerErrorType.RetryWith, (int)StatusCodes.RetryWith, (int)SubStatusCodes.Unknown, DisplayName = "RetryWith")]
         [DataRow(FaultInjectionOperationType.ReadItem, FaultInjectionServerErrorType.TooManyRequests, (int)StatusCodes.TooManyRequests, (int)SubStatusCodes.RUBudgetExceeded, DisplayName = "TooManyRequests")]
@@ -696,7 +709,6 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
         [DataRow(FaultInjectionOperationType.ReadItem, FaultInjectionServerErrorType.Timeout, (int)StatusCodes.RequestTimeout, (int)SubStatusCodes.Unknown, DisplayName = "Timeout")]
         [DataRow(FaultInjectionOperationType.ReadItem, FaultInjectionServerErrorType.PartitionIsMigrating, (int)StatusCodes.Gone, (int)SubStatusCodes.CompletingPartitionMigration, DisplayName = "PartitionIsMigrating")]
         [DataRow(FaultInjectionOperationType.ReadItem, FaultInjectionServerErrorType.PartitionIsSplitting, (int)StatusCodes.Gone, (int)SubStatusCodes.CompletingSplit, DisplayName = "PartitionIsSplitting")]
-        [DataRow(FaultInjectionOperationType.CreateItem, FaultInjectionServerErrorType.Gone, (int)StatusCodes.Gone, (int)SubStatusCodes.ServerGenerated410, DisplayName = "Gone - write")]
         [DataRow(FaultInjectionOperationType.CreateItem, FaultInjectionServerErrorType.InternalServerError, (int)StatusCodes.InternalServerError, (int)SubStatusCodes.Unknown, DisplayName = "InternalServerError - write")]
         [DataRow(FaultInjectionOperationType.CreateItem, FaultInjectionServerErrorType.RetryWith, (int)StatusCodes.RetryWith, (int)SubStatusCodes.Unknown, DisplayName = "RetryWith - write")]
         [DataRow(FaultInjectionOperationType.CreateItem, FaultInjectionServerErrorType.TooManyRequests, (int)StatusCodes.TooManyRequests, (int)SubStatusCodes.RUBudgetExceeded, DisplayName = "TooManyRequests - write")]
@@ -715,6 +727,22 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
             string pk = "deleteMe";
 
             string serverErrorResponseRuleId = "serverErrorResponseRule-" + Guid.NewGuid().ToString();
+
+            // InternalServerError (500) and RetryWith (449) are retried by the SDK. Limiting the rule to a single
+            // application would only fault the first attempt, letting the retry reach the service and mask the
+            // injected error, so those types fault every attempt and the injected error is the terminal one.
+            bool retriedAwayByTheSdk =
+                faultInjectionServerErrorType == FaultInjectionServerErrorType.InternalServerError
+                || faultInjectionServerErrorType == FaultInjectionServerErrorType.RetryWith;
+
+            FaultInjectionServerErrorResultBuilder resultBuilder =
+                FaultInjectionResultBuilder.GetResultBuilder(faultInjectionServerErrorType);
+
+            if (!retriedAwayByTheSdk)
+            {
+                resultBuilder = resultBuilder.WithTimes(1);
+            }
+
             FaultInjectionRule serverErrorResponseRule = new FaultInjectionRuleBuilder(
                 id: serverErrorResponseRuleId,
                 condition:
@@ -722,10 +750,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
                     .WithOperationType(faultInjectionOperationType)
                     .WithConnectionType(FaultInjectionConnectionType.Gateway)
                     .Build(),
-                result:
-                    FaultInjectionResultBuilder.GetResultBuilder(faultInjectionServerErrorType)
-                        .WithTimes(1)
-                        .Build())
+                result: resultBuilder.Build())
                 .WithDuration(TimeSpan.FromMinutes(5))
                 .Build();
             serverErrorResponseRule.Disable();
@@ -760,6 +785,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
                 ValueStopwatch stopwatch = ValueStopwatch.StartNew();
                 TimeSpan elapsed;
 
+                bool injectedErrorSurfaced = false;
 
                 try
                 {
@@ -779,11 +805,12 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
                     {
                         response = await this.fiContainer.ReadItemAsync<FaultInjectionTestObject>(
                             "testId",
-                            new PartitionKey("/pk"));
+                            new PartitionKey("pk"));
                     }
                 }
                 catch (CosmosException ex)
                 {
+                    injectedErrorSurfaced = true;
                     this.ValidateRuleHit(serverErrorResponseRule, 1);
                     this.ValidateFaultInjectionRuleApplication(
                         ex,
@@ -793,6 +820,7 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
                 }
                 catch (DocumentClientException ex)
                 {
+                    injectedErrorSurfaced = true;
                     this.ValidateRuleHit(serverErrorResponseRule, 1);
                     this.ValidateFaultInjectionRuleApplication(
                         ex,
@@ -801,6 +829,10 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
                         serverErrorResponseRule);
                 }
 
+                Assert.IsTrue(
+                    injectedErrorSurfaced,
+                    $"Expected the injected {faultInjectionServerErrorType} fault to surface as an exception, "
+                        + $"but the {faultInjectionOperationType} succeeded. {Describe(serverErrorResponseRule)}");
 
                 elapsed = stopwatch.Elapsed;
                 stopwatch.Stop();
@@ -846,10 +878,13 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
                 id: hitCountRuleId,
                 condition:
                     new FaultInjectionConditionBuilder()
+                    .WithOperationType(FaultInjectionOperationType.ReadItem)
                     .WithConnectionType(FaultInjectionConnectionType.Gateway)
                     .Build(),
                 result:
-                    FaultInjectionResultBuilder.GetResultBuilder(FaultInjectionServerErrorType.Gone)
+                    // TooManyRequests (with MaxRetryAttemptsOnRateLimitedRequests = 0) is used instead of Gone,
+                    // which is Direct only, so that each read produces exactly one rule application.
+                    FaultInjectionResultBuilder.GetResultBuilder(FaultInjectionServerErrorType.TooManyRequests)
                         .WithTimes(1)
                         .Build())
                 .WithHitLimit(2)
@@ -865,7 +900,8 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
                 {
                     ConsistencyLevel = ConsistencyLevel.Session,
                     ConnectionMode = ConnectionMode.Gateway,
-                    Serializer = this.serializer
+                    Serializer = this.serializer,
+                    MaxRetryAttemptsOnRateLimitedRequests = 0,
                 };
 
                 this.fiClient = new CosmosClient(
@@ -888,19 +924,24 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
                         new PartitionKey("pk"));
                         Assert.IsNotNull(response);
 
-                        if (i > 2)
+                        if (i >= 2)
                         {
                             this.ValidateFaultInjectionRuleNotApplied(response, hitCountRule, 2);
+                        }
+                        else
+                        {
+                            Assert.Fail(
+                                $"Expected the hit limit rule to be applied on attempt {i}, but the request succeeded. {Describe(hitCountRule)}");
                         }
                     }
                     catch (DocumentClientException ex)
                     {
-                        this.ValidateFaultInjectionRuleApplication(ex, (int)HttpStatusCode.Gone, hitCountRule);
+                        this.ValidateFaultInjectionRuleApplication(ex, (int)HttpStatusCode.TooManyRequests, hitCountRule);
                         this.ValidateHitCount(hitCountRule, i + 1);
                     }
                     catch (CosmosException ex)
                     {
-                        this.ValidateFaultInjectionRuleApplication(ex, (int)HttpStatusCode.Gone, hitCountRule);
+                        this.ValidateFaultInjectionRuleApplication(ex, (int)HttpStatusCode.TooManyRequests, hitCountRule);
                         this.ValidateHitCount(hitCountRule, i + 1);
                     }
                 }
@@ -913,8 +954,6 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
 
         /// <summary>
         /// Injection rate is set to 0.5, so the rule should be applied ~50% of the time
-        /// This test will fail ~1.2% of the time due to the random nature of the test
-        /// 98.8% of the time the rule will be applied between 38 and 62 times out of 100 with an injection rate of 50%
         /// </summary>
         [TestMethod]
         [Timeout(Timeout)]
@@ -931,7 +970,10 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
                         .WithConnectionType(FaultInjectionConnectionType.Gateway)
                         .Build(),
                 result:
-                    FaultInjectionResultBuilder.GetResultBuilder(FaultInjectionServerErrorType.Gone)
+                    // TooManyRequests (with MaxRetryAttemptsOnRateLimitedRequests = 0) is used instead of Gone,
+                    // which is Direct only. It is terminal, so the hit count matches the number of injected
+                    // reads rather than being inflated by SDK retries.
+                    FaultInjectionResultBuilder.GetResultBuilder(FaultInjectionServerErrorType.TooManyRequests)
                         .WithInjectionRate(.5)
                         .WithTimes(1)
                         .Build())
@@ -947,7 +989,8 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
                 {
                     ConsistencyLevel = ConsistencyLevel.Session,
                     ConnectionMode = ConnectionMode.Gateway,
-                    Serializer = this.serializer
+                    Serializer = this.serializer,
+                    MaxRetryAttemptsOnRateLimitedRequests = 0,
                 };
 
                 this.fiClient = new CosmosClient(
@@ -977,8 +1020,15 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
 
                 }
 
-                Assert.IsTrue(thresholdRule.GetHitCount() >= 38, "This is Expected to fail 0.602% of the time");
-                Assert.IsTrue(thresholdRule.GetHitCount() <= 62, "This is Expected to fail 0.602% of the time");
+                //50% injection rate over 100 requests is Binomial(100, 0.5): mean 50, standard deviation 5.
+                //[30, 70] is +/- 4 standard deviations, so a passing run is not a coin flip while a broken
+                //injection rate (never applied, always applied, or materially off) is still caught.
+                Assert.IsTrue(
+                    thresholdRule.GetHitCount() >= 30,
+                    $"Injection rate too low. {Describe(thresholdRule)}");
+                Assert.IsTrue(
+                    thresholdRule.GetHitCount() <= 70,
+                    $"Injection rate too high. {Describe(thresholdRule)}");
             }
             finally
             {
@@ -1080,14 +1130,35 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
             return (writeRegions, readRegions);
         }
 
+        private static string Describe(FaultInjectionRule rule)
+        {
+            return $"rule '{rule.GetId()}' hitCount={rule.GetHitCount()} "
+                + $"regionEndpoints=[{string.Join(", ", rule.GetRegionEndpoints())}] "
+                + $"addresses={rule.GetAddresses().Count}";
+        }
+
+        private static string Describe(Exception ex)
+        {
+            return ex switch
+            {
+                CosmosException cosmosException =>
+                    $"CosmosException status={(int)cosmosException.StatusCode} subStatus={cosmosException.SubStatusCode} message={cosmosException.Message}",
+                DocumentClientException documentClientException =>
+                    $"DocumentClientException status={(int?)documentClientException.StatusCode} "
+                    + $"subStatus={documentClientException.Headers?.Get(WFConstants.BackendHeaders.SubStatus)} "
+                    + $"message={documentClientException.Message}",
+                _ => $"{ex.GetType().Name}: {ex.Message}",
+            };
+        }
+
         private void ValidateHitCount(FaultInjectionRule rule, long expectedHitCount)
         {
-            Assert.AreEqual(expectedHitCount, rule.GetHitCount());
+            Assert.AreEqual(expectedHitCount, rule.GetHitCount(), Describe(rule));
         }
 
         private void ValidateRuleHit(FaultInjectionRule rule, long expectedHitCount)
         {
-            Assert.IsTrue(expectedHitCount <= rule.GetHitCount());
+            Assert.IsTrue(expectedHitCount <= rule.GetHitCount(), Describe(rule));
         }
 
         private void ValidateFaultInjectionRuleNotApplied(
@@ -1095,9 +1166,9 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
             FaultInjectionRule rule,
             int expectedHitCount = 0)
         {
-            Assert.AreEqual(expectedHitCount, rule.GetHitCount());
-            Assert.AreEqual(0, response.Diagnostics.GetFailedRequestCount());
-            Assert.IsTrue((int)response.StatusCode < 400);
+            Assert.AreEqual(expectedHitCount, rule.GetHitCount(), Describe(rule));
+            Assert.AreEqual(0, response.Diagnostics.GetFailedRequestCount(), Describe(rule));
+            Assert.IsTrue((int)response.StatusCode < 400, Describe(rule));
         }
 
         private void ValidateFaultInjectionRuleApplication(
@@ -1105,9 +1176,9 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
             int statusCode,
             FaultInjectionRule rule)
         {
-            Assert.IsTrue(1 <= rule.GetHitCount());
-            Assert.IsTrue(ex.Message.Contains(rule.GetId()));
-            Assert.AreEqual(statusCode, (int)ex.StatusCode);
+            Assert.IsTrue(1 <= rule.GetHitCount(), Describe(rule));
+            Assert.IsTrue(ex.Message.Contains(rule.GetId()), Describe(ex));
+            Assert.AreEqual(statusCode, (int)ex.StatusCode, Describe(ex));
         }
 
         private void ValidateFaultInjectionRuleApplication(
@@ -1115,9 +1186,9 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
             int statusCode,
             FaultInjectionRule rule)
         {
-            Assert.IsTrue(1 <= rule.GetHitCount());
-            Assert.IsTrue(ex.Message.Contains(rule.GetId()));
-            Assert.AreEqual(statusCode, (int)ex.StatusCode);
+            Assert.IsTrue(1 <= rule.GetHitCount(), Describe(rule));
+            Assert.IsTrue(ex.Message.Contains(rule.GetId()), Describe(ex));
+            Assert.AreEqual(statusCode, (int)ex.StatusCode, Describe(ex));
         }
 
         private void ValidateFaultInjectionRuleApplication(
@@ -1126,10 +1197,10 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
             int subStatusCode,
             FaultInjectionRule rule)
         {
-            Assert.IsTrue(1 <= rule.GetHitCount());
-            Assert.IsTrue(ex.Message.Contains(rule.GetId()));
-            Assert.AreEqual(statusCode, (int)ex.StatusCode);
-            Assert.AreEqual(subStatusCode.ToString(), ex.Headers.Get(WFConstants.BackendHeaders.SubStatus));
+            Assert.IsTrue(1 <= rule.GetHitCount(), Describe(rule));
+            Assert.IsTrue(ex.Message.Contains(rule.GetId()), Describe(ex));
+            Assert.AreEqual(statusCode, (int)ex.StatusCode, Describe(ex));
+            Assert.AreEqual(subStatusCode.ToString(), ex.Headers.Get(WFConstants.BackendHeaders.SubStatus), Describe(ex));
         }
 
         private void ValidateFaultInjectionRuleApplication(
@@ -1138,10 +1209,10 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
             int subStatusCode,
             FaultInjectionRule rule)
         {
-            Assert.IsTrue(1 <= rule.GetHitCount());
-            Assert.IsTrue(ex.Message.Contains(rule.GetId()));
-            Assert.AreEqual(statusCode, (int)ex.StatusCode);
-            Assert.AreEqual(subStatusCode, ex.SubStatusCode);
+            Assert.IsTrue(1 <= rule.GetHitCount(), Describe(rule));
+            Assert.IsTrue(ex.Message.Contains(rule.GetId()), Describe(ex));
+            Assert.AreEqual(statusCode, (int)ex.StatusCode, Describe(ex));
+            Assert.AreEqual(subStatusCode, ex.SubStatusCode, Describe(ex));
         }
 
         [TestMethod]

--- a/Microsoft.Azure.Cosmos/FaultInjection/tests/FaultInjectionMetadataTests.cs
+++ b/Microsoft.Azure.Cosmos/FaultInjection/tests/FaultInjectionMetadataTests.cs
@@ -156,11 +156,12 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
                 // reliable signal (a sub-1s delay that avoids the timeout would be swamped by connection and
                 // cross-region latency and is equally unreliable). Validate the delay's effect deterministically
                 // instead: the rule was applied, the injected delay forced at least one failed/retried metadata
-                // request (GetFailedRequestCount, which is 0 when no fault is applied), and the operation still
-                // succeeds despite the injected delay.
-                Assert.IsTrue(
-                    response.Diagnostics.GetFailedRequestCount() >= 1,
-                    "Expected the injected metadata response delay to produce at least one failed/retried request.");
+                // request, and the operation still succeeds despite the injected delay.
+                //
+                // GetFailedRequestCount() only counts failed direct (RNTBD) store responses, so it stays 0 for a
+                // faulted metadata call. The timed-out metadata request is instead recorded in the diagnostics as
+                // a gateway call with no status code, which is what is asserted here.
+                ValidateTimedOutMetadataRequest(response.Diagnostics);
                 Assert.AreEqual(HttpStatusCode.Created, response.StatusCode);
             }
             finally
@@ -458,11 +459,12 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
                 // reliable signal (a sub-1s delay that avoids the timeout would be swamped by connection and
                 // cross-region latency and is equally unreliable). Validate the delay's effect deterministically
                 // instead: the rule was applied, the injected delay forced at least one failed/retried metadata
-                // request (GetFailedRequestCount, which is 0 when no fault is applied), and the operation still
-                // succeeds despite the injected delay.
-                Assert.IsTrue(
-                    response.Diagnostics.GetFailedRequestCount() >= 1,
-                    "Expected the injected metadata response delay to produce at least one failed/retried request.");
+                // request, and the operation still succeeds despite the injected delay.
+                //
+                // GetFailedRequestCount() only counts failed direct (RNTBD) store responses, so it stays 0 for a
+                // faulted metadata call. The timed-out metadata request is instead recorded in the diagnostics as
+                // a gateway call with no status code, which is what is asserted here.
+                ValidateTimedOutMetadataRequest(response.Diagnostics);
                 Assert.AreEqual(HttpStatusCode.Created, response.StatusCode);
             }
             finally
@@ -530,11 +532,12 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
                 // reliable signal (a sub-1s delay that avoids the timeout would be swamped by connection and
                 // cross-region latency and is equally unreliable). Validate the delay's effect deterministically
                 // instead: the rule was applied, the injected delay forced at least one failed/retried metadata
-                // request (GetFailedRequestCount, which is 0 when no fault is applied), and the operation still
-                // succeeds despite the injected delay.
-                Assert.IsTrue(
-                    response.Diagnostics.GetFailedRequestCount() >= 1,
-                    "Expected the injected metadata response delay to produce at least one failed/retried request.");
+                // request, and the operation still succeeds despite the injected delay.
+                //
+                // GetFailedRequestCount() only counts failed direct (RNTBD) store responses, so it stays 0 for a
+                // faulted metadata call. The timed-out metadata request is instead recorded in the diagnostics as
+                // a gateway call with no status code, which is what is asserted here.
+                ValidateTimedOutMetadataRequest(response.Diagnostics);
                 Assert.AreEqual(HttpStatusCode.Created, response.StatusCode);
             }
             finally
@@ -559,6 +562,25 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
         private void ValidateRuleHit(FaultInjectionRule rule, long expectedHitCount)
         {
             Assert.IsTrue(expectedHitCount <= rule.GetHitCount());
+        }
+
+        /// <summary>
+        /// Asserts the diagnostics record a metadata (gateway) request that never received a status code.
+        ///
+        /// Metadata calls route through HttpTimeoutPolicyControlPlaneRetriableHotPath, whose first attempt times
+        /// out after 1s, so an injected delay longer than that aborts the request and the SDK retries it. The
+        /// aborted attempt shows up in the diagnostics summary as a gateway call with status code 0.
+        /// CosmosDiagnostics.GetFailedRequestCount() cannot be used for this: it only counts failed direct
+        /// (RNTBD) store responses and stays 0 when only a metadata call was faulted.
+        /// </summary>
+        private static void ValidateTimedOutMetadataRequest(CosmosDiagnostics diagnostics)
+        {
+            string diagnosticsString = diagnostics.ToString();
+
+            Assert.IsTrue(
+                diagnosticsString.Contains("\"GatewayCalls\"") && diagnosticsString.Contains("\"(0, 0)\""),
+                "Expected the injected metadata response delay to produce a timed out metadata request. "
+                    + diagnosticsString);
         }
 
         private void ValidateFaultInjectionRuleNotApplied(

--- a/azure-pipelines-faultinjection.yml
+++ b/azure-pipelines-faultinjection.yml
@@ -17,48 +17,17 @@ stages:
         BuildConfiguration: '${{ variables.BuildConfiguration }}'
         VmImage: '${{ variables.VmImage }}'
 
-    # - template:  templates/build-fault-injection-test.yml
-    #   parameters:
-    #     BuildConfiguration: '${{ variables.BuildConfiguration }}'
-    #     Arguments: '${{ variables.ReleaseArguments }}'
-    #     VmImage: '${{ variables.VmImage }}'
-    #     MultiRegionConnectionString: $(COSMOSDB_MULTI_REGION)
-        
-    - job:
-      displayName: FaultInjection Integration Tests ${{ variables.BuildConfiguration }}
-      timeoutInMinutes: 120
-      pool:
-        name: 'OneES'
-      
-      steps:
-      - checkout: self  # self represents the repo where the initial Pipelines YAML file was found
-        clean: true  # if true, execute `execute git clean -ffdx && git reset --hard HEAD` before fetching
-
-      # Add this Command to Include the .NET SDK and runtimes
-      - task: UseDotNet@2
-        displayName: Use .NET 6.0
-        inputs:
-          packageType: 'runtime'
-          version: '6.x'
-
-      - task: UseDotNet@2
-        displayName: Use .NET 8.0
-        inputs:
-          packageType: 'sdk'
-          version: '8.x'
-
-      - task: DotNetCoreCLI@2
-        displayName: Integration Test With Fault Injection
-        condition: succeeded()
-        inputs:
-          command: test
-          projects: 'Microsoft.Azure.Cosmos/FaultInjection/tests/*.csproj'
-          arguments: --verbosity normal --configuration ${{ variables.BuildConfiguration }} /p:OS=Windows
-          nugetConfigPath: NuGet.config
-          publishTestResults: true
-          testRunTitle: FaultInjectionTests
-        env:
-          COSMOSDB_MULTI_REGION: $(COSMOSDB_MULTI_REGION) # Real Account Connection String used by Integration Tests while running as part of release pipeline
+    # Build + unit tests + pack validation, then the live multi-region
+    # integration suite. The same template runs on every PR with
+    # IncludeIntegration=false, so a Direct version bump is caught long before
+    # this pipeline is triggered.
+    - template:  templates/build-fault-injection.yml
+      parameters:
+        BuildConfiguration: '${{ variables.BuildConfiguration }}'
+        Arguments: '${{ variables.ReleaseArguments }}'
+        VmImage: '${{ variables.VmImage }}'
+        IncludeIntegration: true
+        MultiRegionConnectionString: $(COSMOSDB_MULTI_REGION)
 
 - stage:
   displayName: Publish 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,6 +72,16 @@ jobs:
     BuildConfiguration: Release
     Arguments: $(ReleaseArguments)
     VmImage:  $(VmImage)
+
+# FaultInjection compiles against Microsoft.Azure.Cosmos.Direct internals, so a
+# $(DirectVersion) bump can break it while the main SDK still builds. Keep this
+# gate on the PR pipeline; the live-account tests stay in the release pipeline.
+- template:  templates/build-fault-injection.yml
+  parameters:
+    BuildConfiguration: Release
+    Arguments: $(ReleaseArguments)
+    VmImage:  $(VmImage)
+    IncludeIntegration: false
     
 - template:  templates/build-thinclient.yml
   parameters:

--- a/templates/build-fault-injection.yml
+++ b/templates/build-fault-injection.yml
@@ -1,0 +1,130 @@
+# File: templates/build-fault-injection.yml
+#
+# Builds Microsoft.Azure.Cosmos.FaultInjection and runs its account-free tests.
+#
+# Why this exists as a PR gate:
+#   FaultInjection compiles directly against Microsoft.Azure.Cosmos.Direct
+#   (PackageReference "[$(DirectVersion)]" in both FaultInjection.csproj and
+#   FaultInjectionTests.csproj) and consumes Microsoft.Azure.Documents internals
+#   such as IChaosInterceptor, Rntbd.Channel and Rntbd.Dispatcher. A bump to
+#   $(DirectVersion) in Directory.Build.props can therefore break this package
+#   even when the main SDK builds cleanly. Without this job the break is only
+#   discovered when the manually-triggered release pipeline is run.
+#
+# Set IncludeIntegration=true (release pipeline only) to also run the live
+# multi-region integration tests, which require MultiRegionConnectionString.
+
+parameters:
+  BuildConfiguration: ''
+  Arguments: ''
+  VmImage: ''
+  IncludeIntegration: false
+  MultiRegionConnectionString: ''
+  UnitTestFilter: ' --filter "FullyQualifiedName~FaultInjectionUnitTests|FullyQualifiedName~FaultInjectionBuilderValidationTests" --verbosity normal '
+
+jobs:
+
+- job:
+  displayName: FaultInjection Build and Unit Tests ${{ parameters.BuildConfiguration }}
+  pool:
+    name: 'OneES'
+
+  steps:
+  - checkout: self  # self represents the repo where the initial Pipelines YAML file was found
+    clean: true  # if true, execute `execute git clean -ffdx && git reset --hard HEAD` before fetching
+
+  # Add this Command to Include the .NET SDK and runtimes
+  - task: UseDotNet@2
+    displayName: Use .NET 6.0
+    inputs:
+      packageType: 'runtime'
+      version: '6.x'
+
+  - task: UseDotNet@2
+    displayName: Use .NET 8.0
+    inputs:
+      packageType: 'sdk'
+      version: '8.x'
+
+  # Compile gate: fails if a $(DirectVersion) bump removed or changed a
+  # Microsoft.Azure.Documents API that FaultInjection depends on.
+  - task: DotNetCoreCLI@2
+    displayName: Build Microsoft.Azure.Cosmos.FaultInjection
+    condition: succeeded()
+    inputs:
+      command: build
+      nugetConfigPath: NuGet.config
+      projects: 'Microsoft.Azure.Cosmos/FaultInjection/src/FaultInjection.csproj'
+      arguments: --configuration ${{ parameters.BuildConfiguration }} -p:Optimize=true
+      versioningScheme: OFF
+
+  - task: DotNetCoreCLI@2
+    displayName: Build Microsoft.Azure.Cosmos.FaultInjection.Tests
+    condition: succeeded()
+    inputs:
+      command: build
+      nugetConfigPath: NuGet.config
+      projects: 'Microsoft.Azure.Cosmos/FaultInjection/tests/FaultInjectionTests.csproj'
+      arguments: --configuration ${{ parameters.BuildConfiguration }}
+      versioningScheme: OFF
+
+  # Account-free tests. Everything else in this project needs a live
+  # multi-region account and stays in the release pipeline.
+  - task: DotNetCoreCLI@2
+    displayName: Microsoft.Azure.Cosmos.FaultInjection.Tests - Unit Tests
+    condition: succeeded()
+    inputs:
+      command: test
+      projects: 'Microsoft.Azure.Cosmos/FaultInjection/tests/FaultInjectionTests.csproj'
+      arguments: ${{ parameters.UnitTestFilter }} --configuration ${{ parameters.BuildConfiguration }} --no-build
+      nugetConfigPath: NuGet.config
+      publishTestResults: true
+      testRunTitle: FaultInjectionUnitTests
+
+  # Packaging gate: the shipped nupkg is delay-signed and packs from the same
+  # project, so a packaging regression is caught here rather than at release.
+  - task: DotNetCoreCLI@2
+    displayName: Pack Microsoft.Azure.Cosmos.FaultInjection (validation only)
+    condition: succeeded()
+    inputs:
+      command: custom
+      projects: 'Microsoft.Azure.Cosmos/FaultInjection/src/FaultInjection.csproj'
+      custom: pack
+      arguments: '-c ${{ parameters.BuildConfiguration }} --no-build --no-restore -o "$(Build.ArtifactStagingDirectory)/faultinjection-validation"'
+
+- ${{ if eq(parameters.IncludeIntegration, true) }}:
+  - job:
+    displayName: FaultInjection Integration Tests ${{ parameters.BuildConfiguration }}
+    timeoutInMinutes: 120
+    pool:
+      name: 'OneES'
+
+    steps:
+    - checkout: self  # self represents the repo where the initial Pipelines YAML file was found
+      clean: true  # if true, execute `execute git clean -ffdx && git reset --hard HEAD` before fetching
+
+    # Add this Command to Include the .NET SDK and runtimes
+    - task: UseDotNet@2
+      displayName: Use .NET 6.0
+      inputs:
+        packageType: 'runtime'
+        version: '6.x'
+
+    - task: UseDotNet@2
+      displayName: Use .NET 8.0
+      inputs:
+        packageType: 'sdk'
+        version: '8.x'
+
+    - task: DotNetCoreCLI@2
+      displayName: Integration Test With Fault Injection
+      condition: succeeded()
+      inputs:
+        command: test
+        projects: 'Microsoft.Azure.Cosmos/FaultInjection/tests/*.csproj'
+        arguments: --verbosity normal --configuration ${{ parameters.BuildConfiguration }} /p:OS=Windows
+        nugetConfigPath: NuGet.config
+        publishTestResults: true
+        testRunTitle: FaultInjectionTests
+      env:
+        COSMOSDB_MULTI_REGION: ${{ parameters.MultiRegionConnectionString }} # Real Account Connection String used by Integration Tests while running as part of release pipeline


### PR DESCRIPTION

# Pull Request Template

## Description

Two related changes, both driven by the question "how do we know a `DirectVersion` bump hasn't broken `Microsoft.Azure.Cosmos.FaultInjection`?"

### 1. CI gate (the durable fix)

`azure-pipelines.yml` — the PR gate — **never built or tested FaultInjection at all**. Only `azure-pipelines-faultinjection.yml` (the manual release pipeline) did, and it referenced a `templates/build-fault-injection-test.yml` that has never existed in the repo. So a Direct version bump could break FaultInjection and stay invisible until release time.

- **New** `templates/build-fault-injection.yml` — a reusable template with two jobs:
  - *FaultInjection Build and Unit Tests* — restores/builds `FaultInjection/src` and `FaultInjection/tests` in Release, runs the unit tests (no Cosmos account required), and runs `dotnet pack`.
  - *FaultInjection Integration Tests* — opt-in via an `IncludeIntegration` parameter, gated behind a multi-region connection string.
- `azure-pipelines.yml` now consumes the template with `IncludeIntegration: false`. This is the gate that would have caught a Direct break on PR #5976.
- `azure-pipelines-faultinjection.yml` now consumes the same template with `IncludeIntegration: true`, replacing its inline job and the dead template reference.
- `FaultInjection/DEVELOPMENT.md` documents the manual verification ladder for a Direct bump (7 gates: src build → tests build → unit tests → pack → live integration run → baseline diff → downlevel binding check).

I ran that ladder against PR #5976's head. Result: **no regressions.** src and tests build clean (0 warnings), unit tests 32/32, `dotnet pack` succeeds, the bound Direct assembly is 3.44.0, and the set of failing integration tests on the PR is a strict subset of the set failing on `main`.

### 2. Fixing the 18 standing integration test failures

The baseline run above exposed that the FaultInjection integration suite has had 18 failures on `main` for a while. I triaged each one against the product code to determine whether it was a test defect or a real behavior bug.

**All 18 are test defects. There are no product bugs.** The suite is now **124/124 green** (was 108/126).

| Root cause | Tests | Fix |
|---|---|---|
| `Gone` is Direct-mode only — `FaultInjectionRuleBuilder.ValidateGatewayConnection` rejects it for Gateway (by design, per the XML doc on `FaultInjectionServerErrorType.Gone`). The Gateway tests predate that guard. | `FIGatewayRegion`, `FIGatewayHitLimit`, `FIGatewayInjectionRate`, `FIGatewayServerResponse` (`Gone`, `Gone - write`), `..._RegionTest` | Use `TooManyRequests`. Dropped the two `Gone` DataRows — already covered by `FaultInjectionBuilderValidationTests.FaultInjectionRuleBuilder_GatewayWithGone_Throws`. `RegionTest` had a copy/paste `.WithConnectionType(Gateway)` on a Direct-mode rule; corrected. |
| Cross-region retry inflates hit counts. `WithTimes` is enforced **per activityId** (`FaultInjectionServerErrorResultInternal.IsApplicable`), so a retryable 410/403 that `ClientRetryPolicy` retries into another region re-injects. On a 3-region account, "expect exactly 1 hit" observes 3. | `FIGatewayAADRevokedTest`, `FIGatewayUnautharizedTest`, `..._ServerErrorResponseTest`, `..._IncludePrimaryTest` | New `ValidateRuleHit(rule, minimum)` helper. |
| A rule with **no operation-type filter also faults metadata calls** (database account, collection read, PK ranges, address refresh). | `FIGatewayRegion`, `FIGatewayHitLimit` | Scope the rules to `ReadItem` so hit counts are deterministic. |
| `FaultInjectionRuleProcessor.CanErrorLimitToOperation` returns `false` for `Gone`/`ConnectionDelay`, so a `Gone` rule's operation-type filter is silently dropped. The test asserted the opposite. | `..._OperationTypeAddressTest` (`Read`, `Query`) | Expect the rule to apply. |
| `GetFailedRequestCount()` cannot see metadata failures — `IncrementFailedCount()` is only called from `ClientSideRequestStatisticsTraceDatum.RecordResponse` for `StoreResponseStatistics` (RNTBD), never for HTTP/gateway calls. | `AddressRefreshResponseDelayTest`, `PKRangeResponseDelayTest`, `CollectionReadResponseDelayTest` | Assert on the gateway-call diagnostics instead. The injected delay *is* observable there as `"GatewayCalls":{"(0, 0)":1}` + `"A task was canceled."` |
| Read used `new PartitionKey("/pk")` (leading slash) so the post-retry request genuinely 404'd; and `WithTimes(1)` meant SDK-retried errors (500/449) reached the service on attempt 2. | `FIGatewayServerResponse` (`InternalServerError`, `RetryWith`) | Fix the partition key; fault every attempt for those two error types; add a guard so a silently-succeeding row can't pass vacuously. |
| Statistically tight bound (±2.4σ on a 50% injection rate over 100 trials), compounded by the unscoped-metadata issue above. | `FIGatewayInjectionRate`, `..._InjectionRateTest` | `TooManyRequests` + `MaxRetryAttemptsOnRateLimitedRequests = 0` (exactly one hit per injected read) and widen to ±4σ. |

I also threaded diagnostic messages through every assertion helper in the three files, so a future failure reports the rule id, hit count, effective result and exception text directly in the TRX — no local repro needed to diagnose.

I verified the fixes don't hide anything: diffing the passing-test name sets before and after, the only tests that disappear are the two intended `Gone` Gateway DataRows.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [x] Other (Test / CI infrastructure)

## Changelog

- [x] No changelog entry required

Test and pipeline only. `git diff --name-only` confirms the change touches only `templates/`, the two `azure-pipelines-*.yml` files, `FaultInjection/DEVELOPMENT.md`, and `FaultInjection/tests/**`. Nothing under `Microsoft.Azure.Cosmos/src/**` or `FaultInjection/src/**` is modified, and there is no customer-observable behavior change.

## Follow-ups (not in this PR)

Two product-side inconsistencies surfaced during triage. Neither causes a failure today, so I'm leaving them out of this PR, but they're worth issues:

1. `FaultInjectionServerErrorResultBuilder.WithTimes` is documented as "per operation" but implemented per activityId, which is why cross-region retries re-inject.
2. `CanErrorLimitToOperation` silently drops an operation-type filter for `Gone`/`ConnectionDelay` rules instead of surfacing it to the caller — the rule quietly applies more broadly than the author asked for.
