### PR TITLE
Distributed Transactions: Fixes malformed session token capture

### DIFF
--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionCommitter.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionCommitter.cs
@@ -106,7 +106,10 @@ namespace Microsoft.Azure.Cosmos
                     this.clientContext.SerializerCore,
                     cancellationToken);
 
-                return await this.ExecuteCommitWithRetryAsync(serverRequest, trace, cancellationToken);
+                // Resolve once per transaction; retries use the same consistency level.
+                ConsistencyLevel? effectiveConsistencyLevel = await this.ResolveEffectiveConsistencyLevelAsync();
+
+                return await this.ExecuteCommitWithRetryAsync(serverRequest, effectiveConsistencyLevel, trace, cancellationToken);
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
@@ -115,8 +118,41 @@ namespace Microsoft.Azure.Cosmos
             }
         }
 
+        /// <summary>
+        /// Resolves the effective consistency level for the transaction.
+        /// </summary>
+        private async Task<ConsistencyLevel?> ResolveEffectiveConsistencyLevelAsync()
+        {
+            ConsistencyLevel? clientOverride = this.clientContext.ClientOptions?.ConsistencyLevel;
+            if (clientOverride.HasValue)
+            {
+                return clientOverride.Value;
+            }
+
+            DocumentClient documentClient = this.clientContext.DocumentClient;
+            if (documentClient == null)
+            {
+                return null;
+            }
+
+            try
+            {
+                return await documentClient.GetDefaultConsistencyLevelAsync();
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                DefaultTrace.TraceWarning(
+                    "Distributed transaction could not resolve the account consistency level ([{0}] {1}); " +
+                    "session token failures will be traced rather than surfaced.",
+                    ex.GetType().Name,
+                    ex.Message);
+                return null;
+            }
+        }
+
         private async Task<DistributedTransactionResponse> ExecuteCommitWithRetryAsync(
             DistributedTransactionServerRequest serverRequest,
+            ConsistencyLevel? effectiveConsistencyLevel,
             ITrace parentTrace,
             CancellationToken cancellationToken)
         {
@@ -133,7 +169,7 @@ namespace Microsoft.Azure.Cosmos
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                DistributedTransactionResponse response = await this.ExecuteCommitAsync(serverRequest, rotateIdempotencyToken, parentTrace, cancellationToken);
+                DistributedTransactionResponse response = await this.ExecuteCommitAsync(serverRequest, effectiveConsistencyLevel, rotateIdempotencyToken, parentTrace, cancellationToken);
 
                 if (response.IsSuccessStatusCode || !response.IsRetriable)
                 {
@@ -215,6 +251,7 @@ namespace Microsoft.Azure.Cosmos
 
         private async Task<DistributedTransactionResponse> ExecuteCommitAsync(
             DistributedTransactionServerRequest serverRequest,
+            ConsistencyLevel? effectiveConsistencyLevel,
             bool rotateIdempotencyToken,
             ITrace parentTrace,
             CancellationToken cancellationToken)
@@ -256,10 +293,23 @@ namespace Microsoft.Azure.Cosmos
                             attemptTrace,
                             cancellationToken);
 
-                        DistributedTransactionCommitter.MergeSessionTokens(
-                            response,
-                            serverRequest,
-                            this.clientContext.DocumentClient?.sessionContainer);
+                        try
+                        {
+                            DistributedTransactionCommitter.MergeSessionTokens(
+                                response,
+                                serverRequest,
+                                this.clientContext.DocumentClient?.sessionContainer,
+                                effectiveConsistencyLevel,
+                                this.operationType);
+                        }
+                        catch
+                        {
+                            // Ownership of the response transfers to the caller only on the return path.
+                            // When bookkeeping throws, nothing else can reach it, so it is disposed here
+                            // rather than left to the finalizer.
+                            response.Dispose();
+                            throw;
+                        }
 
                         return response;
                     }
