### PR TITLE
[Internal] FaultInjection Tests: Fixes live test assertions blocking the release gate

### DIFF
--- a/Microsoft.Azure.Cosmos/FaultInjection/tests/FaultInjectionDirectModeTests.cs
+++ b/Microsoft.Azure.Cosmos/FaultInjection/tests/FaultInjectionDirectModeTests.cs
@@ -1446,30 +1446,37 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
 
                 dynamicRateRule.Enable();
 
-                //Count the injected 429s directly: this tests the user-visible probability contract and is
-                //immune to any internal re-entry of the rule.
-                int fullRateInjected = await ReadBatchAsync(this.fiContainer, 100);
+                //Assert on the rule hit count, not on 429s surfaced to the caller. WithTimes(1) faults only
+                //the first replica attempt of an operation, and a Session-consistency point read needs just one
+                //valid replica response, so the store reader falls back to a clean replica and the injected 429
+                //never reaches the caller. MaxRetryAttemptsOnRateLimitedRequests = 0 disables the throttling
+                //retry policy, not that replica fan-out.
+                await ReadBatchAsync(this.fiContainer, 100);
 
-                //A rate of 1 with retries disabled injects into every one of the 100 reads.
-                Assert.AreEqual(
-                    100,
-                    fullRateInjected,
-                    $"A rate of 1 should inject into every read. {Describe(dynamicRateRule)}");
+                long fullRateHitCount = dynamicRateRule.GetHitCount();
+
+                //At rate 1 every read is injected, and WithTimes(1) caps the rule at one application per
+                //operation, so the count is at least 100.
+                Assert.IsTrue(
+                    fullRateHitCount >= 100,
+                    $"A rate of 1 should inject into every read. Batch hits: {fullRateHitCount}. {Describe(dynamicRateRule)}");
 
                 // The client is already built and running; this is the behavior under test.
                 dynamicRateRule.SetInjectionRate(0.5);
 
-                int halfRateInjected = await ReadBatchAsync(this.fiContainer, 100);
+                await ReadBatchAsync(this.fiContainer, 100);
+
+                long halfRateHitCount = dynamicRateRule.GetHitCount() - fullRateHitCount;
 
                 //50% injection rate over 100 requests is Binomial(100, 0.5): mean 50, standard deviation 5.
                 //[30, 70] is +/- 4 standard deviations, so a passing run is not a coin flip while a rate change
                 //that never reached the live client (which would inject 100 times) is still caught.
                 Assert.IsTrue(
-                    halfRateInjected >= 30,
-                    $"Injection rate too low after SetInjectionRate. Injected: {halfRateInjected}. {Describe(dynamicRateRule)}");
+                    halfRateHitCount >= 30,
+                    $"Injection rate too low after SetInjectionRate. Batch hits: {halfRateHitCount}. {Describe(dynamicRateRule)}");
                 Assert.IsTrue(
-                    halfRateInjected <= 70,
-                    $"Injection rate too high after SetInjectionRate. Injected: {halfRateInjected}. {Describe(dynamicRateRule)}");
+                    halfRateHitCount <= 70,
+                    $"Injection rate too high after SetInjectionRate. Batch hits: {halfRateHitCount}. {Describe(dynamicRateRule)}");
             }
             finally
             {
@@ -1477,9 +1484,8 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
             }
         }
 
-        private static async Task<int> ReadBatchAsync(Container container, int requestCount)
+        private static async Task ReadBatchAsync(Container container, int requestCount)
         {
-            int injectedCount = 0;
             for (int i = 0; i < requestCount; i++)
             {
                 try
@@ -1488,13 +1494,12 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
                         "testId",
                         new PartitionKey("pk"));
                 }
-                catch (CosmosException ex) when (ex.StatusCode == HttpStatusCode.TooManyRequests)
+                catch (CosmosException)
                 {
-                    injectedCount++;
+                    // Injected faults and missing items both surface as CosmosException; the rule hit count
+                    // is what the injection rate assertions rely on.
                 }
             }
-
-            return injectedCount;
         }
 
         [TestMethod]
