### PR TITLE
[Internal] Distributed Transactions: Refactors dispatch tracker plumbing

### DIFF
--- a/Microsoft.Azure.Cosmos/src/ClientRetryPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/ClientRetryPolicy.cs
@@ -50,6 +50,7 @@ namespace Microsoft.Azure.Cosmos
         private readonly bool isHubRegionProcessingEnabled;
 #endif
         private readonly AuthorizationTokenProvider authorizationTokenProvider;
+        private readonly DistributedTransactionDispatchTracker distributedTransactionDispatchTracker;
         private int failoverRetryCount;
 
         private int sessionTokenRetryCount;
@@ -96,6 +97,28 @@ namespace Microsoft.Azure.Cosmos
             this.isHubRegionProcessingEnabled = isHubRegionProcessingEnabled;
 #endif
             this.authorizationTokenProvider = authorizationTokenProvider;
+        }
+
+        internal ClientRetryPolicy(
+            GlobalEndpointManager globalEndpointManager,
+            GlobalPartitionEndpointManager partitionKeyRangeLocationCache,
+            RetryOptions retryOptions,
+            bool enableEndpointDiscovery,
+            bool isThinClientEnabled,
+            DistributedTransactionDispatchTracker distributedTransactionDispatchTracker,
+            bool isHubRegionProcessingEnabled = true,
+            AuthorizationTokenProvider authorizationTokenProvider = null)
+            : this(
+                globalEndpointManager,
+                partitionKeyRangeLocationCache,
+                retryOptions,
+                enableEndpointDiscovery,
+                isThinClientEnabled,
+                isHubRegionProcessingEnabled,
+                authorizationTokenProvider)
+        {
+            this.distributedTransactionDispatchTracker = distributedTransactionDispatchTracker
+                ?? throw new ArgumentNullException(nameof(distributedTransactionDispatchTracker));
         }
 
         /// <summary> 
@@ -394,7 +417,7 @@ namespace Microsoft.Azure.Cosmos
                 // headers never named. ClearRouteToLocation frees the pin for the next attempt.
                 this.locationEndpoint = this.globalEndpointManager.ResolveServiceEndpoint(request);
 
-                DistributedTransactionDispatchTracker.StampDispatchHeaders(
+                this.distributedTransactionDispatchTracker?.StampDispatchHeaders(
                     request,
                     this.globalEndpointManager.GetLocation(this.locationEndpoint));
             }

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionCommitter.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionCommitter.cs
@@ -278,11 +278,8 @@ namespace Microsoft.Azure.Cosmos
             requestMessage.UseGatewayMode = true;
 
             // ClientRetryPolicy can re-dispatch this message to another write region without returning
