### PR TITLE
[Internal] Pipelines: Skips thin client proxy tests in the FaultInjection release gate

### DIFF
--- a/azure-pipelines-faultinjection.yml
+++ b/azure-pipelines-faultinjection.yml
@@ -28,6 +28,7 @@ stages:
         VmImage: '${{ variables.VmImage }}'
         IncludeIntegration: true
         MultiRegionConnectionString: $(COSMOSDB_MULTI_REGION)
+        ThinClientConnectionString: $(COSMOSDB_THINCLIENT)
 
 - stage:
   displayName: Publish 

--- a/azure-pipelines-faultinjection.yml
+++ b/azure-pipelines-faultinjection.yml
@@ -28,13 +28,18 @@ stages:
         VmImage: '${{ variables.VmImage }}'
         IncludeIntegration: true
         MultiRegionConnectionString: $(COSMOSDB_MULTI_REGION)
-        ThinClientConnectionString: $(COSMOSDB_THINCLIENT)
-        # FaultInjectionProxyTests require COSMOSDB_THIN_CLIENT, which is fed by
-        # the COSMOSDB_THINCLIENT secret variable above. That variable is not yet
-        # defined on this pipeline definition, so the suite is excluded to keep the
-        # release gate meaningful. Once COSMOSDB_THINCLIENT is added to the
-        # dotnet-fault-injection-release definition, delete this parameter to turn
-        # thin client coverage on -- the plumbing above is already in place.
+        # FaultInjectionProxyTests need a thin client account supplied as the
+        # COSMOSDB_THIN_CLIENT environment variable (see FaultInjection/tests/
+        # Utils/TestCommon.cs -> GetThinClientConnectionString). No such variable
+        # is defined on this pipeline definition, so the suite has never actually
+        # run here -- it just fails in TestInitialize. Exclude it so the release
+        # gate reflects real signal.
+        #
+        # To enable it later: add COSMOSDB_THINCLIENT as a secret variable on the
+        # dotnet-fault-injection-release definition, map it into the integration
+        # job's env as COSMOSDB_THIN_CLIENT (note the underscore difference, and
+        # that ADO secret variables are not auto-exported to the environment), and
+        # then drop this parameter.
         IntegrationTestFilter: ' --filter "FullyQualifiedName!~FaultInjectionProxyTests" '
 
 - stage:

--- a/azure-pipelines-faultinjection.yml
+++ b/azure-pipelines-faultinjection.yml
@@ -29,6 +29,13 @@ stages:
         IncludeIntegration: true
         MultiRegionConnectionString: $(COSMOSDB_MULTI_REGION)
         ThinClientConnectionString: $(COSMOSDB_THINCLIENT)
+        # FaultInjectionProxyTests require COSMOSDB_THIN_CLIENT, which is fed by
+        # the COSMOSDB_THINCLIENT secret variable above. That variable is not yet
+        # defined on this pipeline definition, so the suite is excluded to keep the
+        # release gate meaningful. Once COSMOSDB_THINCLIENT is added to the
+        # dotnet-fault-injection-release definition, delete this parameter to turn
+        # thin client coverage on -- the plumbing above is already in place.
+        IntegrationTestFilter: ' --filter "FullyQualifiedName!~FaultInjectionProxyTests" '
 
 - stage:
   displayName: Publish 

--- a/templates/build-fault-injection.yml
+++ b/templates/build-fault-injection.yml
@@ -20,15 +20,9 @@ parameters:
   VmImage: ''
   IncludeIntegration: false
   MultiRegionConnectionString: ''
-  # FaultInjectionProxyTests talks to the thin client proxy and reads
-  # COSMOSDB_THIN_CLIENT (see FaultInjection/tests/Utils/TestCommon.cs ->
-  # GetThinClientConnectionString). Note the env var the tests read is
-  # COSMOSDB_THIN_CLIENT, while the ADO variable holding the account is named
-  # COSMOSDB_THINCLIENT (no underscore) -- the release pipeline bridges the two.
-  ThinClientConnectionString: ''
   # Optional dotnet test --filter applied to the live integration run. Empty
-  # means "run everything". Used to exclude suites whose account is not yet
-  # configured on the release pipeline definition.
+  # means "run everything". Used to exclude suites whose backing account is not
+  # configured on the pipeline definition consuming this template.
   IntegrationTestFilter: ''
   UnitTestFilter: ' --filter "FullyQualifiedName~FaultInjectionUnitTests|FullyQualifiedName~FaultInjectionBuilderValidationTests" --verbosity normal '
 
@@ -138,4 +132,3 @@ jobs:
         testRunTitle: FaultInjectionTests
       env:
         COSMOSDB_MULTI_REGION: ${{ parameters.MultiRegionConnectionString }} # Real Account Connection String used by Integration Tests while running as part of release pipeline
-        COSMOSDB_THIN_CLIENT: ${{ parameters.ThinClientConnectionString }} # Thin client proxy account used by FaultInjectionProxyTests. ADO secret variables are not auto-exported to the process environment, so this mapping is required.

--- a/templates/build-fault-injection.yml
+++ b/templates/build-fault-injection.yml
@@ -26,6 +26,10 @@ parameters:
   # COSMOSDB_THIN_CLIENT, while the ADO variable holding the account is named
   # COSMOSDB_THINCLIENT (no underscore) -- the release pipeline bridges the two.
   ThinClientConnectionString: ''