@@ -279,7 +329,9 @@ namespace Microsoft.Azure.Cosmos
         internal static void MergeSessionTokens(
             DistributedTransactionResponse response,
             DistributedTransactionServerRequest serverRequest,
-            ISessionContainer sessionContainer)
+            ISessionContainer sessionContainer,
+            ConsistencyLevel? effectiveConsistencyLevel,
+            OperationType operationType)
         {
             // Mirror the pattern used by GatewayStoreModel.CaptureSessionTokenAndHandleSplitAsync.
             // after a response is received, store each operation's session token in the SessionContainer
@@ -287,8 +339,7 @@ namespace Microsoft.Azure.Cosmos
             // without getting ReadSessionNotAvailable.
             //
             // DTC spans multiple collections so the server embeds per-operation session tokens in the JSON body.
-            // DistributedTransactionOperationResult.FromJson assembles each token into canonical SDK session-token
-            // format, and capture is gated per sub-operation on the same statuses point operations capture on.
+            // Capture is gated per sub-operation on the same statuses point operations capture on.
             if (response == null || response.Count == 0 || serverRequest == null || sessionContainer == null)
             {
                 return;
@@ -296,11 +347,24 @@ namespace Microsoft.Azure.Cosmos
 
             RequestNameValueCollection headers = new RequestNameValueCollection();
 
+            // Surfacing a token failure ends the transaction with an exception, so it may only happen once
+            // the outcome is settled. ExecuteCommitWithRetryAsync decides on retries after this method
+            // returns, and the message below asserts the transaction committed in full, so both conditions
+            // are evaluated on the envelope rather than on the sub-operation that carried the bad token.
+            bool transactionCommitted = DistributedTransactionCommitter.IsCommittedInFull(response);
+
             for (int i = 0; i < response.Count; i++)
             {
                 DistributedTransactionOperationResult result = response[i];
 
+                bool surfaceTokenFailures = transactionCommitted
+                    && effectiveConsistencyLevel == ConsistencyLevel.Session;
+
                 DistributedTransactionOperation operation = null;
+                string collectionFullName = null;
+                string failureReason = null;
+                Exception failureCause = null;
+
                 try
                 {
                     operation = serverRequest.Operations[result.Index];
@@ -321,30 +385,115 @@ namespace Microsoft.Azure.Cosmos
                         continue;
                     }
 
-                    // SessionToken is already in canonical SDK session-token format, assembled by FromJson.
-                    // Note: each SetSessionToken call acquires a write lock on the SessionContainer.
-                    // For a future optimization, consider a batch-update API on ISessionContainer to
-                    // reduce lock acquisitions when multiple operations target the same collection.
-                    headers.Clear();
-                    headers[HttpConstants.HttpHeaders.SessionToken] = result.SessionToken;
+                    collectionFullName = DistributedTransactionConstants.GetCollectionFullName(operation.Database, operation.Container);
 
-                    sessionContainer.SetSessionToken(
-                        operation.CollectionResourceId,
-                        DistributedTransactionConstants.GetCollectionFullName(operation.Database, operation.Container),
-                        headers);
+                    if (DistributedTransactionCommitter.TryValidateSessionToken(result.SessionToken, out string validationFailure))
+                    {
+                        // SetSessionToken acquires a write lock on the session container.
+                        headers.Clear();
+                        headers[HttpConstants.HttpHeaders.SessionToken] = result.SessionToken;
+
+                        sessionContainer.SetSessionToken(
+                            operation.CollectionResourceId,
+                            collectionFullName,
+                            headers);
+                    }
+                    else
+                    {
+                        failureReason = $"{validationFailure} Token: '{TruncateForLog(result.SessionToken)}'.";
+                    }
                 }
                 catch (Exception ex) when (ex is not OperationCanceledException)
                 {
-                    // Session-token bookkeeping must never fail a transaction the server already committed.
-                    // Log and continue so the remaining operations' tokens are still attempted.
-                    DefaultTrace.TraceWarning(
-                        "DTC session token merge failed for operation index {0} (collection {1}): [{2}] {3}",
-                        result.Index,
-                        operation?.CollectionResourceId ?? "<unknown>",
-                        ex.GetType().Name,
-                        ex.Message);
+                    failureCause = ex;
+                    failureReason = ex.Message;
+                }
+
+                if (failureReason == null)
+                {
+                    continue;
+                }
+
+                // The collection is unknown only when resolving the operation itself threw.
+                string collectionScope = collectionFullName == null
+                    ? string.Empty
+                    : $" for collection '{collectionFullName}'";
+
+                // Apply the same policy to invalid and rejected tokens.
+                string message = $"Session token for operation index {result.Index} could not be recorded{collectionScope}: {failureReason}";
+
+                // Keep server-supplied braces out of the format string.
+                DefaultTrace.TraceWarning("{0} Session token was not recorded.", message);
+
+                if (surfaceTokenFailures)
+                {
+                    // Read transactions never commit, so the caller-facing outcome differs even though the
+                    // capture path is shared.
+                    string outcome = operationType == OperationType.Read
+                        ? " The read transaction completed successfully and should not be retried."
+                        : " The transaction was committed successfully and should not be retried.";
+
+                    // Stop at the first failure; later tokens are intentionally not recorded.
+                    throw new InvalidOperationException(message + outcome, failureCause);
                 }
             }
+        }
+
+        /// <summary>
+        /// Determines whether the response represents a transaction that committed in full: a non-error,
+        /// non-retriable envelope in which every sub-operation also carries a non-error status.
+        /// </summary>
+        /// <remarks>
+        /// A MultiStatus envelope is a success status but reports a rolled back transaction through its
+        /// sub-operations, so the envelope status alone cannot establish that the transaction committed.
+        /// </remarks>
+        private static bool IsCommittedInFull(DistributedTransactionResponse response)
+        {
+            if (response.IsRetriable || (int)response.StatusCode >= (int)StatusCodes.StartingErrorCode)
+            {
+                return false;
+            }
+
+            for (int i = 0; i < response.Count; i++)
+            {
+                if ((int)response[i].StatusCode >= (int)StatusCodes.StartingErrorCode)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Determines whether a session token is usable: it must parse, and it must carry the partition
+        /// key range id the progress was recorded against.
+        /// </summary>
+        /// <param name="sessionToken">The token reported for a single operation.</param>
+        /// <param name="failureReason">The reason the token is unusable, or <c>null</c> when it is usable.</param>
+        /// <remarks>
+        /// The range id is checked separately because
+        /// <see cref="SessionTokenHelper.TryParse(string, out string, out ISessionToken)"/> accepts a bare
+        /// LSN and reports an empty range id for it. Without that check a prefix-less token reaches
+        /// <see cref="ISessionContainer.SetSessionToken(string, string, INameValueCollection)"/>
+        /// and fails there with an <see cref="IndexOutOfRangeException"/>.
+        /// </remarks>
+        private static bool TryValidateSessionToken(string sessionToken, out string failureReason)
+        {
+            if (!SessionTokenHelper.TryParse(sessionToken, out string partitionKeyRangeId, out ISessionToken _))
+            {
+                failureReason = "the token could not be parsed.";
+                return false;
+            }
+
+            if (string.IsNullOrEmpty(partitionKeyRangeId))
+            {
+                failureReason = "the token is missing the partitionKeyRangeId prefix.";
+                return false;
+            }
+
+            failureReason = null;
+            return true;
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionCommitter.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionCommitter.cs
@@ -348,9 +348,10 @@ namespace Microsoft.Azure.Cosmos
             RequestNameValueCollection headers = new RequestNameValueCollection();
 
             // Surfacing a token failure ends the transaction with an exception, so it may only happen once
-            // the outcome is settled. ExecuteCommitWithRetryAsync decides on retries after this method
-            // returns, and the message below asserts the transaction committed in full, so both conditions
-            // are evaluated on the envelope rather than on the sub-operation that carried the bad token.
+            // the outcome is settled. IsCommittedInFull mirrors the terminal condition ExecuteCommitWithRetryAsync
+            // applies after this method returns, and the message below asserts the transaction committed in full,
+            // so both conditions are evaluated on the envelope rather than on the sub-operation that carried
+            // the bad token.
             bool transactionCommitted = DistributedTransactionCommitter.IsCommittedInFull(response);
 
             for (int i = 0; i < response.Count; i++)
@@ -440,8 +441,8 @@ namespace Microsoft.Azure.Cosmos
         }
 
         /// <summary>
-        /// Determines whether the response represents a transaction that committed in full: a non-error,
-        /// non-retriable envelope in which every sub-operation also carries a non-error status.
+        /// Determines whether the response represents a transaction that committed in full: a settled,
+        /// non-error envelope in which every sub-operation also carries a non-error status.
         /// </summary>
         /// <remarks>
         /// A MultiStatus envelope is a success status but reports a rolled back transaction through its
@@ -449,7 +450,13 @@ namespace Microsoft.Azure.Cosmos
         /// </remarks>
         private static bool IsCommittedInFull(DistributedTransactionResponse response)
         {
-            if (response.IsRetriable || (int)response.StatusCode >= (int)StatusCodes.StartingErrorCode)
+            // Mirrors the terminal condition in ExecuteCommitWithRetryAsync. A response that the loop will
+            // not retry is the outcome the caller receives, which is the only point a token failure may
+            // surface on. Testing IsRetriable alone would leave a success envelope that also reports
+            // isRetriable unsettled here even though the loop returns it, silently dropping its token.
+            bool outcomeIsSettled = response.IsSuccessStatusCode || !response.IsRetriable;
+
+            if (!outcomeIsSettled || (int)response.StatusCode >= (int)StatusCodes.StartingErrorCode)
             {
                 return false;
             }

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionCommitter.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionCommitter.cs
@@ -351,24 +351,22 @@ namespace Microsoft.Azure.Cosmos
             // the outcome is settled. IsCommittedInFull mirrors the terminal condition ExecuteCommitWithRetryAsync
             // applies after this method returns, and the message below asserts the transaction committed in full,
             // so both conditions are evaluated on the envelope rather than on the sub-operation that carried
-            // the bad token.
-            bool transactionCommitted = DistributedTransactionCommitter.IsCommittedInFull(response);
+            // the bad token. Ordering the consistency test first skips the envelope scan whenever the failure
+            // could not be surfaced anyway.
+            bool surfaceTokenFailures = effectiveConsistencyLevel == ConsistencyLevel.Session
+                && DistributedTransactionCommitter.IsCommittedInFull(response);
 
             for (int i = 0; i < response.Count; i++)
             {
                 DistributedTransactionOperationResult result = response[i];
 
-                bool surfaceTokenFailures = transactionCommitted
-                    && effectiveConsistencyLevel == ConsistencyLevel.Session;
-
-                DistributedTransactionOperation operation = null;
                 string collectionFullName = null;
                 string failureReason = null;
                 Exception failureCause = null;
 
                 try
                 {
-                    operation = serverRequest.Operations[result.Index];
+                    DistributedTransactionOperation operation = serverRequest.Operations[result.Index];
 
                     if (string.IsNullOrEmpty(result.SessionToken) || string.IsNullOrEmpty(operation.CollectionResourceId))
                     {
@@ -481,7 +479,7 @@ namespace Microsoft.Azure.Cosmos
         /// <remarks>
         /// The range id is checked separately because
         /// <see cref="SessionTokenHelper.TryParse(string, out string, out ISessionToken)"/> accepts a bare
-        /// LSN and reports an empty range id for it. Without that check a prefix-less token reaches
+        /// LSN and reports a null range id for it. Without that check a prefix-less token reaches
         /// <see cref="ISessionContainer.SetSessionToken(string, string, INameValueCollection)"/>
         /// and fails there with an <see cref="IndexOutOfRangeException"/>.
         /// </remarks>

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionCommitter.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionCommitter.cs
@@ -106,10 +106,7 @@ namespace Microsoft.Azure.Cosmos
                     this.clientContext.SerializerCore,
                     cancellationToken);
 
-                // Resolve once per transaction; retries use the same consistency level.
-                ConsistencyLevel? effectiveConsistencyLevel = await this.ResolveEffectiveConsistencyLevelAsync();
-
-                return await this.ExecuteCommitWithRetryAsync(serverRequest, effectiveConsistencyLevel, trace, cancellationToken);
+                return await this.ExecuteCommitWithRetryAsync(serverRequest, trace, cancellationToken);
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
@@ -118,41 +115,8 @@ namespace Microsoft.Azure.Cosmos
             }
         }
 
-        /// <summary>
-        /// Resolves the effective consistency level for the transaction.
-        /// </summary>
-        private async Task<ConsistencyLevel?> ResolveEffectiveConsistencyLevelAsync()
-        {
-            ConsistencyLevel? clientOverride = this.clientContext.ClientOptions?.ConsistencyLevel;
-            if (clientOverride.HasValue)
-            {
-                return clientOverride.Value;
-            }
-
-            DocumentClient documentClient = this.clientContext.DocumentClient;
-            if (documentClient == null)
-            {
-                return null;
-            }
-
-            try
-            {
-                return await documentClient.GetDefaultConsistencyLevelAsync();
-            }
-            catch (Exception ex) when (ex is not OperationCanceledException)
-            {
-                DefaultTrace.TraceWarning(
-                    "Distributed transaction could not resolve the account consistency level ([{0}] {1}); " +
-                    "session token failures will be traced rather than surfaced.",
-                    ex.GetType().Name,
-                    ex.Message);
-                return null;
-            }
-        }
-
         private async Task<DistributedTransactionResponse> ExecuteCommitWithRetryAsync(
             DistributedTransactionServerRequest serverRequest,
-            ConsistencyLevel? effectiveConsistencyLevel,
             ITrace parentTrace,
             CancellationToken cancellationToken)
         {
@@ -169,7 +133,7 @@ namespace Microsoft.Azure.Cosmos
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                DistributedTransactionResponse response = await this.ExecuteCommitAsync(serverRequest, effectiveConsistencyLevel, rotateIdempotencyToken, parentTrace, cancellationToken);
+                DistributedTransactionResponse response = await this.ExecuteCommitAsync(serverRequest, rotateIdempotencyToken, parentTrace, cancellationToken);
 
                 if (response.IsSuccessStatusCode || !response.IsRetriable)
                 {
@@ -251,7 +215,6 @@ namespace Microsoft.Azure.Cosmos
 
         private async Task<DistributedTransactionResponse> ExecuteCommitAsync(
             DistributedTransactionServerRequest serverRequest,
-            ConsistencyLevel? effectiveConsistencyLevel,
             bool rotateIdempotencyToken,
             ITrace parentTrace,
             CancellationToken cancellationToken)
@@ -298,9 +261,7 @@ namespace Microsoft.Azure.Cosmos
                             DistributedTransactionCommitter.MergeSessionTokens(
                                 response,
                                 serverRequest,
-                                this.clientContext.DocumentClient?.sessionContainer,
-                                effectiveConsistencyLevel,
-                                this.operationType);
+                                this.clientContext.DocumentClient?.sessionContainer);
                         }
                         catch
                         {
@@ -329,9 +290,7 @@ namespace Microsoft.Azure.Cosmos
         internal static void MergeSessionTokens(
             DistributedTransactionResponse response,
             DistributedTransactionServerRequest serverRequest,
-            ISessionContainer sessionContainer,
-            ConsistencyLevel? effectiveConsistencyLevel,
-            OperationType operationType)
+            ISessionContainer sessionContainer)
         {
             // Mirror the pattern used by GatewayStoreModel.CaptureSessionTokenAndHandleSplitAsync.
             // after a response is received, store each operation's session token in the SessionContainer
@@ -346,15 +305,6 @@ namespace Microsoft.Azure.Cosmos
             }
 
             RequestNameValueCollection headers = new RequestNameValueCollection();
-
-            // Surfacing a token failure ends the transaction with an exception, so it may only happen once
-            // the outcome is settled. IsCommittedInFull mirrors the terminal condition ExecuteCommitWithRetryAsync
-            // applies after this method returns, and the message below asserts the transaction committed in full,
-            // so both conditions are evaluated on the envelope rather than on the sub-operation that carried
-            // the bad token. Ordering the consistency test first skips the envelope scan whenever the failure
-            // could not be surfaced anyway.
-            bool surfaceTokenFailures = effectiveConsistencyLevel == ConsistencyLevel.Session
-                && DistributedTransactionCommitter.IsCommittedInFull(response);
 
             for (int i = 0; i < response.Count; i++)
             {
@@ -388,7 +338,6 @@ namespace Microsoft.Azure.Cosmos
 
                     if (DistributedTransactionCommitter.TryValidateSessionToken(result.SessionToken, out string validationFailure))
                     {
-                        // SetSessionToken acquires a write lock on the session container.
                         headers.Clear();
                         headers[HttpConstants.HttpHeaders.SessionToken] = result.SessionToken;
 
@@ -413,76 +362,20 @@ namespace Microsoft.Azure.Cosmos
                     continue;
                 }
 
-                // The collection is unknown only when resolving the operation itself threw.
                 string collectionScope = collectionFullName == null
                     ? string.Empty
                     : $" for collection '{collectionFullName}'";
 
-                // Apply the same policy to invalid and rejected tokens.
                 string message = $"Session token for operation index {result.Index} could not be recorded{collectionScope}: {failureReason}";
 
                 // Keep server-supplied braces out of the format string.
                 DefaultTrace.TraceWarning("{0} Session token was not recorded.", message);
 
-                if (surfaceTokenFailures)
-                {
-                    // Read transactions never commit, so the caller-facing outcome differs even though the
-                    // capture path is shared.
-                    string outcome = operationType == OperationType.Read
-                        ? " The read transaction completed successfully and should not be retried."
-                        : " The transaction was committed successfully and should not be retried.";
-
-                    // Stop at the first failure; later tokens are intentionally not recorded.
-                    throw new InvalidOperationException(message + outcome, failureCause);
-                }
+                // Stop at the first failure; later tokens are intentionally not recorded.
+                throw new InvalidOperationException(message, failureCause);
             }
         }
 
-        /// <summary>
-        /// Determines whether the response represents a transaction that committed in full: a settled,
-        /// non-error envelope in which every sub-operation also carries a non-error status.
-        /// </summary>
-        /// <remarks>
-        /// A MultiStatus envelope is a success status but reports a rolled back transaction through its
-        /// sub-operations, so the envelope status alone cannot establish that the transaction committed.
-        /// </remarks>
-        private static bool IsCommittedInFull(DistributedTransactionResponse response)
-        {
-            // Mirrors the terminal condition in ExecuteCommitWithRetryAsync. A response that the loop will
-            // not retry is the outcome the caller receives, which is the only point a token failure may
-            // surface on. Testing IsRetriable alone would leave a success envelope that also reports
-            // isRetriable unsettled here even though the loop returns it, silently dropping its token.
-            bool outcomeIsSettled = response.IsSuccessStatusCode || !response.IsRetriable;
-
-            if (!outcomeIsSettled || (int)response.StatusCode >= (int)StatusCodes.StartingErrorCode)
-            {
-                return false;
-            }
-
-            for (int i = 0; i < response.Count; i++)
-            {
-                if ((int)response[i].StatusCode >= (int)StatusCodes.StartingErrorCode)
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        }
-
-        /// <summary>
-        /// Determines whether a session token is usable: it must parse, and it must carry the partition
-        /// key range id the progress was recorded against.
-        /// </summary>
-        /// <param name="sessionToken">The token reported for a single operation.</param>
-        /// <param name="failureReason">The reason the token is unusable, or <c>null</c> when it is usable.</param>
-        /// <remarks>
-        /// The range id is checked separately because
-        /// <see cref="SessionTokenHelper.TryParse(string, out string, out ISessionToken)"/> accepts a bare
-        /// LSN and reports a null range id for it. Without that check a prefix-less token reaches
-        /// <see cref="ISessionContainer.SetSessionToken(string, string, INameValueCollection)"/>
-        /// and fails there with an <see cref="IndexOutOfRangeException"/>.
-        /// </remarks>
         private static bool TryValidateSessionToken(string sessionToken, out string failureReason)
         {
             if (!SessionTokenHelper.TryParse(sessionToken, out string partitionKeyRangeId, out ISessionToken _))
@@ -491,6 +384,7 @@ namespace Microsoft.Azure.Cosmos
                 return false;
             }
 
+            // TryParse accepts a bare LSN, but the session container requires the range id.
             if (string.IsNullOrEmpty(partitionKeyRangeId))
             {
                 failureReason = "the token is missing the partitionKeyRangeId prefix.";

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperationResult.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperationResult.cs
@@ -9,7 +9,6 @@ namespace Microsoft.Azure.Cosmos
     using System.Net;
     using System.Text;
     using System.Text.Json;
-    using Microsoft.Azure.Cosmos.Core.Trace;
     using Microsoft.Azure.Cosmos.Tracing;
     using Microsoft.Azure.Documents;
 
@@ -98,15 +97,16 @@ namespace Microsoft.Azure.Cosmos
         internal bool HasIndex { get; set; }
 
         /// <summary>
-        /// Gets the session token returned by the distributed transaction coordinator for
-        /// this operation. Callers can pass this value back through
-        /// <c>DistributedTransactionRequestOptions.SessionToken</c> on a subsequent DTx
-        /// operation to enforce read-your-writes session consistency for that op.
+        /// Gets the session token returned for this operation. Callers can pass this value
+        /// back through <c>DistributedTransactionRequestOptions.SessionToken</c> on a
+        /// subsequent operation to enforce read-your-writes session consistency.
         /// </summary>
         /// <remarks>
-        /// Treat the value as opaque: pass it back unchanged via
-        /// <c>DistributedTransactionRequestOptions.SessionToken</c>. It may be <c>null</c> or
-        /// non-canonical if the coordinator omits or misformats the token.
+        /// Treat the value as opaque and pass it back unchanged.
+        /// <para>
+        /// The value is <c>null</c> when no token was returned. A token that is not in
+        /// the expected format is preserved for diagnostics and rejected if passed back.
+        /// </para>
         /// </remarks>
         public virtual string SessionToken { get; internal set; }
 
@@ -165,7 +165,7 @@ namespace Microsoft.Azure.Cosmos
         /// Creates a <see cref="DistributedTransactionOperationResult"/> from a JSON element.
         /// </summary>
         /// <param name="json">The JSON element containing the operation result.</param>
-        /// <returns>The deserialized operation result with a canonical session token.</returns>
+        /// <returns>The deserialized operation result with the session token returned by the server.</returns>
         internal static DistributedTransactionOperationResult FromJson(JsonElement json)
         {
             if (json.ValueKind != JsonValueKind.Object)
@@ -228,27 +228,7 @@ namespace Microsoft.Azure.Cosmos
                 result.ResourceStream = new MemoryStream(bytes, 0, bytes.Length, writable: false, publiclyVisible: true);
             }
 
-            if (!string.IsNullOrWhiteSpace(result.SessionToken))
-            {
-                int colonIndex = result.SessionToken.IndexOf(':');
-                if (colonIndex > 0 && colonIndex < result.SessionToken.Length - 1)
-                {
-                    // Already in canonical SDK session-token format — leave as-is.
-                }
-                else if (!string.IsNullOrWhiteSpace(result.PartitionKeyRangeId))
-                {
-                    result.SessionToken = result.PartitionKeyRangeId + ":" + result.SessionToken;
-                }
-                else
-                {
-                    DefaultTrace.TraceWarning(
-                        "DTC operation index {0} returned session token without a valid partitionKeyRangeId (value: '{1}'); session token will not be merged into the session container.",
-                        result.Index,
-                        result.PartitionKeyRangeId ?? "<absent>");
-                    result.SessionToken = null;
-                }
-            }
-            else if (result.SessionToken != null)
+            if (result.SessionToken != null && string.IsNullOrWhiteSpace(result.SessionToken))
             {
                 // Normalize whitespace-only to null so downstream guards don't need to recheck.
                 result.SessionToken = null;

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperationResult.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperationResult.cs
@@ -228,9 +228,10 @@ namespace Microsoft.Azure.Cosmos
                 result.ResourceStream = new MemoryStream(bytes, 0, bytes.Length, writable: false, publiclyVisible: true);
             }
 
-            if (result.SessionToken != null && string.IsNullOrWhiteSpace(result.SessionToken))
+            if (string.IsNullOrWhiteSpace(result.SessionToken))
             {
-                // Normalize whitespace-only to null so downstream guards don't need to recheck.
+                // Collapse "absent" and "whitespace-only" into a single null so capture-side guards
+                // need only one check.
                 result.SessionToken = null;
             }
 

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperationResult.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionOperationResult.cs
@@ -97,16 +97,15 @@ namespace Microsoft.Azure.Cosmos
         internal bool HasIndex { get; set; }
 
         /// <summary>
-        /// Gets the session token returned for this operation. Callers can pass this value
-        /// back through <c>DistributedTransactionRequestOptions.SessionToken</c> on a
-        /// subsequent operation to enforce read-your-writes session consistency.
+        /// Gets the session token returned by the distributed transaction coordinator for
+        /// this operation. Callers can pass this value back through
+        /// <c>DistributedTransactionRequestOptions.SessionToken</c> on a subsequent DTx
+        /// operation to enforce read-your-writes session consistency for that op.
         /// </summary>
         /// <remarks>
-        /// Treat the value as opaque and pass it back unchanged.
-        /// <para>
-        /// The value is <c>null</c> when no token was returned. A token that is not in
-        /// the expected format is preserved for diagnostics and rejected if passed back.
-        /// </para>
+        /// Treat the value as opaque: pass it back unchanged via
+        /// <c>DistributedTransactionRequestOptions.SessionToken</c>. It may be <c>null</c> or
+        /// non-canonical if the coordinator omits or misformats the token.
         /// </remarks>
         public virtual string SessionToken { get; internal set; }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/DistributedTransaction/DistributedTransactionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/DistributedTransaction/DistributedTransactionTests.cs
@@ -763,9 +763,8 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         // Session token handling
 
         [TestMethod]
-        [Description("When DTC response carries a session token in the new wire format (LSN-only sessionToken + " +
-            "separate partitionKeyRangeId), the SDK assembles the canonical {pkRangeId}:{lsn} token and merges it " +
-            "into the session container so that subsequent Session-consistency reads succeed.")]
+        [Description("When the DTC response carries a canonical {pkRangeId}:{lsn} session token, the SDK merges it " +
+            "verbatim into the session container so that subsequent Session-consistency reads succeed.")]
         public async Task ValidateSessionTokenMergedIntoDtcClient()
         {
             ToDoActivity seedDoc = ToDoActivity.CreateRandomToDoActivity();
@@ -774,15 +773,12 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             string canonicalToken = seedResponse.Headers.Session;
             Assert.IsFalse(string.IsNullOrEmpty(canonicalToken), "A valid session token must be obtained from the emulator for this test to be meaningful.");
 
-            // Split the canonical {pkRangeId}:{lsn} token into the two fields the DTC endpoint sends.
             int colonIndex = canonicalToken.IndexOf(':');
             Assert.IsTrue(colonIndex > 0, $"Emulator session token '{canonicalToken}' must be in {{pkRangeId}}:{{lsn}} format.");
             string pkRangeId = canonicalToken.Substring(0, colonIndex);
-            string lsnOnly = canonicalToken.Substring(colonIndex + 1);
 
-            // Build a DTC mock response using the new wire contract: LSN-only in sessionToken,
-            // pkRangeId in a separate partitionKeyRangeId field.
-            string dtcMockResponse = $@"{{""operationResponses"":[{{""index"":0,""statusCode"":201,""sessionToken"":""{lsnOnly}"",""partitionKeyRangeId"":""{pkRangeId}""}}]}}";
+            // The coordinator is required to send the canonical token; the SDK records it as received.
+            string dtcMockResponse = $@"{{""operationResponses"":[{{""index"":0,""statusCode"":201,""sessionToken"":""{canonicalToken}"",""partitionKeyRangeId"":""{pkRangeId}""}}]}}";
 
             DistributedTransactionMockHandler handler = new DistributedTransactionMockHandler(
                 request => Task.FromResult(this.BuildMockResponse(HttpStatusCode.OK, dtcMockResponse)));
@@ -805,7 +801,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             Assert.IsTrue(dtcResponse.IsSuccessStatusCode, "The simulated DTC commit should appear successful to the client.");
             Assert.AreEqual(canonicalToken, dtcResponse[0].SessionToken,
-                "SessionToken must be assembled as {pkRangeId}:{lsn} from the two separate wire fields.");
+                "SessionToken must be surfaced exactly as the coordinator sent it.");
 
             Container dtcContainer = dtcClient.GetContainer(this.database.Id, this.container.Id);
             try
@@ -830,11 +826,9 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
         }
 
         [TestMethod]
-        [Description("When DTC response carries only an LSN-only sessionToken with no partitionKeyRangeId " +
-            "(current server behavior before coordinator update), the commit must succeed without throwing " +
-            "and the SDK silently skips merging the session token rather than crashing.")]
-        // TODO(issue#5857): Remove this test once the coordinator is updated to emit partitionKeyRangeId and the SDK no longer needs to handle its absence.
-        public async Task ValidateSessionTokenSkipped_WhenPartitionKeyRangeIdAbsent()
+        [Description("A session token that is not in the canonical {pkRangeId}:{lsn} form cannot be recorded, so under " +
+            "Session consistency it surfaces to the caller instead of silently degrading the collection to eventual consistency.")]
+        public async Task ValidateMalformedSessionTokenSurfaces_UnderSessionConsistency()
         {
             ToDoActivity seedDoc = ToDoActivity.CreateRandomToDoActivity();
             ItemResponse<ToDoActivity> seedResponse = await this.container.CreateItemAsync(seedDoc, new PartitionKey(seedDoc.pk), cancellationToken: this.cancellationToken);
@@ -845,7 +839,7 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.IsTrue(colonIndex > 0, $"Emulator session token '{canonicalToken}' must be in {{pkRangeId}}:{{lsn}} format.");
             string lsnOnly = canonicalToken.Substring(colonIndex + 1);
 
-            // Current server behavior: LSN-only token, no partitionKeyRangeId field.
+            // An LSN with no partitionKeyRangeId prefix cannot be attributed to a partition.
             string dtcMockResponse = $@"{{""operationResponses"":[{{""index"":0,""statusCode"":201,""sessionToken"":""{lsnOnly}""}}]}}";
 
             DistributedTransactionMockHandler handler = new DistributedTransactionMockHandler(
@@ -859,21 +853,18 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
                     ConsistencyLevel = Cosmos.ConsistencyLevel.Session,
                 });
 
-            // Use the same partition key as seedDoc for consistency.
             ToDoActivity newDoc = ToDoActivity.CreateRandomToDoActivity(pk: seedDoc.pk);
-            DistributedTransactionResponse dtcResponse = await dtcClient
-                .CreateDistributedWriteTransaction()
-                .CreateItem(this.GetContainerForClient(dtcClient, this.container), new PartitionKey(newDoc.pk), newDoc.id, newDoc)
-                .ExecuteTransactionAsync(this.cancellationToken);
+            InvalidOperationException exception = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+                () => dtcClient
+                    .CreateDistributedWriteTransaction()
+                    .CreateItem(this.GetContainerForClient(dtcClient, this.container), new PartitionKey(newDoc.pk), newDoc.id, newDoc)
+                    .ExecuteTransactionAsync(this.cancellationToken),
+                "A token that cannot be recorded must not be dropped silently.");
 
-            // Commit must succeed — this was the crash point before the fix (IndexOutOfRangeException
-            // in SessionContainer.SetSessionToken when it tried tokenParts[1] on an LSN-only token).
-            Assert.IsTrue(dtcResponse.IsSuccessStatusCode, "Commit must succeed even when partitionKeyRangeId is absent.");
-
-            // Session token must be null — FromJson nulls it out when pkRangeId is absent so that
-            // MergeSessionTokens skips the operation rather than passing a bad token to SetSessionToken.
-            Assert.IsNull(dtcResponse[0].SessionToken,
-                "SessionToken must be null when partitionKeyRangeId is absent; the SDK silently skips merging.");
+            StringAssert.Contains(exception.Message, "partitionKeyRangeId",
+                "The message must state why the token could not be recorded.");
+            StringAssert.Contains(exception.Message, "should not be retried",
+                "The message must state the transaction already committed so callers do not double-apply it.");
         }
 
         // Read Transaction Tests

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/DistributedTransaction/DistributedTransactionTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.EmulatorTests/DistributedTransaction/DistributedTransactionTests.cs
@@ -777,7 +777,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.IsTrue(colonIndex > 0, $"Emulator session token '{canonicalToken}' must be in {{pkRangeId}}:{{lsn}} format.");
             string pkRangeId = canonicalToken.Substring(0, colonIndex);
 
-            // The coordinator is required to send the canonical token; the SDK records it as received.
             string dtcMockResponse = $@"{{""operationResponses"":[{{""index"":0,""statusCode"":201,""sessionToken"":""{canonicalToken}"",""partitionKeyRangeId"":""{pkRangeId}""}}]}}";
 
             DistributedTransactionMockHandler handler = new DistributedTransactionMockHandler(
@@ -839,7 +838,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
             Assert.IsTrue(colonIndex > 0, $"Emulator session token '{canonicalToken}' must be in {{pkRangeId}}:{{lsn}} format.");
             string lsnOnly = canonicalToken.Substring(colonIndex + 1);
 
-            // An LSN with no partitionKeyRangeId prefix cannot be attributed to a partition.
             string dtcMockResponse = $@"{{""operationResponses"":[{{""index"":0,""statusCode"":201,""sessionToken"":""{lsnOnly}""}}]}}";
 
             DistributedTransactionMockHandler handler = new DistributedTransactionMockHandler(
@@ -863,8 +861,6 @@ namespace Microsoft.Azure.Cosmos.SDK.EmulatorTests
 
             StringAssert.Contains(exception.Message, "partitionKeyRangeId",
                 "The message must state why the token could not be recorded.");
-            StringAssert.Contains(exception.Message, "should not be retried",
-                "The message must state the transaction already committed so callers do not double-apply it.");
         }
 
         // Read Transaction Tests

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionCommitterTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionCommitterTests.cs
@@ -813,6 +813,50 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
         }
 
         [TestMethod]
+        [Description("A success envelope that also reports isRetriable is never retried, so it is the outcome the " +
+                     "caller receives and a malformed token on it must surface rather than be traced as unsettled.")]
+        public async Task ExecuteTransactionAsync_ThrowsOnMalformedToken_WhenSuccessEnvelopeAlsoReportsRetriable()
+        {
+            SessionContainer sessionContainer = new SessionContainer("testhost");
+
+            Mock<CosmosClientContext> mockContext = this.CreateMockContext(
+                sessionContainer,
+                responseContent: null,
+                statusCode: HttpStatusCode.OK,
+                accountConsistencyLevel: Cosmos.ConsistencyLevel.Session);
+
+            int attempts = 0;
+            this.SetupProcessResourceOperation(
+                mockContext,
+                () =>
+                {
+                    attempts++;
+
+                    string json = @"{""isRetriable"":true,""operationResponses"":[{""index"":0,""statusCode"":200,""sessionToken"":""malformed""}]}";
+                    return Task.FromResult(new ResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new MemoryStream(Encoding.UTF8.GetBytes(json))
+                    });
+                });
+
+            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
+                this.CreateOperations(1), mockContext.Object, OperationType.CommitDistributedTransaction, TimeSpan.Zero);
+
+            InvalidOperationException exception = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+                () => committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None),
+                "A success status ends the retry loop regardless of isRetriable, so the token failure is settled.");
+
+            Assert.AreEqual(1, attempts, "A success envelope is terminal, so it must not be retried.");
+            StringAssert.Contains(exception.Message, "malformed",
+                "The message must include the offending value so it can be diagnosed.");
+
+            Assert.IsTrue(
+                string.IsNullOrEmpty(sessionContainer.GetSessionToken(
+                    DistributedTransactionConstants.GetCollectionFullName(DatabaseName, ContainerName))),
+                "A malformed token must never reach the session container.");
+        }
+
+        [TestMethod]
         [Description("A malformed token on a NotModified operation surfaces. NotModified is captured on the point " +
                      "operation path, so dropping it here would be the same silent degradation on a read transaction.")]
         public async Task ExecuteTransactionAsync_ThrowsOnMalformedToken_WhenOperationIsNotModified()

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionCommitterTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionCommitterTests.cs
@@ -74,7 +74,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
 
             string storedToken = sessionContainer.GetSessionToken(DistributedTransactionConstants.GetCollectionFullName(DatabaseName, ContainerName));
             Assert.AreEqual(expectedToken, storedToken,
-                "Session token should be assembled as {pkRangeId}:{lsn} and merged into SessionContainer after a successful DTC commit.");
+                "Session token should be recorded in the SessionContainer after a successful DTC commit.");
         }
 
         [TestMethod]