-            // here, so the tracker rides along and the headers are stamped per dispatch.
-            if (serverRequest.DispatchTracker != null)
-            {
-                requestMessage.Properties[DistributedTransactionDispatchTracker.PropertyKey] = serverRequest.DispatchTracker;
-            }
+            // here, so the token-scoped tracker rides along and the headers are stamped per dispatch.
+            requestMessage.DistributedTransactionDispatchTracker = serverRequest.DispatchTracker;
         }
 
         internal static void MergeSessionTokens(

--- a/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionDispatchTracker.cs
+++ b/Microsoft.Azure.Cosmos/src/DistributedTransaction/DistributedTransactionDispatchTracker.cs
@@ -17,14 +17,9 @@ namespace Microsoft.Azure.Cosmos
     /// write region within a single commit attempt, and the committer replays the same token through a new
     /// policy on any retriable non-abort response, so policy-local state would reset while the token lives
     /// on and under-report both signals.
-    ///
-    /// The tracker owns and synchronizes its mutable state. The Properties dictionary only carries the
-    /// tracker reference; callers mutate dispatch state exclusively through this type.
     /// </remarks>
     internal sealed class DistributedTransactionDispatchTracker
     {
-        internal const string PropertyKey = "DistributedTransactionDispatchTracker";
-
         private readonly object stateLock = new object();
         private string originalDispatchRegion;
         private int dispatchCount;
@@ -106,19 +101,16 @@ namespace Microsoft.Azure.Cosmos
         }
 
         /// <summary>
-        /// Stamps both headers when <paramref name="request"/> carries a tracker; read transactions carry
-        /// none and omit the headers entirely.
+        /// Stamps both headers for the next dispatch.
         /// </summary>
-        internal static void StampDispatchHeaders(DocumentServiceRequest request, string regionName)
+        internal void StampDispatchHeaders(DocumentServiceRequest request, string regionName)
         {
-            if (request?.Properties == null
-                || !request.Properties.TryGetValue(DistributedTransactionDispatchTracker.PropertyKey, out object trackerObject)
-                || trackerObject is not DistributedTransactionDispatchTracker tracker)
+            if (request == null)
             {
                 return;
             }
 
-            (bool IsRetry, bool IsCrossRegionRedirect) dispatchSignals = tracker.RecordDispatch(regionName);
+            (bool IsRetry, bool IsCrossRegionRedirect) dispatchSignals = this.RecordDispatch(regionName);
 
             request.Headers[DistributedTransactionConstants.IsDtxRetry] =
                 dispatchSignals.IsRetry ? bool.TrueString : bool.FalseString;

--- a/Microsoft.Azure.Cosmos/src/DocumentClient.cs
+++ b/Microsoft.Azure.Cosmos/src/DocumentClient.cs
@@ -7911,7 +7911,24 @@ namespace Microsoft.Azure.Cosmos
 
             public IDocumentClientRetryPolicy GetRequestPolicy()
             {
-                return new RenameCollectionAwareClientRetryPolicy(this.sessionContainer, this.collectionCache, this.retryPolicy.GetRequestPolicy());
+                return new RenameCollectionAwareClientRetryPolicy(
+                    this.sessionContainer,
+                    this.collectionCache,
+                    this.retryPolicy.GetRequestPolicy());
+            }
+
+            public IDocumentClientRetryPolicy GetRequestPolicy(
+                DistributedTransactionDispatchTracker distributedTransactionDispatchTracker)
+            {
+                if (distributedTransactionDispatchTracker == null)
+                {
+                    throw new ArgumentNullException(nameof(distributedTransactionDispatchTracker));
+                }
+
+                return new RenameCollectionAwareClientRetryPolicy(
+                    this.sessionContainer,
+                    this.collectionCache,
+                    this.retryPolicy.GetRequestPolicy(distributedTransactionDispatchTracker));
             }
         }
 

--- a/Microsoft.Azure.Cosmos/src/Handler/RequestMessage.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/RequestMessage.cs
@@ -149,6 +149,8 @@ namespace Microsoft.Azure.Cosmos
 
         internal Action<DocumentServiceRequest> OnBeforeSendRequestActions { get; set; }
 
+        internal DistributedTransactionDispatchTracker DistributedTransactionDispatchTracker { get; set; }
+
         internal bool IsPropertiesInitialized => this.properties.IsValueCreated;
 
         /// <summary>
@@ -351,6 +353,7 @@ namespace Microsoft.Azure.Cosmos
             clone.UseGatewayMode = this.UseGatewayMode;
             clone.ContainerId = this.ContainerId;
             clone.DatabaseId = this.DatabaseId;
+            clone.DistributedTransactionDispatchTracker = this.DistributedTransactionDispatchTracker;
 
             return clone;
         }

--- a/Microsoft.Azure.Cosmos/src/Handler/RetryHandler.cs
+++ b/Microsoft.Azure.Cosmos/src/Handler/RetryHandler.cs
@@ -28,7 +28,10 @@ namespace Microsoft.Azure.Cosmos.Handlers
 
         internal override Task<IDocumentClientRetryPolicy> GetRetryPolicyAsync(RequestMessage request)
         {
-            IDocumentClientRetryPolicy retryPolicyInstance = this.client.DocumentClient.ResetSessionTokenRetryPolicy.GetRequestPolicy();
+            IDocumentClientRetryPolicy retryPolicyInstance = request.DistributedTransactionDispatchTracker == null
+                ? this.client.DocumentClient.ResetSessionTokenRetryPolicy.GetRequestPolicy()
+                : this.client.DocumentClient.ResetSessionTokenRetryPolicy.GetRequestPolicy(
+                    request.DistributedTransactionDispatchTracker);
 #if !INTERNAL
             Debug.Assert(request.OnBeforeSendRequestActions == null, "Cosmos Request message only supports a single retry policy");
 #endif

--- a/Microsoft.Azure.Cosmos/src/IDocumentClientRetryPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/IDocumentClientRetryPolicy.cs
@@ -36,5 +36,11 @@ namespace Microsoft.Azure.Cosmos
         /// Method that is called to get the retry policy for a non-query request.
         /// </summary>
         IDocumentClientRetryPolicy GetRequestPolicy();
+
+        /// <summary>
+        /// Method that is called to get the retry policy for a distributed transaction request.
+        /// </summary>
+        IDocumentClientRetryPolicy GetRequestPolicy(
+            DistributedTransactionDispatchTracker distributedTransactionDispatchTracker);
     }
 }