@@ -1596,12 +1601,18 @@ namespace Microsoft.Azure.Cosmos.FaultInjection.Tests
 
                 Assert.IsTrue(connectionErrorRule.GetHitCount() == hitCount);
 
+                //FaultInjectionDynamicChannelStore only tracks live channels - a channel is removed from the
+                //store when it is disposed. So a connection error rule did its job when at least one of the
+                //channels captured above is no longer present.
+                List<Guid> liveChannelIds = channelStore.GetAllChannelIds();
                 bool disposedChannel = false;
                 foreach (Guid channelGuid in channelGuids)
                 {
-                    disposedChannel = disposedChannel || channelStore.GetAllChannelIds().Contains(channelGuid);
+                    disposedChannel = disposedChannel || !liveChannelIds.Contains(channelGuid);
                 }
-                Assert.IsTrue(disposedChannel);
+                Assert.IsTrue(
+                    disposedChannel,
+                    $"Expected at least one of the {channelGuids.Count} captured channels to be disposed by rule '{ruldId}'. Hit count: {hitCount}.");
 
             }
             finally


### PR DESCRIPTION
## Problem

The `dotnet-fault-injection-release` gate fails on two live tests in `FaultInjectionDirectModeTests`. Neither is a product defect — both are assertion bugs in the tests themselves.

### 1. `FaultInjectionServerErrorRule_DynamicInjectionRateTest`

```
Assert.AreEqual failed. Expected:<100>. Actual:<0>. A rate of 1 should inject into every read.
rule 'dynamicRateRule-...' hitCount=100 regionEndpoints=[...] addresses=[]
```

The failure message carries its own diagnosis: **`hitCount=100`**. The rule was applied to all 100 reads at rate 1, exactly once each (`WithTimes(1)` caps applications per activity id). The dynamic injection rate feature works.

What does not hold is the assumption that an injected 429 reaches the caller. `WithTimes(1)` faults only the *first* replica attempt of an operation, and a Session-consistency point read only needs **one** valid replica response — so the store reader falls back to a clean replica and the read succeeds. `MaxRetryAttemptsOnRateLimitedRequests = 0` disables the throttling *retry policy*; it does not disable that replica fan-out. So 100 injections surface 0 `CosmosException`s.

This assertion style was introduced in the last review round of #6103 ("Refactors the dynamic rate emulator test to assert on injected 429 counts"). The shape it replaced — asserting on `GetHitCount()` — was correct. This change restores it, and the live run confirms the expected value: `hitCount` was exactly 100.

### 2. `FaultInjectionConnectionErrorRule_Test`

```
Assert.IsTrue failed.   (FaultInjectionDirectModeTests.cs:1604)
```

```csharp
disposedChannel = disposedChannel || channelStore.GetAllChannelIds().Contains(channelGuid);
Assert.IsTrue(disposedChannel);
```

`FaultInjectionDynamicChannelStore` tracks **live** channels — `RemoveChannel` is called when a channel is disposed. So `Contains(...) == true` means the channel is still alive, and the assertion passes only when at least one captured channel **survived**, the inverse of the disposal it is named for. It fails precisely when the `ReceiveStreamClosed` rule works thoroughly enough to dispose every channel captured earlier in the test.

This is latent, not a regression: the assertion is untouched by #5678, #5939, #6060 and #6103.

## Fix

- Assert on the rule hit count rather than on 429s surfaced to the caller, and widen `ReadBatchAsync`'s catch back to `CosmosException` now that it no longer classifies status codes.
- Invert the channel check to actually test for disposal, and add a failure message carrying the channel count, rule id and hit count.

## Why this was not caught before merge

`templates/build-fault-injection.yml` runs the live suite only when `IncludeIntegration: true`, which only the release pipeline sets. The PR gate never executes these tests, so a live-only assertion bug reaches `main` and surfaces for the first time at release time. This is the second instance of that gap in this release (see #6113).

## Testing

Assertion-only change to a live suite that cannot run in the PR gate; validation is the release pipeline run. The expected values are taken from the failing run itself (`hitCount=100`; all captured channels absent from the live store).

No changelog entry: test-only change, no customer-observable behavior, and `changelog-check.yml` only fires for `FaultInjection/src/**`.