@@ -387,6 +387,58 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
         }
 
         [TestMethod]
+        [Description("An unresolvable account consistency level still merges tokens and does not surface token failures")]
+        public async Task ExecuteTransactionAsync_MergesSessionTokens_WhenAccountConsistencyIsUnresolvable()
+        {
+            const string expectedToken = "0:1#14#4=9";
+
+            SessionContainer sessionContainer = new SessionContainer("testhost");
+
+            Mock<CosmosClientContext> mockContext = this.CreateMockContext(
+                new UnresolvableConsistencyDocumentClient { sessionContainer = sessionContainer },
+                responseContent: BuildDtcResponseJson(
+                    new[] { (statusCode: 200, subStatusCode: (int?)null, sessionToken: "1#14#4=9", partitionKeyRangeId: "0") }),
+                statusCode: HttpStatusCode.OK);
+
+            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
+                this.CreateOperations(1), mockContext.Object, OperationType.CommitDistributedTransaction);
+
+            await committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
+
+            Assert.AreEqual(
+                expectedToken,
+                sessionContainer.GetSessionToken(DistributedTransactionConstants.GetCollectionFullName(DatabaseName, ContainerName)),
+                "A transient account read failure must not degrade a session client to eventual consistency.");
+        }
+
+        [TestMethod]
+        [Description("An unresolvable account consistency level traces a malformed token rather than throwing")]
+        public async Task ExecuteTransactionAsync_DoesNotThrowOnMalformedToken_WhenAccountConsistencyIsUnresolvable()
+        {
+            SessionContainer sessionContainer = new SessionContainer("testhost");
+
+            Mock<CosmosClientContext> mockContext = this.CreateMockContext(
+                new UnresolvableConsistencyDocumentClient { sessionContainer = sessionContainer },
+                responseContent: BuildDtcResponseJson(
+                    new[] { (statusCode: 201, subStatusCode: (int?)null, sessionToken: "1#9#4=8#5=7", partitionKeyRangeId: (string)null) },
+                    prefixRangeLessTokens: false),
+                statusCode: HttpStatusCode.OK);
+
+            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
+                this.CreateOperations(1), mockContext.Object, OperationType.CommitDistributedTransaction);
+
+            DistributedTransactionResponse response = await committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
+
+            Assert.IsNotNull(
+                response,
+                "Token failures are surfaced only when the account is known to be session consistent, so an unknown level must trace instead of throw.");
+
+            Assert.IsTrue(
+                string.IsNullOrEmpty(sessionContainer.GetSessionToken(DistributedTransactionConstants.GetCollectionFullName(DatabaseName, ContainerName))),
+                "A malformed token must never be recorded, regardless of the resolved consistency level.");
+        }
+
+        [TestMethod]
         [Description("Capture is not gated on consistency: tokens are merged on a non-session account, matching point-operation behavior")]
         public async Task ExecuteTransactionAsync_MergesSessionTokens_OnNonSessionAccount()
         {
@@ -437,22 +489,22 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
         }
 
         [TestMethod]