--- a/Microsoft.Azure.Cosmos/src/RetryPolicy.cs
+++ b/Microsoft.Azure.Cosmos/src/RetryPolicy.cs
@@ -45,12 +45,34 @@ namespace Microsoft.Azure.Cosmos
         /// </summary>
         public IDocumentClientRetryPolicy GetRequestPolicy()
         {
+            return new ClientRetryPolicy(
+                this.globalEndpointManager,
+                this.partitionKeyRangeLocationCache,
+                this.retryOptions,
+                this.enableEndpointDiscovery,
+                this.isThinClientEnabled,
+                this.isHubRegionProcessingEnabled,
+                this.authorizationTokenProvider);
+        }
+
+        /// <summary>
+        /// Creates a new instance of the ClientRetryPolicy class retrying distributed transaction failures.
+        /// </summary>
+        public IDocumentClientRetryPolicy GetRequestPolicy(
+            DistributedTransactionDispatchTracker distributedTransactionDispatchTracker)
+        {
+            if (distributedTransactionDispatchTracker == null)
+            {
+                throw new System.ArgumentNullException(nameof(distributedTransactionDispatchTracker));
+            }
+
             ClientRetryPolicy clientRetryPolicy = new ClientRetryPolicy(
                 this.globalEndpointManager,
                 this.partitionKeyRangeLocationCache,
                 this.retryOptions,
                 this.enableEndpointDiscovery,
                 this.isThinClientEnabled,
+                distributedTransactionDispatchTracker,
                 this.isHubRegionProcessingEnabled,
                 this.authorizationTokenProvider);
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ClientRetryPolicyTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/ClientRetryPolicyTests.cs
@@ -2995,6 +2995,37 @@ namespace Microsoft.Azure.Cosmos.Client.Tests
         // request without returning to DistributedTransactionCommitter.
 
         [TestMethod]
+        public void DistributedTransactionDispatchTracker_IsRequiredByDtxOverloads()
+        {
+            using GlobalEndpointManager endpointManager = this.Initialize(
+                useMultipleWriteLocations: false,
+                enableEndpointDiscovery: true,
+                isPreferredLocationsListEmpty: false);
+
+            ConnectionPolicy connectionPolicy = new ConnectionPolicy
+            {
+                EnableEndpointDiscovery = true,
+            };
+
+            RetryPolicy retryPolicyFactory = new RetryPolicy(
+                endpointManager,
+                connectionPolicy,
+                this.partitionKeyRangeLocationCache,
+                isThinClientEnabled: false);
+
+            Assert.ThrowsException<ArgumentNullException>(
+                () => retryPolicyFactory.GetRequestPolicy(distributedTransactionDispatchTracker: null));
+            Assert.ThrowsException<ArgumentNullException>(
+                () => new ClientRetryPolicy(
+                    endpointManager,
+                    this.partitionKeyRangeLocationCache,
+                    new RetryOptions(),
+                    enableEndpointDiscovery: true,
+                    isThinClientEnabled: false,
+                    distributedTransactionDispatchTracker: null));
+        }
+
+        [TestMethod]
         [Description("The first dispatch of an idempotency token reports neither signal, and a re-dispatch that stays in the same write region is a retry but not a cross-region redirect.")]
         public void OnBeforeSendRequest_DistributedTransactionWrite_ReportsRetryWithoutRedirectWhileRegionIsUnchanged()
         {
@@ -3003,14 +3034,16 @@ namespace Microsoft.Azure.Cosmos.Client.Tests
                 enableEndpointDiscovery: true,
                 isPreferredLocationsListEmpty: false);
 
+            DistributedTransactionDispatchTracker dispatchTracker = new();
             ClientRetryPolicy retryPolicy = new(
                 endpointManager,
                 this.partitionKeyRangeLocationCache,
                 new RetryOptions(),
                 enableEndpointDiscovery: true,
-                isThinClientEnabled: false);
+                isThinClientEnabled: false,
+                distributedTransactionDispatchTracker: dispatchTracker);
 