+  # Optional dotnet test --filter applied to the live integration run. Empty
+  # means "run everything". Used to exclude suites whose account is not yet
+  # configured on the release pipeline definition.
+  IntegrationTestFilter: ''
   UnitTestFilter: ' --filter "FullyQualifiedName~FaultInjectionUnitTests|FullyQualifiedName~FaultInjectionBuilderValidationTests" --verbosity normal '
 
 jobs:
@@ -128,7 +132,7 @@ jobs:
       inputs:
         command: test
         projects: 'Microsoft.Azure.Cosmos/FaultInjection/tests/*.csproj'
-        arguments: --verbosity normal --configuration ${{ parameters.BuildConfiguration }} /p:OS=Windows
+        arguments: ${{ parameters.IntegrationTestFilter }} --verbosity normal --configuration ${{ parameters.BuildConfiguration }} /p:OS=Windows
         nugetConfigPath: NuGet.config
         publishTestResults: true
         testRunTitle: FaultInjectionTests

--- a/templates/build-fault-injection.yml
+++ b/templates/build-fault-injection.yml
@@ -20,6 +20,12 @@ parameters:
   VmImage: ''
   IncludeIntegration: false
   MultiRegionConnectionString: ''
+  # FaultInjectionProxyTests talks to the thin client proxy and reads
+  # COSMOSDB_THIN_CLIENT (see FaultInjection/tests/Utils/TestCommon.cs ->
+  # GetThinClientConnectionString). Note the env var the tests read is
+  # COSMOSDB_THIN_CLIENT, while the ADO variable holding the account is named
+  # COSMOSDB_THINCLIENT (no underscore) -- the release pipeline bridges the two.
+  ThinClientConnectionString: ''
   UnitTestFilter: ' --filter "FullyQualifiedName~FaultInjectionUnitTests|FullyQualifiedName~FaultInjectionBuilderValidationTests" --verbosity normal '
 
 jobs:
@@ -128,3 +134,4 @@ jobs:
         testRunTitle: FaultInjectionTests
       env:
         COSMOSDB_MULTI_REGION: ${{ parameters.MultiRegionConnectionString }} # Real Account Connection String used by Integration Tests while running as part of release pipeline
+        COSMOSDB_THIN_CLIENT: ${{ parameters.ThinClientConnectionString }} # Thin client proxy account used by FaultInjectionProxyTests. ADO secret variables are not auto-exported to the process environment, so this mapping is required.


### PR DESCRIPTION
# Pull Request Template

## Description

The `Microsoft.Azure.Cosmos.FaultInjection` release pipeline's integration stage fails every `FaultInjectionProxyTests` test:

```
Initialization method Microsoft.Azure.Cosmos.FaultInjection.Tests.FaultInjectionProxyTests.Initialize
threw exception. Assert.Fail failed. Set environment variable COSMOSDB_THIN_CLIENT to run the tests.
```

This blocks the release: the Publish stage never runs because the gate stage is red.

### Root cause

`FaultInjectionProxyTests.Initialize` calls `TestCommon.GetThinClientConnectionString()`, which reads the **`COSMOSDB_THIN_CLIENT`** environment variable. The integration job in `templates/build-fault-injection.yml` runs the whole test project:

```yaml
projects: 'Microsoft.Azure.Cosmos/FaultInjection/tests/*.csproj'
```

with no filter — so the proxy tests are included — but nothing ever supplies that variable. The job's `env:` block maps only `COSMOSDB_MULTI_REGION`, and the `dotnet-fault-injection-release` definition has no thin client variable at all.

This is a latent gap, not a regression. The proxy tests landed in #5264 (2025-07-01), but the release pipeline has only ever set `COSMOSDB_MULTI_REGION` — both in the inline job added by #4909/#4913 and in the template that replaced it in #6060. **This suite has never actually run in the release pipeline.**

### Change

Skip the suite so the release gate reflects real signal:

- `templates/build-fault-injection.yml` — new optional `IntegrationTestFilter` parameter (default `''` = run everything), applied to the integration job's `dotnet test` arguments.
- `azure-pipelines-faultinjection.yml` — passes `--filter "FullyQualifiedName!~FaultInjectionProxyTests"`, with a comment recording why and what enabling the suite would take.

No coverage is lost — these tests have never passed here. This makes the existing gap explicit and honest instead of red.

### Why not wire the connection string instead?

That was the first version of this PR, and it turned out to be inert config:

- The `dotnet-fault-injection-release` definition has no `COSMOSDB_THINCLIENT` variable, so `$(COSMOSDB_THINCLIENT)` would not resolve.
- ADO secret variable values can never be read back (API or UI), so the value cannot be copied over from `dotnet-v3-ci` by automation — it has to be pasted by someone holding the connection string.

Rather than merge plumbing that does nothing until an unrelated manual step happens, this PR skips the suite and documents the enablement path inline:

1. Add `COSMOSDB_THINCLIENT` as a secret variable on the `dotnet-fault-injection-release` definition.
2. Map it into the integration job's `env:` as `COSMOSDB_THIN_CLIENT` — note the underscore difference from the ADO variable name, and that ADO secret variables are not auto-exported to the process environment, so an explicit mapping is required (same pattern as `templates/build-thinclient.yml`).
3. Drop the `IntegrationTestFilter` parameter.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Other (Test / CI infrastructure)

## Changelog

- [x] No changelog entry required

Pipeline-only. Touches only `azure-pipelines-faultinjection.yml` and `templates/build-fault-injection.yml`; nothing under `Microsoft.Azure.Cosmos/src/**` or `FaultInjection/src/**`, and there is no customer-observable behavior change.