-        [Description("When session token is LSN-only and partitionKeyRangeId is present, the token is assembled as {pkRangeId}:{lsn}")]
-        public async Task ExecuteTransactionAsync_AssemblesSessionToken_WhenPartitionKeyRangeIdIsPresent()
+        [Description("When session token is LSN-only, the malformed token is surfaced even when partitionKeyRangeId is present")]
+        public async Task ExecuteTransactionAsync_ThrowsOnLsnOnlySessionToken_WhenPartitionKeyRangeIdIsPresent()
         {
             const string lsnOnly = "1#9#4=8#5=7";
             const string pkRangeId = "0";
-            const string expectedToken = "0:1#9#4=8#5=7";
-
             SessionContainer sessionContainer = new SessionContainer("testhost");
 
             string responseJson = BuildDtcResponseJson(
-                new[] { (statusCode: 201, subStatusCode: (int?)null, sessionToken: lsnOnly, partitionKeyRangeId: pkRangeId) });
+                new[] { (statusCode: 201, subStatusCode: (int?)null, sessionToken: lsnOnly, partitionKeyRangeId: pkRangeId) },
+                prefixRangeLessTokens: false);
 
             Mock<CosmosClientContext> mockContext = this.CreateMockContext(
                 sessionContainer,
                 responseContent: responseJson,
-                statusCode: HttpStatusCode.OK);
+                statusCode: HttpStatusCode.OK,
+                accountConsistencyLevel: Cosmos.ConsistencyLevel.Session);
 
             List<DistributedTransactionOperation> operations = new List<DistributedTransactionOperation>
             {
@@ -468,11 +520,12 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
                 operations, mockContext.Object, OperationType.CommitDistributedTransaction);
 
-            await committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
+            InvalidOperationException exception = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+                () => committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None));
 
-            string storedToken = sessionContainer.GetSessionToken(DistributedTransactionConstants.GetCollectionFullName(DatabaseName, ContainerName));
-            Assert.AreEqual(expectedToken, storedToken,
-                "Session token should be assembled as {pkRangeId}:{lsn} when partitionKeyRangeId is present.");
+            StringAssert.Contains(exception.Message, lsnOnly);
+            Assert.IsTrue(string.IsNullOrEmpty(sessionContainer.GetSessionToken(
+                DistributedTransactionConstants.GetCollectionFullName(DatabaseName, ContainerName))));
         }
 
         [TestMethod]
@@ -656,8 +709,8 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
         }
 
         [TestMethod]
-        [Description("m9: When an operation result has no partitionKeyRangeId, FromJson emits a TraceWarning " +
-                     "so the skip is observable in diagnostic traces.")]
+        [Description("m9: When an operation result carries a session token with no partitionKeyRangeId, the capture path " +
+                     "emits a TraceWarning under non-Session consistency so the skip is observable in diagnostic traces.")]
         public async Task ExecuteTransactionAsync_EmitsTraceWarning_WhenPartitionKeyRangeIdIsAbsent()
         {
             const string lsnOnly = "1#9#4=8#5=7";
@@ -712,7 +765,361 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
 
 
         [TestMethod]
-        [Description("When SetSessionToken throws, the exception is swallowed and ExecuteTransactionAsync still returns the response rather than rethrowing")]
+        [Description("A malformed token on a retriable response must not surface: the retry loop has not yet decided " +
+                     "the outcome, so throwing would pre-empt a retry that could still succeed.")]
+        public async Task ExecuteTransactionAsync_DoesNotThrowOnMalformedToken_WhileTheResponseIsStillRetriable()
+        {
+            SessionContainer sessionContainer = new SessionContainer("testhost");
+
+            Mock<CosmosClientContext> mockContext = this.CreateMockContext(
+                sessionContainer,
+                responseContent: null,
+                statusCode: HttpStatusCode.OK,
+                accountConsistencyLevel: Cosmos.ConsistencyLevel.Session);
+
+            int attempts = 0;
+            this.SetupProcessResourceOperation(
+                mockContext,
+                () =>
+                {
+                    attempts++;
+
+                    // The retriable attempt carries a malformed token; the terminal attempt is clean.
+                    if (attempts == 1)
+                    {
+                        string retriableJson = @"{""isRetriable"":true,""operationResponses"":[{""index"":0,""statusCode"":200,""sessionToken"":""malformed""}]}";
+                        return Task.FromResult(new ResponseMessage((HttpStatusCode)StatusCodes.TransactionAborted)
+                        {
+                            Content = new MemoryStream(Encoding.UTF8.GetBytes(retriableJson))
+                        });
+                    }
+
+                    string successJson = BuildDtcResponseJson(
+                        new[] { (statusCode: 200, subStatusCode: (int?)null, sessionToken: "1#3#4=2", partitionKeyRangeId: "0") });
+
+                    return Task.FromResult(new ResponseMessage(HttpStatusCode.OK)
+                    {
+                        Content = new MemoryStream(Encoding.UTF8.GetBytes(successJson))
+                    });
+                });
+
+            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
+                this.CreateOperations(1), mockContext.Object, OperationType.CommitDistributedTransaction, TimeSpan.Zero);
+
+            DistributedTransactionResponse response = await committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
+
+            Assert.AreEqual(2, attempts, "The retriable attempt must be retried rather than aborted by a token failure.");
+            Assert.IsTrue(response.IsSuccessStatusCode, "The retry succeeded, so the caller sees the successful response.");
+        }
+
+        [TestMethod]
+        [Description("A malformed token on a NotModified operation surfaces. NotModified is captured on the point " +
+                     "operation path, so dropping it here would be the same silent degradation on a read transaction.")]
+        public async Task ExecuteTransactionAsync_ThrowsOnMalformedToken_WhenOperationIsNotModified()
+        {
+            SessionContainer sessionContainer = new SessionContainer("testhost");
+
+            Mock<CosmosClientContext> mockContext = this.CreateMockContext(
+                sessionContainer,
+                responseContent: BuildDtcResponseJson(
+                    new[] { (statusCode: 304, subStatusCode: (int?)null, sessionToken: "malformed", partitionKeyRangeId: (string)null) },
+                    prefixRangeLessTokens: false),
+                statusCode: HttpStatusCode.OK,
+                accountConsistencyLevel: Cosmos.ConsistencyLevel.Session);
+
+            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
+                this.CreateOperations(1), mockContext.Object, OperationType.CommitDistributedTransaction);
+
+            InvalidOperationException exception = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+                () => committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None),
+                "A NotModified operation still observed replica progress, so its token must not be dropped silently.");
+
+            StringAssert.Contains(exception.Message, "malformed",
+                "The message must include the offending value so it can be diagnosed.");
+        }
+
+        [TestMethod]
+        [Description("A read transaction never commits, so a malformed token on a read must not tell the caller the " +
+                     "transaction was committed.")]
+        public async Task ExecuteTransactionAsync_ReportsReadOutcome_WhenMalformedTokenSurfacesOnARead()
+        {
+            SessionContainer sessionContainer = new SessionContainer("testhost");
+
+            Mock<CosmosClientContext> mockContext = this.CreateMockContext(
+                sessionContainer,
+                responseContent: null,
+                statusCode: HttpStatusCode.OK,
+                accountConsistencyLevel: Cosmos.ConsistencyLevel.Session);
+
+            this.SetupProcessResourceOperation(
+                mockContext,
+                () => Task.FromResult(new ResponseMessage(HttpStatusCode.OK)
+                {
+                    Content = new MemoryStream(Encoding.UTF8.GetBytes(BuildDtcResponseJson(
+                        new[] { (statusCode: 200, subStatusCode: (int?)null, sessionToken: "malformed", partitionKeyRangeId: (string)null) },
+                        prefixRangeLessTokens: false)))
+                }));
+
+            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
+                this.CreateOperations(1), mockContext.Object, OperationType.Read);
+
+            InvalidOperationException exception = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+                () => committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None));
+
+            StringAssert.Contains(exception.Message, "read transaction completed successfully",
+                "A read transaction must be described as completed, not committed.");
+            Assert.IsFalse(exception.Message.Contains("was committed"),
+                "A read transaction never commits, so the commit wording must not appear.");
+        }
+
+        [DataTestMethod]
+        [Description("A malformed session token on a committed operation under Session consistency surfaces to the caller " +
+                     "instead of silently degrading the collection to eventual consistency.")]
+        [DataRow("1#9#4=8#5=7", null, "1#9#4=8#5=7", "missing the partitionKeyRangeId prefix", DisplayName = "bare LSN with no partitionKeyRangeId to prefix it")]
+        [DataRow("5", null, "5", "missing the partitionKeyRangeId prefix", DisplayName = "bare number with no partitionKeyRangeId to prefix it")]
+        [DataRow("garbage", "0", "garbage", "could not be parsed", DisplayName = "unparsable token alongside a valid partitionKeyRangeId")]
+        [DataRow("0:garbage", null, "0:garbage", "could not be parsed", DisplayName = "valid partitionKeyRangeId with an unparsable LSN segment")]
+        [DataRow("0:1#5,1:1#7", null, "0:1#5,1:1#7", "could not be parsed", DisplayName = "compound multi-partition token in a partition-local slot")]
+        public async Task ExecuteTransactionAsync_ThrowsOnMalformedToken_WhenCommittedUnderSessionConsistency(
+            string sessionToken,
+            string partitionKeyRangeId,
+            string expectedTokenInMessage,
+            string expectedReason)
+        {
+            SessionContainer sessionContainer = new SessionContainer("testhost");
+
+            Mock<CosmosClientContext> mockContext = this.CreateMockContext(
+                sessionContainer,
+                responseContent: BuildDtcResponseJson(
+                    new[] { (statusCode: 201, subStatusCode: (int?)null, sessionToken, partitionKeyRangeId) },
+                    prefixRangeLessTokens: false),
+                statusCode: HttpStatusCode.OK,
+                accountConsistencyLevel: Cosmos.ConsistencyLevel.Session);
+
+            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
+                this.CreateOperations(1), mockContext.Object, OperationType.CommitDistributedTransaction);
+
+            InvalidOperationException exception = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+                () => committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None),
+                "A malformed token on a committed operation under Session consistency must surface.");
+
+            StringAssert.Contains(exception.Message, "index 0",
+                "The message must identify which operation carried the malformed token.");
+            StringAssert.Contains(exception.Message, expectedTokenInMessage,
+                "The message must include the offending value so it can be diagnosed.");
+            StringAssert.Contains(exception.Message, expectedReason,
+                "The message must state why the token could not be recorded, not a fixed reason.");
+            StringAssert.Contains(exception.Message, DistributedTransactionConstants.GetCollectionFullName(DatabaseName, ContainerName),
+                "The message must name the collection whose progress was lost.");
+            StringAssert.Contains(exception.Message, "should not be retried",
+                "The message must state the transaction already committed so callers do not double-apply it.");
+
+            Assert.IsTrue(
+                string.IsNullOrEmpty(sessionContainer.GetSessionToken(
+                    DistributedTransactionConstants.GetCollectionFullName(DatabaseName, ContainerName))),
+                "A malformed token must never reach the session container.");
+        }
+
+        [TestMethod]
+        [Description("When several operations carry malformed tokens, the failure surfaces on the first one and names that index.")]
+        public async Task ExecuteTransactionAsync_ThrowsOnFirstMalformedToken_WhenSeveralAreMalformed()
+        {
+            const string container0 = "Container0";
+            const string container1 = "Container1";
+            const string container2 = "Container2";
+
+            SessionContainer sessionContainer = new SessionContainer("testhost");
+
+            Mock<CosmosClientContext> mockContext = this.CreateMockContext(
+                sessionContainer,
+                responseContent: BuildDtcResponseJson(new[]
+                {
+                    (statusCode: 200, subStatusCode: (int?)null, sessionToken: "1#3#4=2", partitionKeyRangeId: "0"),
+                    (statusCode: 200, subStatusCode: (int?)null, sessionToken: "malformedfirst", partitionKeyRangeId: (string)null),
+                    (statusCode: 200, subStatusCode: (int?)null, sessionToken: "malformedsecond", partitionKeyRangeId: (string)null)
+                }),
+                statusCode: HttpStatusCode.OK,
+                accountConsistencyLevel: Cosmos.ConsistencyLevel.Session);
+
+            // Distinct collections so that the token recorded before the failure and the tokens skipped
+            // after it occupy separate session container slots.
+            List<DistributedTransactionOperation> operations = new List<DistributedTransactionOperation>
+            {
+                new DistributedTransactionOperation(
+                    OperationType.Create, operationIndex: 0,
+                    DatabaseName, container0, new PartitionKey("pk0"), id: "doc0"),
+                new DistributedTransactionOperation(
+                    OperationType.Create, operationIndex: 1,
+                    DatabaseName, container1, new PartitionKey("pk1"), id: "doc1"),
+                new DistributedTransactionOperation(
+                    OperationType.Create, operationIndex: 2,
+                    DatabaseName, container2, new PartitionKey("pk2"), id: "doc2"),
+            };
+
+            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
+                operations, mockContext.Object, OperationType.CommitDistributedTransaction);
+
+            InvalidOperationException exception = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+                () => committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None));
+
+            StringAssert.Contains(exception.Message, "index 1",
+                "The failure must name the first malformed operation.");
+            StringAssert.Contains(exception.Message, "malformedfirst");
+            Assert.IsFalse(exception.Message.Contains("malformedsecond"),
+                "Validation must stop at the first malformed token rather than accumulating every failure.");
+
+            Assert.AreEqual(
+                "0:1#3#4=2",
+                sessionContainer.GetSessionToken(DistributedTransactionConstants.GetCollectionFullName(DatabaseName, container0)),
+                "Operations validated before the failure keep the progress they already recorded.");
+
+            Assert.IsTrue(
+                string.IsNullOrEmpty(sessionContainer.GetSessionToken(
+                    DistributedTransactionConstants.GetCollectionFullName(DatabaseName, container1))),
+                "The collection carrying the first malformed token must not be recorded.");
+
+            Assert.IsTrue(
+                string.IsNullOrEmpty(sessionContainer.GetSessionToken(
+                    DistributedTransactionConstants.GetCollectionFullName(DatabaseName, container2))),
+                "Validation stops at the first failure, so collections after it are never reached.");
+        }
+
+        [DataTestMethod]
+        [Description("Under a non-Session effective consistency a malformed token carries no guarantee the caller relies on, " +
+                     "so it is traced and skipped while its siblings still merge.")]
+        [DataRow(Cosmos.ConsistencyLevel.Strong, DisplayName = "Strong")]
+        [DataRow(Cosmos.ConsistencyLevel.BoundedStaleness, DisplayName = "BoundedStaleness")]
+        [DataRow(Cosmos.ConsistencyLevel.ConsistentPrefix, DisplayName = "ConsistentPrefix")]
+        [DataRow(Cosmos.ConsistencyLevel.Eventual, DisplayName = "Eventual")]
+        public async Task ExecuteTransactionAsync_SkipsMalformedToken_UnderNonSessionConsistency(
+            Cosmos.ConsistencyLevel accountConsistencyLevel)
+        {
+            SessionContainer sessionContainer = new SessionContainer("testhost");
+
+            Mock<CosmosClientContext> mockContext = this.CreateMockContext(
+                sessionContainer,
+                responseContent: BuildDtcResponseJson(new[]
+                {
+                    (statusCode: 200, subStatusCode: (int?)null, sessionToken: "malformed", partitionKeyRangeId: (string)null),
+                    (statusCode: 200, subStatusCode: (int?)null, sessionToken: "1#3#4=2", partitionKeyRangeId: "1")
+                }),
+                statusCode: HttpStatusCode.OK,
+                accountConsistencyLevel: accountConsistencyLevel);
+
+            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
+                this.CreateOperations(2), mockContext.Object, OperationType.CommitDistributedTransaction);
+
+            DistributedTransactionResponse response = await committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
+
+            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            Assert.AreEqual(
+                "1:1#3#4=2",
+                sessionContainer.GetSessionToken(DistributedTransactionConstants.GetCollectionFullName(DatabaseName, ContainerName)),
+                "A malformed token must not prevent its siblings from recording their progress.");
+        }
+
+        [DataTestMethod]
+        [Description("A malformed token on an operation the server already failed must never replace the server's error: " +
+                     "the caller still receives the status they need to act on.")]
+        [DataRow(409, HttpStatusCode.Conflict, DisplayName = "409 Conflict")]
+        [DataRow(412, HttpStatusCode.PreconditionFailed, DisplayName = "412 PreconditionFailed")]
+        public async Task ExecuteTransactionAsync_SkipsMalformedToken_WhenOperationFailedUnderSessionConsistency(
+            int operationStatusCode,
+            HttpStatusCode envelopeStatusCode)
+        {
+            SessionContainer sessionContainer = new SessionContainer("testhost");
+
+            Mock<CosmosClientContext> mockContext = this.CreateMockContext(
+                sessionContainer,
+                responseContent: BuildDtcResponseJson(
+                    new[] { (operationStatusCode, subStatusCode: (int?)null, sessionToken: "malformed", partitionKeyRangeId: (string)null) }),
+                statusCode: envelopeStatusCode,
+                accountConsistencyLevel: Cosmos.ConsistencyLevel.Session);
+
+            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
+                this.CreateOperations(1), mockContext.Object, OperationType.CommitDistributedTransaction);
+
+            DistributedTransactionResponse response = await committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
+
+            Assert.AreEqual(envelopeStatusCode, response.StatusCode,
+                "The server's error must reach the caller rather than being masked by a token-validation failure.");
+        }
+
+        [DataTestMethod]
+        [Description("Effective consistency is the client override when one is set, and the account default otherwise: " +
+                     "the same precedence the point-operation path applies.")]
+        [DataRow(Cosmos.ConsistencyLevel.Eventual, Cosmos.ConsistencyLevel.Session, true,
+            DisplayName = "client override to Session on an Eventual account surfaces the failure")]
+        [DataRow(Cosmos.ConsistencyLevel.Session, Cosmos.ConsistencyLevel.Eventual, false,
+            DisplayName = "client override to Eventual on a Session account suppresses the failure")]
+        public async Task ExecuteTransactionAsync_UsesClientConsistencyOverride_ToGradeMalformedTokens(
+            Cosmos.ConsistencyLevel accountConsistencyLevel,
+            Cosmos.ConsistencyLevel clientConsistencyOverride,
+            bool expectThrow)
+        {
+            SessionContainer sessionContainer = new SessionContainer("testhost");
+
+            Mock<CosmosClientContext> mockContext = this.CreateMockContext(
+                sessionContainer,
+                responseContent: BuildDtcResponseJson(
+                    new[] { (statusCode: 200, subStatusCode: (int?)null, sessionToken: "malformed", partitionKeyRangeId: (string)null) }),
+                statusCode: HttpStatusCode.OK,
+                accountConsistencyLevel: accountConsistencyLevel);
+
+            mockContext
+                .Setup(c => c.ClientOptions)
+                .Returns(new CosmosClientOptions { ConsistencyLevel = clientConsistencyOverride });
+
+            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
+                this.CreateOperations(1), mockContext.Object, OperationType.CommitDistributedTransaction);
+
+            if (expectThrow)
+            {
+                await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+                    () => committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None),
+                    "The client override, not the account default, decides whether the failure surfaces.");
+            }
+            else
+            {
+                DistributedTransactionResponse response = await committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
+                Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+            }
+        }
+
+        [TestMethod]
+        [Description("A SetSessionToken failure and a malformed token cost the caller the same guarantee, so they are graded " +
+                     "by one policy: both surface on a committed operation under Session consistency.")]
+        public async Task ExecuteTransactionAsync_SurfacesSetSessionTokenException_WhenCommittedUnderSessionConsistency()
+        {
+            Mock<ISessionContainer> mockSessionContainer = new Mock<ISessionContainer>();
+            mockSessionContainer
+                .Setup(s => s.SetSessionToken(
+                    It.IsAny<string>(),
+                    It.IsAny<string>(),
+                    It.IsAny<INameValueCollection>()))
+                .Throws(new InvalidOperationException("simulated SetSessionToken failure"));
+
+            Mock<CosmosClientContext> mockContext = this.CreateMockContext(
+                mockSessionContainer.Object,
+                responseContent: BuildDtcResponseJson(
+                    new[] { (statusCode: 201, subStatusCode: (int?)null, sessionToken: "1#9#4=8#5=7", partitionKeyRangeId: "0") }),
+                statusCode: HttpStatusCode.OK,
+                accountConsistencyLevel: Cosmos.ConsistencyLevel.Session);
+
+            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
+                this.CreateOperations(1), mockContext.Object, OperationType.CommitDistributedTransaction);
+
+            InvalidOperationException exception = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+                () => committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None));
+
+            StringAssert.Contains(exception.Message, "index 0");
+            Assert.IsNotNull(exception.InnerException,
+                "The originating failure must be preserved so the cause is diagnosable.");
+            StringAssert.Contains(exception.InnerException.Message, "simulated SetSessionToken failure");
+        }
+
+        [TestMethod]
+        [Description("When SetSessionToken throws under a non-Session effective consistency, the exception is swallowed and ExecuteTransactionAsync still returns the response rather than rethrowing")]
         public async Task ExecuteTransactionAsync_SwallowsSetSessionTokenException()
         {
             const string lsnOnly = "1#9#4=8#5=7";
@@ -2171,6 +2578,76 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                 $"token2 must appear in request body. Body: {bodyJson}");
         }
 