-            using DocumentServiceRequest request = ClientRetryPolicyTests.CreateDtxRequestWithDispatchTracker();
+            using DocumentServiceRequest request = ClientRetryPolicyTests.CreateDtxRequest();
 
             retryPolicy.OnBeforeSendRequest(request);
             ClientRetryPolicyTests.AssertDispatchHeaders(request, bool.FalseString, bool.FalseString);
@@ -3032,14 +3065,16 @@ namespace Microsoft.Azure.Cosmos.Client.Tests
                 enableEndpointDiscovery: true,
                 isPreferredLocationsListEmpty: false);
 
+            DistributedTransactionDispatchTracker dispatchTracker = new();
             ClientRetryPolicy retryPolicy = new(
                 endpointManager,
                 this.partitionKeyRangeLocationCache,
                 new RetryOptions(),
                 enableEndpointDiscovery: true,
-                isThinClientEnabled: false);
+                isThinClientEnabled: false,
+                distributedTransactionDispatchTracker: dispatchTracker);
 
-            using DocumentServiceRequest request = ClientRetryPolicyTests.CreateDtxRequestWithDispatchTracker();
+            using DocumentServiceRequest request = ClientRetryPolicyTests.CreateDtxRequest();
 
             retryPolicy.OnBeforeSendRequest(request);
             string firstRegion = ClientRetryPolicyTests.ResolveDispatchRegion(endpointManager, request);
@@ -3114,14 +3149,16 @@ namespace Microsoft.Azure.Cosmos.Client.Tests
                 isPreferredLocationsListEmpty: false,
                 enforceSingleMasterSingleWriteLocation: true);
 
+            DistributedTransactionDispatchTracker dispatchTracker = new();
             ClientRetryPolicy retryPolicy = new(
                 endpointManager,
                 this.partitionKeyRangeLocationCache,
                 new RetryOptions(),
                 enableEndpointDiscovery: true,
-                isThinClientEnabled: false);
+                isThinClientEnabled: false,
+                distributedTransactionDispatchTracker: dispatchTracker);
 
-            using DocumentServiceRequest request = ClientRetryPolicyTests.CreateDtxRequestWithDispatchTracker();
+            using DocumentServiceRequest request = ClientRetryPolicyTests.CreateDtxRequest();
 
             retryPolicy.OnBeforeSendRequest(request);
 
@@ -3161,14 +3198,16 @@ namespace Microsoft.Azure.Cosmos.Client.Tests
                 isPreferredLocationsListEmpty: false,
                 configuredEndpointOverride: ClientRetryPolicyTests.NonTopologyEndpoint);
 
+            DistributedTransactionDispatchTracker dispatchTracker = new();
             ClientRetryPolicy retryPolicy = new(
                 endpointManager,
                 this.partitionKeyRangeLocationCache,
                 new RetryOptions(),
                 enableEndpointDiscovery: false,
-                isThinClientEnabled: false);
+                isThinClientEnabled: false,
+                distributedTransactionDispatchTracker: dispatchTracker);
 
-            using DocumentServiceRequest request = ClientRetryPolicyTests.CreateDtxRequestWithDispatchTracker();
+            using DocumentServiceRequest request = ClientRetryPolicyTests.CreateDtxRequest();
 
             retryPolicy.OnBeforeSendRequest(request);
 
@@ -3202,14 +3241,16 @@ namespace Microsoft.Azure.Cosmos.Client.Tests
                 isPreferredLocationsListEmpty: false,
                 configuredEndpointOverride: ClientRetryPolicyTests.NonTopologyEndpoint);
 
+            DistributedTransactionDispatchTracker dispatchTracker = new();
             ClientRetryPolicy retryPolicy = new(
                 endpointManager,
                 this.partitionKeyRangeLocationCache,
                 new RetryOptions(),
                 enableEndpointDiscovery: true,
-                isThinClientEnabled: false);
+                isThinClientEnabled: false,
+                distributedTransactionDispatchTracker: dispatchTracker);
 
-            using DocumentServiceRequest request = ClientRetryPolicyTests.CreateDtxRequestWithDispatchTracker();
+            using DocumentServiceRequest request = ClientRetryPolicyTests.CreateDtxRequest();
 
             retryPolicy.OnBeforeSendRequest(request);
 
@@ -3243,14 +3284,16 @@ namespace Microsoft.Azure.Cosmos.Client.Tests
                 enableEndpointDiscovery: true,
                 isPreferredLocationsListEmpty: false);
 
