### PR TITLE
FaultInjection: Adds 1.0.0-beta.2 release

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
 		<ClientPreviewSuffixVersion>preview.0</ClientPreviewSuffixVersion>
 		<DirectVersion>3.44.0</DirectVersion>
 		<FaultInjectionVersion>1.0.0</FaultInjectionVersion>
-		<FaultInjectionSuffixVersion>beta.1</FaultInjectionSuffixVersion>
+		<FaultInjectionSuffixVersion>beta.2</FaultInjectionSuffixVersion>
 		<EncryptionOfficialVersion>2.0.5</EncryptionOfficialVersion>
 		<EncryptionPreviewVersion>2.1.0</EncryptionPreviewVersion>
 		<EncryptionPreviewSuffixVersion>preview5</EncryptionPreviewSuffixVersion>

--- a/Microsoft.Azure.Cosmos/FaultInjection/changelog.md
+++ b/Microsoft.Azure.Cosmos/FaultInjection/changelog.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### <a name="unreleased-faultinjection"/> Unreleased
 
+### <a name="1.0.0-beta.2"/> [1.0.0-beta.2](https://www.nuget.org/packages/Microsoft.Azure.Cosmos.FaultInjection/1.0.0-beta.2) - 2026-09-10
+
 #### Features Added
 - [#6004](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/6004) RetryWith: Adds `RetryWith` (HTTP 449) server error injection support for Gateway mode
 - [#6103](https://github.com/Azure/azure-cosmos-dotnet-v3/pull/6103) FaultInjectionRule: Adds `GetInjectionRate` and `SetInjectionRate` so the injection rate of a server error rule can be changed at runtime, without recreating the rule or the client


### PR DESCRIPTION
## FaultInjection 1.0.0-beta.2 release

This PR releases the Microsoft.Azure.Cosmos.FaultInjection package at version **1.0.0-beta.2**. The previous release was 1.0.0-beta.1 on 2026-04-30.

### Version
- `FaultInjectionVersion` = 1.0.0
- `FaultInjectionSuffixVersion` = beta.2 (was beta.1)

### Scope
- Only the FaultInjection package is being released. No version bumps for `Microsoft.Azure.Cosmos`, `Microsoft.Azure.Cosmos.Encryption`, or `Microsoft.Azure.Cosmos.Encryption.Custom`.