+        [TestMethod]
+        [Description("Verifies that capture stops at the first malformed token: tokens recorded before it survive, and later operations' valid tokens are deliberately not recorded. The session guarantee is already broken at that point, so a partially advanced token would read no more correctly than the abandoned one.")]
+        public async Task ExecuteTransactionAsync_ThrowsAtFirstMalformedToken_AndDoesNotRecordLaterTokens()
+        {
+            SessionContainer sessionContainer = new SessionContainer("testhost");
+
+            Mock<CosmosClientContext> mockContext = this.CreateMockContext(
+                sessionContainer,
+                responseContent: BuildDtcResponseJson(
+                    new[]
+                    {
+                        (statusCode: 201, sessionToken: "0:1#5"),
+                        (statusCode: 201, sessionToken: "not-a-token"),
+                        (statusCode: 201, sessionToken: "2:1#9"),
+                    }),
+                statusCode: HttpStatusCode.OK,
+                accountConsistencyLevel: Cosmos.ConsistencyLevel.Session);
+
+            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
+                this.CreateOperations(3), mockContext.Object, OperationType.CommitDistributedTransaction);
+
+            InvalidOperationException exception = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+                () => committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None));
+
+            StringAssert.Contains(exception.Message, "index 1",
+                "The first malformed token must be the one reported.");
+
+            string recorded = sessionContainer.GetSessionToken(
+                DistributedTransactionConstants.GetCollectionFullName(DatabaseName, ContainerName));
+
+            StringAssert.Contains(recorded, "0:1#5",
+                "A token already recorded before the failure must not be rolled back.");
+            Assert.IsFalse(recorded.Contains("2:1#9"),
+                "Capture must stop at the first malformed token; a later operation's token is deliberately abandoned.");
+        }
+
+        [TestMethod]
+        [Description("Verifies that a malformed token is only traced when another operation failed. A failure anywhere " +
+                     "rolls the transaction back, so no operation left a durable write to read back, and throwing would " +
+                     "replace the server's own actionable error with a bookkeeping exception.")]
+        public async Task ExecuteTransactionAsync_TracesMalformedToken_WhenAnotherOperationFailed()
+        {
+            SessionContainer sessionContainer = new SessionContainer("testhost");
+
+            Mock<CosmosClientContext> mockContext = this.CreateMockContext(
+                sessionContainer,
+                responseContent: BuildDtcResponseJson(
+                    new[]
+                    {
+                        // Conflict rolls the transaction back, so the sibling's write is not durable.
+                        (statusCode: 409, sessionToken: "bad-on-conflict"),
+                        (statusCode: 201, sessionToken: "bad-on-success"),
+                    }),
+                statusCode: HttpStatusCode.OK,
+                accountConsistencyLevel: Cosmos.ConsistencyLevel.Session);
+
+            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
+                this.CreateOperations(2), mockContext.Object, OperationType.CommitDistributedTransaction);
+
+            DistributedTransactionResponse response = await committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
+
+            Assert.AreEqual(HttpStatusCode.Conflict, response[0].StatusCode,
+                "The server's own error must reach the caller rather than being masked by a token failure.");
+
+            Assert.IsTrue(
+                string.IsNullOrEmpty(sessionContainer.GetSessionToken(
+                    DistributedTransactionConstants.GetCollectionFullName(DatabaseName, ContainerName))),
+                "A malformed token must never reach the session container.");
+        }
+
         // ─── Diagnostics ──────────────────────────────────────────────────────────
 
         [TestMethod]
@@ -2295,8 +2772,11 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                 operations.Select(o => (o.statusCode, o.subStatusCode, o.sessionToken, partitionKeyRangeId: (string)null)).ToArray());
         }
 
+        // The server returns tokens in '<partitionKeyRangeId>:<token>' form. Test cases pass the range id
+        // separately for readability, so it is prefixed here unless a case is exercising a malformed token.
         private static string BuildDtcResponseJson(
-            (int statusCode, int? subStatusCode, string sessionToken, string partitionKeyRangeId)[] operations)
+            (int statusCode, int? subStatusCode, string sessionToken, string partitionKeyRangeId)[] operations,
+            bool prefixRangeLessTokens = true)
         {
             StringBuilder sb = new StringBuilder();
             sb.Append(@"{""operationResponses"":[");
@@ -2313,9 +2793,19 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                     sb.Append($@",""substatuscode"":{operations[i].subStatusCode.Value}");
                 }
 
-                if (operations[i].sessionToken != null)
+                string sessionToken = operations[i].sessionToken;
+                if (prefixRangeLessTokens
+                    && !string.IsNullOrEmpty(sessionToken)
+                    && !sessionToken.Contains(":")
+                    && !string.IsNullOrWhiteSpace(operations[i].partitionKeyRangeId)
+                    && SessionTokenHelper.TryParse(sessionToken, out string _, out ISessionToken _))
                 {
-                    sb.Append($@",""{DistributedTransactionSerializer.SessionToken}"":""{operations[i].sessionToken}""");
+                    sessionToken = operations[i].partitionKeyRangeId + ":" + sessionToken;
+                }
+
+                if (sessionToken != null)
+                {
+                    sb.Append($@",""{DistributedTransactionSerializer.SessionToken}"":""{sessionToken}""");
                 }
 
                 if (operations[i].partitionKeyRangeId != null)
@@ -2348,6 +2838,14 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                 ? new MockDocumentClient(accountConsistencyLevel.Value) { sessionContainer = sessionContainer }
                 : new MockDocumentClient { sessionContainer = sessionContainer };
 