-            using DocumentServiceRequest request = ClientRetryPolicyTests.CreateDtxRequestWithDispatchTracker();
+            DistributedTransactionDispatchTracker dispatchTracker = new();
+            using DocumentServiceRequest request = ClientRetryPolicyTests.CreateDtxRequest();
 
             ClientRetryPolicy firstAttemptPolicy = new(
                 endpointManager,
                 this.partitionKeyRangeLocationCache,
                 new RetryOptions(),
                 enableEndpointDiscovery: true,
-                isThinClientEnabled: false);
+                isThinClientEnabled: false,
+                distributedTransactionDispatchTracker: dispatchTracker);
 
             firstAttemptPolicy.OnBeforeSendRequest(request);
             string firstRegion = ClientRetryPolicyTests.ResolveDispatchRegion(endpointManager, request);
@@ -3275,7 +3318,8 @@ namespace Microsoft.Azure.Cosmos.Client.Tests
                 this.partitionKeyRangeLocationCache,
                 new RetryOptions(),
                 enableEndpointDiscovery: true,
-                isThinClientEnabled: false);
+                isThinClientEnabled: false,
+                distributedTransactionDispatchTracker: dispatchTracker);
 
             // Overwrite the wire state with what a policy-scoped design would have produced, so the
             // assertion below can only pass if the new policy re-derived both signals from the token.
@@ -3299,14 +3343,16 @@ namespace Microsoft.Azure.Cosmos.Client.Tests
                 enableEndpointDiscovery: true,
                 isPreferredLocationsListEmpty: false);
 
+            DistributedTransactionDispatchTracker dispatchTracker = new();
             ClientRetryPolicy retryPolicy = new(
                 endpointManager,
                 this.partitionKeyRangeLocationCache,
                 new RetryOptions(),
                 enableEndpointDiscovery: true,
-                isThinClientEnabled: false);
+                isThinClientEnabled: false,
+                distributedTransactionDispatchTracker: dispatchTracker);
 
-            using DocumentServiceRequest request = ClientRetryPolicyTests.CreateDtxRequestWithDispatchTracker();
+            using DocumentServiceRequest request = ClientRetryPolicyTests.CreateDtxRequest();
 
             retryPolicy.OnBeforeSendRequest(request);
             string firstRegion = ClientRetryPolicyTests.ResolveDispatchRegion(endpointManager, request);
@@ -3341,14 +3387,16 @@ namespace Microsoft.Azure.Cosmos.Client.Tests
                 isPreferredLocationsListEmpty: false,
                 preferedRegionListOverride: new List<string>() { "location2", "location1" }.AsReadOnly());
 
+            DistributedTransactionDispatchTracker dispatchTracker = new();
             ClientRetryPolicy retryPolicy = new(
                 endpointManager,
                 this.partitionKeyRangeLocationCache,
                 new RetryOptions(),
                 enableEndpointDiscovery: true,
-                isThinClientEnabled: false);
+                isThinClientEnabled: false,
+                distributedTransactionDispatchTracker: dispatchTracker);
 
-            using DocumentServiceRequest request = ClientRetryPolicyTests.CreateDtxRequestWithDispatchTracker();
+            using DocumentServiceRequest request = ClientRetryPolicyTests.CreateDtxRequest();
 
             retryPolicy.OnBeforeSendRequest(request);
             Assert.IsTrue(
@@ -3389,14 +3437,16 @@ namespace Microsoft.Azure.Cosmos.Client.Tests
                 enableEndpointDiscovery: true,
                 isPreferredLocationsListEmpty: true);
 
+            DistributedTransactionDispatchTracker dispatchTracker = new();
             ClientRetryPolicy retryPolicy = new(
                 endpointManager,
                 this.partitionKeyRangeLocationCache,
                 new RetryOptions(),
                 enableEndpointDiscovery: true,
-                isThinClientEnabled: false);
+                isThinClientEnabled: false,
+                distributedTransactionDispatchTracker: dispatchTracker);
 
-            using DocumentServiceRequest request = ClientRetryPolicyTests.CreateDtxRequestWithDispatchTracker();
+            using DocumentServiceRequest request = ClientRetryPolicyTests.CreateDtxRequest();
 
             // Dispatch 1: stamp, then let the dispatch site resolve the endpoint.
             retryPolicy.OnBeforeSendRequest(request);
@@ -3461,18 +3511,6 @@ namespace Microsoft.Azure.Cosmos.Client.Tests
             // Reads the region the way the dispatch site does, so assertions compare against the endpoint
             // the request is actually sent to rather than one re-derived from current topology.
             return endpointManager.GetLocation(endpointManager.ResolveServiceEndpoint(request));
