### PR TITLE
fix: Client Encryption -- renames missing cryptography resources

### DIFF
--- a/Microsoft.Azure.Cosmos.Encryption/changelog.md
+++ b/Microsoft.Azure.Cosmos.Encryption/changelog.md
@@ -3,6 +3,11 @@ Preview features are treated as a separate branch and will not be included in th
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Unreleased
+
+#### Bugs Fixed
+- Fixes encryption error reporting so cryptographic validation failures return their intended messages instead of throwing `MissingManifestResourceException`. See [issue 4561](https://github.com/Azure/azure-cosmos-dotnet-v3/issues/4561).
+
 ### <a name="2.0.5"/> [2.0.5](https://www.nuget.org/packages/Microsoft.Azure.Cosmos.Encryption/2.0.5) - 2025-05-23
 
 #### Added

--- a/Microsoft.Azure.Cosmos.Encryption/src/Microsoft.Azure.Cosmos.Encryption.csproj
+++ b/Microsoft.Azure.Cosmos.Encryption/src/Microsoft.Azure.Cosmos.Encryption.csproj
@@ -26,6 +26,7 @@
   </PropertyGroup>
   <ItemGroup>
     <AdditionalFiles Include="..\..\Microsoft.Azure.Cosmos\src\stylecop.json" Link="stylecop.json" />
+    <EmbeddedResource Update="MdeSrc\Resources\Strings.resx" LogicalName="Microsoft.Data.Encryption.Cryptography.Strings.resources" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(SdkProjectRef)' != 'True' AND '$(IsPreview)' != 'True' ">

--- a/Microsoft.Azure.Cosmos.Encryption/tests/Microsoft.Azure.Cosmos.Encryption.Tests/ResourceTests.cs
+++ b/Microsoft.Azure.Cosmos.Encryption/tests/Microsoft.Azure.Cosmos.Encryption.Tests/ResourceTests.cs
@@ -1,0 +1,21 @@
+//------------------------------------------------------------
+// Copyright (c) Microsoft Corporation.  All rights reserved.
+//------------------------------------------------------------
+
+namespace Microsoft.Azure.Cosmos.Encryption.Tests
+{
+    using Microsoft.Data.Encryption.Resources;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class ResourceTests
+    {
+        [TestMethod]
+        public void InvalidAuthenticationTagResourceIsAvailable()
+        {
+            Assert.AreEqual(
+                "Specified ciphertext has an invalid authentication tag.",
+                Strings.InvalidAuthenticationTag);
+        }
+    }
+}


### PR DESCRIPTION
## Description

Fixes cryptographic error-message lookup by embedding the copied MDE resource under the logical manifest name expected by its generated accessor.

Adds a regression test confirming that cryptographic validation messages can be resolved successfully.

Please see simple reproduction in this [fiddle](https://dotnetfiddle.net/x7L9Wi).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Closing issues

Closes #4561

## Changelog

- [x] I have added a changelog entry under `### Unreleased` in `changelog.md`
  for the user-facing impact of this change.