+            return this.CreateMockContext(documentClient, responseContent, statusCode);
+        }
+
+        private Mock<CosmosClientContext> CreateMockContext(
+            MockDocumentClient documentClient,
+            string responseContent,
+            HttpStatusCode statusCode)
+        {
             ContainerProperties containerProperties = ContainerProperties.CreateWithResourceId(CollectionResourceId);
             containerProperties.Id = "TestContainerId";
             containerProperties.PartitionKeyPath = "/pk";
@@ -2605,6 +3103,18 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             ResponseMessage message = new ResponseMessage(statusCode);
             message.Headers.SubStatusCodeLiteral = subStatusCode.ToString();
             return message;
+        }
+
+        /// <summary>
+        /// A <see cref="MockDocumentClient"/> whose account consistency level cannot be resolved,
+        /// standing in for a transient failure of the gateway account read.
+        /// </summary>
+        private sealed class UnresolvableConsistencyDocumentClient : MockDocumentClient
+        {
+            internal override Task<Cosmos.ConsistencyLevel> GetDefaultConsistencyLevelAsync()
+            {
+                throw new InvalidOperationException("Simulated account read failure.");
+            }
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionCommitterTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionCommitterTests.cs
@@ -308,6 +308,44 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                 $"Status {operationStatusCode}/{operationSubStatusCode} should {(expectCaptured ? "be" : "not be")} captured.");
         }
 
+        [DataTestMethod]
+        [DataRow(404, 1002, DisplayName = "404 ReadSessionNotAvailable")]
+        [DataRow(424, SubStatusCodeAbsent, DisplayName = "424 FailedDependency")]
+        [DataRow(429, 3200, DisplayName = "429 TooManyRequests")]
+        [DataRow(410, SubStatusCodeAbsent, DisplayName = "410 Gone")]
+        [DataRow(503, SubStatusCodeAbsent, DisplayName = "503 ServiceUnavailable")]
+        [DataRow(408, SubStatusCodeAbsent, DisplayName = "408 RequestTimeout")]
+        [DataRow(500, SubStatusCodeAbsent, DisplayName = "500 InternalServerError")]
+        public async Task ExecuteTransactionAsync_SkipsMalformedToken_OnNonCapturableStatus(
+            int operationStatusCode,
+            int operationSubStatusCode)
+        {
+            SessionContainer sessionContainer = new SessionContainer("testhost");
+            Mock<CosmosClientContext> mockContext = this.CreateMockContext(
+                sessionContainer,
+                responseContent: BuildDtcResponseJson(
+                    new[]
+                    {
+                        (
+                            statusCode: operationStatusCode,
+                            subStatusCode: operationSubStatusCode == SubStatusCodeAbsent ? (int?)null : operationSubStatusCode,
+                            sessionToken: "malformed",
+                            partitionKeyRangeId: (string)null),
+                    },
+                    prefixRangeLessTokens: false),
+                statusCode: (HttpStatusCode)StatusCodes.MultiStatus);
+
+            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
+                this.CreateOperations(1),
+                mockContext.Object,
+                OperationType.CommitDistributedTransaction);
+
+            await committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
+
+            Assert.IsTrue(string.IsNullOrEmpty(sessionContainer.GetSessionToken(
+                DistributedTransactionConstants.GetCollectionFullName(DatabaseName, ContainerName))));
+        }
+
         [TestMethod]
         [Description("A MultiStatus response mixing captured and skipped per-operation statuses captures only the qualifying operations")]
         public async Task ExecuteTransactionAsync_CapturesPerOperation_WhenMultiStatusMixesStatuses()
@@ -384,58 +422,6 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                 new[] { "0", "1" },
                 tokensByRange.Keys.ToArray(),
                 "A 304 read observed real replica progress, so its token must be captured just as the gateway captures it.");
-        }
-
-        [TestMethod]
-        [Description("An unresolvable account consistency level still merges tokens and does not surface token failures")]
-        public async Task ExecuteTransactionAsync_MergesSessionTokens_WhenAccountConsistencyIsUnresolvable()
-        {
-            const string expectedToken = "0:1#14#4=9";
-
-            SessionContainer sessionContainer = new SessionContainer("testhost");
-
-            Mock<CosmosClientContext> mockContext = this.CreateMockContext(
-                new UnresolvableConsistencyDocumentClient { sessionContainer = sessionContainer },
-                responseContent: BuildDtcResponseJson(
-                    new[] { (statusCode: 200, subStatusCode: (int?)null, sessionToken: "1#14#4=9", partitionKeyRangeId: "0") }),
-                statusCode: HttpStatusCode.OK);
-
-            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
-                this.CreateOperations(1), mockContext.Object, OperationType.CommitDistributedTransaction);
-
-            await committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
-
-            Assert.AreEqual(
-                expectedToken,
-                sessionContainer.GetSessionToken(DistributedTransactionConstants.GetCollectionFullName(DatabaseName, ContainerName)),
-                "A transient account read failure must not degrade a session client to eventual consistency.");
-        }
-
-        [TestMethod]
-        [Description("An unresolvable account consistency level traces a malformed token rather than throwing")]
-        public async Task ExecuteTransactionAsync_DoesNotThrowOnMalformedToken_WhenAccountConsistencyIsUnresolvable()
-        {
-            SessionContainer sessionContainer = new SessionContainer("testhost");
-
-            Mock<CosmosClientContext> mockContext = this.CreateMockContext(
-                new UnresolvableConsistencyDocumentClient { sessionContainer = sessionContainer },
-                responseContent: BuildDtcResponseJson(
-                    new[] { (statusCode: 201, subStatusCode: (int?)null, sessionToken: "1#9#4=8#5=7", partitionKeyRangeId: (string)null) },
-                    prefixRangeLessTokens: false),
-                statusCode: HttpStatusCode.OK);
-
-            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
-                this.CreateOperations(1), mockContext.Object, OperationType.CommitDistributedTransaction);
-
-            DistributedTransactionResponse response = await committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
-
-            Assert.IsNotNull(
-                response,
-                "Token failures are surfaced only when the account is known to be session consistent, so an unknown level must trace instead of throw.");
-
-            Assert.IsTrue(
-                string.IsNullOrEmpty(sessionContainer.GetSessionToken(DistributedTransactionConstants.GetCollectionFullName(DatabaseName, ContainerName))),
-                "A malformed token must never be recorded, regardless of the resolved consistency level.");
         }
 
         [TestMethod]
@@ -529,8 +515,8 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
         }
 
         [TestMethod]
-        [Description("When partitionKeyRangeId is absent, merge is silently skipped")]
-        public async Task ExecuteTransactionAsync_SkipsMerge_WhenLsnOnlyAndPartitionKeyRangeIdIsAbsent()
+        [Description("When partitionKeyRangeId is absent the token cannot be assembled, so it is surfaced rather than merged")]
+        public async Task ExecuteTransactionAsync_ThrowsAndSkipsMerge_WhenLsnOnlyAndPartitionKeyRangeIdIsAbsent()
         {
             const string lsnOnly = "1#9#4=8#5=7";
 
@@ -559,7 +545,10 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
                 operations, mockContext.Object, OperationType.CommitDistributedTransaction);
 
-            await committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
+            InvalidOperationException exception = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+                () => committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None));
+
+            StringAssert.Contains(exception.Message, lsnOnly);
 
             string storedToken = sessionContainer.GetSessionToken(DistributedTransactionConstants.GetCollectionFullName(DatabaseName, ContainerName));
             Assert.IsTrue(string.IsNullOrEmpty(storedToken),
@@ -571,9 +560,8 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
         [DataRow("", DisplayName = "Empty string partitionKeyRangeId")]
         [DataRow(" ", DisplayName = "Whitespace-only partitionKeyRangeId")]
         [DataRow("   ", DisplayName = "Multiple whitespace partitionKeyRangeId")]
-        [Description("When partitionKeyRangeId is present but empty or whitespace, merge is silently skipped. " +
-                     "The server has no validation on this field; throwing would risk failing a committed transaction.")]
-        public async Task ExecuteTransactionAsync_SkipsMerge_WhenPartitionKeyRangeIdIsEmptyOrWhitespace(string pkRangeId)
+        [Description("An empty or whitespace partitionKeyRangeId leaves the token unassembled, so it is surfaced rather than merged.")]
+        public async Task ExecuteTransactionAsync_ThrowsAndSkipsMerge_WhenPartitionKeyRangeIdIsEmptyOrWhitespace(string pkRangeId)
         {
             const string lsnOnly = "1#9#4=8#5=7";
 
@@ -601,7 +589,10 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
                 operations, mockContext.Object, OperationType.CommitDistributedTransaction);
 
-            await committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
+            InvalidOperationException exception = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+                () => committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None));
+
+            StringAssert.Contains(exception.Message, lsnOnly);
 
             string storedToken = sessionContainer.GetSessionToken(DistributedTransactionConstants.GetCollectionFullName(DatabaseName, ContainerName));
             Assert.IsTrue(string.IsNullOrEmpty(storedToken),
@@ -611,9 +602,9 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
         // ─── Retry / Spec-Compliance Tests ─────────────────────────────────────
 
         [TestMethod]
-        [Description("m8: In a multi-operation response, an op whose pkRangeId is absent is skipped while " +
-                     "subsequent ops with pkRangeId still have their session tokens merged correctly.")]
-        public async Task ExecuteTransactionAsync_MultiOp_SkipsOpWithMissingPkRangeId_MergesRemainingOps()
+        [Description("m8: In a multi-operation response, tokens recorded before a malformed one are preserved while " +
+                     "the malformed operation surfaces and is never merged.")]
+        public async Task ExecuteTransactionAsync_MultiOp_PreservesEarlierTokens_WhenLaterOpHasMissingPkRangeId()
         {
             const string lsnOnly = "1#9#4=8#5=7";
             const string pkRangeId = "0";
@@ -647,12 +638,10 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                     It.IsAny<ITrace>(), It.IsAny<CancellationToken>()))
                 .ReturnsAsync(containerProperties2);
 
-            // op 0: missing pkRangeId — should be skipped (SessionToken nulled in FromJson)
-            // op 1: has pkRangeId — should be merged
             string responseJson = BuildDtcResponseJson(new[]
             {
-                (statusCode: 201, subStatusCode: (int?)null, sessionToken: lsnOnly, partitionKeyRangeId: (string)null),
                 (statusCode: 201, subStatusCode: (int?)null, sessionToken: lsnOnly, partitionKeyRangeId: pkRangeId),
+                (statusCode: 201, subStatusCode: (int?)null, sessionToken: lsnOnly, partitionKeyRangeId: (string)null),
             });
 
             ResponseMessage responseMessage = new ResponseMessage(HttpStatusCode.OK)
@@ -687,30 +676,29 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
                 operations, mockContext.Object, OperationType.CommitDistributedTransaction);
 
-            await committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+                () => committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None));
 
-            // op 0 (missing pkRangeId) must NOT have been merged.
             mockSessionContainer.Verify(
                 s => s.SetSessionToken(
                     collectionRid1,
                     DistributedTransactionConstants.GetCollectionFullName(DatabaseName, ContainerName),
-                    It.IsAny<INameValueCollection>()),
-                Times.Never,
-                "SetSessionToken must not be called for an operation whose pkRangeId is absent.");
+                    It.Is<INameValueCollection>(h => h[HttpConstants.HttpHeaders.SessionToken] == assembledToken)),
+                Times.Once,
+                "Tokens recorded before the malformed one must be preserved.");
 
-            // op 1 (has pkRangeId) must have been merged with the assembled token.
             mockSessionContainer.Verify(
                 s => s.SetSessionToken(
                     collectionRid2,
                     DistributedTransactionConstants.GetCollectionFullName(DatabaseName, container2),
-                    It.Is<INameValueCollection>(h => h[HttpConstants.HttpHeaders.SessionToken] == assembledToken)),
-                Times.Once,
-                "SetSessionToken must be called for the operation that has pkRangeId, with the assembled token.");
+                    It.IsAny<INameValueCollection>()),
+                Times.Never,
+                "SetSessionToken must not be called for an operation whose pkRangeId is absent.");
         }
 
         [TestMethod]
         [Description("m9: When an operation result carries a session token with no partitionKeyRangeId, the capture path " +
-                     "emits a TraceWarning under non-Session consistency so the skip is observable in diagnostic traces.")]
+                     "emits a TraceWarning before surfacing so the failure is observable in diagnostic traces.")]
         public async Task ExecuteTransactionAsync_EmitsTraceWarning_WhenPartitionKeyRangeIdIsAbsent()
         {
             const string lsnOnly = "1#9#4=8#5=7";
@@ -750,7 +738,8 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             DefaultTrace.TraceSource.Listeners.Add(listener);
             try
             {
-                await committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
+                await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+                    () => committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None));
             }
             finally
             {
@@ -765,9 +754,8 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
 
 
         [TestMethod]
-        [Description("A malformed token on a retriable response must not surface: the retry loop has not yet decided " +
-                     "the outcome, so throwing would pre-empt a retry that could still succeed.")]
-        public async Task ExecuteTransactionAsync_DoesNotThrowOnMalformedToken_WhileTheResponseIsStillRetriable()
+        [Description("A malformed token on a retriable response surfaces before the transaction can retry.")]
+        public async Task ExecuteTransactionAsync_ThrowsOnMalformedToken_BeforeRetry()
         {
             SessionContainer sessionContainer = new SessionContainer("testhost");
 
@@ -784,7 +772,6 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                 {
                     attempts++;
 
-                    // The retriable attempt carries a malformed token; the terminal attempt is clean.
                     if (attempts == 1)
                     {
                         string retriableJson = @"{""isRetriable"":true,""operationResponses"":[{""index"":0,""statusCode"":200,""sessionToken"":""malformed""}]}";
@@ -806,15 +793,15 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
                 this.CreateOperations(1), mockContext.Object, OperationType.CommitDistributedTransaction, TimeSpan.Zero);
 
-            DistributedTransactionResponse response = await committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
+            InvalidOperationException exception = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+                () => committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None));
 
-            Assert.AreEqual(2, attempts, "The retriable attempt must be retried rather than aborted by a token failure.");
-            Assert.IsTrue(response.IsSuccessStatusCode, "The retry succeeded, so the caller sees the successful response.");
+            Assert.AreEqual(1, attempts, "A malformed token must surface before the next attempt.");
+            StringAssert.Contains(exception.Message, "malformed");
         }
 
         [TestMethod]