-        }
-
-        private static DocumentServiceRequest CreateDtxRequestWithDispatchTracker()
-        {
-            DocumentServiceRequest request = ClientRetryPolicyTests.CreateDtxRequest();
-
-            request.Properties = new Dictionary<string, object>
-            {
-                [DistributedTransactionDispatchTracker.PropertyKey] = new DistributedTransactionDispatchTracker()
-            };
-
-            return request;
         }
 
         private static DocumentClientException CreateWriteForbiddenException(DocumentServiceRequest request)

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionCommitterTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionCommitterTests.cs
@@ -1171,7 +1171,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
 
         // ─── Dispatch signals ──────────────────────────────────────────────────
         // The committer only attaches a tracker whose lifetime matches the idempotency token;
-        // ClientRetryPolicy reads it back and stamps the headers per dispatch.
+        // RetryHandler injects it into ClientRetryPolicy, which stamps the headers per dispatch.
 
         [TestMethod]
         [Description("A write transaction carries the dispatch tracker on the request, which is how ClientRetryPolicy stamps the signals on a dispatch it re-routes to another write region without returning to the committer.")]
@@ -1338,12 +1338,10 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
             })
             {
                 enricher(request);
-
-                return request.Properties.TryGetValue(
-                    DistributedTransactionDispatchTracker.PropertyKey,
-                    out object tracker)
-                        ? tracker as DistributedTransactionDispatchTracker
-                        : null;
+                Assert.IsFalse(
+                    request.IsPropertiesInitialized,
+                    "Distributed transaction dispatch state must not be exposed through the public Properties bag.");
+                return request.DistributedTransactionDispatchTracker;
             }
         }
 

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionDispatchTrackerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/DistributedTransaction/DistributedTransactionDispatchTrackerTests.cs
@@ -4,7 +4,6 @@
 
 namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
 {
-    using System.Collections.Generic;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.Azure.Documents;
@@ -160,72 +159,21 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
 
             using (DocumentServiceRequest request = DistributedTransactionDispatchTrackerTests.CreateRequestWithTracker(tracker))
             {
-                DistributedTransactionDispatchTracker.StampDispatchHeaders(request, EastUs);
+                tracker.StampDispatchHeaders(request, EastUs);
                 DistributedTransactionDispatchTrackerTests.AssertHeaders(request, bool.FalseString, bool.FalseString);
 
-                DistributedTransactionDispatchTracker.StampDispatchHeaders(request, EastUs);
+                tracker.StampDispatchHeaders(request, EastUs);
                 DistributedTransactionDispatchTrackerTests.AssertHeaders(request, bool.TrueString, bool.FalseString);
 
-                DistributedTransactionDispatchTracker.StampDispatchHeaders(request, WestUs);
+                tracker.StampDispatchHeaders(request, WestUs);
                 DistributedTransactionDispatchTrackerTests.AssertHeaders(request, bool.TrueString, bool.TrueString);
-            }
-        }
-
-        [TestMethod]
-        public void StampDispatchHeaders_NoTrackerInProperties_OmitsBothHeaders()
-        {
-            using (DocumentServiceRequest request = DocumentServiceRequest.Create(
-                OperationType.Read,
-                ResourceType.DistributedTransactionBatch,
-                AuthorizationTokenType.PrimaryMasterKey))
-            {
-                request.Properties = new Dictionary<string, object>();
-
-                DistributedTransactionDispatchTracker.StampDispatchHeaders(request, EastUs);
-
-                DistributedTransactionDispatchTrackerTests.AssertHeaders(request, null, null);
-            }
-        }
-
-        [TestMethod]
-        public void StampDispatchHeaders_NullProperties_OmitsBothHeaders()
-        {
-            using (DocumentServiceRequest request = DocumentServiceRequest.Create(
-                OperationType.CommitDistributedTransaction,
-                ResourceType.DistributedTransactionBatch,
-                AuthorizationTokenType.PrimaryMasterKey))
-            {
-                request.Properties = null;
-
-                DistributedTransactionDispatchTracker.StampDispatchHeaders(request, EastUs);
-
-                DistributedTransactionDispatchTrackerTests.AssertHeaders(request, null, null);
-            }
-        }
-
-        [TestMethod]
-        public void StampDispatchHeaders_ForeignValueUnderTrackerKey_OmitsBothHeaders()
-        {
-            using (DocumentServiceRequest request = DocumentServiceRequest.Create(
-                OperationType.CommitDistributedTransaction,
-                ResourceType.DistributedTransactionBatch,
-                AuthorizationTokenType.PrimaryMasterKey))
-            {
-                request.Properties = new Dictionary<string, object>
-                {
-                    [DistributedTransactionDispatchTracker.PropertyKey] = "not a tracker"
-                };
-
-                DistributedTransactionDispatchTracker.StampDispatchHeaders(request, EastUs);
-
-                DistributedTransactionDispatchTrackerTests.AssertHeaders(request, null, null);
             }
         }
 
         [TestMethod]
         public void StampDispatchHeaders_NullRequest_DoesNotThrow()
         {
-            DistributedTransactionDispatchTracker.StampDispatchHeaders(null, EastUs);
+            new DistributedTransactionDispatchTracker().StampDispatchHeaders(null, EastUs);
         }
 
         [TestMethod]
