### PR TITLE
[Internal] Session Tokens: Refactors partition-local token build + adds validation primitives

### DIFF
--- a/Microsoft.Azure.Cosmos/src/SessionContainer.cs
+++ b/Microsoft.Azure.Cosmos/src/SessionContainer.cs
@@ -39,19 +39,8 @@ namespace Microsoft.Azure.Cosmos.Common
             return SessionContainer.GetSessionToken(this.state, collectionLink);
         }
 
-        /// <summary>
-        /// Resolves the session token for a specific partition key range within a collection.
-        /// Returns the token in canonical "{pkRangeId}:{lsn}" format, or null if not found.
-        /// This avoids constructing a full DocumentServiceRequest for lightweight lookups.
-        /// </summary>
-        /// <param name="collectionLink">The collection link (name- or rid-based).</param>
-        /// <param name="partitionKeyRangeId">The target partition key range id.</param>
-        /// <param name="parents">
-        /// Optional parent partition key range ids of <paramref name="partitionKeyRangeId"/>. When the
-        /// target range itself has no token yet (e.g. a freshly-split child), the token is derived by
-        /// merging the parents' tokens — mirroring the gateway path
-        /// (ResolvePartitionLocalSessionTokenForGateway). Pass null/empty to skip the parent walk.
-        /// </param>
+        // Same resolution as ResolvePartitionLocalSessionTokenForGateway without requiring a
+        // DocumentServiceRequest. Pass parents to derive a token for a range that has none of its own.
         internal string GetSessionTokenForPartitionKeyRange(string collectionLink, string partitionKeyRangeId, IReadOnlyList<string> parents = null)
         {
             return SessionContainer.GetSessionTokenForPartitionKeyRange(this.state, collectionLink, partitionKeyRangeId, parents);
@@ -102,7 +91,7 @@ namespace Microsoft.Azure.Cosmos.Common
         private static string GetSessionToken(SessionContainerState self, string collectionLink)
         {
             ConcurrentDictionary<string, ISessionToken> partitionKeyRangeIdToTokenMap =
-                SessionContainer.GetPartitionKeyRangeIdToTokenMap(self, collectionLink);
+                SessionContainer.GetPartitionKeyRangeIdToTokenMapForCollectionLink(self, collectionLink);
 
             if (partitionKeyRangeIdToTokenMap == null)
             {
@@ -115,18 +104,12 @@ namespace Microsoft.Azure.Cosmos.Common
         private static string GetSessionTokenForPartitionKeyRange(SessionContainerState self, string collectionLink, string partitionKeyRangeId, IReadOnlyList<string> parents)
         {
             return SessionContainer.BuildPartitionLocalSessionToken(
-                SessionContainer.GetPartitionKeyRangeIdToTokenMap(self, collectionLink),
+                SessionContainer.GetPartitionKeyRangeIdToTokenMapForCollectionLink(self, collectionLink),
                 partitionKeyRangeId,
                 parents);
         }
 
-        /// <summary>
-        /// Builds the partition-local session token ("{pkRangeId}:{lsn}") for
-        /// <paramref name="partitionKeyRangeId"/> from an already-resolved per-partition token map. If the
-        /// range has no token of its own (e.g. a freshly-split child), falls back to merging the parents'
-        /// tokens. Returns null when the map is null or nothing has a token. Shared by the collection-link
-        /// and gateway resolution paths so the two stay in lock-step.
-        /// </summary>
+        // Shared by the collection-link and gateway paths so the two stay in lock-step.
         private static string BuildPartitionLocalSessionToken(
             ConcurrentDictionary<string, ISessionToken> partitionKeyRangeIdToTokenMap,
             string partitionKeyRangeId,
@@ -149,14 +132,7 @@ namespace Microsoft.Azure.Cosmos.Common
                 {
                     if (partitionKeyRangeIdToTokenMap.TryGetValue(parents[parentIndex], out ISessionToken parentToken))
                     {
-                        // A partition can have more than 1 parent (merge). ISessionToken.Merge takes the
-                        // element-wise MAX of the parents' LSN vectors, so the derived token is the correct
-                        // causal floor for the child (never under-reports either parent's progress). We stamp
-                        // the child partitionKeyRangeId onto that merged vector: the pkRangeId is only a routing
-                        // label, the '#'-delimited LSN vector is the causal payload, and ConvertToString emits
-                        // the canonical service representation. This mirrors the gateway path
-                        // (ResolvePartitionLocalSessionTokenForGateway) so the two stay in lock-step.
-                        // See SessionContainerTest.GetSessionTokenForPartitionKeyRange_DivergentParents_MergesToPerRegionMax.
+                        // A partition can have more than 1 parent (merge). In that case, we apply Merge to generate a token with both parent's max LSNs
                         parentSessionToken = parentSessionToken != null ? parentSessionToken.Merge(parentToken) : parentToken;
                     }
                 }
@@ -322,11 +298,10 @@ namespace Microsoft.Azure.Cosmos.Common
             return partitionKeyRangeIdToTokenMap;
         }
 
-        // Shared by the collection-token and partition-local lookups so collection-rid resolution can't
-        // change in one and miss the other. Kept separate from the DocumentServiceRequest overload above:
-        // that one guards ResourceId.Parse behind a non-empty ResourceId check this path never had, so
-        // merging the two would move where a malformed rid throws.
-        private static ConcurrentDictionary<string, ISessionToken> GetPartitionKeyRangeIdToTokenMap(SessionContainerState self, string collectionLink)
+        // Named apart from the DocumentServiceRequest variant rather than overloading it: that one guards
+        // ResourceId.Parse behind a non-empty ResourceId check this path never had, so a malformed rid throws here
+        // but not there. Sharing a name would hide that difference at the call site.
+        private static ConcurrentDictionary<string, ISessionToken> GetPartitionKeyRangeIdToTokenMapForCollectionLink(SessionContainerState self, string collectionLink)
         {
             if (!PathsHelper.TryParsePathSegments(
                 collectionLink,
@@ -430,18 +405,8 @@ namespace Microsoft.Azure.Cosmos.Common
             }
         }
 
-        /// <summary>
-        /// Returns true when <paramref name="sessionToken"/> has the canonical "{pkRangeId}:{lsn}" shape
-        /// (exactly two non-empty segments); the lsn content is validated separately by
-        /// SessionTokenHelper.Parse. Centralized so callers outside the write path (e.g. distributed
-        /// transactions) share one definition of a structurally malformed token, without mutating state.
-        /// </summary>
-        /// <remarks>
-        /// Intentionally stricter than the SetSessionToken write path: SetSessionToken does an unbounded
-        /// Split(':') and reads only parts[0]/parts[1], silently truncating a token like "0:1:2", whereas
-        /// this requires exactly two segments and rejects it. A 3+ segment token is genuinely malformed —
-        /// reject it up front rather than store a truncated token; do not loosen toward the writer.
-        /// </remarks>
+        // Deliberately stricter than the SetSessionToken write path, which does an unbounded Split(':') and
+        // silently truncates a token like "0:1:2" to "1". A 3+ segment token is malformed; don't loosen toward the writer.
         internal static bool IsCanonicalSessionTokenShape(string sessionToken)
         {
             if (string.IsNullOrWhiteSpace(sessionToken))
@@ -453,20 +418,8 @@ namespace Microsoft.Azure.Cosmos.Common
             return tokenParts.Length == 2 && tokenParts[0].Length > 0 && tokenParts[1].Length > 0;
         }
 
-        /// <summary>
-        /// Returns true when <paramref name="sessionToken"/> is both canonically shaped ("{pkRangeId}:{lsn}")
-        /// and its lsn segment parses. Lets callers outside the write path (e.g. distributed transactions)
-        /// detect a malformed token deterministically up front, without mutating state and without forcing
-        /// the caller to catch parse exceptions.
-        /// </summary>
-        /// <remarks>
-        /// Accepts a strict subset of what <see cref="SetSessionToken(string, string, INameValueCollection)"/>
-        /// accepts, so a true result implies the writer would accept it but not the converse. The writer's
-        /// unbounded Split(':') reads only parts[0]/parts[1], so it stores "0:1#100:extra" as "1#100",
-        /// whereas the canonical-shape check rejects any 3+ segment token outright. See
-        /// <see cref="IsCanonicalSessionTokenShape(string)"/> for why this deliberately does not loosen
-        /// toward the writer.
-        /// </remarks>
+        // Lets callers outside the write path classify a malformed token without mutating state or catching
+        // parse exceptions. Accepts a strict subset of what SetSessionToken accepts, never a superset.
         internal static bool IsValidSessionToken(string sessionToken)
         {
             if (!SessionContainer.IsCanonicalSessionTokenShape(sessionToken))
@@ -482,9 +435,7 @@ namespace Microsoft.Azure.Cosmos.Common
             }
             catch (DocumentClientException)
             {
-                // Parse signals an unparseable lsn by throwing InternalServerErrorException (a
-                // DocumentClientException). Catching only that keeps genuine defects — a null deref or
-                // an argument bug inside Parse — visible instead of silently reported as "malformed token".
+                // Parse throws this for an unparseable lsn. Catching only it keeps genuine defects visible.
                 return false;
             }
         }

--- a/Microsoft.Azure.Cosmos/src/SessionContainer.cs
+++ b/Microsoft.Azure.Cosmos/src/SessionContainer.cs
@@ -101,42 +101,8 @@ namespace Microsoft.Azure.Cosmos.Common
 
         private static string GetSessionToken(SessionContainerState self, string collectionLink)
         {
-            bool arePathSegmentsParsed = PathsHelper.TryParsePathSegments(
-                collectionLink,
-                out _,
-                out _,
-                out string resourceIdOrFullName,
-                out bool isNameBased);
-
-            ConcurrentDictionary<string, ISessionToken> partitionKeyRangeIdToTokenMap = null;
-
-            if (arePathSegmentsParsed)
-            {
-                ulong? maybeRID = null;
-
-                if (isNameBased)
-                {
-                    string collectionName = PathsHelper.GetCollectionPath(resourceIdOrFullName);
-
-                    if (self.collectionNameByResourceId.TryGetValue(collectionName, out ulong rid))
-                    {
-                        maybeRID = rid;
-                    }
-                }
-                else
-                {
-                    ResourceId resourceId = ResourceId.Parse(resourceIdOrFullName);
-                    if (resourceId.DocumentCollection != 0)
-                    {
-                        maybeRID = resourceId.UniqueDocumentCollectionId;
-                    }
-                }
-
-                if (maybeRID.HasValue)
-                {
-                    self.sessionTokensRIDBased.TryGetValue(maybeRID.Value, out partitionKeyRangeIdToTokenMap);
-                }
-            }
+            ConcurrentDictionary<string, ISessionToken> partitionKeyRangeIdToTokenMap =
+                SessionContainer.GetPartitionKeyRangeIdToTokenMap(self, collectionLink);
 
             if (partitionKeyRangeIdToTokenMap == null)
             {
@@ -148,44 +114,10 @@ namespace Microsoft.Azure.Cosmos.Common
 
         private static string GetSessionTokenForPartitionKeyRange(SessionContainerState self, string collectionLink, string partitionKeyRangeId, IReadOnlyList<string> parents)
         {
-            bool arePathSegmentsParsed = PathsHelper.TryParsePathSegments(
-                collectionLink,
-                out _,
-                out _,
-                out string resourceIdOrFullName,
-                out bool isNameBased);
-
-            if (!arePathSegmentsParsed)
-            {
-                return null;
-            }
-
-            ulong? maybeRID = null;
-
-            if (isNameBased)
-            {
-                string collectionName = PathsHelper.GetCollectionPath(resourceIdOrFullName);
-                if (self.collectionNameByResourceId.TryGetValue(collectionName, out ulong rid))
-                {
-                    maybeRID = rid;
-                }
-            }
-            else
-            {
-                ResourceId resourceId = ResourceId.Parse(resourceIdOrFullName);
-                if (resourceId.DocumentCollection != 0)
-                {
-                    maybeRID = resourceId.UniqueDocumentCollectionId;
-                }
-            }
-
-            if (maybeRID.HasValue
-                && self.sessionTokensRIDBased.TryGetValue(maybeRID.Value, out ConcurrentDictionary<string, ISessionToken> partitionKeyRangeIdToTokenMap))
-            {
-                return SessionContainer.BuildPartitionLocalSessionToken(partitionKeyRangeIdToTokenMap, partitionKeyRangeId, parents);
-            }
-
-            return null;
+            return SessionContainer.BuildPartitionLocalSessionToken(
+                SessionContainer.GetPartitionKeyRangeIdToTokenMap(self, collectionLink),
+                partitionKeyRangeId,
+                parents);
         }
 
         /// <summary>
@@ -390,6 +322,52 @@ namespace Microsoft.Azure.Cosmos.Common
             return partitionKeyRangeIdToTokenMap;
         }
 
+        // Shared by the collection-token and partition-local lookups so collection-rid resolution can't
+        // change in one and miss the other. Kept separate from the DocumentServiceRequest overload above:
+        // that one guards ResourceId.Parse behind a non-empty ResourceId check this path never had, so
+        // merging the two would move where a malformed rid throws.
+        private static ConcurrentDictionary<string, ISessionToken> GetPartitionKeyRangeIdToTokenMap(SessionContainerState self, string collectionLink)
+        {
+            if (!PathsHelper.TryParsePathSegments(
+                collectionLink,
+                out _,
+                out _,
+                out string resourceIdOrFullName,
+                out bool isNameBased))
+            {
+                return null;
+            }
+
+            ulong? maybeRID = null;
+
+            if (isNameBased)
+            {
+                string collectionName = PathsHelper.GetCollectionPath(resourceIdOrFullName);
+
+                if (self.collectionNameByResourceId.TryGetValue(collectionName, out ulong rid))
+                {
+                    maybeRID = rid;
+                }
+            }
+            else
+            {
+                ResourceId resourceId = ResourceId.Parse(resourceIdOrFullName);
+                if (resourceId.DocumentCollection != 0)
+                {
+                    maybeRID = resourceId.UniqueDocumentCollectionId;
+                }
+            }
+
+            ConcurrentDictionary<string, ISessionToken> partitionKeyRangeIdToTokenMap = null;
+
+            if (maybeRID.HasValue)
+            {
+                self.sessionTokensRIDBased.TryGetValue(maybeRID.Value, out partitionKeyRangeIdToTokenMap);
+            }
+
+            return partitionKeyRangeIdToTokenMap;
+        }
+
         private static void SetSessionToken(SessionContainerState self, ResourceId resourceId, string collectionName, string encodedToken)
         {
             string partitionKeyRangeId;
@@ -477,10 +455,18 @@ namespace Microsoft.Azure.Cosmos.Common
 
         /// <summary>
         /// Returns true when <paramref name="sessionToken"/> is both canonically shaped ("{pkRangeId}:{lsn}")
-        /// and its lsn segment parses — i.e. <see cref="SetSessionToken(string, string, INameValueCollection)"/>
-        /// will accept it. Lets callers outside the write path (e.g. distributed transactions) detect a
-        /// malformed token deterministically up front, without mutating state, throwing, or catching parse exceptions.
+        /// and its lsn segment parses. Lets callers outside the write path (e.g. distributed transactions)
+        /// detect a malformed token deterministically up front, without mutating state and without forcing
+        /// the caller to catch parse exceptions.
         /// </summary>
+        /// <remarks>
+        /// Accepts a strict subset of what <see cref="SetSessionToken(string, string, INameValueCollection)"/>
+        /// accepts, so a true result implies the writer would accept it but not the converse. The writer's
+        /// unbounded Split(':') reads only parts[0]/parts[1], so it stores "0:1#100:extra" as "1#100",
+        /// whereas the canonical-shape check rejects any 3+ segment token outright. See
+        /// <see cref="IsCanonicalSessionTokenShape(string)"/> for why this deliberately does not loosen
+        /// toward the writer.
+        /// </remarks>
         internal static bool IsValidSessionToken(string sessionToken)
         {
             if (!SessionContainer.IsCanonicalSessionTokenShape(sessionToken))
@@ -494,8 +480,11 @@ namespace Microsoft.Azure.Cosmos.Common
                 SessionTokenHelper.Parse(tokenParts[1], HttpConstants.Versions.CurrentVersion);
                 return true;
             }
-            catch (Exception ex) when (!(ex is OperationCanceledException))
+            catch (DocumentClientException)
             {
+                // Parse signals an unparseable lsn by throwing InternalServerErrorException (a
+                // DocumentClientException). Catching only that keeps genuine defects — a null deref or
+                // an argument bug inside Parse — visible instead of silently reported as "malformed token".
                 return false;
             }
         }

--- a/Microsoft.Azure.Cosmos/src/SessionContainer.cs
+++ b/Microsoft.Azure.Cosmos/src/SessionContainer.cs
@@ -39,6 +39,24 @@ namespace Microsoft.Azure.Cosmos.Common
             return SessionContainer.GetSessionToken(this.state, collectionLink);
         }
 
+        /// <summary>
+        /// Resolves the session token for a specific partition key range within a collection.
+        /// Returns the token in canonical "{pkRangeId}:{lsn}" format, or null if not found.
+        /// This avoids constructing a full DocumentServiceRequest for lightweight lookups.
+        /// </summary>
+        /// <param name="collectionLink">The collection link (name- or rid-based).</param>
+        /// <param name="partitionKeyRangeId">The target partition key range id.</param>
+        /// <param name="parents">
+        /// Optional parent partition key range ids of <paramref name="partitionKeyRangeId"/>. When the
+        /// target range itself has no token yet (e.g. a freshly-split child), the token is derived by
+        /// merging the parents' tokens — mirroring the gateway path
+        /// (ResolvePartitionLocalSessionTokenForGateway). Pass null/empty to skip the parent walk.
+        /// </param>
+        internal string GetSessionTokenForPartitionKeyRange(string collectionLink, string partitionKeyRangeId, IReadOnlyList<string> parents = null)
+        {
+            return SessionContainer.GetSessionTokenForPartitionKeyRange(this.state, collectionLink, partitionKeyRangeId, parents);
+        }
+
         public string ResolveGlobalSessionToken(DocumentServiceRequest request)
         {
             return SessionContainer.ResolveGlobalSessionToken(this.state, request);
@@ -128,6 +146,99 @@ namespace Microsoft.Azure.Cosmos.Common
             return SessionContainer.GetSessionTokenString(partitionKeyRangeIdToTokenMap);
         }
 
+        private static string GetSessionTokenForPartitionKeyRange(SessionContainerState self, string collectionLink, string partitionKeyRangeId, IReadOnlyList<string> parents)
+        {
+            bool arePathSegmentsParsed = PathsHelper.TryParsePathSegments(
+                collectionLink,
+                out _,
+                out _,
+                out string resourceIdOrFullName,
+                out bool isNameBased);
+
+            if (!arePathSegmentsParsed)
+            {
+                return null;
+            }
+
+            ulong? maybeRID = null;
+
+            if (isNameBased)
+            {
+                string collectionName = PathsHelper.GetCollectionPath(resourceIdOrFullName);
+                if (self.collectionNameByResourceId.TryGetValue(collectionName, out ulong rid))
+                {
+                    maybeRID = rid;
+                }
+            }
+            else
+            {
+                ResourceId resourceId = ResourceId.Parse(resourceIdOrFullName);
+                if (resourceId.DocumentCollection != 0)
+                {
+                    maybeRID = resourceId.UniqueDocumentCollectionId;
+                }
+            }
+
+            if (maybeRID.HasValue
+                && self.sessionTokensRIDBased.TryGetValue(maybeRID.Value, out ConcurrentDictionary<string, ISessionToken> partitionKeyRangeIdToTokenMap))
+            {
+                return SessionContainer.BuildPartitionLocalSessionToken(partitionKeyRangeIdToTokenMap, partitionKeyRangeId, parents);
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Builds the partition-local session token ("{pkRangeId}:{lsn}") for
+        /// <paramref name="partitionKeyRangeId"/> from an already-resolved per-partition token map. If the
+        /// range has no token of its own (e.g. a freshly-split child), falls back to merging the parents'
+        /// tokens. Returns null when the map is null or nothing has a token. Shared by the collection-link
+        /// and gateway resolution paths so the two stay in lock-step.
+        /// </summary>
+        private static string BuildPartitionLocalSessionToken(
+            ConcurrentDictionary<string, ISessionToken> partitionKeyRangeIdToTokenMap,
+            string partitionKeyRangeId,
+            IReadOnlyList<string> parents)
+        {
+            if (partitionKeyRangeIdToTokenMap == null)
+            {
+                return null;
+            }
+
+            if (partitionKeyRangeIdToTokenMap.TryGetValue(partitionKeyRangeId, out ISessionToken sessionToken))
+            {
+                return partitionKeyRangeId + SessionContainer.sessionTokenSeparator + sessionToken.ConvertToString();
+            }
+
+            if (parents != null)
+            {
+                ISessionToken parentSessionToken = null;
+                for (int parentIndex = parents.Count - 1; parentIndex >= 0; parentIndex--)
+                {
+                    if (partitionKeyRangeIdToTokenMap.TryGetValue(parents[parentIndex], out ISessionToken parentToken))
+                    {
+                        // A partition can have more than 1 parent (merge). ISessionToken.Merge takes the
+                        // element-wise MAX of the parents' LSN vectors, so the derived token is the correct
+                        // causal floor for the child (never under-reports either parent's progress). We stamp
+                        // the child partitionKeyRangeId onto that merged vector: the pkRangeId is only a routing
+                        // label, the '#'-delimited LSN vector is the causal payload, and ConvertToString emits
+                        // the canonical service representation. This mirrors the gateway path
+                        // (ResolvePartitionLocalSessionTokenForGateway) so the two stay in lock-step.
+                        // See SessionContainerTest.GetSessionTokenForPartitionKeyRange_DivergentParents_MergesToPerRegionMax.
+                        parentSessionToken = parentSessionToken != null ? parentSessionToken.Merge(parentToken) : parentToken;
+                    }
+                }
+
+                // When we don't have the session token for a partition, we can leverage the session token of the parent(s)
+                if (parentSessionToken != null)
+                {
+                    return partitionKeyRangeId + SessionContainer.sessionTokenSeparator + parentSessionToken.ConvertToString();
+                }
+            }
+
+            return null;
+        }
+
         private static string ResolveGlobalSessionToken(SessionContainerState self, DocumentServiceRequest request)
         {
             ConcurrentDictionary<string, ISessionToken> partitionKeyRangeIdToTokenMap = SessionContainer.GetPartitionKeyRangeIdToTokenMap(self, request);
@@ -149,34 +260,10 @@ namespace Microsoft.Azure.Cosmos.Common
                                                                           string partitionKeyRangeId)
         {
             ConcurrentDictionary<string, ISessionToken> partitionKeyRangeIdToTokenMap = SessionContainer.GetPartitionKeyRangeIdToTokenMap(self, request);
-            if (partitionKeyRangeIdToTokenMap != null)
-            {
-                if (partitionKeyRangeIdToTokenMap.TryGetValue(partitionKeyRangeId, out ISessionToken sessionToken))
-                {
-                    return partitionKeyRangeId + SessionContainer.sessionTokenSeparator + sessionToken.ConvertToString();
-                }
-                else if (request.RequestContext.ResolvedPartitionKeyRange.Parents != null)
-                {
-                    ISessionToken parentSessionToken = null;
-                    for (int parentIndex = request.RequestContext.ResolvedPartitionKeyRange.Parents.Count - 1; parentIndex >= 0; parentIndex--)
-                    {
-                        if (partitionKeyRangeIdToTokenMap.TryGetValue(request.RequestContext.ResolvedPartitionKeyRange.Parents[parentIndex], 
-                                                                      out sessionToken))
-                        {
-                            // A partition can have more than 1 parent (merge). In that case, we apply Merge to generate a token with both parent's max LSNs
-                            parentSessionToken = parentSessionToken != null ? parentSessionToken.Merge(sessionToken) : sessionToken;
-                        }
-                    }
-
-                    // When we don't have the session token for a partition, we can leverage the session token of the parent(s)
-                    if (parentSessionToken != null)
-                    {
-                        return partitionKeyRangeId + SessionContainer.sessionTokenSeparator + parentSessionToken.ConvertToString();
-                    }
-                }
-            }
-
-            return null;
+            return SessionContainer.BuildPartitionLocalSessionToken(
+                partitionKeyRangeIdToTokenMap,
+                partitionKeyRangeId,
+                request.RequestContext?.ResolvedPartitionKeyRange?.Parents);
         }
 
         private static void ClearTokenByCollectionFullname(SessionContainerState self, string collectionFullname)
@@ -362,6 +449,54 @@ namespace Microsoft.Azure.Cosmos.Common
                 {
                     self.rwlock.ExitWriteLock();
                 }
+            }
+        }
+
+        /// <summary>
+        /// Returns true when <paramref name="sessionToken"/> has the canonical "{pkRangeId}:{lsn}" shape
+        /// (exactly two non-empty segments); the lsn content is validated separately by
+        /// SessionTokenHelper.Parse. Centralized so callers outside the write path (e.g. distributed
+        /// transactions) share one definition of a structurally malformed token, without mutating state.
+        /// </summary>
+        /// <remarks>
+        /// Intentionally stricter than the SetSessionToken write path: SetSessionToken does an unbounded
+        /// Split(':') and reads only parts[0]/parts[1], silently truncating a token like "0:1:2", whereas
+        /// this requires exactly two segments and rejects it. A 3+ segment token is genuinely malformed —
+        /// reject it up front rather than store a truncated token; do not loosen toward the writer.
+        /// </remarks>
+        internal static bool IsCanonicalSessionTokenShape(string sessionToken)
+        {
+            if (string.IsNullOrWhiteSpace(sessionToken))
+            {
+                return false;
+            }
+
+            string[] tokenParts = sessionToken.Split(SessionContainer.sessionTokenSeparator[0]);
+            return tokenParts.Length == 2 && tokenParts[0].Length > 0 && tokenParts[1].Length > 0;
+        }
+
+        /// <summary>
+        /// Returns true when <paramref name="sessionToken"/> is both canonically shaped ("{pkRangeId}:{lsn}")
+        /// and its lsn segment parses — i.e. <see cref="SetSessionToken(string, string, INameValueCollection)"/>
+        /// will accept it. Lets callers outside the write path (e.g. distributed transactions) detect a
+        /// malformed token deterministically up front, without mutating state, throwing, or catching parse exceptions.
+        /// </summary>
+        internal static bool IsValidSessionToken(string sessionToken)
+        {
+            if (!SessionContainer.IsCanonicalSessionTokenShape(sessionToken))
+            {
+                return false;
+            }
+
+            string[] tokenParts = sessionToken.Split(SessionContainer.sessionTokenSeparator[0]);
+            try
+            {
+                SessionTokenHelper.Parse(tokenParts[1], HttpConstants.Versions.CurrentVersion);
+                return true;
+            }
+            catch (Exception ex) when (!(ex is OperationCanceledException))
+            {
+                return false;
             }
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/SessionContainerTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/SessionContainerTest.cs
@@ -79,6 +79,148 @@ namespace Microsoft.Azure.Cosmos
         }
 
         [TestMethod]
+        // GetSessionTokenForPartitionKeyRange must walk the parent ranges when the target range has no
+        // token of its own (freshly-split child), mirroring ResolvePartitionLocalSessionTokenForGateway,
+        // instead of returning null and forcing the DTX caller onto the compound collection-wide token.
+        public void GetSessionTokenForPartitionKeyRange_WalksParents_WhenChildHasNoToken()
+        {
+            SessionContainer sessionContainer = new SessionContainer("127.0.0.1");
+
+            string collectionResourceId = ResourceId.NewDocumentCollectionId(42, 129).DocumentCollectionId.ToString();
+            const string collectionFullname = "dbs/db1/colls/collName_0";
+
+            // Seed two parent ranges; the child "range_99" intentionally has no token.
+            sessionContainer.SetSessionToken(collectionResourceId, collectionFullname,
+                new RequestNameValueCollection() { { HttpConstants.HttpHeaders.SessionToken, "range_1:1#100#4=90#5=2" } });
+            sessionContainer.SetSessionToken(collectionResourceId, collectionFullname,
+                new RequestNameValueCollection() { { HttpConstants.HttpHeaders.SessionToken, "range_2:1#200#4=91#5=3" } });
+
+            // Direct hit: the range's own token is returned as-is.
+            string directParent = sessionContainer.GetSessionTokenForPartitionKeyRange(collectionFullname, "range_1");
+            Assert.IsNotNull(directParent, "A range with its own token must resolve directly.");
+            StringAssert.StartsWith(directParent, "range_1:");
+
+            // Single-parent walk: child inherits the parent's token (only the pkRangeId prefix differs).
+            string childWalk = sessionContainer.GetSessionTokenForPartitionKeyRange(
+                collectionFullname, "range_99", new List<string> { "range_1" });
+            Assert.IsNotNull(childWalk, "A freshly-split child with a known parent must inherit the parent's token.");
+            string expected = "range_99:" + directParent.Substring("range_1:".Length);
+            Assert.AreEqual(expected, childWalk,
+                "The inherited token must equal the parent's token with the child's pkRangeId prefix.");
+
+            // Multi-parent (merge) walk: both parents are considered and a token is produced.
+            string mergeWalk = sessionContainer.GetSessionTokenForPartitionKeyRange(
+                collectionFullname, "range_99", new List<string> { "range_1", "range_2" });
+            Assert.IsNotNull(mergeWalk, "A split child with multiple known parents must inherit a merged token.");
+            StringAssert.StartsWith(mergeWalk, "range_99:");
+
+            // No own token and no resolvable parent → null (the DTX caller then applies no token for the op).
+            Assert.IsNull(
+                sessionContainer.GetSessionTokenForPartitionKeyRange(collectionFullname, "range_77", new List<string> { "range_x" }),
+                "A range with no token and no known parent must return null.");
+            Assert.IsNull(
+                sessionContainer.GetSessionTokenForPartitionKeyRange(collectionFullname, "range_77"),
+                "Without a parent list, a range with no token must return null (no parent walk).");
+        }
+
+        [TestMethod]
+        // Divergent-parent causal correctness (reviewer feedback K1): when a freshly-split child inherits
+        // from multiple parents whose LSN vectors diverge per region, the merged token stamped under the
+        // child range id must carry the element-wise MAX of the parents' vectors — the correct causal floor.
+        // Stamping the child's pkRangeId onto the merged parent vector is intentional and matches the gateway
+        // path (ResolvePartitionLocalSessionTokenForGateway): the pkRangeId is only a routing label, while the
+        // '#'-delimited LSN vector is the causal payload, and ISessionToken.Merge preserves each region's
+        // high-water mark. This test proves the next request after a merge carries a valid causal token rather
+        // than under-reporting either parent's progress.
+        public void GetSessionTokenForPartitionKeyRange_DivergentParents_MergesToPerRegionMax()
+        {
+            string collectionResourceId = ResourceId.NewDocumentCollectionId(42, 130).DocumentCollectionId.ToString();
+            const string collectionFullname = "dbs/db1/colls/collName_1";
+
+            // Two parents with per-region divergence: parent A leads region 4, parent B leads the
+            // global LSN and region 5. A correct causal merge must take the max of each component.
+            const string parentAToken = "range_10:1#100#4=90#5=2";
+            const string parentBToken = "range_20:1#200#4=80#5=9";
+
+            SessionContainer actualContainer = new SessionContainer("127.0.0.1");
+            actualContainer.SetSessionToken(collectionResourceId, collectionFullname,
+                new RequestNameValueCollection() { { HttpConstants.HttpHeaders.SessionToken, parentAToken } });
+            actualContainer.SetSessionToken(collectionResourceId, collectionFullname,
+                new RequestNameValueCollection() { { HttpConstants.HttpHeaders.SessionToken, parentBToken } });
+
+            string mergedChild = actualContainer.GetSessionTokenForPartitionKeyRange(
+                collectionFullname, "range_child", new List<string> { "range_10", "range_20" });
+
+            // Build the expected token through the same store/read path so the LSN serialization format
+            // (ConvertToString) matches exactly: element-wise max => global 200, region 4 = 90, region 5 = 9.
+            SessionContainer expectedContainer = new SessionContainer("127.0.0.1");
+            expectedContainer.SetSessionToken(collectionResourceId, collectionFullname,
+                new RequestNameValueCollection() { { HttpConstants.HttpHeaders.SessionToken, "range_child:1#200#4=90#5=9" } });
+            string expected = expectedContainer.GetSessionTokenForPartitionKeyRange(collectionFullname, "range_child");
+
+            Assert.IsNotNull(mergedChild, "A split child with two known divergent parents must inherit a merged token.");
+            Assert.AreEqual(expected, mergedChild,
+                "The merged child token must carry the element-wise max of both parents' LSN vectors " +
+                "(the causal floor), stamped under the child pkRangeId.");
+        }
+
+        [DataTestMethod]
+        [DataRow("0:1#100", DisplayName = "canonical two-segment")]
+        [DataRow("0:1#100#4=90#5=2", DisplayName = "canonical with multi-region lsn payload")]
+        [DataRow("range_7:1#5", DisplayName = "canonical with non-numeric range id")]
+        // A canonical session token is exactly two non-empty ':'-separated segments ("{pkRangeId}:{lsn}").
+        // The lsn payload's own '#'/'=' separators do not introduce extra ':' segments, so realistic
+        // multi-region tokens remain canonical. Content of the lsn segment is validated separately by Parse.
+        public void IsCanonicalSessionTokenShape_CanonicalTokens_ReturnTrue(string sessionToken)
+        {
+            Assert.IsTrue(SessionContainer.IsCanonicalSessionTokenShape(sessionToken),
+                $"'{sessionToken}' has the canonical two-segment shape and must be accepted.");
+        }
+
+        [DataTestMethod]
+        [DataRow(null, DisplayName = "null")]
+        [DataRow("", DisplayName = "empty")]
+        [DataRow("   ", DisplayName = "whitespace only")]
+        [DataRow("1#9#4=8#5=7", DisplayName = "lsn only, no colon")]
+        [DataRow("0", DisplayName = "single segment")]
+        [DataRow(":1#100", DisplayName = "empty pkRangeId segment (leading colon)")]
+        [DataRow("0:", DisplayName = "empty lsn segment (trailing colon)")]
+        [DataRow("0:1:2", DisplayName = "three segments (multi-colon)")]
+        [DataRow("0:1#100:extra", DisplayName = "multi-colon with content")]
+        // Anything that is not exactly two non-empty ':'-separated segments is non-canonical. Locks in the
+        // Split-based semantics (multi-colon, leading/trailing colon, blank strings) that differ from the
+        // previous single-IndexOf check.
+        public void IsCanonicalSessionTokenShape_NonCanonicalTokens_ReturnFalse(string sessionToken)
+        {
+            Assert.IsFalse(SessionContainer.IsCanonicalSessionTokenShape(sessionToken),
+                $"'{sessionToken ?? "<null>"}' is not a canonical two-segment token and must be rejected.");
+        }
+
+        [DataTestMethod]
+        [DataRow("0:1#100", DisplayName = "canonical, parseable lsn")]
+        [DataRow("0:1#100#4=90#5=2", DisplayName = "canonical with multi-region lsn payload")]
+        // A valid token is both canonically shaped AND has an lsn segment that SessionTokenHelper.Parse accepts.
+        public void IsValidSessionToken_CanonicalAndParseable_ReturnTrue(string sessionToken)
+        {
+            Assert.IsTrue(SessionContainer.IsValidSessionToken(sessionToken),
+                $"'{sessionToken}' is canonically shaped with a parseable lsn and must be accepted.");
+        }
+
+        [DataTestMethod]
+        [DataRow(null, DisplayName = "null")]
+        [DataRow("", DisplayName = "empty")]
+        [DataRow("1#9#4=8#5=7", DisplayName = "bad shape: lsn only, no colon")]
+        [DataRow("0:not-a-valid-lsn", DisplayName = "shape valid, content unparseable")]
+        [DataRow("0:100", DisplayName = "shape valid, legacy non-Vector lsn rejected by Parse")]
+        // A token that is non-canonical in shape OR whose lsn segment fails Parse is not valid. Content
+        // validation never throws — it returns false so callers can classify deterministically up front.
+        public void IsValidSessionToken_BadShapeOrUnparseableContent_ReturnFalse(string sessionToken)
+        {
+            Assert.IsFalse(SessionContainer.IsValidSessionToken(sessionToken),
+                $"'{sessionToken ?? "<null>"}' is not a valid session token and must be rejected without throwing.");
+        }
+
+        [TestMethod]
         public void TestResolveGlobalSessionTokenReturnsEmptyStringOnEmptyCache()
         {
             SessionContainer sessionContainer = new SessionContainer("127.0.0.1");

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/SessionContainerTest.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/SessionContainerTest.cs
@@ -124,6 +124,47 @@ namespace Microsoft.Azure.Cosmos
         }
 
         [TestMethod]
+        // GetSessionTokenForPartitionKeyRange must resolve a rid-based collection link ("dbs/{rid}/colls/{rid}")
+        // through the ResourceId.Parse branch, not just name-based links, and land on the same per-partition
+        // token map. Both link forms must yield identical tokens for the same range so a DTX caller that holds
+        // a self-link resolves exactly as one holding a name-based link.
+        public void GetSessionTokenForPartitionKeyRange_ResolvesRidBasedCollectionLink()
+        {
+            SessionContainer sessionContainer = new SessionContainer("127.0.0.1");
+
+            ResourceId resourceId = ResourceId.NewDocumentCollectionId(42, 129);
+            string collectionResourceId = resourceId.DocumentCollectionId.ToString();
+            const string collectionFullname = "dbs/db1/colls/collName_rid";
+            string ridBasedLink = string.Format("dbs/{0}/colls/{1}", resourceId.DatabaseId.ToString(), collectionResourceId);
+
+            sessionContainer.SetSessionToken(collectionResourceId, collectionFullname,
+                new RequestNameValueCollection() { { HttpConstants.HttpHeaders.SessionToken, "range_1:1#100#4=90#5=2" } });
+
+            // Direct hit via the rid-based link resolves the same token as the name-based link.
+            string ridResolved = sessionContainer.GetSessionTokenForPartitionKeyRange(ridBasedLink, "range_1");
+            Assert.IsNotNull(ridResolved, "A rid-based collection link must resolve the range's token.");
+            Assert.AreEqual(
+                sessionContainer.GetSessionTokenForPartitionKeyRange(collectionFullname, "range_1"),
+                ridResolved,
+                "The rid-based and name-based links must resolve to the same token for the same range.");
+
+            // Parent-walk also works through the rid-based link.
+            string ridChildWalk = sessionContainer.GetSessionTokenForPartitionKeyRange(
+                ridBasedLink, "range_99", new List<string> { "range_1" });
+            Assert.AreEqual("range_99:" + ridResolved.Substring("range_1:".Length), ridChildWalk,
+                "The parent walk must resolve identically through a rid-based link.");
+
+            // An unknown collection rid (never seeded) resolves to null rather than throwing.
+            string unknownRidLink = string.Format(
+                "dbs/{0}/colls/{1}",
+                resourceId.DatabaseId.ToString(),
+                ResourceId.NewDocumentCollectionId(42, 130).DocumentCollectionId.ToString());
+            Assert.IsNull(
+                sessionContainer.GetSessionTokenForPartitionKeyRange(unknownRidLink, "range_1"),
+                "An unseeded collection rid must resolve to null.");
+        }
+
+        [TestMethod]
         // Divergent-parent causal correctness (reviewer feedback K1): when a freshly-split child inherits
         // from multiple parents whose LSN vectors diverge per region, the merged token stamped under the
         // child range id must carry the element-wise MAX of the parents' vectors — the correct causal floor.


### PR DESCRIPTION
# Pull Request Template

## Description

Extract BuildPartitionLocalSessionToken as the shared helper for the collection-link and gateway partition-local token resolution paths, add GetSessionTokenForPartitionKeyRange for lightweight per-range lookups, tighten IsCanonicalSessionTokenShape (exactly two non-empty segments), and add IsValidSessionToken (shape + parseable lsn) so callers outside the write path share one definition of a malformed token.

Multi-parent merge (reviewer feedback K1): document and test that a freshly-split child inheriting from divergent parents receives the element-wise max of the parents' LSN vectors (the causal floor) stamped under the child pkRangeId, matching the gateway path.


## Type of change

Please delete options that are not relevant.

- [] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [] This change requires a documentation update

## Closing issues

To automatically close an issue: closes #IssueNumber

## Changelog

- [ ] I have added a changelog entry under `### Unreleased` in `changelog.md`
  for the user-facing impact of this change.
- [X] No changelog entry is required because this PR is one of:
  documentation-only, test-only, CI / build-only, or a pure internal refactor
  with no observable customer impact.

If the second box is checked, briefly justify here:

> Internal refactor