-        [Description("A success envelope that also reports isRetriable is never retried, so it is the outcome the " +
-                     "caller receives and a malformed token on it must surface rather than be traced as unsettled.")]
+        [Description("A malformed token on a successful response surfaces even when the response is marked retriable.")]
         public async Task ExecuteTransactionAsync_ThrowsOnMalformedToken_WhenSuccessEnvelopeAlsoReportsRetriable()
         {
             SessionContainer sessionContainer = new SessionContainer("testhost");
@@ -844,7 +831,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
 
             InvalidOperationException exception = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
                 () => committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None),
-                "A success status ends the retry loop regardless of isRetriable, so the token failure is settled.");
+                "A malformed token must surface regardless of the response's retry flag.");
 
             Assert.AreEqual(1, attempts, "A success envelope is terminal, so it must not be retried.");
             StringAssert.Contains(exception.Message, "malformed",
@@ -882,49 +869,15 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                 "The message must include the offending value so it can be diagnosed.");
         }
 
-        [TestMethod]
-        [Description("A read transaction never commits, so a malformed token on a read must not tell the caller the " +
-                     "transaction was committed.")]
-        public async Task ExecuteTransactionAsync_ReportsReadOutcome_WhenMalformedTokenSurfacesOnARead()
-        {
-            SessionContainer sessionContainer = new SessionContainer("testhost");
-
-            Mock<CosmosClientContext> mockContext = this.CreateMockContext(
-                sessionContainer,
-                responseContent: null,
-                statusCode: HttpStatusCode.OK,
-                accountConsistencyLevel: Cosmos.ConsistencyLevel.Session);
-
-            this.SetupProcessResourceOperation(
-                mockContext,
-                () => Task.FromResult(new ResponseMessage(HttpStatusCode.OK)
-                {
-                    Content = new MemoryStream(Encoding.UTF8.GetBytes(BuildDtcResponseJson(
-                        new[] { (statusCode: 200, subStatusCode: (int?)null, sessionToken: "malformed", partitionKeyRangeId: (string)null) },
-                        prefixRangeLessTokens: false)))
-                }));
-
-            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
-                this.CreateOperations(1), mockContext.Object, OperationType.Read);
-
-            InvalidOperationException exception = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
-                () => committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None));
-
-            StringAssert.Contains(exception.Message, "read transaction completed successfully",
-                "A read transaction must be described as completed, not committed.");
-            Assert.IsFalse(exception.Message.Contains("was committed"),
-                "A read transaction never commits, so the commit wording must not appear.");
-        }
-
         [DataTestMethod]
-        [Description("A malformed session token on a committed operation under Session consistency surfaces to the caller " +
+        [Description("A malformed session token on a committed operation surfaces to the caller " +
                      "instead of silently degrading the collection to eventual consistency.")]
         [DataRow("1#9#4=8#5=7", null, "1#9#4=8#5=7", "missing the partitionKeyRangeId prefix", DisplayName = "bare LSN with no partitionKeyRangeId to prefix it")]
         [DataRow("5", null, "5", "missing the partitionKeyRangeId prefix", DisplayName = "bare number with no partitionKeyRangeId to prefix it")]
         [DataRow("garbage", "0", "garbage", "could not be parsed", DisplayName = "unparsable token alongside a valid partitionKeyRangeId")]
         [DataRow("0:garbage", null, "0:garbage", "could not be parsed", DisplayName = "valid partitionKeyRangeId with an unparsable LSN segment")]
         [DataRow("0:1#5,1:1#7", null, "0:1#5,1:1#7", "could not be parsed", DisplayName = "compound multi-partition token in a partition-local slot")]
-        public async Task ExecuteTransactionAsync_ThrowsOnMalformedToken_WhenCommittedUnderSessionConsistency(
+        public async Task ExecuteTransactionAsync_ThrowsOnMalformedToken_WhenCommitted(
             string sessionToken,
             string partitionKeyRangeId,
             string expectedTokenInMessage,
@@ -945,7 +898,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
 
             InvalidOperationException exception = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
                 () => committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None),
-                "A malformed token on a committed operation under Session consistency must surface.");
+                "A malformed token on a committed operation must surface.");
 
             StringAssert.Contains(exception.Message, "index 0",
                 "The message must identify which operation carried the malformed token.");
@@ -955,9 +908,6 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                 "The message must state why the token could not be recorded, not a fixed reason.");
             StringAssert.Contains(exception.Message, DistributedTransactionConstants.GetCollectionFullName(DatabaseName, ContainerName),
                 "The message must name the collection whose progress was lost.");
-            StringAssert.Contains(exception.Message, "should not be retried",
-                "The message must state the transaction already committed so callers do not double-apply it.");
-
             Assert.IsTrue(
                 string.IsNullOrEmpty(sessionContainer.GetSessionToken(
                     DistributedTransactionConstants.GetCollectionFullName(DatabaseName, ContainerName))),
@@ -985,8 +935,6 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                 statusCode: HttpStatusCode.OK,
                 accountConsistencyLevel: Cosmos.ConsistencyLevel.Session);
 
-            // Distinct collections so that the token recorded before the failure and the tokens skipped
-            // after it occupy separate session container slots.
             List<DistributedTransactionOperation> operations = new List<DistributedTransactionOperation>
             {
                 new DistributedTransactionOperation(
@@ -1029,45 +977,44 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
         }
 
         [DataTestMethod]
-        [Description("Under a non-Session effective consistency a malformed token carries no guarantee the caller relies on, " +
-                     "so it is traced and skipped while its siblings still merge.")]
+        [Description("A token that cannot be recorded costs the caller the same guarantee at every consistency level, and the " +
+                     "point-operation path never grades a token against consistency either, so the failure surfaces regardless.")]
         [DataRow(Cosmos.ConsistencyLevel.Strong, DisplayName = "Strong")]
         [DataRow(Cosmos.ConsistencyLevel.BoundedStaleness, DisplayName = "BoundedStaleness")]
         [DataRow(Cosmos.ConsistencyLevel.ConsistentPrefix, DisplayName = "ConsistentPrefix")]
         [DataRow(Cosmos.ConsistencyLevel.Eventual, DisplayName = "Eventual")]
-        public async Task ExecuteTransactionAsync_SkipsMalformedToken_UnderNonSessionConsistency(
+        [DataRow(Cosmos.ConsistencyLevel.Session, DisplayName = "Session")]
+        public async Task ExecuteTransactionAsync_ThrowsOnMalformedToken_RegardlessOfConsistency(
             Cosmos.ConsistencyLevel accountConsistencyLevel)
         {
             SessionContainer sessionContainer = new SessionContainer("testhost");
 
             Mock<CosmosClientContext> mockContext = this.CreateMockContext(
                 sessionContainer,
-                responseContent: BuildDtcResponseJson(new[]
-                {
-                    (statusCode: 200, subStatusCode: (int?)null, sessionToken: "malformed", partitionKeyRangeId: (string)null),
-                    (statusCode: 200, subStatusCode: (int?)null, sessionToken: "1#3#4=2", partitionKeyRangeId: "1")
-                }),
+                responseContent: BuildDtcResponseJson(
+                    new[] { (statusCode: 200, subStatusCode: (int?)null, sessionToken: "malformed", partitionKeyRangeId: (string)null) }),
                 statusCode: HttpStatusCode.OK,
                 accountConsistencyLevel: accountConsistencyLevel);
 
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
-                this.CreateOperations(2), mockContext.Object, OperationType.CommitDistributedTransaction);
+                this.CreateOperations(1), mockContext.Object, OperationType.CommitDistributedTransaction);
 
-            DistributedTransactionResponse response = await committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
+            await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+                () => committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None),
+                "A committed transaction that could not record its token must surface that at every consistency level.");
 
-            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
-            Assert.AreEqual(
-                "1:1#3#4=2",
-                sessionContainer.GetSessionToken(DistributedTransactionConstants.GetCollectionFullName(DatabaseName, ContainerName)),
-                "A malformed token must not prevent its siblings from recording their progress.");
+            Assert.IsTrue(
+                string.IsNullOrEmpty(sessionContainer.GetSessionToken(
+                    DistributedTransactionConstants.GetCollectionFullName(DatabaseName, ContainerName))),
+                "A malformed token must never reach the session container.");
         }
 
         [DataTestMethod]
-        [Description("A malformed token on an operation the server already failed must never replace the server's error: " +
-                     "the caller still receives the status they need to act on.")]
+        [Description("A malformed token on a capturable error status surfaces.")]
         [DataRow(409, HttpStatusCode.Conflict, DisplayName = "409 Conflict")]
         [DataRow(412, HttpStatusCode.PreconditionFailed, DisplayName = "412 PreconditionFailed")]
-        public async Task ExecuteTransactionAsync_SkipsMalformedToken_WhenOperationFailedUnderSessionConsistency(
+        [DataRow(404, HttpStatusCode.NotFound, DisplayName = "404 NotFound")]
+        public async Task ExecuteTransactionAsync_ThrowsOnMalformedToken_WhenOperationFailed(
             int operationStatusCode,
             HttpStatusCode envelopeStatusCode)
         {
@@ -1083,57 +1030,15 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
                 this.CreateOperations(1), mockContext.Object, OperationType.CommitDistributedTransaction);
 
-            DistributedTransactionResponse response = await committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
+            InvalidOperationException exception = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+                () => committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None));
 
-            Assert.AreEqual(envelopeStatusCode, response.StatusCode,
-                "The server's error must reach the caller rather than being masked by a token-validation failure.");
-        }
-
-        [DataTestMethod]
-        [Description("Effective consistency is the client override when one is set, and the account default otherwise: " +
-                     "the same precedence the point-operation path applies.")]
-        [DataRow(Cosmos.ConsistencyLevel.Eventual, Cosmos.ConsistencyLevel.Session, true,
-            DisplayName = "client override to Session on an Eventual account surfaces the failure")]
-        [DataRow(Cosmos.ConsistencyLevel.Session, Cosmos.ConsistencyLevel.Eventual, false,
-            DisplayName = "client override to Eventual on a Session account suppresses the failure")]
-        public async Task ExecuteTransactionAsync_UsesClientConsistencyOverride_ToGradeMalformedTokens(
-            Cosmos.ConsistencyLevel accountConsistencyLevel,
-            Cosmos.ConsistencyLevel clientConsistencyOverride,
-            bool expectThrow)
-        {
-            SessionContainer sessionContainer = new SessionContainer("testhost");
-
-            Mock<CosmosClientContext> mockContext = this.CreateMockContext(
-                sessionContainer,
-                responseContent: BuildDtcResponseJson(
-                    new[] { (statusCode: 200, subStatusCode: (int?)null, sessionToken: "malformed", partitionKeyRangeId: (string)null) }),
-                statusCode: HttpStatusCode.OK,
-                accountConsistencyLevel: accountConsistencyLevel);
-
-            mockContext
-                .Setup(c => c.ClientOptions)
-                .Returns(new CosmosClientOptions { ConsistencyLevel = clientConsistencyOverride });
-
-            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
-                this.CreateOperations(1), mockContext.Object, OperationType.CommitDistributedTransaction);
-
-            if (expectThrow)
-            {
-                await Assert.ThrowsExceptionAsync<InvalidOperationException>(
-                    () => committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None),
-                    "The client override, not the account default, decides whether the failure surfaces.");
-            }
-            else
-            {
-                DistributedTransactionResponse response = await committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
-                Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
-            }
+            StringAssert.Contains(exception.Message, "malformed");
         }
 
         [TestMethod]
-        [Description("A SetSessionToken failure and a malformed token cost the caller the same guarantee, so they are graded " +
-                     "by one policy: both surface on a committed operation under Session consistency.")]
-        public async Task ExecuteTransactionAsync_SurfacesSetSessionTokenException_WhenCommittedUnderSessionConsistency()
+        [Description("A SetSessionToken failure surfaces to the caller.")]
+        public async Task ExecuteTransactionAsync_SurfacesSetSessionTokenException()
         {
             Mock<ISessionContainer> mockSessionContainer = new Mock<ISessionContainer>();
             mockSessionContainer
@@ -1160,79 +1065,6 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             Assert.IsNotNull(exception.InnerException,
                 "The originating failure must be preserved so the cause is diagnosable.");
             StringAssert.Contains(exception.InnerException.Message, "simulated SetSessionToken failure");
-        }
-
-        [TestMethod]
-        [Description("When SetSessionToken throws under a non-Session effective consistency, the exception is swallowed and ExecuteTransactionAsync still returns the response rather than rethrowing")]
-        public async Task ExecuteTransactionAsync_SwallowsSetSessionTokenException()
-        {
-            const string lsnOnly = "1#9#4=8#5=7";
-            const string pkRangeId = "0";
-
-            Mock<ISessionContainer> mockSessionContainer = new Mock<ISessionContainer>();
-            mockSessionContainer
-                .Setup(s => s.SetSessionToken(
-                    It.IsAny<string>(),
-                    It.IsAny<string>(),
-                    It.IsAny<INameValueCollection>()))
-                .Throws(new InvalidOperationException("simulated SetSessionToken failure"));
-
-            MockDocumentClient documentClient = new MockDocumentClient
-            {
-                sessionContainer = mockSessionContainer.Object
-            };
-
-            ContainerProperties containerProperties = ContainerProperties.CreateWithResourceId(CollectionResourceId);
-            containerProperties.Id = "TestContainerId";
-            containerProperties.PartitionKeyPath = "/pk";
-
-            Mock<CosmosClientContext> mockContext = new Mock<CosmosClientContext>();
-            mockContext.Setup(c => c.DocumentClient).Returns(documentClient);
-            mockContext.Setup(c => c.SerializerCore).Returns(MockCosmosUtil.Serializer);
-            mockContext.Setup(c => c.GetCachedContainerPropertiesAsync(
-                    It.IsAny<string>(), It.IsAny<ITrace>(), It.IsAny<CancellationToken>()))
-                .ReturnsAsync(containerProperties);
-
-            string responseJson = BuildDtcResponseJson(
-                new[] { (statusCode: 201, subStatusCode: (int?)null, sessionToken: lsnOnly, partitionKeyRangeId: pkRangeId) });
-
-            ResponseMessage responseMessage = new ResponseMessage(HttpStatusCode.OK)
-            {
-                Content = new MemoryStream(Encoding.UTF8.GetBytes(responseJson))
-            };
-
-            mockContext.Setup(c => c.ProcessResourceOperationStreamAsync(
-                    It.IsAny<string>(),
-                    ResourceType.DistributedTransactionBatch,
-                    OperationType.CommitDistributedTransaction,
-                    It.IsAny<RequestOptions>(),
-                    It.IsAny<ContainerInternal>(),
-                    It.IsAny<Cosmos.PartitionKey?>(),
-                    It.IsAny<string>(),
-                    It.IsAny<Stream>(),
-                    It.IsAny<Action<RequestMessage>>(),
-                    It.IsAny<ITrace>(),
-                    It.IsAny<CancellationToken>()))
-                .ReturnsAsync(responseMessage);
-
-            List<DistributedTransactionOperation> operations = new List<DistributedTransactionOperation>
-            {
-                new DistributedTransactionOperation(
-                    OperationType.Create,
-                    operationIndex: 0,
-                    DatabaseName,
-                    ContainerName,
-                    new PartitionKey("pk1"),
-                    id: "doc1")
-            };
-
-            DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
-                operations, mockContext.Object, OperationType.CommitDistributedTransaction);
-
-            // Must not throw even though SetSessionToken throws internally.
-            DistributedTransactionResponse response = await committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
-            Assert.IsNotNull(response, "ExecuteTransactionAsync should return a response even when SetSessionToken throws.");
-            Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
         }
 
         [TestMethod]