@@ -235,10 +183,10 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
 
             using (DocumentServiceRequest request = DistributedTransactionDispatchTrackerTests.CreateRequestWithTracker(tracker))
             {
-                DistributedTransactionDispatchTracker.StampDispatchHeaders(request, EastUs);
-                DistributedTransactionDispatchTracker.StampDispatchHeaders(request, WestUs);
+                tracker.StampDispatchHeaders(request, EastUs);
+                tracker.StampDispatchHeaders(request, WestUs);
 
-                DistributedTransactionDispatchTracker.StampDispatchHeaders(request, null);
+                tracker.StampDispatchHeaders(request, null);
 
                 DistributedTransactionDispatchTrackerTests.AssertHeaders(request, bool.TrueString, bool.TrueString);
             }
@@ -264,7 +212,7 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
                             ? DistributedTransactionDispatchTrackerTests.EastUs
                             : DistributedTransactionDispatchTrackerTests.WestUs;
 
-                        DistributedTransactionDispatchTracker.StampDispatchHeaders(request, regionName);
+                        tracker.StampDispatchHeaders(request, regionName);
 
                         bool isRetry = bool.Parse(
                             request.Headers[DistributedTransactionConstants.IsDtxRetry]);
@@ -300,17 +248,10 @@ namespace Microsoft.Azure.Cosmos.Tests.DistributedTransaction
 
         private static DocumentServiceRequest CreateRequestWithTracker(DistributedTransactionDispatchTracker tracker)
         {
-            DocumentServiceRequest request = DocumentServiceRequest.Create(
+            return DocumentServiceRequest.Create(
                 OperationType.CommitDistributedTransaction,
                 ResourceType.DistributedTransactionBatch,
                 AuthorizationTokenType.PrimaryMasterKey);
-
-            request.Properties = new Dictionary<string, object>
-            {
-                [DistributedTransactionDispatchTracker.PropertyKey] = tracker
-            };
-
-            return request;
         }
     }
 }

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/HandlerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/HandlerTests.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Azure.Cosmos.Tests
     using Microsoft.Azure.Cosmos.Handlers;
     using Microsoft.Azure.Cosmos.Scripts;
     using Microsoft.Azure.Cosmos.Telemetry;
+    using Microsoft.Azure.Cosmos.Tracing;
     using Microsoft.Azure.Documents;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Newtonsoft.Json;
@@ -82,6 +83,20 @@ namespace Microsoft.Azure.Cosmos.Tests
                     ResourceType.Document,
                     OperationType.Read));
         }
+
+            [TestMethod]
+            public void RequestMessageClone_PreservesDistributedTransactionDispatchTracker()
+            {
+                DistributedTransactionDispatchTracker dispatchTracker = new();
+                using RequestMessage request = new RequestMessage
+                {
+                    DistributedTransactionDispatchTracker = dispatchTracker
+                };
+
+                using RequestMessage clone = request.Clone(NoOpTrace.Singleton, cloneContent: null);
+
+                Assert.AreSame(dispatchTracker, clone.DistributedTransactionDispatchTracker);
+            }
 
         [TestMethod]
         public async Task TestPreProcessingHandler()