@@ -2659,10 +2491,8 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
         }
 
         [TestMethod]
-        [Description("Verifies that a malformed token is only traced when another operation failed. A failure anywhere " +
-                     "rolls the transaction back, so no operation left a durable write to read back, and throwing would " +
-                     "replace the server's own actionable error with a bookkeeping exception.")]
-        public async Task ExecuteTransactionAsync_TracesMalformedToken_WhenAnotherOperationFailed()
+        [Description("A malformed token on a capturable failed operation surfaces immediately.")]
+        public async Task ExecuteTransactionAsync_ThrowsOnMalformedToken_WhenAnotherOperationFailed()
         {
             SessionContainer sessionContainer = new SessionContainer("testhost");
 
@@ -2671,7 +2501,6 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                 responseContent: BuildDtcResponseJson(
                     new[]
                     {
-                        // Conflict rolls the transaction back, so the sibling's write is not durable.
                         (statusCode: 409, sessionToken: "bad-on-conflict"),
                         (statusCode: 201, sessionToken: "bad-on-success"),
                     }),
@@ -2681,11 +2510,10 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             DistributedTransactionCommitter committer = new DistributedTransactionCommitter(
                 this.CreateOperations(2), mockContext.Object, OperationType.CommitDistributedTransaction);
 
-            DistributedTransactionResponse response = await committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None);
+            InvalidOperationException exception = await Assert.ThrowsExceptionAsync<InvalidOperationException>(
+                () => committer.ExecuteTransactionAsync(NoOpTrace.Singleton, CancellationToken.None));
 
-            Assert.AreEqual(HttpStatusCode.Conflict, response[0].StatusCode,
-                "The server's own error must reach the caller rather than being masked by a token failure.");
-
+            StringAssert.Contains(exception.Message, "bad-on-conflict");
             Assert.IsTrue(
                 string.IsNullOrEmpty(sessionContainer.GetSessionToken(
                     DistributedTransactionConstants.GetCollectionFullName(DatabaseName, ContainerName))),
@@ -2816,8 +2644,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                 operations.Select(o => (o.statusCode, o.subStatusCode, o.sessionToken, partitionKeyRangeId: (string)null)).ToArray());
         }
 
-        // The server returns tokens in '<partitionKeyRangeId>:<token>' form. Test cases pass the range id
-        // separately for readability, so it is prefixed here unless a case is exercising a malformed token.
+        // Prefix valid test tokens as the server does.
         private static string BuildDtcResponseJson(
             (int statusCode, int? subStatusCode, string sessionToken, string partitionKeyRangeId)[] operations,
             bool prefixRangeLessTokens = true)
@@ -3147,18 +2974,6 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             ResponseMessage message = new ResponseMessage(statusCode);
             message.Headers.SubStatusCodeLiteral = subStatusCode.ToString();
             return message;
-        }
-
-        /// <summary>
-        /// A <see cref="MockDocumentClient"/> whose account consistency level cannot be resolved,
-        /// standing in for a transient failure of the gateway account read.
-        /// </summary>
-        private sealed class UnresolvableConsistencyDocumentClient : MockDocumentClient
-        {
-            internal override Task<Cosmos.ConsistencyLevel> GetDefaultConsistencyLevelAsync()
-            {
-                throw new InvalidOperationException("Simulated account read failure.");
-            }
         }
 
         /// <summary>

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionResponseTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionResponseTests.cs
@@ -1454,12 +1454,11 @@ namespace Microsoft.Azure.Cosmos.Tests
         }
 
         [TestMethod]
-        [Description("SessionToken is assembled as {pkRangeId}:{lsn} from the separate 'sessionToken' (LSN-only) and 'partitionKeyRangeId' JSON fields.")]
-        public async Task FromResponseMessage_OperationResult_SessionToken_DeserializesCorrectly()
+        [Description("SessionToken is preserved as returned by the coordinator.")]
+        public async Task FromResponseMessage_OperationResult_SessionToken_PreservesCoordinatorValue()
         {
             const string lsnOnly = "12345";
             const string pkRangeId = "0";
-            const string expectedSessionToken = "0:12345";
             DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
 
             string json = $@"{{""operationResponses"":[{{""index"":0,""statusCode"":201,""sessionToken"":""{lsnOnly}"",""partitionKeyRangeId"":""{pkRangeId}""}}]}}";
@@ -1472,14 +1471,13 @@ namespace Microsoft.Azure.Cosmos.Tests
                 NoOpTrace.Singleton,
                 CancellationToken.None);
 
-            Assert.AreEqual(expectedSessionToken, response[0].SessionToken,
-                "SessionToken must be assembled as {pkRangeId}:{lsn} from the two separate JSON fields.");
+            Assert.AreEqual(lsnOnly, response[0].SessionToken,
+                "SessionToken must not be canonicalized from a separate partitionKeyRangeId.");
         }
 
         [TestMethod]
-        [Description("When partitionKeyRangeId is absent, FromJson sets SessionToken to null so MergeSessionTokens skips the operation.")]
-        // TODO(issue#5857): Remove once the coordinator starts emitting partitionKeyRangeId for all operations.
-        public async Task FromResponseMessage_OperationResult_SessionToken_NullWhenPartitionKeyRangeIdAbsent()
+        [Description("When partitionKeyRangeId is absent, FromJson preserves the raw server value so the capture path can reject it.")]
+        public async Task FromResponseMessage_OperationResult_SessionToken_PreservedWhenPartitionKeyRangeIdAbsent()
         {
             const string lsnOnly = "12345";
             DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
@@ -1495,18 +1493,17 @@ namespace Microsoft.Azure.Cosmos.Tests
                 NoOpTrace.Singleton,
                 CancellationToken.None);
 
-            Assert.IsNull(response[0].SessionToken,
-                "SessionToken must be null when partitionKeyRangeId is absent so the merge is skipped.");
+            Assert.AreEqual(lsnOnly, response[0].SessionToken,
+                "The raw server value must survive so the capture path can reject the malformed token.");
         }
 
         [DataTestMethod]
         [DataRow("", DisplayName = "Empty string partitionKeyRangeId")]
         [DataRow(" ", DisplayName = "Whitespace-only partitionKeyRangeId")]
         [DataRow("   ", DisplayName = "Multiple spaces partitionKeyRangeId")]
-        [Description("When partitionKeyRangeId is present but empty or whitespace, FromJson sets SessionToken to null " +
-                     "so MergeSessionTokens skips the operation. The server has no validation on this field and can " +
-                     "send blank values; failing the commit would be worse than skipping the merge.")]
-        public async Task FromResponseMessage_OperationResult_SessionToken_NullWhenPartitionKeyRangeIdIsBlank(string pkRangeId)
+        [Description("When partitionKeyRangeId is present but empty or whitespace, FromJson preserves the raw server value " +
+                     "and the capture path rejects the malformed token.")]
+        public async Task FromResponseMessage_OperationResult_SessionToken_PreservedWhenPartitionKeyRangeIdIsBlank(string pkRangeId)
         {
             const string lsnOnly = "12345";
             DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
@@ -1521,8 +1518,8 @@ namespace Microsoft.Azure.Cosmos.Tests
                 NoOpTrace.Singleton,
                 CancellationToken.None);
 
-            Assert.IsNull(response[0].SessionToken,
-                $"SessionToken must be null when partitionKeyRangeId is '{pkRangeId}' (empty/whitespace) so the merge is safely skipped.");
+            Assert.AreEqual(lsnOnly, response[0].SessionToken,
+                $"A blank partitionKeyRangeId ('{pkRangeId}') must not change the raw token.");
         }
 
         [DataTestMethod]
@@ -1550,7 +1547,7 @@ namespace Microsoft.Azure.Cosmos.Tests
         [DataTestMethod]
         [DataRow("0:-1#425344#1=12345", "0:-1#425344#1=12345", DisplayName = "Well-formed canonical token preserved")]
         [DataRow("3:500", "3:500", DisplayName = "Simple pkRangeId:lsn preserved")]
-        [Description("When sessionToken is already in canonical {pkRangeId}:{lsn} form (colon at position > 0 with content on both sides), FromJson leaves it as-is even without partitionKeyRangeId.")]
+        [Description("When sessionToken is already in canonical {pkRangeId}:{lsn} form, FromJson leaves it as-is.")]
         public async Task FromResponseMessage_OperationResult_SessionToken_PreservedWhenAlreadyCanonical(string token, string expected)
         {
             DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
@@ -1571,10 +1568,10 @@ namespace Microsoft.Azure.Cosmos.Tests
         }
 
         [DataTestMethod]
-        [DataRow(":-1#425344", "3", DisplayName = "Leading colon (no pkRangeId) — not canonical, assembles with pkRangeId")]
-        [DataRow("3:", "5", DisplayName = "Trailing colon only (no LSN) — not canonical, assembles with pkRangeId")]
-        [Description("Session tokens with a colon at position 0 or at the last character are not valid canonical tokens — they get assembled with the provided partitionKeyRangeId.")]
-        public async Task FromResponseMessage_OperationResult_SessionToken_AssembledWhenColonIsAtEdge(string token, string pkRangeId)
+        [DataRow(":-1#425344", "3", ":-1#425344", DisplayName = "Leading colon is preserved")]
+        [DataRow("3:", "5", "3:", DisplayName = "Trailing colon is preserved")]
+        [Description("Tokens that are not in canonical form are preserved for the capture path to reject.")]
+        public async Task FromResponseMessage_OperationResult_SessionToken_PreservesNonCanonicalToken(string token, string pkRangeId, string expected)
         {
             DistributedTransactionServerRequest serverRequest = await BuildServerRequestAsync(operationCount: 1);
 
@@ -1588,8 +1585,8 @@ namespace Microsoft.Azure.Cosmos.Tests
                 NoOpTrace.Singleton,
                 CancellationToken.None);
 
-            Assert.AreEqual(pkRangeId + ":" + token, response[0].SessionToken,
-                $"A token with edge colon '{token}' must be assembled with pkRangeId '{pkRangeId}'.");
+            Assert.AreEqual(expected, response[0].SessionToken,
+                $"Non-canonical token '{token}' must be preserved as returned.");
         }
 
         [TestMethod]

--- a/changelog.md
+++ b/changelog.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [5991](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5991) TargetReplicaSetSize : Updated address cache logic to use partition-specific target replica set size when available, falling back to the user replication policy value.
 - [6081](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/6081) Distributed Transactions (preview): Fixes per-operation session tokens being captured from erroneous sub-operations with error codes scoped to 409s, 412s and 404s which don't map to read/write session not available errors. 
+- [6082](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/6082) Distributed Transactions (preview): Fixes a malformed per-operation session token being silently discarded, which downgraded the affected collection to eventual consistency with no signal to the caller. A token that is not in the expected `<partitionKeyRangeId>:<token>` form is no longer reshaped or dropped; tokens that cannot be recorded now surface as an `InvalidOperationException` after a successful transaction at session consistency, while preserving tokens recorded by earlier operations.
 
 ### <a name="3.63.0-preview.1"/> [3.63.0-preview.1](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.63.0-preview.1) - 2026-8-5
 

--- a/changelog.md
+++ b/changelog.md
@@ -46,7 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [5991](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/5991) TargetReplicaSetSize : Updated address cache logic to use partition-specific target replica set size when available, falling back to the user replication policy value.
 - [6081](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/6081) Distributed Transactions (preview): Fixes per-operation session tokens being captured from erroneous sub-operations with error codes scoped to 409s, 412s and 404s which don't map to read/write session not available errors. 
-- [6082](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/6082) Distributed Transactions (preview): Fixes a malformed per-operation session token being silently discarded, which downgraded the affected collection to eventual consistency with no signal to the caller. A token that is not in the expected `<partitionKeyRangeId>:<token>` form is no longer reshaped or dropped; tokens that cannot be recorded now surface as an `InvalidOperationException` after a successful transaction at session consistency, while preserving tokens recorded by earlier operations.
+- [6082](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/6082) Distributed Transactions (preview): Malformed per-operation session tokens now surface as an `InvalidOperationException` instead of being silently discarded.
 
 ### <a name="3.63.0-preview.1"/> [3.63.0-preview.1](https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.63.0-preview.1) - 2026-8-5
 


### PR DESCRIPTION
## Description

A malformed per-operation session token was silently dropped, which could leave the affected collection without the session progress returned by the distributed transaction coordinator.

The SDK now preserves non-empty tokens as returned, validates them before recording, and surfaces an `InvalidOperationException` when a token cannot be parsed, lacks a partition-key-range prefix, or is rejected by the session container. Tokens recorded before the failure are preserved, and the response is disposed when token processing throws.

The behavior is independent of consistency level and follows the point-operation capture-status filter: successful operations and capturable `409`, `412`, and eligible `404` responses are processed, while other error statuses remain skipped. For a capturable malformed token, the exception surfaces immediately, including on failed or retriable transaction responses.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Closing issues

N/A

## Changelog

- [x] I have added a changelog entry under `### Unreleased` in `changelog.md` for the user-facing impact of this change.