--- a/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/RetryHandlerTests.cs
+++ b/Microsoft.Azure.Cosmos/tests/Microsoft.Azure.Cosmos.Tests/RetryHandlerTests.cs
@@ -23,6 +23,19 @@ namespace Microsoft.Azure.Cosmos.Tests
     public class RetryHandlerTests
     {
         private static readonly Uri TestUri = new Uri("https://dummy.documents.azure.com:443/dbs");
+
+        private sealed class RetryPolicyFactoryDocumentClient : MockDocumentClient
+        {
+            private readonly IRetryPolicyFactory retryPolicyFactory;
+
+            public RetryPolicyFactoryDocumentClient(IRetryPolicyFactory retryPolicyFactory)
+            {
+                this.retryPolicyFactory = retryPolicyFactory;
+            }
+
+            internal override IRetryPolicyFactory ResetSessionTokenRetryPolicy => this.retryPolicyFactory;
+        }
+
         [TestMethod]
         public async Task ValidateQueryPlanDoesNotThrowExceptionForOverlappingRanges()
         {
@@ -313,6 +326,61 @@ namespace Microsoft.Azure.Cosmos.Tests
             requestMessage.OperationType = OperationType.Read;
             await invoker.SendAsync(requestMessage, new CancellationToken());
             Assert.AreEqual(expectedHandlerCalls, handlerCalls);
+        }
+
+        [TestMethod]
+        public async Task GetRetryPolicyAsync_RequestWithoutDispatchTracker_UsesDefaultFactoryOverload()
+        {
+            Mock<IDocumentClientRetryPolicy> retryPolicy = new();
+            Mock<IRetryPolicyFactory> retryPolicyFactory = new();
+            retryPolicyFactory.Setup(factory => factory.GetRequestPolicy()).Returns(retryPolicy.Object);
+
+            using DocumentClient documentClient = new RetryPolicyFactoryDocumentClient(retryPolicyFactory.Object);
+            using CosmosClient client = new CosmosClient(
+                RetryHandlerTests.TestUri.OriginalString,
+                MockCosmosUtil.RandomInvalidCorrectlyFormatedAuthKey,
+                new CosmosClientOptions(),
+                documentClient);
+
+            RetryHandler retryHandler = new(client);
+
+            IDocumentClientRetryPolicy actual = await retryHandler.GetRetryPolicyAsync(new RequestMessage());
+
+            Assert.AreSame(retryPolicy.Object, actual);
+            retryPolicyFactory.Verify(factory => factory.GetRequestPolicy(), Times.Once);
+            retryPolicyFactory.Verify(
+                factory => factory.GetRequestPolicy(It.IsAny<DistributedTransactionDispatchTracker>()),
+                Times.Never);
+        }
+
+        [TestMethod]
+        public async Task GetRetryPolicyAsync_RequestWithDispatchTracker_UsesDtxFactoryOverload()
+        {
+            DistributedTransactionDispatchTracker dispatchTracker = new();
+            Mock<IDocumentClientRetryPolicy> retryPolicy = new();
+            Mock<IRetryPolicyFactory> retryPolicyFactory = new();
+            retryPolicyFactory
+                .Setup(factory => factory.GetRequestPolicy(dispatchTracker))
+                .Returns(retryPolicy.Object);
+
+            using DocumentClient documentClient = new RetryPolicyFactoryDocumentClient(retryPolicyFactory.Object);
+            using CosmosClient client = new CosmosClient(
+                RetryHandlerTests.TestUri.OriginalString,
+                MockCosmosUtil.RandomInvalidCorrectlyFormatedAuthKey,
+                new CosmosClientOptions(),
+                documentClient);
+
+            RetryHandler retryHandler = new(client);
+            RequestMessage request = new RequestMessage
+            {
+                DistributedTransactionDispatchTracker = dispatchTracker
+            };
+
+            IDocumentClientRetryPolicy actual = await retryHandler.GetRetryPolicyAsync(request);
+
+            Assert.AreSame(retryPolicy.Object, actual);
+            retryPolicyFactory.Verify(factory => factory.GetRequestPolicy(dispatchTracker), Times.Once);
+            retryPolicyFactory.Verify(factory => factory.GetRequestPolicy(), Times.Never);
         }
 
         [TestMethod]


### PR DESCRIPTION
## Summary
- carries the token-scoped DTX dispatch tracker through a typed internal RequestMessage property
- injects the tracker through explicit DTX-only retry-policy overloads
- removes the tracker from the public RequestMessage.Properties dictionary
- preserves the same tracker across request clones and same-token retries while replacing it on token rotation

## Validation
- Release test project build succeeded
- 250 focused unit tests passed, 0 failed, 0 skipped
- diff check passed

## Changelog
No changelog entry required: this is an internal refactor of the unmerged DTX retry-signal implementation in #6086.